### PR TITLE
Fix overflow in Zarith forging

### DIFF
--- a/src/Tezos/Forging.cpp
+++ b/src/Tezos/Forging.cpp
@@ -60,7 +60,7 @@ Data forgePublicKey(PublicKey publicKey) {
 }
 
 // Forge the given zarith hash into a hex encoded string.
-Data forgeZarith(uint16_t input) {
+Data forgeZarith(uint64_t input) {
     Data forged = Data();
     while (input > 0x80) {
         forged.push_back(static_cast<byte>((input & 0xff) | 0x80));

--- a/src/Tezos/Forging.h
+++ b/src/Tezos/Forging.h
@@ -12,4 +12,4 @@ using namespace TW;
 Data forgeBool(bool input);
 Data forgePublicKeyHash(const std::string &publicKeyHash);
 Data forgePublicKey(PublicKey publicKey);
-Data forgeZarith(uint16_t input);
+Data forgeZarith(uint64_t input);

--- a/tests/Tezos/ForgingTests.cpp
+++ b/tests/Tezos/ForgingTests.cpp
@@ -68,6 +68,14 @@ TEST(Forging, ForgeZarithOneHundredFifty) {
     ASSERT_EQ(output, parse_hex(expected));
 }
 
+TEST(Forging, ForgeZarithLarge) {
+    auto expected = "82fc43";
+  
+    auto output = forgeZarith(1113602);
+  
+    ASSERT_EQ(output, parse_hex(expected));
+}
+
 TEST(Forging, forge_tz1) {
     auto expected = "00cfa4aae60f5d9389752d41e320da224d43287fe2";
 


### PR DESCRIPTION
## Description

This PR fixes a bug where zariths could not be bigger than 16 bits.

Added a test to prove that code is now correct for large values.

## Testing instructions

Run bootstrap.sh to run tests. 
## Types of changes

 * Bug fix (non-breaking change which fixes an issue) 

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ X] Prefix PR title with `[WIP]` if necessary.
- [X ] Add tests to cover changes as needed.
- [ X] Update documentation as needed.
