### PR TITLE
Fix zcash t address validation

### DIFF
--- a/src/Zcash/TAddress.cpp
+++ b/src/Zcash/TAddress.cpp
@@ -34,7 +34,7 @@ bool TAddress::isValid(const std::string& string, const std::vector<byte>& valid
         return false;
     }
 
-    if (std::find(validPrefixes.begin(), validPrefixes.end(), buffer[0]) == validPrefixes.end()) {
+    if (std::find(validPrefixes.begin(), validPrefixes.end(), buffer[1]) == validPrefixes.end()) {
         return false;
     }
 

--- a/tests/CoinTests.cpp
+++ b/tests/CoinTests.cpp
@@ -50,11 +50,17 @@ TEST(Coin, ValidateAddressBitcoinCash) {
 }
 
 TEST(Coin, ValidateAddressTezos) {
-  EXPECT_TRUE(validateAddress(TWCoinTypeTezos, "tz1d1qQL3mYVuiH4JPFvuikEpFwaDm85oabM"));
+    EXPECT_TRUE(validateAddress(TWCoinTypeTezos, "tz1d1qQL3mYVuiH4JPFvuikEpFwaDm85oabM"));
 
-  EXPECT_FALSE(validateAddress(TWCoinTypeTezos, "NmH7tmeJUmHcncBDvpr7aJNEBk7rp5zYsB1qt"));
-  EXPECT_FALSE(validateAddress(TWCoinTypeTezos, "tz1eZwq8b5cvE2bPKokatLkVMzkxz24z3AAAA"));
-  EXPECT_FALSE(validateAddress(TWCoinTypeTezos, "1tzeZwq8b5cvE2bPKokatLkVMzkxz24zAAAAA"));
+    EXPECT_FALSE(validateAddress(TWCoinTypeTezos, "NmH7tmeJUmHcncBDvpr7aJNEBk7rp5zYsB1qt"));
+    EXPECT_FALSE(validateAddress(TWCoinTypeTezos, "tz1eZwq8b5cvE2bPKokatLkVMzkxz24z3AAAA"));
+    EXPECT_FALSE(validateAddress(TWCoinTypeTezos, "1tzeZwq8b5cvE2bPKokatLkVMzkxz24zAAAAA"));
+}
+
+TEST(Coin, validateAddressZcash) {
+    EXPECT_TRUE(validateAddress(TWCoinTypeZcash, "t3WeKQDxCijL5X7rwFem1MTL9ZwVJkUFhpF"));
+    EXPECT_TRUE(validateAddress(TWCoinTypeZcash, "t1aQ1JEFMqciA58XU6CR8CNohAYzESm8c1L"));
+    EXPECT_FALSE(validateAddress(TWCoinTypeZcash, "1Ma2DrB78K7jmAwaomqZNRMCvgQrNjE2QC"));
 }
 
 } // namespace


### PR DESCRIPTION
## Description

Fix #134.  Zcash has two bytes prefix, we should check `buffer[1]`

## Testing instructions

./boostrap.sh

## Types of changes

* Bug fix

## Checklist

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
