### PR TITLE
Return  transaction hash

### DIFF
--- a/JNI/java/com/wallet/crypto/trustapp/proto/Binance.java
+++ b/JNI/java/com/wallet/crypto/trustapp/proto/Binance.java
@@ -123,6 +123,7 @@ public final class Binance {
       msgs_ = java.util.Collections.emptyList();
       signatures_ = java.util.Collections.emptyList();
       memo_ = "";
+      source_ = 0L;
       data_ = com.google.protobuf.ByteString.EMPTY;
     }
 
@@ -151,7 +152,7 @@ public final class Binance {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 msgs_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -159,7 +160,7 @@ public final class Binance {
               break;
             }
             case 18: {
-              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
+              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
                 signatures_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
                 mutable_bitField0_ |= 0x00000002;
               }
@@ -183,7 +184,7 @@ public final class Binance {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -197,11 +198,11 @@ public final class Binance {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) != 0)) {
-          msgs_ = java.util.Collections.unmodifiableList(msgs_); // C
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          msgs_ = java.util.Collections.unmodifiableList(msgs_);
         }
-        if (((mutable_bitField0_ & 0x00000002) != 0)) {
-          signatures_ = java.util.Collections.unmodifiableList(signatures_); // C
+        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+          signatures_ = java.util.Collections.unmodifiableList(signatures_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -442,18 +443,19 @@ public final class Binance {
       }
       com.wallet.crypto.trustapp.proto.Binance.Transaction other = (com.wallet.crypto.trustapp.proto.Binance.Transaction) obj;
 
-      if (!getMsgsList()
-          .equals(other.getMsgsList())) return false;
-      if (!getSignaturesList()
-          .equals(other.getSignaturesList())) return false;
-      if (!getMemo()
-          .equals(other.getMemo())) return false;
-      if (getSource()
-          != other.getSource()) return false;
-      if (!getData()
-          .equals(other.getData())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      boolean result = true;
+      result = result && getMsgsList()
+          .equals(other.getMsgsList());
+      result = result && getSignaturesList()
+          .equals(other.getSignaturesList());
+      result = result && getMemo()
+          .equals(other.getMemo());
+      result = result && (getSource()
+          == other.getSource());
+      result = result && getData()
+          .equals(other.getData());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -649,12 +651,12 @@ public final class Binance {
         com.wallet.crypto.trustapp.proto.Binance.Transaction result = new com.wallet.crypto.trustapp.proto.Binance.Transaction(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((bitField0_ & 0x00000001) != 0)) {
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
           msgs_ = java.util.Collections.unmodifiableList(msgs_);
           bitField0_ = (bitField0_ & ~0x00000001);
         }
         result.msgs_ = msgs_;
-        if (((bitField0_ & 0x00000002) != 0)) {
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
           signatures_ = java.util.Collections.unmodifiableList(signatures_);
           bitField0_ = (bitField0_ & ~0x00000002);
         }
@@ -669,35 +671,35 @@ public final class Binance {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -773,7 +775,7 @@ public final class Binance {
 
       private java.util.List<com.google.protobuf.ByteString> msgs_ = java.util.Collections.emptyList();
       private void ensureMsgsIsMutable() {
-        if (!((bitField0_ & 0x00000001) != 0)) {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
           msgs_ = new java.util.ArrayList<com.google.protobuf.ByteString>(msgs_);
           bitField0_ |= 0x00000001;
          }
@@ -788,8 +790,7 @@ public final class Binance {
        */
       public java.util.List<com.google.protobuf.ByteString>
           getMsgsList() {
-        return ((bitField0_ & 0x00000001) != 0) ?
-                 java.util.Collections.unmodifiableList(msgs_) : msgs_;
+        return java.util.Collections.unmodifiableList(msgs_);
       }
       /**
        * <pre>
@@ -881,7 +882,7 @@ public final class Binance {
 
       private java.util.List<com.google.protobuf.ByteString> signatures_ = java.util.Collections.emptyList();
       private void ensureSignaturesIsMutable() {
-        if (!((bitField0_ & 0x00000002) != 0)) {
+        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
           signatures_ = new java.util.ArrayList<com.google.protobuf.ByteString>(signatures_);
           bitField0_ |= 0x00000002;
          }
@@ -895,8 +896,7 @@ public final class Binance {
        */
       public java.util.List<com.google.protobuf.ByteString>
           getSignaturesList() {
-        return ((bitField0_ & 0x00000002) != 0) ?
-                 java.util.Collections.unmodifiableList(signatures_) : signatures_;
+        return java.util.Collections.unmodifiableList(signatures_);
       }
       /**
        * <pre>
@@ -1150,7 +1150,7 @@ public final class Binance {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -1255,6 +1255,8 @@ public final class Binance {
     private Signature() {
       pubKey_ = com.google.protobuf.ByteString.EMPTY;
       signature_ = com.google.protobuf.ByteString.EMPTY;
+      accountNumber_ = 0L;
+      sequence_ = 0L;
     }
 
     @java.lang.Override
@@ -1302,7 +1304,7 @@ public final class Binance {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -1381,7 +1383,7 @@ public final class Binance {
                 done = true;
                 break;
               default: {
-                if (!parseUnknownField(
+                if (!parseUnknownFieldProto3(
                     input, unknownFields, extensionRegistry, tag)) {
                   done = true;
                 }
@@ -1450,8 +1452,9 @@ public final class Binance {
         }
         com.wallet.crypto.trustapp.proto.Binance.Signature.PubKey other = (com.wallet.crypto.trustapp.proto.Binance.Signature.PubKey) obj;
 
-        if (!unknownFields.equals(other.unknownFields)) return false;
-        return true;
+        boolean result = true;
+        result = result && unknownFields.equals(other.unknownFields);
+        return result;
       }
 
       @java.lang.Override
@@ -1631,35 +1634,35 @@ public final class Binance {
 
         @java.lang.Override
         public Builder clone() {
-          return super.clone();
+          return (Builder) super.clone();
         }
         @java.lang.Override
         public Builder setField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return super.setField(field, value);
+          return (Builder) super.setField(field, value);
         }
         @java.lang.Override
         public Builder clearField(
             com.google.protobuf.Descriptors.FieldDescriptor field) {
-          return super.clearField(field);
+          return (Builder) super.clearField(field);
         }
         @java.lang.Override
         public Builder clearOneof(
             com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-          return super.clearOneof(oneof);
+          return (Builder) super.clearOneof(oneof);
         }
         @java.lang.Override
         public Builder setRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             int index, java.lang.Object value) {
-          return super.setRepeatedField(field, index, value);
+          return (Builder) super.setRepeatedField(field, index, value);
         }
         @java.lang.Override
         public Builder addRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return super.addRepeatedField(field, value);
+          return (Builder) super.addRepeatedField(field, value);
         }
         @java.lang.Override
         public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -1704,7 +1707,7 @@ public final class Binance {
         @java.lang.Override
         public final Builder setUnknownFields(
             final com.google.protobuf.UnknownFieldSet unknownFields) {
-          return super.setUnknownFields(unknownFields);
+          return super.setUnknownFieldsProto3(unknownFields);
         }
 
         @java.lang.Override
@@ -1872,16 +1875,17 @@ public final class Binance {
       }
       com.wallet.crypto.trustapp.proto.Binance.Signature other = (com.wallet.crypto.trustapp.proto.Binance.Signature) obj;
 
-      if (!getPubKey()
-          .equals(other.getPubKey())) return false;
-      if (!getSignature()
-          .equals(other.getSignature())) return false;
-      if (getAccountNumber()
-          != other.getAccountNumber()) return false;
-      if (getSequence()
-          != other.getSequence()) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      boolean result = true;
+      result = result && getPubKey()
+          .equals(other.getPubKey());
+      result = result && getSignature()
+          .equals(other.getSignature());
+      result = result && (getAccountNumber()
+          == other.getAccountNumber());
+      result = result && (getSequence()
+          == other.getSequence());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -2078,35 +2082,35 @@ public final class Binance {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -2321,7 +2325,7 @@ public final class Binance {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -2481,6 +2485,11 @@ public final class Binance {
       sender_ = com.google.protobuf.ByteString.EMPTY;
       id_ = "";
       symbol_ = "";
+      ordertype_ = 0L;
+      side_ = 0L;
+      price_ = 0L;
+      quantity_ = 0L;
+      timeinforce_ = 0L;
     }
 
     @java.lang.Override
@@ -2550,7 +2559,7 @@ public final class Binance {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -2835,24 +2844,25 @@ public final class Binance {
       }
       com.wallet.crypto.trustapp.proto.Binance.TradeOrder other = (com.wallet.crypto.trustapp.proto.Binance.TradeOrder) obj;
 
-      if (!getSender()
-          .equals(other.getSender())) return false;
-      if (!getId()
-          .equals(other.getId())) return false;
-      if (!getSymbol()
-          .equals(other.getSymbol())) return false;
-      if (getOrdertype()
-          != other.getOrdertype()) return false;
-      if (getSide()
-          != other.getSide()) return false;
-      if (getPrice()
-          != other.getPrice()) return false;
-      if (getQuantity()
-          != other.getQuantity()) return false;
-      if (getTimeinforce()
-          != other.getTimeinforce()) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      boolean result = true;
+      result = result && getSender()
+          .equals(other.getSender());
+      result = result && getId()
+          .equals(other.getId());
+      result = result && getSymbol()
+          .equals(other.getSymbol());
+      result = result && (getOrdertype()
+          == other.getOrdertype());
+      result = result && (getSide()
+          == other.getSide());
+      result = result && (getPrice()
+          == other.getPrice());
+      result = result && (getQuantity()
+          == other.getQuantity());
+      result = result && (getTimeinforce()
+          == other.getTimeinforce());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -3072,35 +3082,35 @@ public final class Binance {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -3580,7 +3590,7 @@ public final class Binance {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -3739,7 +3749,7 @@ public final class Binance {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -3924,14 +3934,15 @@ public final class Binance {
       }
       com.wallet.crypto.trustapp.proto.Binance.CancelTradeOrder other = (com.wallet.crypto.trustapp.proto.Binance.CancelTradeOrder) obj;
 
-      if (!getSender()
-          .equals(other.getSender())) return false;
-      if (!getSymbol()
-          .equals(other.getSymbol())) return false;
-      if (!getRefid()
-          .equals(other.getRefid())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      boolean result = true;
+      result = result && getSender()
+          .equals(other.getSender());
+      result = result && getSymbol()
+          .equals(other.getSymbol());
+      result = result && getRefid()
+          .equals(other.getRefid());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -4121,35 +4132,35 @@ public final class Binance {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -4424,7 +4435,7 @@ public final class Binance {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -4568,7 +4579,7 @@ public final class Binance {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 inputs_ = new java.util.ArrayList<com.wallet.crypto.trustapp.proto.Binance.SendOrder.Input>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -4577,7 +4588,7 @@ public final class Binance {
               break;
             }
             case 18: {
-              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
+              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
                 outputs_ = new java.util.ArrayList<com.wallet.crypto.trustapp.proto.Binance.SendOrder.Output>();
                 mutable_bitField0_ |= 0x00000002;
               }
@@ -4586,7 +4597,7 @@ public final class Binance {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -4600,10 +4611,10 @@ public final class Binance {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) != 0)) {
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
           inputs_ = java.util.Collections.unmodifiableList(inputs_);
         }
-        if (((mutable_bitField0_ & 0x00000002) != 0)) {
+        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
           outputs_ = java.util.Collections.unmodifiableList(outputs_);
         }
         this.unknownFields = unknownFields.build();
@@ -4660,6 +4671,7 @@ public final class Binance {
       }
       private Token() {
         denom_ = "";
+        amount_ = 0L;
       }
 
       @java.lang.Override
@@ -4698,7 +4710,7 @@ public final class Binance {
                 break;
               }
               default: {
-                if (!parseUnknownField(
+                if (!parseUnknownFieldProto3(
                     input, unknownFields, extensionRegistry, tag)) {
                   done = true;
                 }
@@ -4823,12 +4835,13 @@ public final class Binance {
         }
         com.wallet.crypto.trustapp.proto.Binance.SendOrder.Token other = (com.wallet.crypto.trustapp.proto.Binance.SendOrder.Token) obj;
 
-        if (!getDenom()
-            .equals(other.getDenom())) return false;
-        if (getAmount()
-            != other.getAmount()) return false;
-        if (!unknownFields.equals(other.unknownFields)) return false;
-        return true;
+        boolean result = true;
+        result = result && getDenom()
+            .equals(other.getDenom());
+        result = result && (getAmount()
+            == other.getAmount());
+        result = result && unknownFields.equals(other.unknownFields);
+        return result;
       }
 
       @java.lang.Override
@@ -5018,35 +5031,35 @@ public final class Binance {
 
         @java.lang.Override
         public Builder clone() {
-          return super.clone();
+          return (Builder) super.clone();
         }
         @java.lang.Override
         public Builder setField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return super.setField(field, value);
+          return (Builder) super.setField(field, value);
         }
         @java.lang.Override
         public Builder clearField(
             com.google.protobuf.Descriptors.FieldDescriptor field) {
-          return super.clearField(field);
+          return (Builder) super.clearField(field);
         }
         @java.lang.Override
         public Builder clearOneof(
             com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-          return super.clearOneof(oneof);
+          return (Builder) super.clearOneof(oneof);
         }
         @java.lang.Override
         public Builder setRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             int index, java.lang.Object value) {
-          return super.setRepeatedField(field, index, value);
+          return (Builder) super.setRepeatedField(field, index, value);
         }
         @java.lang.Override
         public Builder addRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return super.addRepeatedField(field, value);
+          return (Builder) super.addRepeatedField(field, value);
         }
         @java.lang.Override
         public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -5193,7 +5206,7 @@ public final class Binance {
         @java.lang.Override
         public final Builder setUnknownFields(
             final com.google.protobuf.UnknownFieldSet unknownFields) {
-          return super.setUnknownFields(unknownFields);
+          return super.setUnknownFieldsProto3(unknownFields);
         }
 
         @java.lang.Override
@@ -5323,7 +5336,7 @@ public final class Binance {
                 break;
               }
               case 18: {
-                if (!((mutable_bitField0_ & 0x00000002) != 0)) {
+                if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
                   coins_ = new java.util.ArrayList<com.wallet.crypto.trustapp.proto.Binance.SendOrder.Token>();
                   mutable_bitField0_ |= 0x00000002;
                 }
@@ -5332,7 +5345,7 @@ public final class Binance {
                 break;
               }
               default: {
-                if (!parseUnknownField(
+                if (!parseUnknownFieldProto3(
                     input, unknownFields, extensionRegistry, tag)) {
                   done = true;
                 }
@@ -5346,7 +5359,7 @@ public final class Binance {
           throw new com.google.protobuf.InvalidProtocolBufferException(
               e).setUnfinishedMessage(this);
         } finally {
-          if (((mutable_bitField0_ & 0x00000002) != 0)) {
+          if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
             coins_ = java.util.Collections.unmodifiableList(coins_);
           }
           this.unknownFields = unknownFields.build();
@@ -5463,12 +5476,13 @@ public final class Binance {
         }
         com.wallet.crypto.trustapp.proto.Binance.SendOrder.Input other = (com.wallet.crypto.trustapp.proto.Binance.SendOrder.Input) obj;
 
-        if (!getAddress()
-            .equals(other.getAddress())) return false;
-        if (!getCoinsList()
-            .equals(other.getCoinsList())) return false;
-        if (!unknownFields.equals(other.unknownFields)) return false;
-        return true;
+        boolean result = true;
+        result = result && getAddress()
+            .equals(other.getAddress());
+        result = result && getCoinsList()
+            .equals(other.getCoinsList());
+        result = result && unknownFields.equals(other.unknownFields);
+        return result;
       }
 
       @java.lang.Override
@@ -5656,7 +5670,7 @@ public final class Binance {
           int to_bitField0_ = 0;
           result.address_ = address_;
           if (coinsBuilder_ == null) {
-            if (((bitField0_ & 0x00000002) != 0)) {
+            if (((bitField0_ & 0x00000002) == 0x00000002)) {
               coins_ = java.util.Collections.unmodifiableList(coins_);
               bitField0_ = (bitField0_ & ~0x00000002);
             }
@@ -5671,35 +5685,35 @@ public final class Binance {
 
         @java.lang.Override
         public Builder clone() {
-          return super.clone();
+          return (Builder) super.clone();
         }
         @java.lang.Override
         public Builder setField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return super.setField(field, value);
+          return (Builder) super.setField(field, value);
         }
         @java.lang.Override
         public Builder clearField(
             com.google.protobuf.Descriptors.FieldDescriptor field) {
-          return super.clearField(field);
+          return (Builder) super.clearField(field);
         }
         @java.lang.Override
         public Builder clearOneof(
             com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-          return super.clearOneof(oneof);
+          return (Builder) super.clearOneof(oneof);
         }
         @java.lang.Override
         public Builder setRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             int index, java.lang.Object value) {
-          return super.setRepeatedField(field, index, value);
+          return (Builder) super.setRepeatedField(field, index, value);
         }
         @java.lang.Override
         public Builder addRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return super.addRepeatedField(field, value);
+          return (Builder) super.addRepeatedField(field, value);
         }
         @java.lang.Override
         public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -5804,7 +5818,7 @@ public final class Binance {
         private java.util.List<com.wallet.crypto.trustapp.proto.Binance.SendOrder.Token> coins_ =
           java.util.Collections.emptyList();
         private void ensureCoinsIsMutable() {
-          if (!((bitField0_ & 0x00000002) != 0)) {
+          if (!((bitField0_ & 0x00000002) == 0x00000002)) {
             coins_ = new java.util.ArrayList<com.wallet.crypto.trustapp.proto.Binance.SendOrder.Token>(coins_);
             bitField0_ |= 0x00000002;
            }
@@ -6033,7 +6047,7 @@ public final class Binance {
             coinsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
                 com.wallet.crypto.trustapp.proto.Binance.SendOrder.Token, com.wallet.crypto.trustapp.proto.Binance.SendOrder.Token.Builder, com.wallet.crypto.trustapp.proto.Binance.SendOrder.TokenOrBuilder>(
                     coins_,
-                    ((bitField0_ & 0x00000002) != 0),
+                    ((bitField0_ & 0x00000002) == 0x00000002),
                     getParentForChildren(),
                     isClean());
             coins_ = null;
@@ -6043,7 +6057,7 @@ public final class Binance {
         @java.lang.Override
         public final Builder setUnknownFields(
             final com.google.protobuf.UnknownFieldSet unknownFields) {
-          return super.setUnknownFields(unknownFields);
+          return super.setUnknownFieldsProto3(unknownFields);
         }
 
         @java.lang.Override
@@ -6173,7 +6187,7 @@ public final class Binance {
                 break;
               }
               case 18: {
-                if (!((mutable_bitField0_ & 0x00000002) != 0)) {
+                if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
                   coins_ = new java.util.ArrayList<com.wallet.crypto.trustapp.proto.Binance.SendOrder.Token>();
                   mutable_bitField0_ |= 0x00000002;
                 }
@@ -6182,7 +6196,7 @@ public final class Binance {
                 break;
               }
               default: {
-                if (!parseUnknownField(
+                if (!parseUnknownFieldProto3(
                     input, unknownFields, extensionRegistry, tag)) {
                   done = true;
                 }
@@ -6196,7 +6210,7 @@ public final class Binance {
           throw new com.google.protobuf.InvalidProtocolBufferException(
               e).setUnfinishedMessage(this);
         } finally {
-          if (((mutable_bitField0_ & 0x00000002) != 0)) {
+          if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
             coins_ = java.util.Collections.unmodifiableList(coins_);
           }
           this.unknownFields = unknownFields.build();
@@ -6313,12 +6327,13 @@ public final class Binance {
         }
         com.wallet.crypto.trustapp.proto.Binance.SendOrder.Output other = (com.wallet.crypto.trustapp.proto.Binance.SendOrder.Output) obj;
 
-        if (!getAddress()
-            .equals(other.getAddress())) return false;
-        if (!getCoinsList()
-            .equals(other.getCoinsList())) return false;
-        if (!unknownFields.equals(other.unknownFields)) return false;
-        return true;
+        boolean result = true;
+        result = result && getAddress()
+            .equals(other.getAddress());
+        result = result && getCoinsList()
+            .equals(other.getCoinsList());
+        result = result && unknownFields.equals(other.unknownFields);
+        return result;
       }
 
       @java.lang.Override
@@ -6506,7 +6521,7 @@ public final class Binance {
           int to_bitField0_ = 0;
           result.address_ = address_;
           if (coinsBuilder_ == null) {
-            if (((bitField0_ & 0x00000002) != 0)) {
+            if (((bitField0_ & 0x00000002) == 0x00000002)) {
               coins_ = java.util.Collections.unmodifiableList(coins_);
               bitField0_ = (bitField0_ & ~0x00000002);
             }
@@ -6521,35 +6536,35 @@ public final class Binance {
 
         @java.lang.Override
         public Builder clone() {
-          return super.clone();
+          return (Builder) super.clone();
         }
         @java.lang.Override
         public Builder setField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return super.setField(field, value);
+          return (Builder) super.setField(field, value);
         }
         @java.lang.Override
         public Builder clearField(
             com.google.protobuf.Descriptors.FieldDescriptor field) {
-          return super.clearField(field);
+          return (Builder) super.clearField(field);
         }
         @java.lang.Override
         public Builder clearOneof(
             com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-          return super.clearOneof(oneof);
+          return (Builder) super.clearOneof(oneof);
         }
         @java.lang.Override
         public Builder setRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             int index, java.lang.Object value) {
-          return super.setRepeatedField(field, index, value);
+          return (Builder) super.setRepeatedField(field, index, value);
         }
         @java.lang.Override
         public Builder addRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return super.addRepeatedField(field, value);
+          return (Builder) super.addRepeatedField(field, value);
         }
         @java.lang.Override
         public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -6654,7 +6669,7 @@ public final class Binance {
         private java.util.List<com.wallet.crypto.trustapp.proto.Binance.SendOrder.Token> coins_ =
           java.util.Collections.emptyList();
         private void ensureCoinsIsMutable() {
-          if (!((bitField0_ & 0x00000002) != 0)) {
+          if (!((bitField0_ & 0x00000002) == 0x00000002)) {
             coins_ = new java.util.ArrayList<com.wallet.crypto.trustapp.proto.Binance.SendOrder.Token>(coins_);
             bitField0_ |= 0x00000002;
            }
@@ -6883,7 +6898,7 @@ public final class Binance {
             coinsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
                 com.wallet.crypto.trustapp.proto.Binance.SendOrder.Token, com.wallet.crypto.trustapp.proto.Binance.SendOrder.Token.Builder, com.wallet.crypto.trustapp.proto.Binance.SendOrder.TokenOrBuilder>(
                     coins_,
-                    ((bitField0_ & 0x00000002) != 0),
+                    ((bitField0_ & 0x00000002) == 0x00000002),
                     getParentForChildren(),
                     isClean());
             coins_ = null;
@@ -6893,7 +6908,7 @@ public final class Binance {
         @java.lang.Override
         public final Builder setUnknownFields(
             final com.google.protobuf.UnknownFieldSet unknownFields) {
-          return super.setUnknownFields(unknownFields);
+          return super.setUnknownFieldsProto3(unknownFields);
         }
 
         @java.lang.Override
@@ -7065,12 +7080,13 @@ public final class Binance {
       }
       com.wallet.crypto.trustapp.proto.Binance.SendOrder other = (com.wallet.crypto.trustapp.proto.Binance.SendOrder) obj;
 
-      if (!getInputsList()
-          .equals(other.getInputsList())) return false;
-      if (!getOutputsList()
-          .equals(other.getOutputsList())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      boolean result = true;
+      result = result && getInputsList()
+          .equals(other.getInputsList());
+      result = result && getOutputsList()
+          .equals(other.getOutputsList());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -7263,7 +7279,7 @@ public final class Binance {
         com.wallet.crypto.trustapp.proto.Binance.SendOrder result = new com.wallet.crypto.trustapp.proto.Binance.SendOrder(this);
         int from_bitField0_ = bitField0_;
         if (inputsBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) != 0)) {
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
             inputs_ = java.util.Collections.unmodifiableList(inputs_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -7272,7 +7288,7 @@ public final class Binance {
           result.inputs_ = inputsBuilder_.build();
         }
         if (outputsBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) != 0)) {
+          if (((bitField0_ & 0x00000002) == 0x00000002)) {
             outputs_ = java.util.Collections.unmodifiableList(outputs_);
             bitField0_ = (bitField0_ & ~0x00000002);
           }
@@ -7286,35 +7302,35 @@ public final class Binance {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -7413,7 +7429,7 @@ public final class Binance {
       private java.util.List<com.wallet.crypto.trustapp.proto.Binance.SendOrder.Input> inputs_ =
         java.util.Collections.emptyList();
       private void ensureInputsIsMutable() {
-        if (!((bitField0_ & 0x00000001) != 0)) {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
           inputs_ = new java.util.ArrayList<com.wallet.crypto.trustapp.proto.Binance.SendOrder.Input>(inputs_);
           bitField0_ |= 0x00000001;
          }
@@ -7642,7 +7658,7 @@ public final class Binance {
           inputsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               com.wallet.crypto.trustapp.proto.Binance.SendOrder.Input, com.wallet.crypto.trustapp.proto.Binance.SendOrder.Input.Builder, com.wallet.crypto.trustapp.proto.Binance.SendOrder.InputOrBuilder>(
                   inputs_,
-                  ((bitField0_ & 0x00000001) != 0),
+                  ((bitField0_ & 0x00000001) == 0x00000001),
                   getParentForChildren(),
                   isClean());
           inputs_ = null;
@@ -7653,7 +7669,7 @@ public final class Binance {
       private java.util.List<com.wallet.crypto.trustapp.proto.Binance.SendOrder.Output> outputs_ =
         java.util.Collections.emptyList();
       private void ensureOutputsIsMutable() {
-        if (!((bitField0_ & 0x00000002) != 0)) {
+        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
           outputs_ = new java.util.ArrayList<com.wallet.crypto.trustapp.proto.Binance.SendOrder.Output>(outputs_);
           bitField0_ |= 0x00000002;
          }
@@ -7882,7 +7898,7 @@ public final class Binance {
           outputsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               com.wallet.crypto.trustapp.proto.Binance.SendOrder.Output, com.wallet.crypto.trustapp.proto.Binance.SendOrder.Output.Builder, com.wallet.crypto.trustapp.proto.Binance.SendOrder.OutputOrBuilder>(
                   outputs_,
-                  ((bitField0_ & 0x00000002) != 0),
+                  ((bitField0_ & 0x00000002) == 0x00000002),
                   getParentForChildren(),
                   isClean());
           outputs_ = null;
@@ -7892,7 +7908,7 @@ public final class Binance {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -7997,6 +8013,7 @@ public final class Binance {
     private TokenFreezeOrder() {
       from_ = com.google.protobuf.ByteString.EMPTY;
       symbol_ = "";
+      amount_ = 0L;
     }
 
     @java.lang.Override
@@ -8040,7 +8057,7 @@ public final class Binance {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -8197,14 +8214,15 @@ public final class Binance {
       }
       com.wallet.crypto.trustapp.proto.Binance.TokenFreezeOrder other = (com.wallet.crypto.trustapp.proto.Binance.TokenFreezeOrder) obj;
 
-      if (!getFrom()
-          .equals(other.getFrom())) return false;
-      if (!getSymbol()
-          .equals(other.getSymbol())) return false;
-      if (getAmount()
-          != other.getAmount()) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      boolean result = true;
+      result = result && getFrom()
+          .equals(other.getFrom());
+      result = result && getSymbol()
+          .equals(other.getSymbol());
+      result = result && (getAmount()
+          == other.getAmount());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -8395,35 +8413,35 @@ public final class Binance {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -8646,7 +8664,7 @@ public final class Binance {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -8751,6 +8769,7 @@ public final class Binance {
     private TokenUnfreezeOrder() {
       from_ = com.google.protobuf.ByteString.EMPTY;
       symbol_ = "";
+      amount_ = 0L;
     }
 
     @java.lang.Override
@@ -8794,7 +8813,7 @@ public final class Binance {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -8951,14 +8970,15 @@ public final class Binance {
       }
       com.wallet.crypto.trustapp.proto.Binance.TokenUnfreezeOrder other = (com.wallet.crypto.trustapp.proto.Binance.TokenUnfreezeOrder) obj;
 
-      if (!getFrom()
-          .equals(other.getFrom())) return false;
-      if (!getSymbol()
-          .equals(other.getSymbol())) return false;
-      if (getAmount()
-          != other.getAmount()) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      boolean result = true;
+      result = result && getFrom()
+          .equals(other.getFrom());
+      result = result && getSymbol()
+          .equals(other.getSymbol());
+      result = result && (getAmount()
+          == other.getAmount());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -9149,35 +9169,35 @@ public final class Binance {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -9400,7 +9420,7 @@ public final class Binance {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -9584,8 +9604,12 @@ public final class Binance {
     }
     private SigningInput() {
       chainId_ = "";
+      accountNumber_ = 0L;
+      sequence_ = 0L;
+      source_ = 0L;
       memo_ = "";
       privateKey_ = com.google.protobuf.ByteString.EMPTY;
+      testNet_ = false;
     }
 
     @java.lang.Override
@@ -9720,7 +9744,7 @@ public final class Binance {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -10158,47 +10182,50 @@ public final class Binance {
       }
       com.wallet.crypto.trustapp.proto.Binance.SigningInput other = (com.wallet.crypto.trustapp.proto.Binance.SigningInput) obj;
 
-      if (!getChainId()
-          .equals(other.getChainId())) return false;
-      if (getAccountNumber()
-          != other.getAccountNumber()) return false;
-      if (getSequence()
-          != other.getSequence()) return false;
-      if (getSource()
-          != other.getSource()) return false;
-      if (!getMemo()
-          .equals(other.getMemo())) return false;
-      if (!getPrivateKey()
-          .equals(other.getPrivateKey())) return false;
-      if (getTestNet()
-          != other.getTestNet()) return false;
-      if (!getOrderOneofCase().equals(other.getOrderOneofCase())) return false;
+      boolean result = true;
+      result = result && getChainId()
+          .equals(other.getChainId());
+      result = result && (getAccountNumber()
+          == other.getAccountNumber());
+      result = result && (getSequence()
+          == other.getSequence());
+      result = result && (getSource()
+          == other.getSource());
+      result = result && getMemo()
+          .equals(other.getMemo());
+      result = result && getPrivateKey()
+          .equals(other.getPrivateKey());
+      result = result && (getTestNet()
+          == other.getTestNet());
+      result = result && getOrderOneofCase().equals(
+          other.getOrderOneofCase());
+      if (!result) return false;
       switch (orderOneofCase_) {
         case 8:
-          if (!getTradeOrder()
-              .equals(other.getTradeOrder())) return false;
+          result = result && getTradeOrder()
+              .equals(other.getTradeOrder());
           break;
         case 9:
-          if (!getCancelTradeOrder()
-              .equals(other.getCancelTradeOrder())) return false;
+          result = result && getCancelTradeOrder()
+              .equals(other.getCancelTradeOrder());
           break;
         case 10:
-          if (!getSendOrder()
-              .equals(other.getSendOrder())) return false;
+          result = result && getSendOrder()
+              .equals(other.getSendOrder());
           break;
         case 11:
-          if (!getFreezeOrder()
-              .equals(other.getFreezeOrder())) return false;
+          result = result && getFreezeOrder()
+              .equals(other.getFreezeOrder());
           break;
         case 12:
-          if (!getUnfreezeOrder()
-              .equals(other.getUnfreezeOrder())) return false;
+          result = result && getUnfreezeOrder()
+              .equals(other.getUnfreezeOrder());
           break;
         case 0:
         default:
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -10478,35 +10505,35 @@ public final class Binance {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -11565,7 +11592,7 @@ public final class Binance {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override

--- a/JNI/java/com/wallet/crypto/trustapp/proto/Bitcoin.java
+++ b/JNI/java/com/wallet/crypto/trustapp/proto/Bitcoin.java
@@ -137,6 +137,8 @@ public final class Bitcoin {
       super(builder);
     }
     private Transaction() {
+      version_ = 0;
+      lockTime_ = 0;
       inputs_ = java.util.Collections.emptyList();
       outputs_ = java.util.Collections.emptyList();
     }
@@ -176,7 +178,7 @@ public final class Bitcoin {
               break;
             }
             case 26: {
-              if (!((mutable_bitField0_ & 0x00000004) != 0)) {
+              if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
                 inputs_ = new java.util.ArrayList<com.wallet.crypto.trustapp.proto.Bitcoin.TransactionInput>();
                 mutable_bitField0_ |= 0x00000004;
               }
@@ -185,7 +187,7 @@ public final class Bitcoin {
               break;
             }
             case 34: {
-              if (!((mutable_bitField0_ & 0x00000008) != 0)) {
+              if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
                 outputs_ = new java.util.ArrayList<com.wallet.crypto.trustapp.proto.Bitcoin.TransactionOutput>();
                 mutable_bitField0_ |= 0x00000008;
               }
@@ -194,7 +196,7 @@ public final class Bitcoin {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -208,10 +210,10 @@ public final class Bitcoin {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000004) != 0)) {
+        if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
           inputs_ = java.util.Collections.unmodifiableList(inputs_);
         }
-        if (((mutable_bitField0_ & 0x00000008) != 0)) {
+        if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
           outputs_ = java.util.Collections.unmodifiableList(outputs_);
         }
         this.unknownFields = unknownFields.build();
@@ -434,16 +436,17 @@ public final class Bitcoin {
       }
       com.wallet.crypto.trustapp.proto.Bitcoin.Transaction other = (com.wallet.crypto.trustapp.proto.Bitcoin.Transaction) obj;
 
-      if (getVersion()
-          != other.getVersion()) return false;
-      if (getLockTime()
-          != other.getLockTime()) return false;
-      if (!getInputsList()
-          .equals(other.getInputsList())) return false;
-      if (!getOutputsList()
-          .equals(other.getOutputsList())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      boolean result = true;
+      result = result && (getVersion()
+          == other.getVersion());
+      result = result && (getLockTime()
+          == other.getLockTime());
+      result = result && getInputsList()
+          .equals(other.getInputsList());
+      result = result && getOutputsList()
+          .equals(other.getOutputsList());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -647,7 +650,7 @@ public final class Bitcoin {
         result.version_ = version_;
         result.lockTime_ = lockTime_;
         if (inputsBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) != 0)) {
+          if (((bitField0_ & 0x00000004) == 0x00000004)) {
             inputs_ = java.util.Collections.unmodifiableList(inputs_);
             bitField0_ = (bitField0_ & ~0x00000004);
           }
@@ -656,7 +659,7 @@ public final class Bitcoin {
           result.inputs_ = inputsBuilder_.build();
         }
         if (outputsBuilder_ == null) {
-          if (((bitField0_ & 0x00000008) != 0)) {
+          if (((bitField0_ & 0x00000008) == 0x00000008)) {
             outputs_ = java.util.Collections.unmodifiableList(outputs_);
             bitField0_ = (bitField0_ & ~0x00000008);
           }
@@ -671,35 +674,35 @@ public final class Bitcoin {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -880,7 +883,7 @@ public final class Bitcoin {
       private java.util.List<com.wallet.crypto.trustapp.proto.Bitcoin.TransactionInput> inputs_ =
         java.util.Collections.emptyList();
       private void ensureInputsIsMutable() {
-        if (!((bitField0_ & 0x00000004) != 0)) {
+        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
           inputs_ = new java.util.ArrayList<com.wallet.crypto.trustapp.proto.Bitcoin.TransactionInput>(inputs_);
           bitField0_ |= 0x00000004;
          }
@@ -1181,7 +1184,7 @@ public final class Bitcoin {
           inputsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               com.wallet.crypto.trustapp.proto.Bitcoin.TransactionInput, com.wallet.crypto.trustapp.proto.Bitcoin.TransactionInput.Builder, com.wallet.crypto.trustapp.proto.Bitcoin.TransactionInputOrBuilder>(
                   inputs_,
-                  ((bitField0_ & 0x00000004) != 0),
+                  ((bitField0_ & 0x00000004) == 0x00000004),
                   getParentForChildren(),
                   isClean());
           inputs_ = null;
@@ -1192,7 +1195,7 @@ public final class Bitcoin {
       private java.util.List<com.wallet.crypto.trustapp.proto.Bitcoin.TransactionOutput> outputs_ =
         java.util.Collections.emptyList();
       private void ensureOutputsIsMutable() {
-        if (!((bitField0_ & 0x00000008) != 0)) {
+        if (!((bitField0_ & 0x00000008) == 0x00000008)) {
           outputs_ = new java.util.ArrayList<com.wallet.crypto.trustapp.proto.Bitcoin.TransactionOutput>(outputs_);
           bitField0_ |= 0x00000008;
          }
@@ -1493,7 +1496,7 @@ public final class Bitcoin {
           outputsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               com.wallet.crypto.trustapp.proto.Bitcoin.TransactionOutput, com.wallet.crypto.trustapp.proto.Bitcoin.TransactionOutput.Builder, com.wallet.crypto.trustapp.proto.Bitcoin.TransactionOutputOrBuilder>(
                   outputs_,
-                  ((bitField0_ & 0x00000008) != 0),
+                  ((bitField0_ & 0x00000008) == 0x00000008),
                   getParentForChildren(),
                   isClean());
           outputs_ = null;
@@ -1503,7 +1506,7 @@ public final class Bitcoin {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -1617,6 +1620,7 @@ public final class Bitcoin {
       super(builder);
     }
     private TransactionInput() {
+      sequence_ = 0;
       script_ = com.google.protobuf.ByteString.EMPTY;
     }
 
@@ -1668,7 +1672,7 @@ public final class Bitcoin {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -1817,17 +1821,18 @@ public final class Bitcoin {
       }
       com.wallet.crypto.trustapp.proto.Bitcoin.TransactionInput other = (com.wallet.crypto.trustapp.proto.Bitcoin.TransactionInput) obj;
 
-      if (hasPreviousOutput() != other.hasPreviousOutput()) return false;
+      boolean result = true;
+      result = result && (hasPreviousOutput() == other.hasPreviousOutput());
       if (hasPreviousOutput()) {
-        if (!getPreviousOutput()
-            .equals(other.getPreviousOutput())) return false;
+        result = result && getPreviousOutput()
+            .equals(other.getPreviousOutput());
       }
-      if (getSequence()
-          != other.getSequence()) return false;
-      if (!getScript()
-          .equals(other.getScript())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      result = result && (getSequence()
+          == other.getSequence());
+      result = result && getScript()
+          .equals(other.getScript());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -2031,35 +2036,35 @@ public final class Bitcoin {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -2111,7 +2116,7 @@ public final class Bitcoin {
         return this;
       }
 
-      private com.wallet.crypto.trustapp.proto.Bitcoin.OutPoint previousOutput_;
+      private com.wallet.crypto.trustapp.proto.Bitcoin.OutPoint previousOutput_ = null;
       private com.google.protobuf.SingleFieldBuilderV3<
           com.wallet.crypto.trustapp.proto.Bitcoin.OutPoint, com.wallet.crypto.trustapp.proto.Bitcoin.OutPoint.Builder, com.wallet.crypto.trustapp.proto.Bitcoin.OutPointOrBuilder> previousOutputBuilder_;
       /**
@@ -2345,7 +2350,7 @@ public final class Bitcoin {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -2444,6 +2449,8 @@ public final class Bitcoin {
     }
     private OutPoint() {
       hash_ = com.google.protobuf.ByteString.EMPTY;
+      index_ = 0;
+      sequence_ = 0;
     }
 
     @java.lang.Override
@@ -2486,7 +2493,7 @@ public final class Bitcoin {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -2615,14 +2622,15 @@ public final class Bitcoin {
       }
       com.wallet.crypto.trustapp.proto.Bitcoin.OutPoint other = (com.wallet.crypto.trustapp.proto.Bitcoin.OutPoint) obj;
 
-      if (!getHash()
-          .equals(other.getHash())) return false;
-      if (getIndex()
-          != other.getIndex()) return false;
-      if (getSequence()
-          != other.getSequence()) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      boolean result = true;
+      result = result && getHash()
+          .equals(other.getHash());
+      result = result && (getIndex()
+          == other.getIndex());
+      result = result && (getSequence()
+          == other.getSequence());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -2816,35 +2824,35 @@ public final class Bitcoin {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -3015,7 +3023,7 @@ public final class Bitcoin {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -3104,6 +3112,7 @@ public final class Bitcoin {
       super(builder);
     }
     private TransactionOutput() {
+      value_ = 0L;
       script_ = com.google.protobuf.ByteString.EMPTY;
     }
 
@@ -3142,7 +3151,7 @@ public final class Bitcoin {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -3251,12 +3260,13 @@ public final class Bitcoin {
       }
       com.wallet.crypto.trustapp.proto.Bitcoin.TransactionOutput other = (com.wallet.crypto.trustapp.proto.Bitcoin.TransactionOutput) obj;
 
-      if (getValue()
-          != other.getValue()) return false;
-      if (!getScript()
-          .equals(other.getScript())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      boolean result = true;
+      result = result && (getValue()
+          == other.getValue());
+      result = result && getScript()
+          .equals(other.getScript());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -3446,35 +3456,35 @@ public final class Bitcoin {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -3604,7 +3614,7 @@ public final class Bitcoin {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -3695,6 +3705,7 @@ public final class Bitcoin {
     }
     private UnspentTransaction() {
       script_ = com.google.protobuf.ByteString.EMPTY;
+      amount_ = 0L;
     }
 
     @java.lang.Override
@@ -3745,7 +3756,7 @@ public final class Bitcoin {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -3874,17 +3885,18 @@ public final class Bitcoin {
       }
       com.wallet.crypto.trustapp.proto.Bitcoin.UnspentTransaction other = (com.wallet.crypto.trustapp.proto.Bitcoin.UnspentTransaction) obj;
 
-      if (hasOutPoint() != other.hasOutPoint()) return false;
+      boolean result = true;
+      result = result && (hasOutPoint() == other.hasOutPoint());
       if (hasOutPoint()) {
-        if (!getOutPoint()
-            .equals(other.getOutPoint())) return false;
+        result = result && getOutPoint()
+            .equals(other.getOutPoint());
       }
-      if (!getScript()
-          .equals(other.getScript())) return false;
-      if (getAmount()
-          != other.getAmount()) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      result = result && getScript()
+          .equals(other.getScript());
+      result = result && (getAmount()
+          == other.getAmount());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -4085,35 +4097,35 @@ public final class Bitcoin {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -4165,7 +4177,7 @@ public final class Bitcoin {
         return this;
       }
 
-      private com.wallet.crypto.trustapp.proto.Bitcoin.OutPoint outPoint_;
+      private com.wallet.crypto.trustapp.proto.Bitcoin.OutPoint outPoint_ = null;
       private com.google.protobuf.SingleFieldBuilderV3<
           com.wallet.crypto.trustapp.proto.Bitcoin.OutPoint, com.wallet.crypto.trustapp.proto.Bitcoin.OutPoint.Builder, com.wallet.crypto.trustapp.proto.Bitcoin.OutPointOrBuilder> outPointBuilder_;
       /**
@@ -4339,7 +4351,7 @@ public final class Bitcoin {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -4605,10 +4617,14 @@ public final class Bitcoin {
       super(builder);
     }
     private SigningInput() {
+      hashType_ = 0;
+      amount_ = 0L;
+      byteFee_ = 0L;
       toAddress_ = "";
       changeAddress_ = "";
       privateKey_ = java.util.Collections.emptyList();
       utxo_ = java.util.Collections.emptyList();
+      useMaxAmount_ = false;
     }
 
     @java.lang.Override
@@ -4663,7 +4679,7 @@ public final class Bitcoin {
               break;
             }
             case 82: {
-              if (!((mutable_bitField0_ & 0x00000020) != 0)) {
+              if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
                 privateKey_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
                 mutable_bitField0_ |= 0x00000020;
               }
@@ -4671,7 +4687,7 @@ public final class Bitcoin {
               break;
             }
             case 90: {
-              if (!((mutable_bitField0_ & 0x00000040) != 0)) {
+              if (!((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
                 scripts_ = com.google.protobuf.MapField.newMapField(
                     ScriptsDefaultEntryHolder.defaultEntry);
                 mutable_bitField0_ |= 0x00000040;
@@ -4684,7 +4700,7 @@ public final class Bitcoin {
               break;
             }
             case 98: {
-              if (!((mutable_bitField0_ & 0x00000080) != 0)) {
+              if (!((mutable_bitField0_ & 0x00000080) == 0x00000080)) {
                 utxo_ = new java.util.ArrayList<com.wallet.crypto.trustapp.proto.Bitcoin.UnspentTransaction>();
                 mutable_bitField0_ |= 0x00000080;
               }
@@ -4698,7 +4714,7 @@ public final class Bitcoin {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -4712,10 +4728,10 @@ public final class Bitcoin {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000020) != 0)) {
-          privateKey_ = java.util.Collections.unmodifiableList(privateKey_); // C
+        if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+          privateKey_ = java.util.Collections.unmodifiableList(privateKey_);
         }
-        if (((mutable_bitField0_ & 0x00000080) != 0)) {
+        if (((mutable_bitField0_ & 0x00000080) == 0x00000080)) {
           utxo_ = java.util.Collections.unmodifiableList(utxo_);
         }
         this.unknownFields = unknownFields.build();
@@ -5178,26 +5194,27 @@ public final class Bitcoin {
       }
       com.wallet.crypto.trustapp.proto.Bitcoin.SigningInput other = (com.wallet.crypto.trustapp.proto.Bitcoin.SigningInput) obj;
 
-      if (getHashType()
-          != other.getHashType()) return false;
-      if (getAmount()
-          != other.getAmount()) return false;
-      if (getByteFee()
-          != other.getByteFee()) return false;
-      if (!getToAddress()
-          .equals(other.getToAddress())) return false;
-      if (!getChangeAddress()
-          .equals(other.getChangeAddress())) return false;
-      if (!getPrivateKeyList()
-          .equals(other.getPrivateKeyList())) return false;
-      if (!internalGetScripts().equals(
-          other.internalGetScripts())) return false;
-      if (!getUtxoList()
-          .equals(other.getUtxoList())) return false;
-      if (getUseMaxAmount()
-          != other.getUseMaxAmount()) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      boolean result = true;
+      result = result && (getHashType()
+          == other.getHashType());
+      result = result && (getAmount()
+          == other.getAmount());
+      result = result && (getByteFee()
+          == other.getByteFee());
+      result = result && getToAddress()
+          .equals(other.getToAddress());
+      result = result && getChangeAddress()
+          .equals(other.getChangeAddress());
+      result = result && getPrivateKeyList()
+          .equals(other.getPrivateKeyList());
+      result = result && internalGetScripts().equals(
+          other.internalGetScripts());
+      result = result && getUtxoList()
+          .equals(other.getUtxoList());
+      result = result && (getUseMaxAmount()
+          == other.getUseMaxAmount());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -5448,7 +5465,7 @@ public final class Bitcoin {
         result.byteFee_ = byteFee_;
         result.toAddress_ = toAddress_;
         result.changeAddress_ = changeAddress_;
-        if (((bitField0_ & 0x00000020) != 0)) {
+        if (((bitField0_ & 0x00000020) == 0x00000020)) {
           privateKey_ = java.util.Collections.unmodifiableList(privateKey_);
           bitField0_ = (bitField0_ & ~0x00000020);
         }
@@ -5456,7 +5473,7 @@ public final class Bitcoin {
         result.scripts_ = internalGetScripts();
         result.scripts_.makeImmutable();
         if (utxoBuilder_ == null) {
-          if (((bitField0_ & 0x00000080) != 0)) {
+          if (((bitField0_ & 0x00000080) == 0x00000080)) {
             utxo_ = java.util.Collections.unmodifiableList(utxo_);
             bitField0_ = (bitField0_ & ~0x00000080);
           }
@@ -5472,35 +5489,35 @@ public final class Bitcoin {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -5896,7 +5913,7 @@ public final class Bitcoin {
 
       private java.util.List<com.google.protobuf.ByteString> privateKey_ = java.util.Collections.emptyList();
       private void ensurePrivateKeyIsMutable() {
-        if (!((bitField0_ & 0x00000020) != 0)) {
+        if (!((bitField0_ & 0x00000020) == 0x00000020)) {
           privateKey_ = new java.util.ArrayList<com.google.protobuf.ByteString>(privateKey_);
           bitField0_ |= 0x00000020;
          }
@@ -5910,8 +5927,7 @@ public final class Bitcoin {
        */
       public java.util.List<com.google.protobuf.ByteString>
           getPrivateKeyList() {
-        return ((bitField0_ & 0x00000020) != 0) ?
-                 java.util.Collections.unmodifiableList(privateKey_) : privateKey_;
+        return java.util.Collections.unmodifiableList(privateKey_);
       }
       /**
        * <pre>
@@ -6149,7 +6165,7 @@ public final class Bitcoin {
       private java.util.List<com.wallet.crypto.trustapp.proto.Bitcoin.UnspentTransaction> utxo_ =
         java.util.Collections.emptyList();
       private void ensureUtxoIsMutable() {
-        if (!((bitField0_ & 0x00000080) != 0)) {
+        if (!((bitField0_ & 0x00000080) == 0x00000080)) {
           utxo_ = new java.util.ArrayList<com.wallet.crypto.trustapp.proto.Bitcoin.UnspentTransaction>(utxo_);
           bitField0_ |= 0x00000080;
          }
@@ -6450,7 +6466,7 @@ public final class Bitcoin {
           utxoBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               com.wallet.crypto.trustapp.proto.Bitcoin.UnspentTransaction, com.wallet.crypto.trustapp.proto.Bitcoin.UnspentTransaction.Builder, com.wallet.crypto.trustapp.proto.Bitcoin.UnspentTransactionOrBuilder>(
                   utxo_,
-                  ((bitField0_ & 0x00000080) != 0),
+                  ((bitField0_ & 0x00000080) == 0x00000080),
                   getParentForChildren(),
                   isClean());
           utxo_ = null;
@@ -6498,7 +6514,7 @@ public final class Bitcoin {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -6649,6 +6665,10 @@ public final class Bitcoin {
       super(builder);
     }
     private TransactionPlan() {
+      amount_ = 0L;
+      availableAmount_ = 0L;
+      fee_ = 0L;
+      change_ = 0L;
       utxos_ = java.util.Collections.emptyList();
     }
 
@@ -6697,7 +6717,7 @@ public final class Bitcoin {
               break;
             }
             case 42: {
-              if (!((mutable_bitField0_ & 0x00000010) != 0)) {
+              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
                 utxos_ = new java.util.ArrayList<com.wallet.crypto.trustapp.proto.Bitcoin.UnspentTransaction>();
                 mutable_bitField0_ |= 0x00000010;
               }
@@ -6706,7 +6726,7 @@ public final class Bitcoin {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -6720,7 +6740,7 @@ public final class Bitcoin {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000010) != 0)) {
+        if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
           utxos_ = java.util.Collections.unmodifiableList(utxos_);
         }
         this.unknownFields = unknownFields.build();
@@ -6921,18 +6941,19 @@ public final class Bitcoin {
       }
       com.wallet.crypto.trustapp.proto.Bitcoin.TransactionPlan other = (com.wallet.crypto.trustapp.proto.Bitcoin.TransactionPlan) obj;
 
-      if (getAmount()
-          != other.getAmount()) return false;
-      if (getAvailableAmount()
-          != other.getAvailableAmount()) return false;
-      if (getFee()
-          != other.getFee()) return false;
-      if (getChange()
-          != other.getChange()) return false;
-      if (!getUtxosList()
-          .equals(other.getUtxosList())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      boolean result = true;
+      result = result && (getAmount()
+          == other.getAmount());
+      result = result && (getAvailableAmount()
+          == other.getAvailableAmount());
+      result = result && (getFee()
+          == other.getFee());
+      result = result && (getChange()
+          == other.getChange());
+      result = result && getUtxosList()
+          .equals(other.getUtxosList());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -7143,7 +7164,7 @@ public final class Bitcoin {
         result.fee_ = fee_;
         result.change_ = change_;
         if (utxosBuilder_ == null) {
-          if (((bitField0_ & 0x00000010) != 0)) {
+          if (((bitField0_ & 0x00000010) == 0x00000010)) {
             utxos_ = java.util.Collections.unmodifiableList(utxos_);
             bitField0_ = (bitField0_ & ~0x00000010);
           }
@@ -7158,35 +7179,35 @@ public final class Bitcoin {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -7423,7 +7444,7 @@ public final class Bitcoin {
       private java.util.List<com.wallet.crypto.trustapp.proto.Bitcoin.UnspentTransaction> utxos_ =
         java.util.Collections.emptyList();
       private void ensureUtxosIsMutable() {
-        if (!((bitField0_ & 0x00000010) != 0)) {
+        if (!((bitField0_ & 0x00000010) == 0x00000010)) {
           utxos_ = new java.util.ArrayList<com.wallet.crypto.trustapp.proto.Bitcoin.UnspentTransaction>(utxos_);
           bitField0_ |= 0x00000010;
          }
@@ -7724,7 +7745,7 @@ public final class Bitcoin {
           utxosBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               com.wallet.crypto.trustapp.proto.Bitcoin.UnspentTransaction, com.wallet.crypto.trustapp.proto.Bitcoin.UnspentTransaction.Builder, com.wallet.crypto.trustapp.proto.Bitcoin.UnspentTransactionOrBuilder>(
                   utxos_,
-                  ((bitField0_ & 0x00000010) != 0),
+                  ((bitField0_ & 0x00000010) == 0x00000010),
                   getParentForChildren(),
                   isClean());
           utxos_ = null;
@@ -7734,7 +7755,7 @@ public final class Bitcoin {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -7876,6 +7897,8 @@ public final class Bitcoin {
     }
     private SigningOutput() {
       encoded_ = com.google.protobuf.ByteString.EMPTY;
+      fee_ = 0L;
+      maxAmount_ = 0L;
       transactionHash_ = "";
     }
 
@@ -7938,7 +7961,7 @@ public final class Bitcoin {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -8155,21 +8178,22 @@ public final class Bitcoin {
       }
       com.wallet.crypto.trustapp.proto.Bitcoin.SigningOutput other = (com.wallet.crypto.trustapp.proto.Bitcoin.SigningOutput) obj;
 
-      if (hasTransaction() != other.hasTransaction()) return false;
+      boolean result = true;
+      result = result && (hasTransaction() == other.hasTransaction());
       if (hasTransaction()) {
-        if (!getTransaction()
-            .equals(other.getTransaction())) return false;
+        result = result && getTransaction()
+            .equals(other.getTransaction());
       }
-      if (!getEncoded()
-          .equals(other.getEncoded())) return false;
-      if (getFee()
-          != other.getFee()) return false;
-      if (getMaxAmount()
-          != other.getMaxAmount()) return false;
-      if (!getTransactionHash()
-          .equals(other.getTransactionHash())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      result = result && getEncoded()
+          .equals(other.getEncoded());
+      result = result && (getFee()
+          == other.getFee());
+      result = result && (getMaxAmount()
+          == other.getMaxAmount());
+      result = result && getTransactionHash()
+          .equals(other.getTransactionHash());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -8385,35 +8409,35 @@ public final class Bitcoin {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -8472,7 +8496,7 @@ public final class Bitcoin {
         return this;
       }
 
-      private com.wallet.crypto.trustapp.proto.Bitcoin.Transaction transaction_;
+      private com.wallet.crypto.trustapp.proto.Bitcoin.Transaction transaction_ = null;
       private com.google.protobuf.SingleFieldBuilderV3<
           com.wallet.crypto.trustapp.proto.Bitcoin.Transaction, com.wallet.crypto.trustapp.proto.Bitcoin.Transaction.Builder, com.wallet.crypto.trustapp.proto.Bitcoin.TransactionOrBuilder> transactionBuilder_;
       /**
@@ -8833,7 +8857,7 @@ public final class Bitcoin {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override

--- a/JNI/java/com/wallet/crypto/trustapp/proto/Bitcoin.java
+++ b/JNI/java/com/wallet/crypto/trustapp/proto/Bitcoin.java
@@ -7839,6 +7839,24 @@ public final class Bitcoin {
      * <code>int64 max_amount = 4;</code>
      */
     long getMaxAmount();
+
+    /**
+     * <pre>
+     * Transaction hash
+     * </pre>
+     *
+     * <code>string transaction_hash = 5;</code>
+     */
+    java.lang.String getTransactionHash();
+    /**
+     * <pre>
+     * Transaction hash
+     * </pre>
+     *
+     * <code>string transaction_hash = 5;</code>
+     */
+    com.google.protobuf.ByteString
+        getTransactionHashBytes();
   }
   /**
    * <pre>
@@ -7858,6 +7876,7 @@ public final class Bitcoin {
     }
     private SigningOutput() {
       encoded_ = com.google.protobuf.ByteString.EMPTY;
+      transactionHash_ = "";
     }
 
     @java.lang.Override
@@ -7910,6 +7929,12 @@ public final class Bitcoin {
             case 32: {
 
               maxAmount_ = input.readInt64();
+              break;
+            }
+            case 42: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              transactionHash_ = s;
               break;
             }
             default: {
@@ -8016,6 +8041,48 @@ public final class Bitcoin {
       return maxAmount_;
     }
 
+    public static final int TRANSACTION_HASH_FIELD_NUMBER = 5;
+    private volatile java.lang.Object transactionHash_;
+    /**
+     * <pre>
+     * Transaction hash
+     * </pre>
+     *
+     * <code>string transaction_hash = 5;</code>
+     */
+    public java.lang.String getTransactionHash() {
+      java.lang.Object ref = transactionHash_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        transactionHash_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Transaction hash
+     * </pre>
+     *
+     * <code>string transaction_hash = 5;</code>
+     */
+    public com.google.protobuf.ByteString
+        getTransactionHashBytes() {
+      java.lang.Object ref = transactionHash_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        transactionHash_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -8042,6 +8109,9 @@ public final class Bitcoin {
       if (maxAmount_ != 0L) {
         output.writeInt64(4, maxAmount_);
       }
+      if (!getTransactionHashBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 5, transactionHash_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -8066,6 +8136,9 @@ public final class Bitcoin {
       if (maxAmount_ != 0L) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(4, maxAmount_);
+      }
+      if (!getTransactionHashBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, transactionHash_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -8093,6 +8166,8 @@ public final class Bitcoin {
           != other.getFee()) return false;
       if (getMaxAmount()
           != other.getMaxAmount()) return false;
+      if (!getTransactionHash()
+          .equals(other.getTransactionHash())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -8116,6 +8191,8 @@ public final class Bitcoin {
       hash = (37 * hash) + MAX_AMOUNT_FIELD_NUMBER;
       hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
           getMaxAmount());
+      hash = (37 * hash) + TRANSACTION_HASH_FIELD_NUMBER;
+      hash = (53 * hash) + getTransactionHash().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -8265,6 +8342,8 @@ public final class Bitcoin {
 
         maxAmount_ = 0L;
 
+        transactionHash_ = "";
+
         return this;
       }
 
@@ -8299,6 +8378,7 @@ public final class Bitcoin {
         result.encoded_ = encoded_;
         result.fee_ = fee_;
         result.maxAmount_ = maxAmount_;
+        result.transactionHash_ = transactionHash_;
         onBuilt();
         return result;
       }
@@ -8358,6 +8438,10 @@ public final class Bitcoin {
         }
         if (other.getMaxAmount() != 0L) {
           setMaxAmount(other.getMaxAmount());
+        }
+        if (!other.getTransactionHash().isEmpty()) {
+          transactionHash_ = other.transactionHash_;
+          onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -8657,6 +8741,95 @@ public final class Bitcoin {
         onChanged();
         return this;
       }
+
+      private java.lang.Object transactionHash_ = "";
+      /**
+       * <pre>
+       * Transaction hash
+       * </pre>
+       *
+       * <code>string transaction_hash = 5;</code>
+       */
+      public java.lang.String getTransactionHash() {
+        java.lang.Object ref = transactionHash_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          transactionHash_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Transaction hash
+       * </pre>
+       *
+       * <code>string transaction_hash = 5;</code>
+       */
+      public com.google.protobuf.ByteString
+          getTransactionHashBytes() {
+        java.lang.Object ref = transactionHash_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          transactionHash_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Transaction hash
+       * </pre>
+       *
+       * <code>string transaction_hash = 5;</code>
+       */
+      public Builder setTransactionHash(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        transactionHash_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Transaction hash
+       * </pre>
+       *
+       * <code>string transaction_hash = 5;</code>
+       */
+      public Builder clearTransactionHash() {
+        
+        transactionHash_ = getDefaultInstance().getTransactionHash();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Transaction hash
+       * </pre>
+       *
+       * <code>string transaction_hash = 5;</code>
+       */
+      public Builder setTransactionHashBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        transactionHash_ = value;
+        onChanged();
+        return this;
+      }
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -8788,11 +8961,12 @@ public final class Bitcoin {
       "ctionPlan\022\016\n\006amount\030\001 \001(\003\022\030\n\020available_a" +
       "mount\030\002 \001(\003\022\013\n\003fee\030\003 \001(\003\022\016\n\006change\030\004 \001(\003" +
       "\0223\n\005utxos\030\005 \003(\0132$.TW.Bitcoin.Proto.Unspe" +
-      "ntTransaction\"u\n\rSigningOutput\0222\n\013transa" +
-      "ction\030\001 \001(\0132\035.TW.Bitcoin.Proto.Transacti" +
-      "on\022\017\n\007encoded\030\002 \001(\014\022\013\n\003fee\030\003 \001(\003\022\022\n\nmax_" +
-      "amount\030\004 \001(\003B\"\n com.wallet.crypto.trusta" +
-      "pp.protob\006proto3"
+      "ntTransaction\"\217\001\n\rSigningOutput\0222\n\013trans" +
+      "action\030\001 \001(\0132\035.TW.Bitcoin.Proto.Transact" +
+      "ion\022\017\n\007encoded\030\002 \001(\014\022\013\n\003fee\030\003 \001(\003\022\022\n\nmax" +
+      "_amount\030\004 \001(\003\022\030\n\020transaction_hash\030\005 \001(\tB" +
+      "\"\n com.wallet.crypto.trustapp.protob\006pro" +
+      "to3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -8859,7 +9033,7 @@ public final class Bitcoin {
     internal_static_TW_Bitcoin_Proto_SigningOutput_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_TW_Bitcoin_Proto_SigningOutput_descriptor,
-        new java.lang.String[] { "Transaction", "Encoded", "Fee", "MaxAmount", });
+        new java.lang.String[] { "Transaction", "Encoded", "Fee", "MaxAmount", "TransactionHash", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/JNI/java/com/wallet/crypto/trustapp/proto/Bitcoin.java
+++ b/JNI/java/com/wallet/crypto/trustapp/proto/Bitcoin.java
@@ -7863,21 +7863,21 @@ public final class Bitcoin {
 
     /**
      * <pre>
-     * Transaction hash
+     * Transaction id
      * </pre>
      *
-     * <code>string transaction_hash = 5;</code>
+     * <code>string transaction_id = 5;</code>
      */
-    java.lang.String getTransactionHash();
+    java.lang.String getTransactionId();
     /**
      * <pre>
-     * Transaction hash
+     * Transaction id
      * </pre>
      *
-     * <code>string transaction_hash = 5;</code>
+     * <code>string transaction_id = 5;</code>
      */
     com.google.protobuf.ByteString
-        getTransactionHashBytes();
+        getTransactionIdBytes();
   }
   /**
    * <pre>
@@ -7899,7 +7899,7 @@ public final class Bitcoin {
       encoded_ = com.google.protobuf.ByteString.EMPTY;
       fee_ = 0L;
       maxAmount_ = 0L;
-      transactionHash_ = "";
+      transactionId_ = "";
     }
 
     @java.lang.Override
@@ -7957,7 +7957,7 @@ public final class Bitcoin {
             case 42: {
               java.lang.String s = input.readStringRequireUtf8();
 
-              transactionHash_ = s;
+              transactionId_ = s;
               break;
             }
             default: {
@@ -8064,42 +8064,42 @@ public final class Bitcoin {
       return maxAmount_;
     }
 
-    public static final int TRANSACTION_HASH_FIELD_NUMBER = 5;
-    private volatile java.lang.Object transactionHash_;
+    public static final int TRANSACTION_ID_FIELD_NUMBER = 5;
+    private volatile java.lang.Object transactionId_;
     /**
      * <pre>
-     * Transaction hash
+     * Transaction id
      * </pre>
      *
-     * <code>string transaction_hash = 5;</code>
+     * <code>string transaction_id = 5;</code>
      */
-    public java.lang.String getTransactionHash() {
-      java.lang.Object ref = transactionHash_;
+    public java.lang.String getTransactionId() {
+      java.lang.Object ref = transactionId_;
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
-        transactionHash_ = s;
+        transactionId_ = s;
         return s;
       }
     }
     /**
      * <pre>
-     * Transaction hash
+     * Transaction id
      * </pre>
      *
-     * <code>string transaction_hash = 5;</code>
+     * <code>string transaction_id = 5;</code>
      */
     public com.google.protobuf.ByteString
-        getTransactionHashBytes() {
-      java.lang.Object ref = transactionHash_;
+        getTransactionIdBytes() {
+      java.lang.Object ref = transactionId_;
       if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
-        transactionHash_ = b;
+        transactionId_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
@@ -8132,8 +8132,8 @@ public final class Bitcoin {
       if (maxAmount_ != 0L) {
         output.writeInt64(4, maxAmount_);
       }
-      if (!getTransactionHashBytes().isEmpty()) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 5, transactionHash_);
+      if (!getTransactionIdBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 5, transactionId_);
       }
       unknownFields.writeTo(output);
     }
@@ -8160,8 +8160,8 @@ public final class Bitcoin {
         size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(4, maxAmount_);
       }
-      if (!getTransactionHashBytes().isEmpty()) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, transactionHash_);
+      if (!getTransactionIdBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, transactionId_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -8190,8 +8190,8 @@ public final class Bitcoin {
           == other.getFee());
       result = result && (getMaxAmount()
           == other.getMaxAmount());
-      result = result && getTransactionHash()
-          .equals(other.getTransactionHash());
+      result = result && getTransactionId()
+          .equals(other.getTransactionId());
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -8215,8 +8215,8 @@ public final class Bitcoin {
       hash = (37 * hash) + MAX_AMOUNT_FIELD_NUMBER;
       hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
           getMaxAmount());
-      hash = (37 * hash) + TRANSACTION_HASH_FIELD_NUMBER;
-      hash = (53 * hash) + getTransactionHash().hashCode();
+      hash = (37 * hash) + TRANSACTION_ID_FIELD_NUMBER;
+      hash = (53 * hash) + getTransactionId().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -8366,7 +8366,7 @@ public final class Bitcoin {
 
         maxAmount_ = 0L;
 
-        transactionHash_ = "";
+        transactionId_ = "";
 
         return this;
       }
@@ -8402,7 +8402,7 @@ public final class Bitcoin {
         result.encoded_ = encoded_;
         result.fee_ = fee_;
         result.maxAmount_ = maxAmount_;
-        result.transactionHash_ = transactionHash_;
+        result.transactionId_ = transactionId_;
         onBuilt();
         return result;
       }
@@ -8463,8 +8463,8 @@ public final class Bitcoin {
         if (other.getMaxAmount() != 0L) {
           setMaxAmount(other.getMaxAmount());
         }
-        if (!other.getTransactionHash().isEmpty()) {
-          transactionHash_ = other.transactionHash_;
+        if (!other.getTransactionId().isEmpty()) {
+          transactionId_ = other.transactionId_;
           onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
@@ -8766,21 +8766,21 @@ public final class Bitcoin {
         return this;
       }
 
-      private java.lang.Object transactionHash_ = "";
+      private java.lang.Object transactionId_ = "";
       /**
        * <pre>
-       * Transaction hash
+       * Transaction id
        * </pre>
        *
-       * <code>string transaction_hash = 5;</code>
+       * <code>string transaction_id = 5;</code>
        */
-      public java.lang.String getTransactionHash() {
-        java.lang.Object ref = transactionHash_;
+      public java.lang.String getTransactionId() {
+        java.lang.Object ref = transactionId_;
         if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
-          transactionHash_ = s;
+          transactionId_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -8788,19 +8788,19 @@ public final class Bitcoin {
       }
       /**
        * <pre>
-       * Transaction hash
+       * Transaction id
        * </pre>
        *
-       * <code>string transaction_hash = 5;</code>
+       * <code>string transaction_id = 5;</code>
        */
       public com.google.protobuf.ByteString
-          getTransactionHashBytes() {
-        java.lang.Object ref = transactionHash_;
+          getTransactionIdBytes() {
+        java.lang.Object ref = transactionId_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
-          transactionHash_ = b;
+          transactionId_ = b;
           return b;
         } else {
           return (com.google.protobuf.ByteString) ref;
@@ -8808,49 +8808,49 @@ public final class Bitcoin {
       }
       /**
        * <pre>
-       * Transaction hash
+       * Transaction id
        * </pre>
        *
-       * <code>string transaction_hash = 5;</code>
+       * <code>string transaction_id = 5;</code>
        */
-      public Builder setTransactionHash(
+      public Builder setTransactionId(
           java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
   
-        transactionHash_ = value;
+        transactionId_ = value;
         onChanged();
         return this;
       }
       /**
        * <pre>
-       * Transaction hash
+       * Transaction id
        * </pre>
        *
-       * <code>string transaction_hash = 5;</code>
+       * <code>string transaction_id = 5;</code>
        */
-      public Builder clearTransactionHash() {
+      public Builder clearTransactionId() {
         
-        transactionHash_ = getDefaultInstance().getTransactionHash();
+        transactionId_ = getDefaultInstance().getTransactionId();
         onChanged();
         return this;
       }
       /**
        * <pre>
-       * Transaction hash
+       * Transaction id
        * </pre>
        *
-       * <code>string transaction_hash = 5;</code>
+       * <code>string transaction_id = 5;</code>
        */
-      public Builder setTransactionHashBytes(
+      public Builder setTransactionIdBytes(
           com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
   checkByteStringIsUtf8(value);
         
-        transactionHash_ = value;
+        transactionId_ = value;
         onChanged();
         return this;
       }
@@ -8985,12 +8985,12 @@ public final class Bitcoin {
       "ctionPlan\022\016\n\006amount\030\001 \001(\003\022\030\n\020available_a" +
       "mount\030\002 \001(\003\022\013\n\003fee\030\003 \001(\003\022\016\n\006change\030\004 \001(\003" +
       "\0223\n\005utxos\030\005 \003(\0132$.TW.Bitcoin.Proto.Unspe" +
-      "ntTransaction\"\217\001\n\rSigningOutput\0222\n\013trans" +
+      "ntTransaction\"\215\001\n\rSigningOutput\0222\n\013trans" +
       "action\030\001 \001(\0132\035.TW.Bitcoin.Proto.Transact" +
       "ion\022\017\n\007encoded\030\002 \001(\014\022\013\n\003fee\030\003 \001(\003\022\022\n\nmax" +
-      "_amount\030\004 \001(\003\022\030\n\020transaction_hash\030\005 \001(\tB" +
-      "\"\n com.wallet.crypto.trustapp.protob\006pro" +
-      "to3"
+      "_amount\030\004 \001(\003\022\026\n\016transaction_id\030\005 \001(\tB\"\n" +
+      " com.wallet.crypto.trustapp.protob\006proto" +
+      "3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -9057,7 +9057,7 @@ public final class Bitcoin {
     internal_static_TW_Bitcoin_Proto_SigningOutput_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_TW_Bitcoin_Proto_SigningOutput_descriptor,
-        new java.lang.String[] { "Transaction", "Encoded", "Fee", "MaxAmount", "TransactionHash", });
+        new java.lang.String[] { "Transaction", "Encoded", "Fee", "MaxAmount", "TransactionId", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/JNI/java/com/wallet/crypto/trustapp/proto/Common.java
+++ b/JNI/java/com/wallet/crypto/trustapp/proto/Common.java
@@ -106,6 +106,7 @@ public final class Common {
       super(builder);
     }
     private Result() {
+      success_ = false;
       error_ = "";
       objects_ = java.util.Collections.emptyList();
     }
@@ -146,7 +147,7 @@ public final class Common {
               break;
             }
             case 26: {
-              if (!((mutable_bitField0_ & 0x00000004) != 0)) {
+              if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
                 objects_ = new java.util.ArrayList<com.google.protobuf.Any>();
                 mutable_bitField0_ |= 0x00000004;
               }
@@ -155,7 +156,7 @@ public final class Common {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -169,7 +170,7 @@ public final class Common {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000004) != 0)) {
+        if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
           objects_ = java.util.Collections.unmodifiableList(objects_);
         }
         this.unknownFields = unknownFields.build();
@@ -358,14 +359,15 @@ public final class Common {
       }
       com.wallet.crypto.trustapp.proto.Common.Result other = (com.wallet.crypto.trustapp.proto.Common.Result) obj;
 
-      if (getSuccess()
-          != other.getSuccess()) return false;
-      if (!getError()
-          .equals(other.getError())) return false;
-      if (!getObjectsList()
-          .equals(other.getObjectsList())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      boolean result = true;
+      result = result && (getSuccess()
+          == other.getSuccess());
+      result = result && getError()
+          .equals(other.getError());
+      result = result && getObjectsList()
+          .equals(other.getObjectsList());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -563,7 +565,7 @@ public final class Common {
         result.success_ = success_;
         result.error_ = error_;
         if (objectsBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) != 0)) {
+          if (((bitField0_ & 0x00000004) == 0x00000004)) {
             objects_ = java.util.Collections.unmodifiableList(objects_);
             bitField0_ = (bitField0_ & ~0x00000004);
           }
@@ -578,35 +580,35 @@ public final class Common {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -813,7 +815,7 @@ public final class Common {
       private java.util.List<com.google.protobuf.Any> objects_ =
         java.util.Collections.emptyList();
       private void ensureObjectsIsMutable() {
-        if (!((bitField0_ & 0x00000004) != 0)) {
+        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
           objects_ = new java.util.ArrayList<com.google.protobuf.Any>(objects_);
           bitField0_ |= 0x00000004;
          }
@@ -1114,7 +1116,7 @@ public final class Common {
           objectsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder>(
                   objects_,
-                  ((bitField0_ & 0x00000004) != 0),
+                  ((bitField0_ & 0x00000004) == 0x00000004),
                   getParentForChildren(),
                   isClean());
           objects_ = null;
@@ -1124,7 +1126,7 @@ public final class Common {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override

--- a/JNI/java/org/tron/protos/Protocol.java
+++ b/JNI/java/org/tron/protos/Protocol.java
@@ -84,7 +84,7 @@ public final class Protocol {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -185,12 +185,13 @@ public final class Protocol {
       }
       org.tron.protos.Protocol.AccountId other = (org.tron.protos.Protocol.AccountId) obj;
 
-      if (!getName()
-          .equals(other.getName())) return false;
-      if (!getAddress()
-          .equals(other.getAddress())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      boolean result = true;
+      result = result && getName()
+          .equals(other.getName());
+      result = result && getAddress()
+          .equals(other.getAddress());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -379,35 +380,35 @@ public final class Protocol {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -516,7 +517,7 @@ public final class Protocol {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -647,7 +648,7 @@ public final class Protocol {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -760,15 +761,16 @@ public final class Protocol {
       }
       org.tron.protos.Protocol.authority other = (org.tron.protos.Protocol.authority) obj;
 
-      if (hasAccount() != other.hasAccount()) return false;
+      boolean result = true;
+      result = result && (hasAccount() == other.hasAccount());
       if (hasAccount()) {
-        if (!getAccount()
-            .equals(other.getAccount())) return false;
+        result = result && getAccount()
+            .equals(other.getAccount());
       }
-      if (!getPermissionName()
-          .equals(other.getPermissionName())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      result = result && getPermissionName()
+          .equals(other.getPermissionName());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -963,35 +965,35 @@ public final class Protocol {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -1040,7 +1042,7 @@ public final class Protocol {
         return this;
       }
 
-      private org.tron.protos.Protocol.AccountId account_;
+      private org.tron.protos.Protocol.AccountId account_ = null;
       private com.google.protobuf.SingleFieldBuilderV3<
           org.tron.protos.Protocol.AccountId, org.tron.protos.Protocol.AccountId.Builder, org.tron.protos.Protocol.AccountIdOrBuilder> accountBuilder_;
       /**
@@ -1188,7 +1190,7 @@ public final class Protocol {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -1359,7 +1361,7 @@ public final class Protocol {
               break;
             }
             case 18: {
-              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
+              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
                 signature_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
                 mutable_bitField0_ |= 0x00000002;
               }
@@ -1367,7 +1369,7 @@ public final class Protocol {
               break;
             }
             case 42: {
-              if (!((mutable_bitField0_ & 0x00000004) != 0)) {
+              if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
                 ret_ = new java.util.ArrayList<org.tron.protos.Protocol.Transaction.Result>();
                 mutable_bitField0_ |= 0x00000004;
               }
@@ -1376,7 +1378,7 @@ public final class Protocol {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -1390,10 +1392,10 @@ public final class Protocol {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000002) != 0)) {
-          signature_ = java.util.Collections.unmodifiableList(signature_); // C
+        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+          signature_ = java.util.Collections.unmodifiableList(signature_);
         }
-        if (((mutable_bitField0_ & 0x00000004) != 0)) {
+        if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
           ret_ = java.util.Collections.unmodifiableList(ret_);
         }
         this.unknownFields = unknownFields.build();
@@ -1521,7 +1523,7 @@ public final class Protocol {
                 break;
               }
               default: {
-                if (!parseUnknownField(
+                if (!parseUnknownFieldProto3(
                     input, unknownFields, extensionRegistry, tag)) {
                   done = true;
                 }
@@ -2018,18 +2020,19 @@ public final class Protocol {
         }
         org.tron.protos.Protocol.Transaction.Contract other = (org.tron.protos.Protocol.Transaction.Contract) obj;
 
-        if (type_ != other.type_) return false;
-        if (hasParameter() != other.hasParameter()) return false;
+        boolean result = true;
+        result = result && type_ == other.type_;
+        result = result && (hasParameter() == other.hasParameter());
         if (hasParameter()) {
-          if (!getParameter()
-              .equals(other.getParameter())) return false;
+          result = result && getParameter()
+              .equals(other.getParameter());
         }
-        if (!getProvider()
-            .equals(other.getProvider())) return false;
-        if (!getContractName()
-            .equals(other.getContractName())) return false;
-        if (!unknownFields.equals(other.unknownFields)) return false;
-        return true;
+        result = result && getProvider()
+            .equals(other.getProvider());
+        result = result && getContractName()
+            .equals(other.getContractName());
+        result = result && unknownFields.equals(other.unknownFields);
+        return result;
       }
 
       @java.lang.Override
@@ -2234,35 +2237,35 @@ public final class Protocol {
 
         @java.lang.Override
         public Builder clone() {
-          return super.clone();
+          return (Builder) super.clone();
         }
         @java.lang.Override
         public Builder setField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return super.setField(field, value);
+          return (Builder) super.setField(field, value);
         }
         @java.lang.Override
         public Builder clearField(
             com.google.protobuf.Descriptors.FieldDescriptor field) {
-          return super.clearField(field);
+          return (Builder) super.clearField(field);
         }
         @java.lang.Override
         public Builder clearOneof(
             com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-          return super.clearOneof(oneof);
+          return (Builder) super.clearOneof(oneof);
         }
         @java.lang.Override
         public Builder setRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             int index, java.lang.Object value) {
-          return super.setRepeatedField(field, index, value);
+          return (Builder) super.setRepeatedField(field, index, value);
         }
         @java.lang.Override
         public Builder addRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return super.addRepeatedField(field, value);
+          return (Builder) super.addRepeatedField(field, value);
         }
         @java.lang.Override
         public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -2362,7 +2365,7 @@ public final class Protocol {
           return this;
         }
 
-        private com.google.protobuf.Any parameter_;
+        private com.google.protobuf.Any parameter_ = null;
         private com.google.protobuf.SingleFieldBuilderV3<
             com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder> parameterBuilder_;
         /**
@@ -2539,7 +2542,7 @@ public final class Protocol {
         @java.lang.Override
         public final Builder setUnknownFields(
             final com.google.protobuf.UnknownFieldSet unknownFields) {
-          return super.setUnknownFields(unknownFields);
+          return super.setUnknownFieldsProto3(unknownFields);
         }
 
         @java.lang.Override
@@ -2639,8 +2642,11 @@ public final class Protocol {
         super(builder);
       }
       private Result() {
+        fee_ = 0L;
         ret_ = 0;
         contractRet_ = 0;
+        withdrawAmount_ = 0L;
+        unfreezeAmount_ = 0L;
       }
 
       @java.lang.Override
@@ -2695,7 +2701,7 @@ public final class Protocol {
                 break;
               }
               default: {
-                if (!parseUnknownField(
+                if (!parseUnknownFieldProto3(
                     input, unknownFields, extensionRegistry, tag)) {
                   done = true;
                 }
@@ -3164,16 +3170,17 @@ public final class Protocol {
         }
         org.tron.protos.Protocol.Transaction.Result other = (org.tron.protos.Protocol.Transaction.Result) obj;
 
-        if (getFee()
-            != other.getFee()) return false;
-        if (ret_ != other.ret_) return false;
-        if (contractRet_ != other.contractRet_) return false;
-        if (getWithdrawAmount()
-            != other.getWithdrawAmount()) return false;
-        if (getUnfreezeAmount()
-            != other.getUnfreezeAmount()) return false;
-        if (!unknownFields.equals(other.unknownFields)) return false;
-        return true;
+        boolean result = true;
+        result = result && (getFee()
+            == other.getFee());
+        result = result && ret_ == other.ret_;
+        result = result && contractRet_ == other.contractRet_;
+        result = result && (getWithdrawAmount()
+            == other.getWithdrawAmount());
+        result = result && (getUnfreezeAmount()
+            == other.getUnfreezeAmount());
+        result = result && unknownFields.equals(other.unknownFields);
+        return result;
       }
 
       @java.lang.Override
@@ -3376,35 +3383,35 @@ public final class Protocol {
 
         @java.lang.Override
         public Builder clone() {
-          return super.clone();
+          return (Builder) super.clone();
         }
         @java.lang.Override
         public Builder setField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return super.setField(field, value);
+          return (Builder) super.setField(field, value);
         }
         @java.lang.Override
         public Builder clearField(
             com.google.protobuf.Descriptors.FieldDescriptor field) {
-          return super.clearField(field);
+          return (Builder) super.clearField(field);
         }
         @java.lang.Override
         public Builder clearOneof(
             com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-          return super.clearOneof(oneof);
+          return (Builder) super.clearOneof(oneof);
         }
         @java.lang.Override
         public Builder setRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             int index, java.lang.Object value) {
-          return super.setRepeatedField(field, index, value);
+          return (Builder) super.setRepeatedField(field, index, value);
         }
         @java.lang.Override
         public Builder addRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return super.addRepeatedField(field, value);
+          return (Builder) super.addRepeatedField(field, value);
         }
         @java.lang.Override
         public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -3632,7 +3639,7 @@ public final class Protocol {
         @java.lang.Override
         public final Builder setUnknownFields(
             final com.google.protobuf.UnknownFieldSet unknownFields) {
-          return super.setUnknownFields(unknownFields);
+          return super.setUnknownFieldsProto3(unknownFields);
         }
 
         @java.lang.Override
@@ -3816,11 +3823,15 @@ public final class Protocol {
       }
       private raw() {
         refBlockBytes_ = com.google.protobuf.ByteString.EMPTY;
+        refBlockNum_ = 0L;
         refBlockHash_ = com.google.protobuf.ByteString.EMPTY;
+        expiration_ = 0L;
         auths_ = java.util.Collections.emptyList();
         data_ = com.google.protobuf.ByteString.EMPTY;
         contract_ = java.util.Collections.emptyList();
         scripts_ = com.google.protobuf.ByteString.EMPTY;
+        timestamp_ = 0L;
+        feeLimit_ = 0L;
       }
 
       @java.lang.Override
@@ -3868,7 +3879,7 @@ public final class Protocol {
                 break;
               }
               case 74: {
-                if (!((mutable_bitField0_ & 0x00000010) != 0)) {
+                if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
                   auths_ = new java.util.ArrayList<org.tron.protos.Protocol.authority>();
                   mutable_bitField0_ |= 0x00000010;
                 }
@@ -3882,7 +3893,7 @@ public final class Protocol {
                 break;
               }
               case 90: {
-                if (!((mutable_bitField0_ & 0x00000040) != 0)) {
+                if (!((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
                   contract_ = new java.util.ArrayList<org.tron.protos.Protocol.Transaction.Contract>();
                   mutable_bitField0_ |= 0x00000040;
                 }
@@ -3906,7 +3917,7 @@ public final class Protocol {
                 break;
               }
               default: {
-                if (!parseUnknownField(
+                if (!parseUnknownFieldProto3(
                     input, unknownFields, extensionRegistry, tag)) {
                   done = true;
                 }
@@ -3920,10 +3931,10 @@ public final class Protocol {
           throw new com.google.protobuf.InvalidProtocolBufferException(
               e).setUnfinishedMessage(this);
         } finally {
-          if (((mutable_bitField0_ & 0x00000010) != 0)) {
+          if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
             auths_ = java.util.Collections.unmodifiableList(auths_);
           }
-          if (((mutable_bitField0_ & 0x00000040) != 0)) {
+          if (((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
             contract_ = java.util.Collections.unmodifiableList(contract_);
           }
           this.unknownFields = unknownFields.build();
@@ -4222,28 +4233,29 @@ public final class Protocol {
         }
         org.tron.protos.Protocol.Transaction.raw other = (org.tron.protos.Protocol.Transaction.raw) obj;
 
-        if (!getRefBlockBytes()
-            .equals(other.getRefBlockBytes())) return false;
-        if (getRefBlockNum()
-            != other.getRefBlockNum()) return false;
-        if (!getRefBlockHash()
-            .equals(other.getRefBlockHash())) return false;
-        if (getExpiration()
-            != other.getExpiration()) return false;
-        if (!getAuthsList()
-            .equals(other.getAuthsList())) return false;
-        if (!getData()
-            .equals(other.getData())) return false;
-        if (!getContractList()
-            .equals(other.getContractList())) return false;
-        if (!getScripts()
-            .equals(other.getScripts())) return false;
-        if (getTimestamp()
-            != other.getTimestamp()) return false;
-        if (getFeeLimit()
-            != other.getFeeLimit()) return false;
-        if (!unknownFields.equals(other.unknownFields)) return false;
-        return true;
+        boolean result = true;
+        result = result && getRefBlockBytes()
+            .equals(other.getRefBlockBytes());
+        result = result && (getRefBlockNum()
+            == other.getRefBlockNum());
+        result = result && getRefBlockHash()
+            .equals(other.getRefBlockHash());
+        result = result && (getExpiration()
+            == other.getExpiration());
+        result = result && getAuthsList()
+            .equals(other.getAuthsList());
+        result = result && getData()
+            .equals(other.getData());
+        result = result && getContractList()
+            .equals(other.getContractList());
+        result = result && getScripts()
+            .equals(other.getScripts());
+        result = result && (getTimestamp()
+            == other.getTimestamp());
+        result = result && (getFeeLimit()
+            == other.getFeeLimit());
+        result = result && unknownFields.equals(other.unknownFields);
+        return result;
       }
 
       @java.lang.Override
@@ -4477,7 +4489,7 @@ public final class Protocol {
           result.refBlockHash_ = refBlockHash_;
           result.expiration_ = expiration_;
           if (authsBuilder_ == null) {
-            if (((bitField0_ & 0x00000010) != 0)) {
+            if (((bitField0_ & 0x00000010) == 0x00000010)) {
               auths_ = java.util.Collections.unmodifiableList(auths_);
               bitField0_ = (bitField0_ & ~0x00000010);
             }
@@ -4487,7 +4499,7 @@ public final class Protocol {
           }
           result.data_ = data_;
           if (contractBuilder_ == null) {
-            if (((bitField0_ & 0x00000040) != 0)) {
+            if (((bitField0_ & 0x00000040) == 0x00000040)) {
               contract_ = java.util.Collections.unmodifiableList(contract_);
               bitField0_ = (bitField0_ & ~0x00000040);
             }
@@ -4505,35 +4517,35 @@ public final class Protocol {
 
         @java.lang.Override
         public Builder clone() {
-          return super.clone();
+          return (Builder) super.clone();
         }
         @java.lang.Override
         public Builder setField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return super.setField(field, value);
+          return (Builder) super.setField(field, value);
         }
         @java.lang.Override
         public Builder clearField(
             com.google.protobuf.Descriptors.FieldDescriptor field) {
-          return super.clearField(field);
+          return (Builder) super.clearField(field);
         }
         @java.lang.Override
         public Builder clearOneof(
             com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-          return super.clearOneof(oneof);
+          return (Builder) super.clearOneof(oneof);
         }
         @java.lang.Override
         public Builder setRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             int index, java.lang.Object value) {
-          return super.setRepeatedField(field, index, value);
+          return (Builder) super.setRepeatedField(field, index, value);
         }
         @java.lang.Override
         public Builder addRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return super.addRepeatedField(field, value);
+          return (Builder) super.addRepeatedField(field, value);
         }
         @java.lang.Override
         public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -4766,7 +4778,7 @@ public final class Protocol {
         private java.util.List<org.tron.protos.Protocol.authority> auths_ =
           java.util.Collections.emptyList();
         private void ensureAuthsIsMutable() {
-          if (!((bitField0_ & 0x00000010) != 0)) {
+          if (!((bitField0_ & 0x00000010) == 0x00000010)) {
             auths_ = new java.util.ArrayList<org.tron.protos.Protocol.authority>(auths_);
             bitField0_ |= 0x00000010;
            }
@@ -4995,7 +5007,7 @@ public final class Protocol {
             authsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
                 org.tron.protos.Protocol.authority, org.tron.protos.Protocol.authority.Builder, org.tron.protos.Protocol.authorityOrBuilder>(
                     auths_,
-                    ((bitField0_ & 0x00000010) != 0),
+                    ((bitField0_ & 0x00000010) == 0x00000010),
                     getParentForChildren(),
                     isClean());
             auths_ = null;
@@ -5047,7 +5059,7 @@ public final class Protocol {
         private java.util.List<org.tron.protos.Protocol.Transaction.Contract> contract_ =
           java.util.Collections.emptyList();
         private void ensureContractIsMutable() {
-          if (!((bitField0_ & 0x00000040) != 0)) {
+          if (!((bitField0_ & 0x00000040) == 0x00000040)) {
             contract_ = new java.util.ArrayList<org.tron.protos.Protocol.Transaction.Contract>(contract_);
             bitField0_ |= 0x00000040;
            }
@@ -5348,7 +5360,7 @@ public final class Protocol {
             contractBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
                 org.tron.protos.Protocol.Transaction.Contract, org.tron.protos.Protocol.Transaction.Contract.Builder, org.tron.protos.Protocol.Transaction.ContractOrBuilder>(
                     contract_,
-                    ((bitField0_ & 0x00000040) != 0),
+                    ((bitField0_ & 0x00000040) == 0x00000040),
                     getParentForChildren(),
                     isClean());
             contract_ = null;
@@ -5451,7 +5463,7 @@ public final class Protocol {
         @java.lang.Override
         public final Builder setUnknownFields(
             final com.google.protobuf.UnknownFieldSet unknownFields) {
-          return super.setUnknownFields(unknownFields);
+          return super.setUnknownFieldsProto3(unknownFields);
         }
 
         @java.lang.Override
@@ -5656,17 +5668,18 @@ public final class Protocol {
       }
       org.tron.protos.Protocol.Transaction other = (org.tron.protos.Protocol.Transaction) obj;
 
-      if (hasRawData() != other.hasRawData()) return false;
+      boolean result = true;
+      result = result && (hasRawData() == other.hasRawData());
       if (hasRawData()) {
-        if (!getRawData()
-            .equals(other.getRawData())) return false;
+        result = result && getRawData()
+            .equals(other.getRawData());
       }
-      if (!getSignatureList()
-          .equals(other.getSignatureList())) return false;
-      if (!getRetList()
-          .equals(other.getRetList())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      result = result && getSignatureList()
+          .equals(other.getSignatureList());
+      result = result && getRetList()
+          .equals(other.getRetList());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -5869,13 +5882,13 @@ public final class Protocol {
         } else {
           result.rawData_ = rawDataBuilder_.build();
         }
-        if (((bitField0_ & 0x00000002) != 0)) {
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
           signature_ = java.util.Collections.unmodifiableList(signature_);
           bitField0_ = (bitField0_ & ~0x00000002);
         }
         result.signature_ = signature_;
         if (retBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) != 0)) {
+          if (((bitField0_ & 0x00000004) == 0x00000004)) {
             ret_ = java.util.Collections.unmodifiableList(ret_);
             bitField0_ = (bitField0_ & ~0x00000004);
           }
@@ -5890,35 +5903,35 @@ public final class Protocol {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -6001,7 +6014,7 @@ public final class Protocol {
       }
       private int bitField0_;
 
-      private org.tron.protos.Protocol.Transaction.raw rawData_;
+      private org.tron.protos.Protocol.Transaction.raw rawData_ = null;
       private com.google.protobuf.SingleFieldBuilderV3<
           org.tron.protos.Protocol.Transaction.raw, org.tron.protos.Protocol.Transaction.raw.Builder, org.tron.protos.Protocol.Transaction.rawOrBuilder> rawDataBuilder_;
       /**
@@ -6120,7 +6133,7 @@ public final class Protocol {
 
       private java.util.List<com.google.protobuf.ByteString> signature_ = java.util.Collections.emptyList();
       private void ensureSignatureIsMutable() {
-        if (!((bitField0_ & 0x00000002) != 0)) {
+        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
           signature_ = new java.util.ArrayList<com.google.protobuf.ByteString>(signature_);
           bitField0_ |= 0x00000002;
          }
@@ -6134,8 +6147,7 @@ public final class Protocol {
        */
       public java.util.List<com.google.protobuf.ByteString>
           getSignatureList() {
-        return ((bitField0_ & 0x00000002) != 0) ?
-                 java.util.Collections.unmodifiableList(signature_) : signature_;
+        return java.util.Collections.unmodifiableList(signature_);
       }
       /**
        * <pre>
@@ -6222,7 +6234,7 @@ public final class Protocol {
       private java.util.List<org.tron.protos.Protocol.Transaction.Result> ret_ =
         java.util.Collections.emptyList();
       private void ensureRetIsMutable() {
-        if (!((bitField0_ & 0x00000004) != 0)) {
+        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
           ret_ = new java.util.ArrayList<org.tron.protos.Protocol.Transaction.Result>(ret_);
           bitField0_ |= 0x00000004;
          }
@@ -6451,7 +6463,7 @@ public final class Protocol {
           retBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               org.tron.protos.Protocol.Transaction.Result, org.tron.protos.Protocol.Transaction.Result.Builder, org.tron.protos.Protocol.Transaction.ResultOrBuilder>(
                   ret_,
-                  ((bitField0_ & 0x00000004) != 0),
+                  ((bitField0_ & 0x00000004) == 0x00000004),
                   getParentForChildren(),
                   isClean());
           ret_ = null;
@@ -6461,7 +6473,7 @@ public final class Protocol {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -6592,7 +6604,7 @@ public final class Protocol {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -6680,9 +6692,13 @@ public final class Protocol {
         super(builder);
       }
       private raw() {
+        timestamp_ = 0L;
         txTrieRoot_ = com.google.protobuf.ByteString.EMPTY;
         parentHash_ = com.google.protobuf.ByteString.EMPTY;
+        number_ = 0L;
+        witnessId_ = 0L;
         witnessAddress_ = com.google.protobuf.ByteString.EMPTY;
+        version_ = 0;
       }
 
       @java.lang.Override
@@ -6745,7 +6761,7 @@ public final class Protocol {
                 break;
               }
               default: {
-                if (!parseUnknownField(
+                if (!parseUnknownFieldProto3(
                     input, unknownFields, extensionRegistry, tag)) {
                   done = true;
                 }
@@ -6931,22 +6947,23 @@ public final class Protocol {
         }
         org.tron.protos.Protocol.BlockHeader.raw other = (org.tron.protos.Protocol.BlockHeader.raw) obj;
 
-        if (getTimestamp()
-            != other.getTimestamp()) return false;
-        if (!getTxTrieRoot()
-            .equals(other.getTxTrieRoot())) return false;
-        if (!getParentHash()
-            .equals(other.getParentHash())) return false;
-        if (getNumber()
-            != other.getNumber()) return false;
-        if (getWitnessId()
-            != other.getWitnessId()) return false;
-        if (!getWitnessAddress()
-            .equals(other.getWitnessAddress())) return false;
-        if (getVersion()
-            != other.getVersion()) return false;
-        if (!unknownFields.equals(other.unknownFields)) return false;
-        return true;
+        boolean result = true;
+        result = result && (getTimestamp()
+            == other.getTimestamp());
+        result = result && getTxTrieRoot()
+            .equals(other.getTxTrieRoot());
+        result = result && getParentHash()
+            .equals(other.getParentHash());
+        result = result && (getNumber()
+            == other.getNumber());
+        result = result && (getWitnessId()
+            == other.getWitnessId());
+        result = result && getWitnessAddress()
+            .equals(other.getWitnessAddress());
+        result = result && (getVersion()
+            == other.getVersion());
+        result = result && unknownFields.equals(other.unknownFields);
+        return result;
       }
 
       @java.lang.Override
@@ -7159,35 +7176,35 @@ public final class Protocol {
 
         @java.lang.Override
         public Builder clone() {
-          return super.clone();
+          return (Builder) super.clone();
         }
         @java.lang.Override
         public Builder setField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return super.setField(field, value);
+          return (Builder) super.setField(field, value);
         }
         @java.lang.Override
         public Builder clearField(
             com.google.protobuf.Descriptors.FieldDescriptor field) {
-          return super.clearField(field);
+          return (Builder) super.clearField(field);
         }
         @java.lang.Override
         public Builder clearOneof(
             com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-          return super.clearOneof(oneof);
+          return (Builder) super.clearOneof(oneof);
         }
         @java.lang.Override
         public Builder setRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             int index, java.lang.Object value) {
-          return super.setRepeatedField(field, index, value);
+          return (Builder) super.setRepeatedField(field, index, value);
         }
         @java.lang.Override
         public Builder addRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return super.addRepeatedField(field, value);
+          return (Builder) super.addRepeatedField(field, value);
         }
         @java.lang.Override
         public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -7459,7 +7476,7 @@ public final class Protocol {
         @java.lang.Override
         public final Builder setUnknownFields(
             final com.google.protobuf.UnknownFieldSet unknownFields) {
-          return super.setUnknownFields(unknownFields);
+          return super.setUnknownFieldsProto3(unknownFields);
         }
 
         @java.lang.Override
@@ -7591,15 +7608,16 @@ public final class Protocol {
       }
       org.tron.protos.Protocol.BlockHeader other = (org.tron.protos.Protocol.BlockHeader) obj;
 
-      if (hasRawData() != other.hasRawData()) return false;
+      boolean result = true;
+      result = result && (hasRawData() == other.hasRawData());
       if (hasRawData()) {
-        if (!getRawData()
-            .equals(other.getRawData())) return false;
+        result = result && getRawData()
+            .equals(other.getRawData());
       }
-      if (!getWitnessSignature()
-          .equals(other.getWitnessSignature())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      result = result && getWitnessSignature()
+          .equals(other.getWitnessSignature());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -7794,35 +7812,35 @@ public final class Protocol {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -7871,7 +7889,7 @@ public final class Protocol {
         return this;
       }
 
-      private org.tron.protos.Protocol.BlockHeader.raw rawData_;
+      private org.tron.protos.Protocol.BlockHeader.raw rawData_ = null;
       private com.google.protobuf.SingleFieldBuilderV3<
           org.tron.protos.Protocol.BlockHeader.raw, org.tron.protos.Protocol.BlockHeader.raw.Builder, org.tron.protos.Protocol.BlockHeader.rawOrBuilder> rawDataBuilder_;
       /**
@@ -8019,7 +8037,7 @@ public final class Protocol {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -8103,6 +8121,7 @@ public final class Protocol {
     private TransferContract() {
       ownerAddress_ = com.google.protobuf.ByteString.EMPTY;
       toAddress_ = com.google.protobuf.ByteString.EMPTY;
+      amount_ = 0L;
     }
 
     @java.lang.Override
@@ -8145,7 +8164,7 @@ public final class Protocol {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -8262,14 +8281,15 @@ public final class Protocol {
       }
       org.tron.protos.Protocol.TransferContract other = (org.tron.protos.Protocol.TransferContract) obj;
 
-      if (!getOwnerAddress()
-          .equals(other.getOwnerAddress())) return false;
-      if (!getToAddress()
-          .equals(other.getToAddress())) return false;
-      if (getAmount()
-          != other.getAmount()) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      boolean result = true;
+      result = result && getOwnerAddress()
+          .equals(other.getOwnerAddress());
+      result = result && getToAddress()
+          .equals(other.getToAddress());
+      result = result && (getAmount()
+          == other.getAmount());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -8460,35 +8480,35 @@ public final class Protocol {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -8626,7 +8646,7 @@ public final class Protocol {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override
@@ -8716,6 +8736,7 @@ public final class Protocol {
       assetName_ = com.google.protobuf.ByteString.EMPTY;
       ownerAddress_ = com.google.protobuf.ByteString.EMPTY;
       toAddress_ = com.google.protobuf.ByteString.EMPTY;
+      amount_ = 0L;
     }
 
     @java.lang.Override
@@ -8763,7 +8784,7 @@ public final class Protocol {
               break;
             }
             default: {
-              if (!parseUnknownField(
+              if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -8896,16 +8917,17 @@ public final class Protocol {
       }
       org.tron.protos.Protocol.TransferAssetContract other = (org.tron.protos.Protocol.TransferAssetContract) obj;
 
-      if (!getAssetName()
-          .equals(other.getAssetName())) return false;
-      if (!getOwnerAddress()
-          .equals(other.getOwnerAddress())) return false;
-      if (!getToAddress()
-          .equals(other.getToAddress())) return false;
-      if (getAmount()
-          != other.getAmount()) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
+      boolean result = true;
+      result = result && getAssetName()
+          .equals(other.getAssetName());
+      result = result && getOwnerAddress()
+          .equals(other.getOwnerAddress());
+      result = result && getToAddress()
+          .equals(other.getToAddress());
+      result = result && (getAmount()
+          == other.getAmount());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
     }
 
     @java.lang.Override
@@ -9101,35 +9123,35 @@ public final class Protocol {
 
       @java.lang.Override
       public Builder clone() {
-        return super.clone();
+        return (Builder) super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.setField(field, value);
+        return (Builder) super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
+        return (Builder) super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
+        return (Builder) super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
+        return (Builder) super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return super.addRepeatedField(field, value);
+        return (Builder) super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -9299,7 +9321,7 @@ public final class Protocol {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
+        return super.setUnknownFieldsProto3(unknownFields);
       }
 
       @java.lang.Override

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -29,8 +29,8 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
       "requires": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "1.1.2",
+        "@protobufjs/inquire": "1.1.0"
       }
     },
     "@protobufjs/float": {
@@ -78,19 +78,19 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
       "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
       "requires": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
-        "long": "^4.0.0"
+        "@protobufjs/aspromise": "1.1.2",
+        "@protobufjs/base64": "1.1.2",
+        "@protobufjs/codegen": "2.0.4",
+        "@protobufjs/eventemitter": "1.1.0",
+        "@protobufjs/fetch": "1.1.0",
+        "@protobufjs/float": "1.0.2",
+        "@protobufjs/inquire": "1.1.0",
+        "@protobufjs/path": "1.1.2",
+        "@protobufjs/pool": "1.1.0",
+        "@protobufjs/utf8": "1.1.0",
+        "@types/long": "4.0.0",
+        "@types/node": "10.12.21",
+        "long": "4.0.0"
       }
     }
   }

--- a/src/interface/TWBitcoinTransactionSigner.cpp
+++ b/src/interface/TWBitcoinTransactionSigner.cpp
@@ -59,7 +59,7 @@ TW_Proto_Result TWBitcoinTransactionSignerSign(struct TWBitcoinTransactionSigner
     }
     auto txHash = TW::Hash::sha256(TW::Hash::sha256(txHashData));
     std::reverse(txHash.begin(), txHash.end());
-    protoOutput.set_transaction_hash(TW::hex(txHash));
+    protoOutput.set_transaction_id(TW::hex(txHash));
 
     protoResult.set_success(true);
     protoResult.add_objects()->PackFrom(protoOutput);

--- a/src/interface/TWBitcoinTransactionSigner.cpp
+++ b/src/interface/TWBitcoinTransactionSigner.cpp
@@ -54,7 +54,7 @@ TW_Proto_Result TWBitcoinTransactionSignerSign(struct TWBitcoinTransactionSigner
 
     TW::Data txHashData = encoded;
     if (hasWitness) {
-        TW::Data txHashData;
+        txHashData.clear();
         tx.encode(false, txHashData);
     }
     auto txHash = TW::Hash::sha256(TW::Hash::sha256(txHashData));

--- a/src/interface/TWBitcoinTransactionSigner.cpp
+++ b/src/interface/TWBitcoinTransactionSigner.cpp
@@ -4,12 +4,14 @@
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
 
+#include <algorithm>
 #include <TrustWalletCore/TWBitcoinTransactionSigner.h>
-
 #include "../Bitcoin/TransactionBuilder.h"
 #include "../Bitcoin/TransactionSigner.h"
 
 #include "../Data.h"
+#include "../Hash.h"
+#include "../HexCoding.h"
 #include "../proto/Common.pb.h"
 #include "../proto/Bitcoin.pb.h"
 
@@ -49,6 +51,15 @@ TW_Proto_Result TWBitcoinTransactionSignerSign(struct TWBitcoinTransactionSigner
     auto hasWitness = std::any_of(tx.inputs.begin(), tx.inputs.end(), [](auto& input) { return !input.scriptWitness.empty(); });
     tx.encode(hasWitness, encoded);
     protoOutput.set_encoded(encoded.data(), encoded.size());
+
+    TW::Data txHashData = encoded;
+    if (hasWitness) {
+        TW::Data txHashData;
+        tx.encode(false, txHashData);
+    }
+    auto txHash = TW::Hash::sha256(TW::Hash::sha256(txHashData));
+    std::reverse(txHash.begin(), txHash.end());
+    protoOutput.set_transaction_hash(TW::hex(txHash));
 
     protoResult.set_success(true);
     protoResult.add_objects()->PackFrom(protoOutput);

--- a/src/proto/Bitcoin.proto
+++ b/src/proto/Bitcoin.proto
@@ -118,6 +118,6 @@ message SigningOutput {
     // Maximum spendable amount.
     int64 max_amount = 4;
 
-    // Transaction hash
-    string transaction_hash = 5;
+    // Transaction id
+    string transaction_id = 5;
 }

--- a/src/proto/Bitcoin.proto
+++ b/src/proto/Bitcoin.proto
@@ -117,4 +117,7 @@ message SigningOutput {
 
     // Maximum spendable amount.
     int64 max_amount = 4;
+
+    // Transaction hash
+    string transaction_hash = 5;
 }

--- a/swift/Sources/Bitcoin.pb.swift
+++ b/swift/Sources/Bitcoin.pb.swift
@@ -242,10 +242,10 @@ public struct TW_Bitcoin_Proto_SigningOutput {
     set {_uniqueStorage()._maxAmount = newValue}
   }
 
-  /// Transaction hash
-  public var transactionHash: String {
-    get {return _storage._transactionHash}
-    set {_uniqueStorage()._transactionHash = newValue}
+  /// Transaction id
+  public var transactionID: String {
+    get {return _storage._transactionID}
+    set {_uniqueStorage()._transactionID = newValue}
   }
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -673,7 +673,7 @@ extension TW_Bitcoin_Proto_SigningOutput: SwiftProtobuf.Message, SwiftProtobuf._
     2: .same(proto: "encoded"),
     3: .same(proto: "fee"),
     4: .standard(proto: "max_amount"),
-    5: .standard(proto: "transaction_hash"),
+    5: .standard(proto: "transaction_id"),
   ]
 
   fileprivate class _StorageClass {
@@ -681,7 +681,7 @@ extension TW_Bitcoin_Proto_SigningOutput: SwiftProtobuf.Message, SwiftProtobuf._
     var _encoded: Data = SwiftProtobuf.Internal.emptyData
     var _fee: Int64 = 0
     var _maxAmount: Int64 = 0
-    var _transactionHash: String = String()
+    var _transactionID: String = String()
 
     static let defaultInstance = _StorageClass()
 
@@ -692,7 +692,7 @@ extension TW_Bitcoin_Proto_SigningOutput: SwiftProtobuf.Message, SwiftProtobuf._
       _encoded = source._encoded
       _fee = source._fee
       _maxAmount = source._maxAmount
-      _transactionHash = source._transactionHash
+      _transactionID = source._transactionID
     }
   }
 
@@ -712,7 +712,7 @@ extension TW_Bitcoin_Proto_SigningOutput: SwiftProtobuf.Message, SwiftProtobuf._
         case 2: try decoder.decodeSingularBytesField(value: &_storage._encoded)
         case 3: try decoder.decodeSingularInt64Field(value: &_storage._fee)
         case 4: try decoder.decodeSingularInt64Field(value: &_storage._maxAmount)
-        case 5: try decoder.decodeSingularStringField(value: &_storage._transactionHash)
+        case 5: try decoder.decodeSingularStringField(value: &_storage._transactionID)
         default: break
         }
       }
@@ -733,8 +733,8 @@ extension TW_Bitcoin_Proto_SigningOutput: SwiftProtobuf.Message, SwiftProtobuf._
       if _storage._maxAmount != 0 {
         try visitor.visitSingularInt64Field(value: _storage._maxAmount, fieldNumber: 4)
       }
-      if !_storage._transactionHash.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._transactionHash, fieldNumber: 5)
+      if !_storage._transactionID.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._transactionID, fieldNumber: 5)
       }
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -749,7 +749,7 @@ extension TW_Bitcoin_Proto_SigningOutput: SwiftProtobuf.Message, SwiftProtobuf._
         if _storage._encoded != rhs_storage._encoded {return false}
         if _storage._fee != rhs_storage._fee {return false}
         if _storage._maxAmount != rhs_storage._maxAmount {return false}
-        if _storage._transactionHash != rhs_storage._transactionHash {return false}
+        if _storage._transactionID != rhs_storage._transactionID {return false}
         return true
       }
       if !storagesAreEqual {return false}

--- a/swift/Sources/Bitcoin.pb.swift
+++ b/swift/Sources/Bitcoin.pb.swift
@@ -242,6 +242,12 @@ public struct TW_Bitcoin_Proto_SigningOutput {
     set {_uniqueStorage()._maxAmount = newValue}
   }
 
+  /// Transaction hash
+  public var transactionHash: String {
+    get {return _storage._transactionHash}
+    set {_uniqueStorage()._transactionHash = newValue}
+  }
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -667,6 +673,7 @@ extension TW_Bitcoin_Proto_SigningOutput: SwiftProtobuf.Message, SwiftProtobuf._
     2: .same(proto: "encoded"),
     3: .same(proto: "fee"),
     4: .standard(proto: "max_amount"),
+    5: .standard(proto: "transaction_hash"),
   ]
 
   fileprivate class _StorageClass {
@@ -674,6 +681,7 @@ extension TW_Bitcoin_Proto_SigningOutput: SwiftProtobuf.Message, SwiftProtobuf._
     var _encoded: Data = SwiftProtobuf.Internal.emptyData
     var _fee: Int64 = 0
     var _maxAmount: Int64 = 0
+    var _transactionHash: String = String()
 
     static let defaultInstance = _StorageClass()
 
@@ -684,6 +692,7 @@ extension TW_Bitcoin_Proto_SigningOutput: SwiftProtobuf.Message, SwiftProtobuf._
       _encoded = source._encoded
       _fee = source._fee
       _maxAmount = source._maxAmount
+      _transactionHash = source._transactionHash
     }
   }
 
@@ -703,6 +712,7 @@ extension TW_Bitcoin_Proto_SigningOutput: SwiftProtobuf.Message, SwiftProtobuf._
         case 2: try decoder.decodeSingularBytesField(value: &_storage._encoded)
         case 3: try decoder.decodeSingularInt64Field(value: &_storage._fee)
         case 4: try decoder.decodeSingularInt64Field(value: &_storage._maxAmount)
+        case 5: try decoder.decodeSingularStringField(value: &_storage._transactionHash)
         default: break
         }
       }
@@ -723,6 +733,9 @@ extension TW_Bitcoin_Proto_SigningOutput: SwiftProtobuf.Message, SwiftProtobuf._
       if _storage._maxAmount != 0 {
         try visitor.visitSingularInt64Field(value: _storage._maxAmount, fieldNumber: 4)
       }
+      if !_storage._transactionHash.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._transactionHash, fieldNumber: 5)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -736,6 +749,7 @@ extension TW_Bitcoin_Proto_SigningOutput: SwiftProtobuf.Message, SwiftProtobuf._
         if _storage._encoded != rhs_storage._encoded {return false}
         if _storage._fee != rhs_storage._fee {return false}
         if _storage._maxAmount != rhs_storage._maxAmount {return false}
+        if _storage._transactionHash != rhs_storage._transactionHash {return false}
         return true
       }
       if !storagesAreEqual {return false}

--- a/swift/Tests/BitcoinTransactionSignerTests.swift
+++ b/swift/Tests/BitcoinTransactionSignerTests.swift
@@ -57,8 +57,8 @@ class BitcoinTransactionSignerTests: XCTestCase {
         let signedTx = output.transaction
         XCTAssertEqual(signedTx.version, 1)
 
-        let txHash = output.transactionHash
-        XCTAssertEqual(txHash, "b588f910d7ff03d5fbc3da91f62e48bab47153229c8d1b114b43cb31b9c4d0dd")
+        let txId = output.transactionID
+        XCTAssertEqual(txId, "b588f910d7ff03d5fbc3da91f62e48bab47153229c8d1b114b43cb31b9c4d0dd")
 
         XCTAssertEqual(signedTx.inputs.count, 1)  // Only one UTXO available
         XCTAssertEqual(signedTx.inputs[0].script.hexString, "")

--- a/swift/Tests/BitcoinTransactionSignerTests.swift
+++ b/swift/Tests/BitcoinTransactionSignerTests.swift
@@ -57,8 +57,8 @@ class BitcoinTransactionSignerTests: XCTestCase {
         let signedTx = output.transaction
         XCTAssertEqual(signedTx.version, 1)
 
-        let txHash = output.transaction_hash
-        XCTAssertEqual(txHash, "96ee20002b34e468f9d3c5ee54f6a8ddaa61c118889c4f35395c2cd93ba5bbb4")
+        let txHash = output.transactionHash
+        XCTAssertEqual(txHash, "b588f910d7ff03d5fbc3da91f62e48bab47153229c8d1b114b43cb31b9c4d0dd")
 
         XCTAssertEqual(signedTx.inputs.count, 1)  // Only one UTXO available
         XCTAssertEqual(signedTx.inputs[0].script.hexString, "")
@@ -67,6 +67,8 @@ class BitcoinTransactionSignerTests: XCTestCase {
         XCTAssertEqual(signedTx.outputs[0].value, 1000)
 
         let encoded = output.encoded
+        let witnessHash = Data(Hash.sha256SHA256(data: encoded).reversed())
+        XCTAssertEqual(witnessHash.hexString, "16a17dd8f6e507220010c56c07a8479e3f909f87791683577d4e6aad61ab113a")
         XCTAssertEqual(encoded.hexString, "01000000" +
             "0001" +
             "01" +

--- a/swift/Tests/BitcoinTransactionSignerTests.swift
+++ b/swift/Tests/BitcoinTransactionSignerTests.swift
@@ -57,6 +57,9 @@ class BitcoinTransactionSignerTests: XCTestCase {
         let signedTx = output.transaction
         XCTAssertEqual(signedTx.version, 1)
 
+        let txHash = output.transaction_hash
+        XCTAssertEqual(txHash, "96ee20002b34e468f9d3c5ee54f6a8ddaa61c118889c4f35395c2cd93ba5bbb4")
+
         XCTAssertEqual(signedTx.inputs.count, 1)  // Only one UTXO available
         XCTAssertEqual(signedTx.inputs[0].script.hexString, "")
 


### PR DESCRIPTION
## Description

Fix #10, return transaction hash in signing output, since we don't expose non-witness encoding method

## Testing instructions

UT passed

## Types of changes

it's a minor bugfix change

1. Add `transaction_hash` to `SigningOutput`
2. Compute and set transaction hash in `WBitcoinTransactionSigner`
3. Update `BitcoinTransactionSignerTests`

## Checklist

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
