### PR TITLE
[WIP/RFC] Groestlcoin (GRS) support

### DIFF
--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -31,6 +31,7 @@ enum TWCoinType {
     TWCoinTypeEthereum = 60,
     TWCoinTypeEthereumClassic = 61,
     TWCoinTypeGo = 6060,
+    TWCoinTypeGroestlcoin = 17,
     TWCoinTypeICON = 74,
     TWCoinTypeKIN = 2017,
     TWCoinTypeLitecoin = 2,

--- a/include/TrustWalletCore/TWGroestlcoinAddress.h
+++ b/include/TrustWalletCore/TWGroestlcoinAddress.h
@@ -1,0 +1,44 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "TWBase.h"
+#include "TWData.h"
+#include "TWString.h"
+
+TW_EXTERN_C_BEGIN
+
+struct TWPublicKey;
+
+/// Represents a legacy Groestlcoin address.
+TW_EXPORT_CLASS
+struct TWGroestlcoinAddress;
+
+/// Compares two addresses for equality.
+TW_EXPORT_STATIC_METHOD
+bool TWGroestlcoinAddressEqual(struct TWGroestlcoinAddress *_Nonnull lhs, struct TWGroestlcoinAddress *_Nonnull rhs);
+
+/// Determines if the string is a valid Groestlcoin address.
+TW_EXPORT_STATIC_METHOD
+bool TWGroestlcoinAddressIsValidString(TWString *_Nonnull string);
+
+/// Create an address from a base58 sring representaion.
+TW_EXPORT_STATIC_METHOD
+struct TWGroestlcoinAddress *_Nullable TWGroestlcoinAddressCreateWithString(TWString *_Nonnull string);
+
+/// Create an address from a public key and a prefix byte.
+TW_EXPORT_STATIC_METHOD
+struct TWGroestlcoinAddress *_Nonnull TWGroestlcoinAddressCreateWithPublicKey(struct TWPublicKey *_Nonnull publicKey, uint8_t prefix);
+
+TW_EXPORT_METHOD
+void TWGroestlcoinAddressDelete(struct TWGroestlcoinAddress *_Nonnull address);
+
+/// Returns the address base58 string representation.
+TW_EXPORT_PROPERTY
+TWString *_Nonnull TWGroestlcoinAddressDescription(struct TWGroestlcoinAddress *_Nonnull address);
+
+TW_EXTERN_C_END

--- a/include/TrustWalletCore/TWHRP.h
+++ b/include/TrustWalletCore/TWHRP.h
@@ -21,6 +21,7 @@ enum TWHRP {
     TWHRPBinance     /* "bnb" */,
     TWHRPBinanceTest /* "tbnb" */,
     TWHRPCosmos      /* "cosmos" */,
+    TWHRPGroestlcoin /* "grs" */,
 };
 
 static const char *_Nonnull HRP_BINANCE = "bnb";
@@ -29,6 +30,7 @@ static const char *_Nonnull HRP_BITCOIN = "bc";
 static const char *_Nonnull HRP_BITCOINCASH = "bitcoincash";
 static const char *_Nonnull HRP_LITECOIN = "ltc";
 static const char *_Nonnull HRP_COSMOS = "cosmos";
+static const char *_Nonnull HRP_GROESTLCOIN = "grs";
 
 const char *_Nullable stringForHRP(enum TWHRP hrp);
 enum TWHRP hrpForString(const char *_Nonnull string);

--- a/include/TrustWalletCore/TWP2PKHPrefix.h
+++ b/include/TrustWalletCore/TWP2PKHPrefix.h
@@ -18,6 +18,7 @@ enum TWP2PKHPrefix {
     TWP2PKHPrefixLitecoin = 0x30,
     TWP2PKHPrefixDash = 0x4C,
     TWP2PKHPrefixDecred = 0x3f,
+    TWP2PKHPrefixGroestlcoin = 0x24,
     TWP2PKHPrefixZcoin = 0x52,
     TWP2PKHPrefixZcashT = 0xB8,
 };

--- a/include/TrustWalletCore/TWP2SHPrefix.h
+++ b/include/TrustWalletCore/TWP2SHPrefix.h
@@ -18,6 +18,7 @@ enum TWP2SHPrefix {
     TWP2SHPrefixLitecoin = 0x32,
     TWP2SHPrefixDash = 0x10,
     TWP2SHPrefixDecred = 0x1a,
+    TWP2SHPrefixGroestlcoin = 0x05,
     TWP2SHPrefixZcoin = 0x07,
     TWP2SHPrefixZcashT = 0xBD,
 };

--- a/include/TrustWalletCore/TWP2SHPrefix.h
+++ b/include/TrustWalletCore/TWP2SHPrefix.h
@@ -18,9 +18,13 @@ enum TWP2SHPrefix {
     TWP2SHPrefixLitecoin = 0x32,
     TWP2SHPrefixDash = 0x10,
     TWP2SHPrefixDecred = 0x1a,
-    TWP2SHPrefixGroestlcoin = 0x05,
     TWP2SHPrefixZcoin = 0x07,
     TWP2SHPrefixZcashT = 0xBD,
 };
+
+// Do not export TWP2SHPrefixGroestlcoin because it the same to
+// TWP2SHPrefixBitcoin and causes problems in Java:
+// public static P2SHPrefix createFromValue(byte value)
+static const uint8_t TWP2SHPrefixGroestlcoin = 0x05;
 
 TW_EXTERN_C_END

--- a/src/Bitcoin/Script.cpp
+++ b/src/Bitcoin/Script.cpp
@@ -12,6 +12,7 @@
 
 #include "../BinaryCoding.h"
 #include "../Decred/Address.h"
+#include "../Groestlcoin/Address.h"
 #include "../Hash.h"
 #include "../PublicKey.h"
 #include "../Zcash/TAddress.h"
@@ -285,6 +286,17 @@ Script Script::buildForAddress(const std::string& string) {
     } else if (Decred::Address::isValid(string)) {
         auto address = Decred::Address(string);
         return buildPayToPublicKeyHash(Data(address.keyhash.begin(), address.keyhash.end()));
+    } else if (Groestlcoin::Address::isValid(string)) {
+        auto address = Groestlcoin::Address(string);
+        auto data = std::vector<uint8_t>();
+        data.reserve(Address::size - 1);
+        std::copy(address.bytes.begin() + 1, address.bytes.end(), std::back_inserter(data));
+        if (address.bytes[0] == TWP2PKHPrefixGroestlcoin) {
+            return buildPayToPublicKeyHash(data);
+        }
+        if (address.bytes[0] == TWP2SHPrefixGroestlcoin) {
+            return buildPayToScriptHash(data);
+        }
     } else if (Zcash::TAddress::isValid(string)) {
         auto address = Zcash::TAddress(string);
         auto data = std::vector<uint8_t>();

--- a/src/Coin.cpp
+++ b/src/Coin.cpp
@@ -12,6 +12,7 @@
 #include "Bitcoin/CashAddress.h"
 #include "Decred/Address.h"
 #include "Ethereum/Address.h"
+#include "Groestlcoin/Address.h"
 #include "Icon/Address.h"
 #include "NEO/Address.h"
 #include "Nimiq/Address.h"
@@ -58,6 +59,10 @@ bool TW::validateAddress(TWCoinType coin, const std::string& string) {
 
     case TWCoinTypeDecred:
         return Decred::Address::isValid(string);
+
+    case TWCoinTypeGroestlcoin:
+        return Bitcoin::Bech32Address::isValid(string, HRP_GROESTLCOIN) ||
+               Groestlcoin::Address::isValid(string, {TWP2PKHPrefixGroestlcoin, TWP2SHPrefixGroestlcoin});
 
     case TWCoinTypeCallisto:
     case TWCoinTypeEthereum:
@@ -142,6 +147,7 @@ TWPurpose TW::purpose(TWCoinType coin) {
         return TWPurposeBIP44;
     case TWCoinTypeBitcoin:
     case TWCoinTypeLitecoin:
+    case TWCoinTypeGroestlcoin:
         return TWPurposeBIP84;
     }
 }
@@ -157,6 +163,7 @@ TWCurve TW::curve(TWCoinType coin) {
     case TWCoinTypeEthereum:
     case TWCoinTypeEthereumClassic:
     case TWCoinTypeGo:
+    case TWCoinTypeGroestlcoin:
     case TWCoinTypeICON:
     case TWCoinTypeLitecoin:
     case TWCoinTypePoa:
@@ -192,6 +199,7 @@ TWHDVersion TW::xpubVersion(TWCoinType coin) {
     switch (coin) {
     case TWCoinTypeBitcoin:
     case TWCoinTypeLitecoin:
+    case TWCoinTypeGroestlcoin:
         return TWHDVersionZPUB;
 
     case TWCoinTypeBitcoinCash:
@@ -234,6 +242,7 @@ TWHDVersion TW::xprvVersion(TWCoinType coin) {
     switch (coin) {
     case TWCoinTypeBitcoin:
     case TWCoinTypeLitecoin:
+    case TWCoinTypeGroestlcoin:
         return TWHDVersionZPRV;
 
     case TWCoinTypeBitcoinCash:
@@ -283,6 +292,7 @@ DerivationPath TW::derivationPath(TWCoinType coin) {
     case TWCoinTypeEthereum:
     case TWCoinTypeEthereumClassic:
     case TWCoinTypeGo:
+    case TWCoinTypeGroestlcoin:
     case TWCoinTypeICON:
     case TWCoinTypeLitecoin:
     case TWCoinTypeOntology:
@@ -334,6 +344,7 @@ PublicKeyType TW::publicKeyType(TWCoinType coin) {
     case TWCoinTypeCosmos:
     case TWCoinTypeDash:
     case TWCoinTypeDecred:
+    case TWCoinTypeGroestlcoin:
     case TWCoinTypeLitecoin:
     case TWCoinTypeZcash:
     case TWCoinTypeZcoin:
@@ -392,6 +403,9 @@ std::string TW::deriveAddress(TWCoinType coin, const PublicKey& publicKey) {
 
     case TWCoinTypeDecred:
         return Decred::Address(publicKey).string();
+
+    case TWCoinTypeGroestlcoin:
+        return Bitcoin::Bech32Address(publicKey, 0, HRP_GROESTLCOIN).string();
 
     case TWCoinTypeCallisto:
     case TWCoinTypeEthereum:
@@ -455,6 +469,7 @@ Hash::Hasher TW::publicKeyHasher(TWCoinType coin) {
     case TWCoinTypeEthereum:
     case TWCoinTypeEthereumClassic:
     case TWCoinTypeGo:
+    case TWCoinTypeGroestlcoin:
     case TWCoinTypeICON:
     case TWCoinTypeKIN:
     case TWCoinTypeLitecoin:
@@ -517,6 +532,9 @@ Hash::Hasher TW::base58Hasher(TWCoinType coin) {
 
     case TWCoinTypeDecred:
         return Hash::blake256d;
+
+    case TWCoinTypeGroestlcoin:
+        return Hash::groestl512d;
     }
 }
 

--- a/src/Groestlcoin/Address.cpp
+++ b/src/Groestlcoin/Address.cpp
@@ -1,0 +1,62 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Address.h"
+
+#include "../Base58.h"
+#include <TrezorCrypto/ecdsa.h>
+
+#include <cassert>
+
+using namespace TW::Groestlcoin;
+
+bool Address::isValid(const std::string& string) {
+    const auto decoded = Base58::bitcoin.decodeCheck(string, Hash::groestl512d);
+    if (decoded.size() != Address::size) {
+        return false;
+    }
+    return true;
+    // return isValid(string, std::vector<byte>{36, 5});
+}
+
+bool Address::isValid(const std::string& string, const std::vector<byte>& validPrefixes) {
+    const auto decoded = Base58::bitcoin.decodeCheck(string, Hash::groestl512d);
+    if (decoded.size() != Address::size) {
+        return false;
+    }
+    if (std::find(validPrefixes.begin(), validPrefixes.end(), decoded[0]) == validPrefixes.end()) {
+        return false;
+    }
+    return true;
+}
+
+Address::Address(const std::string& string) {
+    const auto decoded = Base58::bitcoin.decodeCheck(string, Hash::groestl512d);
+    if (decoded.size() != Address::size) {
+        throw std::invalid_argument("Invalid address string");
+    }
+
+    std::copy(decoded.begin(), decoded.end(), bytes.begin());
+}
+
+Address::Address(const std::vector<uint8_t>& data) {
+    if (!isValid(data)) {
+        throw std::invalid_argument("Invalid address key data");
+    }
+    std::copy(data.begin(), data.end(), bytes.begin());
+}
+
+Address::Address(const PublicKey& publicKey, uint8_t prefix) {
+    if (publicKey.type() != PublicKeyType::secp256k1) {
+        throw std::invalid_argument("Groestlcoin::Address needs a compressed SECP256k1 public key.");
+    }
+    bytes[0] = prefix;
+    ecdsa_get_pubkeyhash(publicKey.bytes.data(), HASHER_SHA2_RIPEMD, bytes.data() + 1);
+}
+
+std::string Address::string() const {
+    return Base58::bitcoin.encodeCheck(bytes, Hash::groestl512d);
+}

--- a/src/Groestlcoin/Address.h
+++ b/src/Groestlcoin/Address.h
@@ -1,0 +1,61 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "../Data.h"
+#include "../PublicKey.h"
+
+#include <array>
+#include <string>
+
+namespace TW::Groestlcoin {
+
+class Address {
+  public:
+    /// Number of bytes in an address.
+    static const size_t size = 21;
+
+    /// Address data consisting of a prefix byte followed by the public key
+    /// hash.
+    std::array<byte, size> bytes;
+
+    /// Determines whether a collection of bytes makes a valid  address.
+    template <typename T>
+    static bool isValid(const T& data) {
+        return data.size() == size;
+    }
+
+    /// Determines whether a string makes a valid address.
+    static bool isValid(const std::string& string);
+
+    /// Determines whether a string makes a valid address, and the prefix is
+    /// within the valid set.
+    static bool isValid(const std::string& string, const std::vector<byte>& validPrefixes);
+
+    /// Initializes a  address with a string representation.
+    explicit Address(const std::string& string);
+
+    /// Initializes a  address with a collection of bytes.
+    explicit Address(const std::vector<uint8_t>& data);
+
+    /// Initializes a  address with a public key and a prefix.
+    Address(const PublicKey& publicKey, uint8_t prefix);
+
+    /// Returns a string representation of the address.
+    std::string string() const;
+};
+
+inline bool operator==(const Address& lhs, const Address& rhs) {
+    return lhs.bytes == rhs.bytes;
+}
+
+} // namespace TW::Groestlcoin
+
+/// Wrapper for C interface.
+struct TWGroestlcoinAddress {
+    TW::Groestlcoin::Address impl;
+};

--- a/src/interface/TWCoinTypeConfiguration.cpp
+++ b/src/interface/TWCoinTypeConfiguration.cpp
@@ -26,6 +26,7 @@ TWString *_Nullable TWCoinTypeConfigurationGetSymbol(enum TWCoinType type) {
     case TWCoinTypeDecred: string = "DCR"; break;
     case TWCoinTypeEthereumClassic:  string = "ETC"; break;
     case TWCoinTypeGo:  string =  "GO"; break;
+    case TWCoinTypeGroestlcoin: string = "GRS"; break;
     case TWCoinTypeICON:  string =  "ICX"; break;
     case TWCoinTypeLitecoin: string = "LTC"; break;
     case TWCoinTypeOntology: string = "ONT"; break;
@@ -74,6 +75,7 @@ int TWCoinTypeConfigurationGetDecimals(enum TWCoinType type) {
     case TWCoinTypeBitcoin:
     case TWCoinTypeDash:
     case TWCoinTypeDecred:
+    case TWCoinTypeGroestlcoin:
     case TWCoinTypeLitecoin:
     case TWCoinTypeBinance:
     case TWCoinTypeZcoin:
@@ -114,6 +116,7 @@ TWString *_Nullable TWCoinTypeConfigurationGetTransactionURL(enum TWCoinType typ
     case TWCoinTypeCallisto:
     case TWCoinTypeEthereumClassic:
     case TWCoinTypeGo:
+    case TWCoinTypeGroestlcoin:
     case TWCoinTypeWanChain:
     case TWCoinTypeXDai:
     case TWCoinTypeZcoin:
@@ -169,6 +172,7 @@ const char *explorerURLForCoinType(enum TWCoinType type) {
     case TWCoinTypeDecred: return "https://mainnet.decred.org";
     case TWCoinTypeEthereumClassic: return "https://gastracker.io";
     case TWCoinTypeGo: return "https://explorer.gochain.io";
+    case TWCoinTypeGroestlcoin: return "https://blockbook.groestlcoin.org";
     case TWCoinTypeICON: return "https://tracker.icon.foundation";
     case TWCoinTypeLitecoin: return "https://blockchair.com/litecoin";
     case TWCoinTypeOntology: return "https://explorer.ont.io/";
@@ -206,6 +210,7 @@ TWString *_Nonnull TWCoinTypeConfigurationGetID(enum TWCoinType type) {
     case TWCoinTypeDecred: string = "decred"; break;
     case TWCoinTypeEthereumClassic:  string = "classic"; break;
     case TWCoinTypeGo:  string =  "gochain"; break;
+    case TWCoinTypeGroestlcoin: string = "groestlcoin"; break;
     case TWCoinTypeICON:  string =  "icon"; break;
     case TWCoinTypeLitecoin: string = "litecoin"; break;
     case TWCoinTypeOntology: string = "ontology"; break;
@@ -244,6 +249,7 @@ TWString *_Nonnull TWCoinTypeConfigurationGetName(enum TWCoinType type) {
     case TWCoinTypeDecred: string = "Decred"; break;
     case TWCoinTypeEthereumClassic:  string = "Ethereum Classic"; break;
     case TWCoinTypeGo:  string =  "GoChain"; break;
+    case TWCoinTypeGroestlcoin: string =  "Groestlcoin"; break;
     case TWCoinTypeICON:  string =  "ICON"; break;
     case TWCoinTypeLitecoin: string = "Litecoin"; break;
     case TWCoinTypeOntology: string = "Ontology"; break;

--- a/src/interface/TWGroestlcoinAddress.cpp
+++ b/src/interface/TWGroestlcoinAddress.cpp
@@ -1,0 +1,44 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include <TrustWalletCore/TWGroestlcoinAddress.h>
+#include <TrustWalletCore/TWPublicKey.h>
+
+#include "../Groestlcoin/Address.h"
+
+#include <cstring>
+
+using namespace TW::Groestlcoin;
+
+bool TWGroestlcoinAddressEqual(struct TWGroestlcoinAddress *_Nonnull lhs, struct TWGroestlcoinAddress *_Nonnull rhs) {
+    return lhs->impl.bytes == rhs->impl.bytes;
+}
+
+bool TWGroestlcoinAddressIsValidString(TWString *_Nonnull string) {
+    auto& s = *reinterpret_cast<const std::string*>(string);
+    return Address::isValid(s);
+}
+
+struct TWGroestlcoinAddress *_Nullable TWGroestlcoinAddressCreateWithString(TWString *_Nonnull string) {
+    auto& s = *reinterpret_cast<const std::string*>(string);
+    if (!Address::isValid(s)) {
+        return nullptr;
+    }
+    return new TWGroestlcoinAddress{ Address(s) };
+}
+
+struct TWGroestlcoinAddress *_Nonnull TWGroestlcoinAddressCreateWithPublicKey(struct TWPublicKey *_Nonnull publicKey, uint8_t prefix) {
+    return new TWGroestlcoinAddress{ Address(publicKey->impl, prefix) };
+}
+
+void TWGroestlcoinAddressDelete(struct TWGroestlcoinAddress *_Nonnull address) {
+    delete address;
+}
+
+TWString *_Nonnull TWGroestlcoinAddressDescription(struct TWGroestlcoinAddress *_Nonnull address) {
+    const auto str = address->impl.string();
+    return TWStringCreateWithUTF8Bytes(str.c_str());
+}

--- a/src/interface/TWHRP.cpp
+++ b/src/interface/TWHRP.cpp
@@ -16,6 +16,7 @@ const char* stringForHRP(enum TWHRP hrp) {
     case TWHRPBinance: return HRP_BINANCE;
     case TWHRPBinanceTest: return HRP_BINANCE_TEST;
     case TWHRPCosmos: return HRP_COSMOS;
+    case TWHRPGroestlcoin: return HRP_GROESTLCOIN;
     default: return nullptr;
     }
 }
@@ -33,6 +34,8 @@ enum TWHRP hrpForString(const char *_Nonnull string) {
         return TWHRPBinanceTest;
     } else if (std::strcmp(string, HRP_COSMOS) == 0) {
         return TWHRPCosmos;
+    } else if (std::strcmp(string, HRP_GROESTLCOIN) == 0) {
+        return TWHRPGroestlcoin;
     } else {
         return TWHRPUnknown;
     }

--- a/tests/CoinTests.cpp
+++ b/tests/CoinTests.cpp
@@ -63,6 +63,17 @@ TEST(Coin, validateAddressOntology){
     EXPECT_FALSE(validateAddress(TWCoinTypeOntology,"4646464646464646464646464646464646464646464646464646464646464646"));
 }
 
+TEST(Coin, validateAddressGroestlcoin){
+    EXPECT_TRUE(validateAddress(TWCoinTypeGroestlcoin, "Fj62rBJi8LvbmWu2jzkaUX1NFXLEqDLoZM"));
+    EXPECT_FALSE(validateAddress(TWCoinTypeGroestlcoin,"Fj62rBJi8LvbmWu2jzkaUX1NFXLEsNpjgw")); // sha256d checksum instead of groestl512d
+    EXPECT_FALSE(validateAddress(TWCoinTypeGroestlcoin,"mvbu1Gdy8SUjTenqerxUaZyYjmvedc787y")); // valid checksum, but testnet prefix
+    EXPECT_TRUE(validateAddress(TWCoinTypeGroestlcoin, "31inaRqambLsd9D7Ke4USZmGEVd3PHkh7P"));
+    EXPECT_FALSE(validateAddress(TWCoinTypeGroestlcoin,"31inaRqambLsd9D7Ke4USZmGEVd3LVt8yd")); // sha256d checksum instead of groestl512d
+    EXPECT_FALSE(validateAddress(TWCoinTypeGroestlcoin,"2N4Q5FhU2497BryFfUgbqkAJE87aKDv3V3e")); // valid checksum, but testnet prefix
+    EXPECT_TRUE(validateAddress(TWCoinTypeGroestlcoin, "grs1qw4teyraux2s77nhjdwh9ar8rl9dt7zww8r6lne"));
+    EXPECT_FALSE(validateAddress(TWCoinTypeGroestlcoin,"bc1qhkfq3zahaqkkzx5mjnamwjsfpq2jk7z00ppggv"));
+}
+
 TEST(Coin, DeriveAddress) {
     const auto privateKey = PrivateKey(parse_hex("0x4646464646464646464646464646464646464646464646464646464646464646"));
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeAion, privateKey), "0xa0010b0ea04ba4d76ca6e5e9900bacf19bc4402eaec7e36ea7ddd8eed48f60f3");
@@ -75,6 +86,7 @@ TEST(Coin, DeriveAddress) {
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeEthereum, privateKey), "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F");
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeEthereumClassic, privateKey), "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F");
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeGo, privateKey), "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F");
+    EXPECT_EQ(TW::deriveAddress(TWCoinTypeGroestlcoin, privateKey), "grs1qhkfq3zahaqkkzx5mjnamwjsfpq2jk7z0jsaf3d");
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeICON, privateKey), "hx4728fc65c31728f0d3538b8783b5394b31a136b9");
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeLitecoin, privateKey), "ltc1qhkfq3zahaqkkzx5mjnamwjsfpq2jk7z0tamvsu");
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeNimiq, privateKey), "NQ74 D40G N3M0 9EJD ET56 UPLR 02VC X6DU 8G1E");

--- a/tests/Groestlcoin/AddressTests.cpp
+++ b/tests/Groestlcoin/AddressTests.cpp
@@ -1,0 +1,45 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Groestlcoin/Address.h"
+
+#include "Coin.h"
+#include "HDWallet.h"
+#include "HexCoding.h"
+
+#include <gtest/gtest.h>
+
+using namespace TW;
+using namespace TW::Groestlcoin;
+
+TEST(GroestlcoinAddress, FromPublicKey) {
+    const auto publicKey = PublicKey(parse_hex("03b85cc59b67c35851eb5060cfc3a759a482254553c5857075c9e247d74d412c91"));
+    const auto address = Address(publicKey, 36);
+    ASSERT_EQ(address.string(), "Fj62rBJi8LvbmWu2jzkaUX1NFXLEqDLoZM");
+}
+
+TEST(GroestlcoinAddress, Valid) {
+    ASSERT_TRUE(Address::isValid(std::string("Fj62rBJi8LvbmWu2jzkaUX1NFXLEqDLoZM")));
+}
+
+TEST(GroestlcoinAddress, Invalid) {
+    ASSERT_FALSE(Address::isValid(std::string("1JAd7XCBzGudGpJQSDSfpmJhiygtLQWaGL"))); // Valid bitcoin address
+}
+
+TEST(GroestlcoinAddress, FromString) {
+    const auto string = "Fj62rBJi8LvbmWu2jzkaUX1NFXLEqDLoZM";
+    const auto address = Address(string);
+
+    ASSERT_EQ(address.string(), string);
+}
+
+TEST(GroestlcoinAddress, Derive) {
+    const auto mnemonic = "all all all all all all all all all all all all";
+    const auto wallet = HDWallet(mnemonic, "");
+    const auto path = TW::derivationPath(TWCoinTypeGroestlcoin);
+    const auto address = TW::deriveAddress(TWCoinTypeGroestlcoin, wallet.getKey(path));
+    ASSERT_EQ(address, "grs1qw4teyraux2s77nhjdwh9ar8rl9dt7zww8r6lne");
+}

--- a/tests/interface/TWCoinTypeConfigTests.cpp
+++ b/tests/interface/TWCoinTypeConfigTests.cpp
@@ -82,6 +82,10 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetSymbol) {
 
     auto value24 = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeTheta));
     assertStringsEqual(value24, "THETA");
+
+    auto value25 = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeGroestlcoin));
+    assertStringsEqual(value25, "GRS");
+
 }
 
 TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetDecimals) {
@@ -93,6 +97,7 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetDecimals) {
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeDecred), 8);
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeEthereumClassic), 18);
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeGo), 18);
+    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeGroestlcoin), 8);
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeICON), 18);
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeLitecoin), 8);
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypePoa), 18);
@@ -193,6 +198,9 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetTransactionURL) {
 
     auto value27 = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeTheta, txId));
     assertStringsEqual(value27, "https://explorer.thetatoken.org/txs/123");
+
+    auto value28 = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeGroestlcoin, txId));
+    assertStringsEqual(value28, "https://blockbook.groestlcoin.org/tx/123");
 }
 
 TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetID) {
@@ -264,6 +272,9 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetID) {
 
     auto value24 = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeTheta));
     assertStringsEqual(value24, "theta");
+
+    auto value25 = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeGroestlcoin));
+    assertStringsEqual(value25, "groestlcoin");
 }
 
 TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetName) {
@@ -338,4 +349,7 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetName) {
 
     auto value25 = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeTheta));
     assertStringsEqual(value25, "Theta");
+
+    auto value26 = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeGroestlcoin));
+    assertStringsEqual(value26, "Groestlcoin");
 }

--- a/tests/interface/TWGroestlcoinTests.cpp
+++ b/tests/interface/TWGroestlcoinTests.cpp
@@ -1,0 +1,92 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "TWTestUtilities.h"
+
+#include <TrustWalletCore/TWBech32Address.h>
+#include <TrustWalletCore/TWGroestlcoinAddress.h>
+#include <TrustWalletCore/TWBitcoinScript.h>
+#include <TrustWalletCore/TWHash.h>
+#include <TrustWalletCore/TWHDWallet.h>
+#include <TrustWalletCore/TWHRP.h>
+#include <TrustWalletCore/TWP2PKHPrefix.h>
+#include <TrustWalletCore/TWPrivateKey.h>
+
+#include <gtest/gtest.h>
+
+TEST(Groestlcoin, Address) {
+    auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("3c3385ddc6fd95ba7282051aeb440bc75820b8c10db5c83c052d7586e3e98e84").get()));
+    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
+    auto address = WRAP(TWGroestlcoinAddress, TWGroestlcoinAddressCreateWithPublicKey(publicKey, TWP2PKHPrefixGroestlcoin));
+    auto addressString = WRAPS(TWGroestlcoinAddressDescription(address.get()));
+    assertStringsEqual(addressString, "Fj62rBJi8LvbmWu2jzkaUX1NFXLEqDLoZM");
+
+    auto address2 = WRAP(TWGroestlcoinAddress, TWGroestlcoinAddressCreateWithString(STRING("Fj62rBJi8LvbmWu2jzkaUX1NFXLEqDLoZM").get()));
+    auto address2String = WRAPS(TWGroestlcoinAddressDescription(address2.get()));
+    assertStringsEqual(address2String, "Fj62rBJi8LvbmWu2jzkaUX1NFXLEqDLoZM");
+
+    ASSERT_TRUE(TWGroestlcoinAddressEqual(address.get(), address2.get()));
+}
+
+TEST(Groestlcoin, BuildForLegacyAddress) {
+    auto script = WRAP(TWBitcoinScript, TWBitcoinScriptBuildForAddress(STRING("Fj62rBJi8LvbmWu2jzkaUX1NFXLEqDLoZM").get()));
+    auto scriptData = WRAPD(TWBitcoinScriptData(script.get()));
+    assertHexEqual(scriptData, "76a91498af0aaca388a7e1024f505c033626d908e3b54a88ac");
+}
+
+TEST(Groestlcoin, BuildForSegwitP2SHAddress) {
+    auto script = WRAP(TWBitcoinScript, TWBitcoinScriptBuildForAddress(STRING("31inaRqambLsd9D7Ke4USZmGEVd3PHkh7P").get()));
+    auto scriptData = WRAPD(TWBitcoinScriptData(script.get()));
+    assertHexEqual(scriptData, "a9140055b0c94df477ee6b9f75185dfc9aa8ce2e52e487");
+}
+
+TEST(Groestlcoin, BuildForNativeSegwitAddress) {
+    auto script = WRAP(TWBitcoinScript, TWBitcoinScriptBuildForAddress(STRING("grs1qw4teyraux2s77nhjdwh9ar8rl9dt7zww8r6lne").get()));
+    auto scriptData = WRAPD(TWBitcoinScriptData(script.get()));
+    assertHexEqual(scriptData, "00147557920fbc32a1ef4ef26bae5e8ce3f95abf09ce");
+}
+
+TEST(Groestlcoin, ExtendedKeys) {
+    auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(
+        STRING("all all all all all all all all all all all all").get(),
+        STRING("").get()
+    ));
+
+    // .bip44
+    auto xprv = WRAPS(TWHDWalletGetExtendedPrivateKey(wallet.get(), TWPurposeBIP44, TWCoinTypeGroestlcoin, TWHDVersionXPRV));
+    auto xpub = WRAPS(TWHDWalletGetExtendedPublicKey(wallet.get(), TWPurposeBIP44, TWCoinTypeGroestlcoin, TWHDVersionXPUB));
+
+    assertStringsEqual(xprv, "xprv9zHDfLCJPTf5UrS16CrJ56WzSSoAYhJriX8Lfsco3TtPhG2DkwkVXjaDxZKU5USfmq5xjp1CZhpSrpHAPFwZWN75egb19TxWmMMmkd3csxP");
+    assertStringsEqual(xpub, "xpub6DGa4qjCDqDNhLWUCEPJSETizUdexA2i5k3wUG2QboRNa4MNJV4k5XthorGcogStY5K5iJ6NHtsznNK599ir8PmA3d1jqEoZHsixDTddNA9");
+
+    // .bip49
+    auto yprv = WRAPS(TWHDWalletGetExtendedPrivateKey(wallet.get(), TWPurposeBIP49, TWCoinTypeGroestlcoin, TWHDVersionYPRV));
+    auto ypub = WRAPS(TWHDWalletGetExtendedPublicKey(wallet.get(), TWPurposeBIP49, TWCoinTypeGroestlcoin, TWHDVersionYPUB));
+
+    assertStringsEqual(yprv, "yprvAJkRD9AD6QrU1hvSdcJT1Cdc1DwEMsBHFt4Gqd5NsK8Vhdn3ArEHYGaJhWotcn24VWx9rC6dDutHNea9zws8owL1qWEt3pVD2GGk4DSXyvm");
+    assertStringsEqual(ypub, "ypub6Xjmceh6vnQmEBzujdqTNLaLZFmimKu8d6yse1UzRefUaS7BiPYY64tnYpQQydp1gnb2cGkccBd1RtHRDtGXagqmRLxTStV88GWaeYh8ndG");
+
+    // .bip84
+    auto zprv = WRAPS(TWHDWalletGetExtendedPrivateKey(wallet.get(), TWPurposeBIP84, TWCoinTypeGroestlcoin, TWHDVersionZPRV));
+    auto zpub = WRAPS(TWHDWalletGetExtendedPublicKey(wallet.get(), TWPurposeBIP84, TWCoinTypeGroestlcoin, TWHDVersionZPUB));
+    assertStringsEqual(zprv, "zprvAcXuP1BeFt59rhLMnqTEL9j2TUz5mzXkj8NPcfvLKGzHm5mofJAeJMvFzzbNizahKxVEvptBpSxdhBcGbxdbaFP58caWLWAjZWMT7Jb6pFW");
+    assertStringsEqual(zpub, "zpub6qXFnWiY6FdT5BQptrzEhHfm1WpaBTFc6MHzR4KwscXGdt6xCqUtrAEjrHdeEsjaYEwVMgjtTvENQ83yo2fmkYYGjTpJoH7vFWKQJp1bg1X");
+}
+
+TEST(Groestlcoin, DeriveFromZpub) {
+    auto zpub = STRING("zpub6qXFnWiY6FdT5BQptrzEhHfm1WpaBTFc6MHzR4KwscXGdt6xCqUtrAEjrHdeEsjaYEwVMgjtTvENQ83yo2fmkYYGjTpJoH7vFWKQJp1bg1X");
+    auto pubKey4 = TWHDWalletGetPublicKeyFromExtended(zpub.get(), TWCoinTypeGroestlcoin, TWHDVersionZPUB, TWHDVersionZPRV, 0, 4);
+    auto pubKey11 = TWHDWalletGetPublicKeyFromExtended(zpub.get(), TWCoinTypeGroestlcoin, TWHDVersionZPUB, TWHDVersionZPRV, 0, 11);
+
+    auto address4 = WRAP(TWBech32Address, TWBech32AddressCreateWithPublicKey(TWHRPGroestlcoin, pubKey4));
+    auto address4String = WRAPS(TWBech32AddressDescription(address4.get()));
+
+    auto address11 = WRAP(TWBech32Address, TWBech32AddressCreateWithPublicKey(TWHRPGroestlcoin, pubKey11));
+    auto address11String = WRAPS(TWBech32AddressDescription(address11.get()));
+
+    assertStringsEqual(address4String, "grs1quwq6ml2r8rc25tue5ltfa6uc4pdzhtzul3c0rk");
+    assertStringsEqual(address11String, "grs1ql0a7czm8wrj253h78dm2h5j2k89zwpy2qjq0q9");
+}

--- a/tests/interface/TWHRPTests.cpp
+++ b/tests/interface/TWHRPTests.cpp
@@ -17,6 +17,7 @@ TEST(TWHRP, StringForHRP) {
     ASSERT_STREQ(stringForHRP(TWHRPBitcoinCash), "bitcoincash");
     ASSERT_STREQ(stringForHRP(TWHRPBinance), "bnb");
     ASSERT_STREQ(stringForHRP(TWHRPCosmos), "cosmos");
+    ASSERT_STREQ(stringForHRP(TWHRPGroestlcoin), "grs");
 }
 
 TEST(TWHRP, HRPForString) {
@@ -26,4 +27,5 @@ TEST(TWHRP, HRPForString) {
     ASSERT_EQ(hrpForString("bitcoincash"), TWHRPBitcoinCash);
     ASSERT_EQ(hrpForString("bnb"), TWHRPBinance);
     ASSERT_EQ(hrpForString("cosmos"), TWHRPCosmos);
+    ASSERT_EQ(hrpForString("grs"), TWHRPGroestlcoin);
 }


### PR DESCRIPTION
## Description

Groestlcoin differences comparing to Bitcoin from a wallet point of view:
1. Base58check uses Groestl hash for checksum in addresses, WIF and xpub.
2. Transaction signing uses single round of SHA256 instead of double.

This PR adds support for custom hashers in base58check, adds `secp256k1-groestl` trezor-crypto curve (to generate xpubs correctly), implements Groestlcoin address in C++, adds coin configuration and relevant tests. Please review are changes acceptable so far.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality) 

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
