### PR TITLE
Add origination operation for Tezos

### DIFF
--- a/include/TrustWalletCore/TWTezosProto.h
+++ b/include/TrustWalletCore/TWTezosProto.h
@@ -14,3 +14,4 @@ typedef TWData *_Nonnull TW_Tezos_Proto_OperationList;
 typedef TWData *_Nonnull TW_Tezos_Proto_Operation;
 typedef TWData *_Nonnull TW_Tezos_Proto_TransactionOperationData;
 typedef TWData *_Nonnull TW_Tezos_Proto_RevealOperationData;
+typedef TWData *_Nonnull TW_Tezos_Proto_OriginationOperationData;

--- a/src/Tezos/Forging.cpp
+++ b/src/Tezos/Forging.cpp
@@ -90,6 +90,22 @@ Data forgeOperation(const Operation& operation) {
       append(forged, forgedStorageLimit);
       append(forged, forgePublicKey(publicKey));
       return forged;
+  } else if (operation.kind() == Operation_OperationKind_ORIGINATION) {
+      auto managerPublicKey = operation.origination_operation_data().manager_pubkey();
+      auto balance = operation.origination_operation_data().balance();
+      forged.push_back(0x09);
+      append(forged, forgedSource);
+      append(forged, forgedFee);
+      append(forged, forgedCounter);
+      append(forged, forgedGasLimit);
+      append(forged, forgedStorageLimit);
+      append(forged, forgePublicKeyHash(managerPublicKey));
+      append(forged, forgeZarith(balance));
+      append(forged, forgeBool(true));
+      append(forged, forgeBool(true));
+      append(forged, forgeBool(false));
+      append(forged, forgeBool(false));
+      return forged;
   } else {
       auto forgedAmount = forgeZarith(operation.transaction_operation_data().amount());
       auto forgedDestination = Address(operation.transaction_operation_data().destination()).forge();

--- a/src/proto/Tezos.proto
+++ b/src/proto/Tezos.proto
@@ -24,7 +24,7 @@ message OperationList {
 }
 
 // An operation that can be applied to the Tezos blockchain.
-// Next field: 10
+// Next field: 11
 message Operation {
   int64 counter = 1;
   string source = 2;
@@ -38,6 +38,7 @@ message Operation {
 
     REVEAL = 7;
     TRANSACTION = 8;
+    ORIGINATION = 9;
   }
   OperationKind kind = 7;
 
@@ -45,6 +46,7 @@ message Operation {
   oneof operation_data {
     RevealOperationData reveal_operation_data = 8;
     TransactionOperationData transaction_operation_data = 9;
+    OriginationOperationData origination_operation_data = 10;
   }
 }
 
@@ -59,4 +61,11 @@ message TransactionOperationData {
 // Next field: 2
 message RevealOperationData {
   bytes public_key = 1;
+}
+
+// Origination operation specific data.
+// Next field: 3
+message OriginationOperationData {
+  string manager_pubkey = 1;
+  int64 balance = 2;
 }

--- a/tests/Tezos/OperationListTests.cpp
+++ b/tests/Tezos/OperationListTests.cpp
@@ -69,6 +69,29 @@ TEST(TezosOperationList, ForgeOperationList_RevealOnly) {
       ASSERT_EQ(op_list.forge(), parse_hex(expected));
 }
 
+TEST(TezosOperationList, ForgeOperationList_OriginationOnly) {
+    auto branch = "BLoCyPwBk3XoS5jLbKNzvYPe4RwFbnDdMSLqvsbhMmxopcPfAhP";
+    auto op_list = TW::Tezos::OperationList(branch);
+
+    auto originationOperationData = new TW::Tezos::Proto::OriginationOperationData();
+    originationOperationData -> set_manager_pubkey("tz1XVJ8bZUXs7r5NV8dHvuiBhzECvLRLR3jW");
+    originationOperationData -> set_balance(0);
+
+    auto originationOperation = TW::Tezos::Proto::Operation();
+    originationOperation.set_source("tz1XVJ8bZUXs7r5NV8dHvuiBhzECvLRLR3jW");
+    originationOperation.set_fee(1285);
+    originationOperation.set_counter(30871);
+    originationOperation.set_gas_limit(10000);
+    originationOperation.set_storage_limit(257);
+    originationOperation.set_kind(TW::Tezos::Proto::Operation::ORIGINATION);
+    originationOperation.set_allocated_origination_operation_data(originationOperationData);
+    
+    op_list.addOperation(originationOperation);
+
+    auto expected = "8ee0e04e6e66717f5b580bd494f1c00b73c171f5ebd85e0ef4c1dbc4def1f6f109000081faa75f741ef614b0e35fcc8c90dfa3b0b95721850a97f101904e81020081faa75f741ef614b0e35fcc8c90dfa3b0b9572100ffff0000";
+    ASSERT_EQ(hex(op_list.forge()), hex(parse_hex(expected)));
+}
+
 TEST(TezosOperationList, ForgeOperationList_TransactionAndReveal) {
     auto branch = "BL8euoCWqNCny9AR3AKjnpi38haYMxjei1ZqNHuXMn19JSQnoWp";
     auto op_list = TW::Tezos::OperationList(branch);


### PR DESCRIPTION
## Description

Add an origination operation for Tezos. 

Origination operations allow tz1 addresses to originate KT1 addresses which they manage. 

## Testing instructions

Run ./bootstrap.sh

Forged an operation using a Tezos node and then created a unit test around it.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ X ] Prefix PR title with `[WIP]` if necessary.
- [ X ] Add tests to cover changes as needed.
- [ X ] Update documentation as needed.
