### PR TITLE
Change visibility scope of TWBitcoin* type aliases to public

### DIFF
--- a/swift/Sources/Blockchains/Bitcoin.swift
+++ b/swift/Sources/Blockchains/Bitcoin.swift
@@ -6,11 +6,11 @@
 
 import Foundation
 
-typealias TWBitcoinSigningInput = TW_Bitcoin_Proto_SigningInput
-typealias TWBitcoinSigningOutput = TW_Bitcoin_Proto_SigningOutput
-typealias TWBitcoinUnspentTransaction = TW_Bitcoin_Proto_UnspentTransaction
-typealias TWBitcoinTransactionPlan = TW_Bitcoin_Proto_TransactionPlan
-typealias TWBitcoinOutPoint = TW_Bitcoin_Proto_OutPoint
+public typealias TWBitcoinSigningInput = TW_Bitcoin_Proto_SigningInput
+public typealias TWBitcoinSigningOutput = TW_Bitcoin_Proto_SigningOutput
+public typealias TWBitcoinUnspentTransaction = TW_Bitcoin_Proto_UnspentTransaction
+public typealias TWBitcoinTransactionPlan = TW_Bitcoin_Proto_TransactionPlan
+public typealias TWBitcoinOutPoint = TW_Bitcoin_Proto_OutPoint
 
 /// Bitcoin blockchain.
 ///

--- a/swift/Tests/BitcoinTransactionSignerTests.swift
+++ b/swift/Tests/BitcoinTransactionSignerTests.swift
@@ -7,12 +7,6 @@
 import XCTest
 import TrustWalletCore
 
-typealias TWBitcoinSigningInput = TW_Bitcoin_Proto_SigningInput
-typealias TWBitcoinSigningOutput = TW_Bitcoin_Proto_SigningOutput
-typealias TWBitcoinUnspentTransaction = TW_Bitcoin_Proto_UnspentTransaction
-typealias TWBitcoinTransactionPlan = TW_Bitcoin_Proto_TransactionPlan
-typealias TWBitcoinOutPoint = TW_Bitcoin_Proto_OutPoint
-
 class BitcoinTransactionSignerTests: XCTestCase {
     override func setUp() {
         continueAfterFailure = false


### PR DESCRIPTION
## Description

It looks like we are missing `public` scope in following type aliases:

* TWBitcoinSigningInput
* TWBitcoinSigningOutput
* TWBitcoinUnspentTransaction
* TWBitcoinTransactionPlan 
* TWBitcoinOutPoint

## Testing instructions

Check if following types should be visible outside TrustCore.

I've removed them also from `BitcoinTransactionSignerTests.swift` so test will failed without `public` in `Bitcoin.swift`

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.