### PR TITLE
Add support for Qtum

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Trust Wallet Core is a cross-platform library that implements low-level cryptogr
 <a href="https://ont.io/" target="_blank"><img src="https://raw.githubusercontent.com/TrustWallet/tokens/master/coins/1024.png" width="32" /></a>
 <a href="https://www.groestlcoin.org/" target="_blank"><img src="https://raw.githubusercontent.com/TrustWallet/tokens/master/coins/17.png" width="32" /></a>
 <a href="https://cosmos.network/" target="_blank"><img src="https://raw.githubusercontent.com/TrustWallet/tokens/master/coins/118.png" width="32" /></a>
+<a href="https://qtum.org/" target="_blank"><img src="https://raw.githubusercontent.com/TrustWallet/tokens/master/coins/2301.png" width="32" /></a>
 # Usage
 
 If you want to use wallet core in your project follow these instructions.

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
@@ -32,6 +32,7 @@ import wallet.core.jni.CoinType.STELLAR
 import wallet.core.jni.CoinType.AION
 import wallet.core.jni.CoinType.NEO
 import wallet.core.jni.CoinType.THETA
+import wallet.core.jni.CoinType.QTUM
 
 class CoinAddressDerivationTests {
 
@@ -77,6 +78,7 @@ class CoinAddressDerivationTests {
                     AION -> assertEquals("0xa0629f34c9ea4757ad0b275628d4d02e3db6c9009ba2ceeba76a5b55fb2ca42e", address)
                     NEO -> assertEquals("AUa3rzbGJe7MbHf8Kra9em8oaLBL1MDYKF", address)
                     THETA -> assertEquals("0x0d1fa20c218Fec2f2C55d52aB267940485fa5DA4", address)
+                    QTUM -> assertEquals("QhceuaTdeCZtcxmVc6yyEDEJ7Riu5gWFoF", address)
                 }
             }
         }

--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -53,6 +53,7 @@ enum TWCoinType {
     TWCoinTypeXDai = 700,
     TWCoinTypeZcash = 133,
     TWCoinTypeZcoin = 136,
+    TWCoinTypeQtum = 2301,
 };
 
 /// Returns the purpose for a coin type.

--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -40,6 +40,7 @@ enum TWCoinType {
     TWCoinTypeNimiq = 242,
     TWCoinTypeOntology = 1024,
     TWCoinTypePoa = 178,
+    TWCoinTypeQtum = 2301,
     TWCoinTypeRipple = 144,
     TWCoinTypeStellar = 148,
     TWCoinTypeTezos = 1729,
@@ -53,7 +54,6 @@ enum TWCoinType {
     TWCoinTypeXDai = 700,
     TWCoinTypeZcash = 133,
     TWCoinTypeZcoin = 136,
-    TWCoinTypeQtum = 2301,
 };
 
 /// Returns the purpose for a coin type.

--- a/include/TrustWalletCore/TWHRP.h
+++ b/include/TrustWalletCore/TWHRP.h
@@ -23,6 +23,7 @@ enum TWHRP {
     TWHRPBinanceTest /* "tbnb" */,
     TWHRPCosmos      /* "cosmos" */,
     TWHRPGroestlcoin /* "grs" */,
+    TWHRPQtum        /* "qtum" */,
 };
 
 static const char *_Nonnull HRP_BINANCE = "bnb";
@@ -33,6 +34,7 @@ static const char *_Nonnull HRP_LITECOIN = "ltc";
 static const char *_Nonnull HRP_COSMOS = "cosmos";
 static const char *_Nonnull HRP_GROESTLCOIN = "grs";
 static const char *_Nonnull HRP_VIACOIN = "via";
+static const char *_Nonnull HRP_QTUM = "qc";
 
 const char *_Nullable stringForHRP(enum TWHRP hrp);
 enum TWHRP hrpForString(const char *_Nonnull string);

--- a/include/TrustWalletCore/TWP2PKHPrefix.h
+++ b/include/TrustWalletCore/TWP2PKHPrefix.h
@@ -20,10 +20,10 @@ enum TWP2PKHPrefix {
     TWP2PKHPrefixDogecoin = 0x1e,
     TWP2PKHPrefixGroestlcoin = 0x24,
     TWP2PKHPrefixLitecoin = 0x30,
+    TWP2PKHPrefixQtum = 0x3a,
     TWP2PKHPrefixViacoin = 0x47,
     TWP2PKHPrefixZcashT = 0xB8,
     TWP2PKHPrefixZcoin = 0x52,
-    TWP2PKHPrefixQtum = 0x3a,
 };
 
 TW_EXTERN_C_END

--- a/include/TrustWalletCore/TWP2PKHPrefix.h
+++ b/include/TrustWalletCore/TWP2PKHPrefix.h
@@ -23,6 +23,7 @@ enum TWP2PKHPrefix {
     TWP2PKHPrefixViacoin = 0x47,
     TWP2PKHPrefixZcashT = 0xB8,
     TWP2PKHPrefixZcoin = 0x52,
+    TWP2PKHPrefixQtum = 0x3a,
 };
 
 TW_EXTERN_C_END

--- a/include/TrustWalletCore/TWP2SHPrefix.h
+++ b/include/TrustWalletCore/TWP2SHPrefix.h
@@ -22,6 +22,7 @@ enum TWP2SHPrefix {
     TWP2SHPrefixViacoin = 0x21,
     TWP2SHPrefixZcashT = 0xBD,
     TWP2SHPrefixZcoin = 0x07,
+    TWP2SHPrefixQtum = 0x32,
 };
 
 // Do not export TWP2SHPrefixGroestlcoin because it the same to

--- a/include/TrustWalletCore/TWP2SHPrefix.h
+++ b/include/TrustWalletCore/TWP2SHPrefix.h
@@ -22,7 +22,6 @@ enum TWP2SHPrefix {
     TWP2SHPrefixViacoin = 0x21,
     TWP2SHPrefixZcashT = 0xBD,
     TWP2SHPrefixZcoin = 0x07,
-    TWP2SHPrefixQtum = 0x32,
 };
 
 // Do not export TWP2SHPrefixGroestlcoin because it the same to

--- a/src/Bitcoin/Script.cpp
+++ b/src/Bitcoin/Script.cpp
@@ -254,7 +254,7 @@ Script Script::buildForAddress(const std::string& string) {
     static const std::vector<uint8_t> p2pkhPrefixes = {TWP2PKHPrefixBitcoin, TWP2PKHPrefixLitecoin,
                                                        TWP2PKHPrefixDash, TWP2PKHPrefixZcoin, TWP2PKHPrefixViacoin, TWP2PKHPrefixQtum};
     static const std::vector<uint8_t> p2shPrefixes = {TWP2SHPrefixBitcoin, TWP2SHPrefixLitecoin,
-                                                      TWP2SHPrefixDash, TWP2SHPrefixZcoin, TWP2SHPrefixViacoin, TWP2SHPrefixQtum};
+                                                      TWP2SHPrefixDash, TWP2SHPrefixZcoin, TWP2SHPrefixViacoin};
 
     if (Address::isValid(string)) {
         auto address = Address(string);

--- a/src/Bitcoin/Script.cpp
+++ b/src/Bitcoin/Script.cpp
@@ -252,9 +252,9 @@ void Script::encode(std::vector<uint8_t>& data) const {
 
 Script Script::buildForAddress(const std::string& string) {
     static const std::vector<uint8_t> p2pkhPrefixes = {TWP2PKHPrefixBitcoin, TWP2PKHPrefixLitecoin,
-                                                       TWP2PKHPrefixDash, TWP2PKHPrefixZcoin, TWP2PKHPrefixViacoin};
+                                                       TWP2PKHPrefixDash, TWP2PKHPrefixZcoin, TWP2PKHPrefixViacoin, TWP2PKHPrefixQtum};
     static const std::vector<uint8_t> p2shPrefixes = {TWP2SHPrefixBitcoin, TWP2SHPrefixLitecoin,
-                                                      TWP2SHPrefixDash, TWP2SHPrefixZcoin, TWP2SHPrefixViacoin};
+                                                      TWP2SHPrefixDash, TWP2SHPrefixZcoin, TWP2SHPrefixViacoin, TWP2SHPrefixQtum};
 
     if (Address::isValid(string)) {
         auto address = Address(string);

--- a/src/Coin.cpp
+++ b/src/Coin.cpp
@@ -121,7 +121,7 @@ bool TW::validateAddress(TWCoinType coin, const std::string& string) {
 
     case TWCoinTypeQtum:
         return Bitcoin::Bech32Address::isValid(string, HRP_QTUM) ||
-               Bitcoin::Address::isValid(string, {TWP2PKHPrefixQtum, TWP2SHPrefixQtum});
+               Bitcoin::Address::isValid(string, {{TWP2PKHPrefixQtum}, {TWP2SHPrefixQtum}});
     }
 }
 

--- a/src/Coin.cpp
+++ b/src/Coin.cpp
@@ -121,7 +121,7 @@ bool TW::validateAddress(TWCoinType coin, const std::string& string) {
 
     case TWCoinTypeQtum:
         return Bitcoin::Bech32Address::isValid(string, HRP_QTUM) ||
-               Bitcoin::Address::isValid(string, {{TWP2PKHPrefixQtum}, {TWP2SHPrefixQtum}});
+               Bitcoin::Address::isValid(string, {{TWP2PKHPrefixQtum}});
     }
 }
 

--- a/src/Coin.cpp
+++ b/src/Coin.cpp
@@ -118,6 +118,10 @@ bool TW::validateAddress(TWCoinType coin, const std::string& string) {
 
     case TWCoinTypeNEO:
         return NEO::Address::isValid(string);
+
+    case TWCoinTypeQtum:
+        return Bitcoin::Bech32Address::isValid(string, HRP_QTUM) ||
+               Bitcoin::Address::isValid(string, {TWP2PKHPrefixQtum, TWP2SHPrefixQtum});
     }
 }
 
@@ -152,6 +156,7 @@ TWPurpose TW::purpose(TWCoinType coin) {
     case TWCoinTypeNEO:
     case TWCoinTypeKIN:
     case TWCoinTypeTheta:
+    case TWCoinTypeQtum:
         return TWPurposeBIP44;
     case TWCoinTypeBitcoin:
     case TWCoinTypeViacoin:
@@ -189,6 +194,7 @@ TWCurve TW::curve(TWCoinType coin) {
     case TWCoinTypeZcoin:
     case TWCoinTypeCosmos:
     case TWCoinTypeTheta:
+    case TWCoinTypeQtum:
         return TWCurveSECP256k1;
 
     case TWCoinTypeNEO:
@@ -218,6 +224,7 @@ TWHDVersion TW::xpubVersion(TWCoinType coin) {
     case TWCoinTypeDash:
     case TWCoinTypeZcash:
     case TWCoinTypeZcoin:
+    case TWCoinTypeQtum:
         return TWHDVersionXPUB;
 
     case TWCoinTypeDecred:
@@ -265,6 +272,7 @@ TWHDVersion TW::xprvVersion(TWCoinType coin) {
     case TWCoinTypeDash:
     case TWCoinTypeZcash:
     case TWCoinTypeZcoin:
+    case TWCoinTypeQtum:
         return TWHDVersionXPRV;
 
     case TWCoinTypeDecred:
@@ -329,6 +337,7 @@ DerivationPath TW::derivationPath(TWCoinType coin) {
     case TWCoinTypeZcash:
     case TWCoinTypeZcoin:
     case TWCoinTypeTheta:
+    case TWCoinTypeQtum:
         return DerivationPath(purpose(coin), coin, 0, 0, 0);
     case TWCoinTypeAion:
     case TWCoinTypeNEO:
@@ -373,6 +382,7 @@ PublicKeyType TW::publicKeyType(TWCoinType coin) {
     case TWCoinTypeZcash:
     case TWCoinTypeZcoin:
     case TWCoinTypeRipple:
+    case TWCoinTypeQtum:
         return PublicKeyType::secp256k1;
 
     case TWCoinTypeCallisto:
@@ -483,6 +493,9 @@ std::string TW::deriveAddress(TWCoinType coin, const PublicKey& publicKey) {
 
     case TWCoinTypeNEO:
         return NEO::Address(publicKey).string();
+
+    case TWCoinTypeQtum:
+        return Bitcoin::Address(publicKey, TWP2PKHPrefixQtum).string();
     }
 }
 
@@ -520,6 +533,7 @@ Hash::Hasher TW::publicKeyHasher(TWCoinType coin) {
     case TWCoinTypeXDai:
     case TWCoinTypeZcash:
     case TWCoinTypeZcoin:
+    case TWCoinTypeQtum:
         return Hash::sha256ripemd;
 
     case TWCoinTypeDecred:
@@ -561,6 +575,7 @@ Hash::Hasher TW::base58Hasher(TWCoinType coin) {
     case TWCoinTypeXDai:
     case TWCoinTypeZcash:
     case TWCoinTypeZcoin:
+    case TWCoinTypeQtum:
         return Hash::sha256d;
 
     case TWCoinTypeDecred:

--- a/src/interface/TWCoinTypeConfiguration.cpp
+++ b/src/interface/TWCoinTypeConfiguration.cpp
@@ -51,6 +51,7 @@ TWString *_Nullable TWCoinTypeConfigurationGetSymbol(enum TWCoinType type) {
     case TWCoinTypeNEO: string = "NEO"; break;
     case TWCoinTypeKIN: string = "KIN"; break;
     case TWCoinTypeTheta: string = "THETA"; break;
+    case TWCoinTypeQtum: string = "QTUM"; break;
     default: string = ""; break;
     }
     return TWStringCreateWithUTF8Bytes(string.c_str());
@@ -84,6 +85,7 @@ int TWCoinTypeConfigurationGetDecimals(enum TWCoinType type) {
     case TWCoinTypeZcoin:
     case TWCoinTypeZcash:
     case TWCoinTypeNEO:
+    case TWCoinTypeQtum:
         return 8;
     case TWCoinTypeStellar:
         return 7;
@@ -114,6 +116,7 @@ TWString *_Nullable TWCoinTypeConfigurationGetTransactionURL(enum TWCoinType typ
     case TWCoinTypeLitecoin:
     case TWCoinTypeNEO:
     case TWCoinTypeStellar:
+    case TWCoinTypeQtum:
         url += "/transaction/" + txId;
         break;
     case TWCoinTypeCallisto:
@@ -203,6 +206,7 @@ const char *explorerURLForCoinType(enum TWCoinType type) {
     case TWCoinTypeNEO: return "https://neoscan.io";
     case TWCoinTypeKIN: return "https://kinexplorer.com";
     case TWCoinTypeTheta: return "https://explorer.thetatoken.org";
+    case TWCoinTypeQtum: return "https://explorer.qtum.org";
     default: return "";
     }
 }
@@ -243,6 +247,7 @@ TWString *_Nonnull TWCoinTypeConfigurationGetID(enum TWCoinType type) {
     case TWCoinTypeNEO: string = "neo"; break;
     case TWCoinTypeKIN: string = "kin"; break;
     case TWCoinTypeTheta: string = "theta"; break;
+    case TWCoinTypeQtum: string = "qtum"; break;
     default: string = ""; break;
     }
     return TWStringCreateWithUTF8Bytes(string.c_str());
@@ -284,6 +289,7 @@ TWString *_Nonnull TWCoinTypeConfigurationGetName(enum TWCoinType type) {
     case TWCoinTypeNEO: string = "NEO"; break;
     case TWCoinTypeKIN: string = "Kin"; break;
     case TWCoinTypeTheta: string = "Theta"; break;
+    case TWCoinTypeQtum: string = "Qtum"; break;
     default: string = ""; break;
     }
     return TWStringCreateWithUTF8Bytes(string.c_str());

--- a/src/interface/TWCoinTypeConfiguration.cpp
+++ b/src/interface/TWCoinTypeConfiguration.cpp
@@ -206,7 +206,7 @@ const char *explorerURLForCoinType(enum TWCoinType type) {
     case TWCoinTypeNEO: return "https://neoscan.io";
     case TWCoinTypeKIN: return "https://kinexplorer.com";
     case TWCoinTypeTheta: return "https://explorer.thetatoken.org";
-    case TWCoinTypeQtum: return "https://explorer.qtum.org";
+    case TWCoinTypeQtum: return "https://qtum.info";
     default: return "";
     }
 }

--- a/src/interface/TWCoinTypeConfiguration.cpp
+++ b/src/interface/TWCoinTypeConfiguration.cpp
@@ -116,7 +116,6 @@ TWString *_Nullable TWCoinTypeConfigurationGetTransactionURL(enum TWCoinType typ
     case TWCoinTypeLitecoin:
     case TWCoinTypeNEO:
     case TWCoinTypeStellar:
-    case TWCoinTypeQtum:
         url += "/transaction/" + txId;
         break;
     case TWCoinTypeCallisto:
@@ -130,6 +129,7 @@ TWString *_Nullable TWCoinTypeConfigurationGetTransactionURL(enum TWCoinType typ
     case TWCoinTypeWanChain:
     case TWCoinTypeXDai:
     case TWCoinTypeZcoin:
+    case TWCoinTypeQtum:
         url += "/tx/" + txId;
         break;
     case TWCoinTypeOntology:

--- a/src/interface/TWHRP.cpp
+++ b/src/interface/TWHRP.cpp
@@ -18,6 +18,7 @@ const char* stringForHRP(enum TWHRP hrp) {
     case TWHRPBinanceTest: return HRP_BINANCE_TEST;
     case TWHRPCosmos: return HRP_COSMOS;
     case TWHRPGroestlcoin: return HRP_GROESTLCOIN;
+    case TWHRPQtum: return HRP_QTUM;
     default: return nullptr;
     }
 }
@@ -39,6 +40,8 @@ enum TWHRP hrpForString(const char *_Nonnull string) {
         return TWHRPCosmos;
     } else if (std::strcmp(string, HRP_GROESTLCOIN) == 0) {
         return TWHRPGroestlcoin;
+    } else if (std::strcmp(string, HRP_QTUM) == 0) {
+        return TWHRPQtum;
     } else {
         return TWHRPUnknown;
     }

--- a/swift/Sources/Addresses/CoinType+Address.swift
+++ b/swift/Sources/Addresses/CoinType+Address.swift
@@ -84,7 +84,7 @@ public extension CoinType {
         case .zcash:
             return Set([P2SHPrefix.zcashT.rawValue, P2PKHPrefix.zcashT.rawValue])
         case .qtum:
-            return Set([P2SHPrefix.qtum.rawValue, P2PKHPrefix.qtum.rawValue])
+            return Set([P2PKHPrefix.qtum.rawValue])
         default:
             return Set()
         }

--- a/swift/Sources/Addresses/CoinType+Address.swift
+++ b/swift/Sources/Addresses/CoinType+Address.swift
@@ -12,7 +12,7 @@ public extension CoinType {
         switch self {
         case .binance, .cosmos:
             if let addr = CosmosAddress(string: string), addr.hrp == hrp { return addr }
-        case .bitcoin, .litecoin, .viacoin:
+        case .bitcoin, .litecoin, .viacoin, .qtum:
             if let addr = Bech32Address(string: string), addr.hrp == hrp {
                 return addr
             } else if let addr = BitcoinAddress(string: string), prefixSet.contains(addr.prefix) { return addr }
@@ -83,6 +83,8 @@ public extension CoinType {
             return Set([P2SHPrefix.zcoin.rawValue, P2PKHPrefix.zcoin.rawValue])
         case .zcash:
             return Set([P2SHPrefix.zcashT.rawValue, P2PKHPrefix.zcashT.rawValue])
+        case .qtum:
+            return Set([P2SHPrefix.qtum.rawValue, P2PKHPrefix.qtum.rawValue])
         default:
             return Set()
         }
@@ -103,6 +105,8 @@ public extension CoinType {
             return .litecoin
         case .groestlcoin:
             return .groestlcoin
+        case .qtum:
+            return .qtum
         default:
             return HRP.unknown
         }

--- a/swift/Tests/Blockchains/QtumTests.swift
+++ b/swift/Tests/Blockchains/QtumTests.swift
@@ -1,0 +1,74 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+import TrustWalletCore
+import XCTest
+
+class QtumTests: XCTestCase {
+    func testAddress() {
+        let privateKey1 = PrivateKey(data: Data(hexString: "a22ddec5c567b4488bb00f69b6146c50da2ee883e2c096db098726394d585730")!)!
+        let publicKey1 = privateKey1.getPublicKeySecp256k1(compressed: true)
+
+        let legacyAddress = BitcoinAddress(publicKey: publicKey1, prefix: P2PKHPrefix.qtum.rawValue)
+        XCTAssertEqual(BitcoinAddress(string: "QWVNLCXwhJqzut9YCLxbeMTximr2hmw7Vr")!.description, legacyAddress.description)
+
+        let privateKey2 = PrivateKey(data: Data(hexString: "55f9cbb0376c422946fa28397c1219933ac60b312ede41bfacaf701ecd546625")!)!
+        let publicKey2 = privateKey2.getPublicKeySecp256k1(compressed: true)
+        let bech32Address = Bech32Address(hrp: .qtum, publicKey: publicKey2)
+        XCTAssertEqual(Bech32Address(string: "qc1qytnqzjknvv03jwfgrsmzt0ycmwqgl0as6uywkk")!.description, bech32Address.description)
+    }
+
+    func testQtumBlockchain() {
+        let chain = CoinType.qtum
+        XCTAssertTrue(chain.validate(address: "qc1qn9gjawre2t6xmcv5gyqkujqhd8cfvvyx0rx2mp"))
+        XCTAssertTrue(chain.validate(address: "Qbmj3ufB1TaRSSP5DYR4KQxsyHBNrk8Y4p"))
+        XCTAssertFalse(chain.validate(address: "Qb4j3ufB1TaRSSP5DYR4KQxsyHBNrk8Y4p"))
+        XCTAssertFalse(chain.validate(address: "qc2qn9gjawre2t6xmcv5gyqkujqhd8cfvvyx0rx2mp"))
+    }
+
+    func testExtendedKeys() {
+        let wallet = HDWallet.test
+
+        // .bip44
+        let xprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .qtum, version: .xprv)
+        let xpub = wallet.getExtendedPubKey(purpose: .bip44, coin: .qtum, version: .xpub)
+
+        XCTAssertEqual(xprv, "xprv9yBPu3rkmyffD3A4TngwcpffYASEEfYnShyhuUsL3h9GiYdUjJh9S2s3vcYMoKi8L2cDqQcsFU5TkC1zgusTENCjatpnxp72X4uYkrej2tj")
+        XCTAssertEqual(xpub, "xpub6CAkJZPecMDxRXEXZpDwyxcQ6CGie8GdovuJhsGwc2gFbLxdGr1PyqBXmsL7aYds1wfY2rB3YMVZiEE3CB3Lkj6KGoq1rEJ1wuaGkMDBf1m")
+
+        // .bip49
+        let yprv = wallet.getExtendedPrivateKey(purpose: .bip49, coin: .qtum, version: .yprv)
+        let ypub = wallet.getExtendedPubKey(purpose: .bip49, coin: .qtum, version: .ypub)
+        XCTAssertEqual(yprv, "yprvAJdTrS1VXxDTRFGxPLJmjSECVCwqePCeCH7i6pLP3SiDg6G5omNiwEt88ENDy9nWMPmErGT5c1nGBsZRUjaTunFqw1w6xhWsAsLG6x8fR7d")
+        XCTAssertEqual(ypub, "ypub6XcpFwYPNKmkdjMRVMqn6aAw3EnL3qvVZW3JuCjzbnFCYtbEMJgyV3CbyY8jVCtSBfSB5H12uLcFYUSEtsBYNaf46Zv2smueAZKGmDgT8k8")
+
+        // .bip84
+        let zprv = wallet.getExtendedPrivateKey(purpose: .bip84, coin: .qtum, version: .zprv)
+        let zpub = wallet.getExtendedPubKey(purpose: .bip84, coin: .qtum, version: .zpub)
+        XCTAssertEqual(zprv, "zprvAdJxRo2izCdp1NZQShHqyXXwNrkAbYqi9YwAkG6kCJ2V5JZY7s2TdmbF2YxTzQKVx3SWQiHpVpsKyZ59Y8Th7edf2hJBWuyTvnCadLMLxAz")
+        XCTAssertEqual(zpub, "zpub6rJJqJZcpaC7DrdsYiprLfUfvtaf11ZZWmrmYeWMkdZTx6tgfQLiBZuisraogskwBRLMGWfXoCyWRrXSypwPdNV2UWJXm5bDVQvBXvrzz9d")
+    }
+
+    func testDeriveFromXpub() {
+        let xpub = "xpub6CAkJZPecMDxRXEXZpDwyxcQ6CGie8GdovuJhsGwc2gFbLxdGr1PyqBXmsL7aYds1wfY2rB3YMVZiEE3CB3Lkj6KGoq1rEJ1wuaGkMDBf1m"
+        let qtum = CoinType.qtum
+        let xpubAddr2 = HDWallet.derive(from: xpub, at: DerivationPath(purpose: qtum.purpose, coinType: qtum, account: 0, change: 0, address: 2))!
+        let xpubAddr9 = HDWallet.derive(from: xpub, at: DerivationPath(purpose: qtum.purpose, coinType: qtum, account: 0, change: 0, address: 9))!
+
+        XCTAssertEqual(BitcoinAddress(publicKey: xpubAddr2, prefix: P2PKHPrefix.qtum.rawValue).description, "QStYeAAfiYKxsABzY9yugHDpm5bsynYPqc")
+        XCTAssertEqual(BitcoinAddress(publicKey: xpubAddr9, prefix: P2PKHPrefix.qtum.rawValue).description, "QfbKFChfhx1s4VXS9BzaVJgyKw5a1hnFg4")
+    }
+
+    func testDeriveFromZPub() {
+        let zpub = "zpub6rJJqJZcpaC7DrdsYiprLfUfvtaf11ZZWmrmYeWMkdZTx6tgfQLiBZuisraogskwBRLMGWfXoCyWRrXSypwPdNV2UWJXm5bDVQvBXvrzz9d"
+        let qtum = CoinType.qtum
+        let zpubAddr4 = HDWallet.derive(from: zpub, at: DerivationPath(purpose: .bip84, coinType: qtum, account: 0, change: 0, address: 4))!
+        let zpubAddr11 = HDWallet.derive(from: zpub, at: DerivationPath(purpose: .bip84, coinType: qtum, account: 0, change: 0, address: 11))!
+
+        XCTAssertEqual(Bech32Address(hrp: .qtum, publicKey: zpubAddr4).description, "qc1q3cvjmc2cgjkz9y58waj3r9ccchmrmrdzq03783")
+        XCTAssertEqual(Bech32Address(hrp: .qtum, publicKey: zpubAddr11).description, "qc1qrlk0ajg6khu2unsdppggs3pgpxxvdeymky58af")
+    }
+}

--- a/swift/Tests/CoinAddressDerivationTests.swift
+++ b/swift/Tests/CoinAddressDerivationTests.swift
@@ -83,6 +83,8 @@ class CoinAddressDerivationTests: XCTestCase {
                     XCTAssertEqual("grs1qexwmshts5pdpeqglkl39zyl6693tmfwp0cue4j", address)
                 case .viacoin:
                     XCTAssertEqual("via1qnmsgjd6cvfprnszdgmyg9kewtjfgqflz67wwhc", address)
+                case .qtum:
+                    XCTAssertEqual("QhceuaTdeCZtcxmVc6yyEDEJ7Riu5gWFoF", address)
                 }
             }
         }

--- a/swift/Tests/SlipTests.swift
+++ b/swift/Tests/SlipTests.swift
@@ -26,5 +26,6 @@ class SlipTests: XCTestCase {
         XCTAssertEqual(CoinType.tomoChain.rawValue, 889)
         XCTAssertEqual(CoinType.tezos.rawValue, 1729)
         XCTAssertEqual(CoinType.xdai.rawValue, 700)
+        XCTAssertEqual(CoinType.qtum.rawValue, 2301)
     }
 }

--- a/tests/CoinTests.cpp
+++ b/tests/CoinTests.cpp
@@ -89,6 +89,14 @@ TEST(Coin, validateAddressGroestlcoin){
     EXPECT_FALSE(validateAddress(TWCoinTypeGroestlcoin,"bc1qhkfq3zahaqkkzx5mjnamwjsfpq2jk7z00ppggv"));
 }
 
+TEST(Coin, validateAddressQtum) {
+    EXPECT_TRUE(validateAddress(TWCoinTypeQtum, "qc1qn9gjawre2t6xmcv5gyqkujqhd8cfvvyx0rx2mp"));
+    EXPECT_TRUE(validateAddress(TWCoinTypeQtum, "Qbmj3ufB1TaRSSP5DYR4KQxsyHBNrk8Y4p"));
+
+    EXPECT_FALSE(validateAddress(TWCoinTypeQtum, "Qb4j3ufB1TaRSSP5DYR4KQxsyHBNrk8Y4p"));
+    EXPECT_FALSE(validateAddress(TWCoinTypeQtum, "qc2qn9gjawre2t6xmcv5gyqkujqhd8cfvvyx0rx2mp"));
+}
+
 TEST(Coin, DeriveAddress) {
     const auto privateKey = PrivateKey(parse_hex("0x4646464646464646464646464646464646464646464646464646464646464646"));
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeAion, privateKey), "0xa0010b0ea04ba4d76ca6e5e9900bacf19bc4402eaec7e36ea7ddd8eed48f60f3");
@@ -122,6 +130,7 @@ TEST(Coin, DeriveAddress) {
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeNEO, privateKey), "AeicEjZyiXKgUeSBbYQHxsU1X3V5Buori5");
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeKIN, privateKey), "GDXJHJHWN6GRNOAZXON6XH74ZX6NYFAS5B7642RSJQVJTIPA4ZYUQLEB");
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeTheta, privateKey), "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F");
+    EXPECT_EQ(TW::deriveAddress(TWCoinTypeQtum, privateKey), "QdtLm8ccxhuJFF5zCgikpaghbM3thdaGsW");
 }
 
 } // namespace

--- a/tests/interface/TWCoinTypeConfigTests.cpp
+++ b/tests/interface/TWCoinTypeConfigTests.cpp
@@ -206,7 +206,7 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetTransactionURL) {
     assertStringsEqual(value28, "https://blockbook.groestlcoin.org/tx/123");
 
     auto value29 = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeQtum, txId));
-    assertStringsEqual(value29, "https://explorer.qtum.org/tx/123");
+    assertStringsEqual(value29, "https://qtum.info/tx/123");
 }
 
 TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetID) {

--- a/tests/interface/TWCoinTypeConfigTests.cpp
+++ b/tests/interface/TWCoinTypeConfigTests.cpp
@@ -86,6 +86,8 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetSymbol) {
     auto value25 = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeGroestlcoin));
     assertStringsEqual(value25, "GRS");
 
+    auto value26 = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeQtum));
+    assertStringsEqual(value26, "QTUM");
 }
 
 TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetDecimals) {
@@ -116,6 +118,7 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetDecimals) {
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeKIN), 5);
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeCosmos), 6);
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeTheta), 18);
+    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeQtum), 8);
 }
 
 TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetTransactionURL) {
@@ -201,6 +204,9 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetTransactionURL) {
 
     auto value28 = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeGroestlcoin, txId));
     assertStringsEqual(value28, "https://blockbook.groestlcoin.org/tx/123");
+
+    auto value29 = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeQtum, txId));
+    assertStringsEqual(value29, "https://explorer.qtum.org/tx/123");
 }
 
 TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetID) {
@@ -275,6 +281,9 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetID) {
 
     auto value25 = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeGroestlcoin));
     assertStringsEqual(value25, "groestlcoin");
+
+    auto value26 = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeQtum));
+    assertStringsEqual(value26, "qtum");
 }
 
 TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetName) {
@@ -352,4 +361,7 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetName) {
 
     auto value26 = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeGroestlcoin));
     assertStringsEqual(value26, "Groestlcoin");
+
+    auto value27 = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeQtum));
+    assertStringsEqual(value27, "Qtum");
 }

--- a/tests/interface/TWCoinTypeConfigTests.cpp
+++ b/tests/interface/TWCoinTypeConfigTests.cpp
@@ -208,8 +208,8 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetTransactionURL) {
     auto value29 = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeDogecoin, txId));
     assertStringsEqual(value29, "https://live.blockcypher.com/doge/tx/123");
 
-    auto value30 WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeQtum, txId));
-    assertStringsEqual(value30 "https://qtum.info/tx/123");
+    auto value30 = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeQtum, txId));
+    assertStringsEqual(value30, "https://qtum.info/tx/123");
 }
 
 TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetID) {

--- a/tests/interface/TWHRPTests.cpp
+++ b/tests/interface/TWHRPTests.cpp
@@ -18,6 +18,7 @@ TEST(TWHRP, StringForHRP) {
     ASSERT_STREQ(stringForHRP(TWHRPBinance), "bnb");
     ASSERT_STREQ(stringForHRP(TWHRPCosmos), "cosmos");
     ASSERT_STREQ(stringForHRP(TWHRPGroestlcoin), "grs");
+    ASSERT_STREQ(stringForHRP(TWHRPQtum), "qc");
 }
 
 TEST(TWHRP, HRPForString) {
@@ -28,4 +29,5 @@ TEST(TWHRP, HRPForString) {
     ASSERT_EQ(hrpForString("bnb"), TWHRPBinance);
     ASSERT_EQ(hrpForString("cosmos"), TWHRPCosmos);
     ASSERT_EQ(hrpForString("grs"), TWHRPGroestlcoin);
+    ASSERT_EQ(hrpForString("qc"), TWHRPQtum);
 }

--- a/tests/interface/TWQtumTests.cpp
+++ b/tests/interface/TWQtumTests.cpp
@@ -100,12 +100,6 @@ TEST(Qtum, DeriveFromZpub) {
     assertStringsEqual(address11String, "qc1qrlk0ajg6khu2unsdppggs3pgpxxvdeymky58af");
 }
 
-TEST(Qtum, LockScripts) {
-    auto script = WRAP(TWBitcoinScript, TWBitcoinScriptBuildForAddress(STRING("MHhghmmCTASDnuwpgsPUNJVPTFaj61GzaG").get()));
-    auto scriptData = WRAPD(TWBitcoinScriptData(script.get()));
-    assertHexEqual(scriptData, "a9146b85b3dac9340f36b9d32bbacf2ffcb0851ef17987");
-}
-
 /*
 HD scheme that is used in qtum desktop wallet is "<MASTER KEY>/<COIN>/<INTERNAL>":
 m/88'/0'
@@ -116,6 +110,5 @@ m/49'/2301'
 m/84'/2301'
 The master key is used to derive the other keys, so the wallet should work but will not be compatible with qtum desktop wallet.
 The rules for creating send/receive Qtum transactions are the same as Bitcoin.
-The script address prefix for Qtum is not unique, it is the same as Litecoin.
 The default addresses in Qtum are the legacy addresses.
 */

--- a/tests/interface/TWQtumTests.cpp
+++ b/tests/interface/TWQtumTests.cpp
@@ -70,8 +70,8 @@ TEST(Qtum, ExtendedKeys) {
 
 TEST(Qtum, DeriveFromXpub) {
     auto xpub = STRING("xpub6CAkJZPecMDxRXEXZpDwyxcQ6CGie8GdovuJhsGwc2gFbLxdGr1PyqBXmsL7aYds1wfY2rB3YMVZiEE3CB3Lkj6KGoq1rEJ1wuaGkMDBf1m");
-    auto pubKey2 = TWHDWalletGetPublicKeyFromExtended(xpub.get(), TWCurveSECP256k1, TWHDVersionXPUB, TWHDVersionXPRV, 0, 2);
-    auto pubKey9 = TWHDWalletGetPublicKeyFromExtended(xpub.get(), TWCurveSECP256k1, TWHDVersionXPUB, TWHDVersionXPRV, 0, 9);
+    auto pubKey2 = TWHDWalletGetPublicKeyFromExtended(xpub.get(), TWCoinTypeQtum, TWHDVersionXPUB, TWHDVersionXPRV, 0, 2);
+    auto pubKey9 = TWHDWalletGetPublicKeyFromExtended(xpub.get(), TWCoinTypeQtum, TWHDVersionXPUB, TWHDVersionXPRV, 0, 9);
 
     TWBitcoinAddress address2;
     TWBitcoinAddressInitWithPublicKey(&address2, pubKey2, TWP2PKHPrefixQtum);
@@ -87,8 +87,8 @@ TEST(Qtum, DeriveFromXpub) {
 
 TEST(Qtum, DeriveFromZpub) {
     auto zpub = STRING("zpub6rJJqJZcpaC7DrdsYiprLfUfvtaf11ZZWmrmYeWMkdZTx6tgfQLiBZuisraogskwBRLMGWfXoCyWRrXSypwPdNV2UWJXm5bDVQvBXvrzz9d");
-    auto pubKey4 = TWHDWalletGetPublicKeyFromExtended(zpub.get(), TWCurveSECP256k1, TWHDVersionZPUB, TWHDVersionZPRV, 0, 4);
-    auto pubKey11 = TWHDWalletGetPublicKeyFromExtended(zpub.get(), TWCurveSECP256k1, TWHDVersionZPUB, TWHDVersionZPRV, 0, 11);
+    auto pubKey4 = TWHDWalletGetPublicKeyFromExtended(zpub.get(), TWCoinTypeQtum, TWHDVersionZPUB, TWHDVersionZPRV, 0, 4);
+    auto pubKey11 = TWHDWalletGetPublicKeyFromExtended(zpub.get(), TWCoinTypeQtum, TWHDVersionZPUB, TWHDVersionZPRV, 0, 11);
 
     auto address4 = WRAP(TWBech32Address, TWBech32AddressCreateWithPublicKey(TWHRPQtum, pubKey4));
     auto address4String = WRAPS(TWBech32AddressDescription(address4.get()));

--- a/tests/interface/TWQtumTests.cpp
+++ b/tests/interface/TWQtumTests.cpp
@@ -1,0 +1,107 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "TWTestUtilities.h"
+
+#include <TrustWalletCore/TWBech32Address.h>
+#include <TrustWalletCore/TWBitcoinAddress.h>
+#include <TrustWalletCore/TWBitcoinScript.h>
+#include <TrustWalletCore/TWHash.h>
+#include <TrustWalletCore/TWHDWallet.h>
+#include <TrustWalletCore/TWHRP.h>
+#include <TrustWalletCore/TWP2PKHPrefix.h>
+#include <TrustWalletCore/TWPrivateKey.h>
+
+#include <gtest/gtest.h>
+
+TEST(Qtum, LegacyAddress) {
+    auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("a22ddec5c567b4488bb00f69b6146c50da2ee883e2c096db098726394d585730").get()));
+    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
+    auto address = TWBitcoinAddress();
+    TWBitcoinAddressInitWithPublicKey(&address, publicKey, TWP2PKHPrefixQtum);
+    auto addressString = WRAPS(TWBitcoinAddressDescription(address));
+    assertStringsEqual(addressString, "QWVNLCXwhJqzut9YCLxbeMTximr2hmw7Vr");
+}
+
+TEST(Qtum, Address) {
+    auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("55f9cbb0376c422946fa28397c1219933ac60b312ede41bfacaf701ecd546625").get()));
+    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
+    auto address = WRAP(TWBech32Address, TWBech32AddressCreateWithPublicKey(TWHRPQtum, publicKey));
+    auto string = WRAPS(TWBech32AddressDescription(address.get()));
+
+    assertStringsEqual(string, "qc1qytnqzjknvv03jwfgrsmzt0ycmwqgl0as6uywkk");
+}
+
+TEST(Qtum, BuildForAddressM) {
+    auto script = WRAP(TWBitcoinScript, TWBitcoinScriptBuildForAddress(STRING("MHhghmmCTASDnuwpgsPUNJVPTFaj61GzaG").get()));
+    auto scriptData = WRAPD(TWBitcoinScriptData(script.get()));
+    assertHexEqual(scriptData, "a9146b85b3dac9340f36b9d32bbacf2ffcb0851ef17987");
+}
+
+TEST(Qtum, ExtendedKeys) {
+    auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(
+        STRING("ripple scissors kick mammal hire column oak again sun offer wealth tomorrow wagon turn fatal").get(),
+        STRING("TREZOR").get()
+    ));
+
+    // .bip44
+    auto xprv = WRAPS(TWHDWalletGetExtendedPrivateKey(wallet.get(), TWPurposeBIP44, TWCoinTypeQtum, TWHDVersionXPRV));
+    auto xpub = WRAPS(TWHDWalletGetExtendedPublicKey(wallet.get(), TWPurposeBIP44, TWCoinTypeQtum, TWHDVersionXPUB));
+
+    assertStringsEqual(xprv, "xprv9yBPu3rkmyffD3A4TngwcpffYASEEfYnShyhuUsL3h9GiYdUjJh9S2s3vcYMoKi8L2cDqQcsFU5TkC1zgusTENCjatpnxp72X4uYkrej2tj");
+    assertStringsEqual(xpub, "xpub6CAkJZPecMDxRXEXZpDwyxcQ6CGie8GdovuJhsGwc2gFbLxdGr1PyqBXmsL7aYds1wfY2rB3YMVZiEE3CB3Lkj6KGoq1rEJ1wuaGkMDBf1m");
+
+    // .bip49
+    auto yprv = WRAPS(TWHDWalletGetExtendedPrivateKey(wallet.get(), TWPurposeBIP49, TWCoinTypeQtum, TWHDVersionYPRV));
+    auto ypub = WRAPS(TWHDWalletGetExtendedPublicKey(wallet.get(), TWPurposeBIP49, TWCoinTypeQtum, TWHDVersionYPUB));
+
+    assertStringsEqual(yprv, "yprvAJdTrS1VXxDTRFGxPLJmjSECVCwqePCeCH7i6pLP3SiDg6G5omNiwEt88ENDy9nWMPmErGT5c1nGBsZRUjaTunFqw1w6xhWsAsLG6x8fR7d");
+    assertStringsEqual(ypub, "ypub6XcpFwYPNKmkdjMRVMqn6aAw3EnL3qvVZW3JuCjzbnFCYtbEMJgyV3CbyY8jVCtSBfSB5H12uLcFYUSEtsBYNaf46Zv2smueAZKGmDgT8k8");
+
+    // .bip84
+    auto zprv = WRAPS(TWHDWalletGetExtendedPrivateKey(wallet.get(), TWPurposeBIP84, TWCoinTypeQtum, TWHDVersionZPRV));
+    auto zpub = WRAPS(TWHDWalletGetExtendedPublicKey(wallet.get(), TWPurposeBIP84, TWCoinTypeQtum, TWHDVersionZPUB));
+    assertStringsEqual(zprv, "zprvAdJxRo2izCdp1NZQShHqyXXwNrkAbYqi9YwAkG6kCJ2V5JZY7s2TdmbF2YxTzQKVx3SWQiHpVpsKyZ59Y8Th7edf2hJBWuyTvnCadLMLxAz");
+    assertStringsEqual(zpub, "zpub6rJJqJZcpaC7DrdsYiprLfUfvtaf11ZZWmrmYeWMkdZTx6tgfQLiBZuisraogskwBRLMGWfXoCyWRrXSypwPdNV2UWJXm5bDVQvBXvrzz9d");
+}
+
+TEST(Qtum, DeriveFromXpub) {
+    auto xpub = STRING("xpub6CAkJZPecMDxRXEXZpDwyxcQ6CGie8GdovuJhsGwc2gFbLxdGr1PyqBXmsL7aYds1wfY2rB3YMVZiEE3CB3Lkj6KGoq1rEJ1wuaGkMDBf1m");
+    auto pubKey2 = TWHDWalletGetPublicKeyFromExtended(xpub.get(), TWCurveSECP256k1, TWHDVersionXPUB, TWHDVersionXPRV, 0, 2);
+    auto pubKey9 = TWHDWalletGetPublicKeyFromExtended(xpub.get(), TWCurveSECP256k1, TWHDVersionXPUB, TWHDVersionXPRV, 0, 9);
+
+    TWBitcoinAddress address2;
+    TWBitcoinAddressInitWithPublicKey(&address2, pubKey2, TWP2PKHPrefixQtum);
+    auto address2String = WRAPS(TWBitcoinAddressDescription(address2));
+
+    TWBitcoinAddress address9;
+    TWBitcoinAddressInitWithPublicKey(&address9, pubKey9, TWP2PKHPrefixQtum);
+    auto address9String = WRAPS(TWBitcoinAddressDescription(address9));
+
+    assertStringsEqual(address2String, "QStYeAAfiYKxsABzY9yugHDpm5bsynYPqc");
+    assertStringsEqual(address9String, "QfbKFChfhx1s4VXS9BzaVJgyKw5a1hnFg4");
+}
+
+TEST(Qtum, DeriveFromZpub) {
+    auto zpub = STRING("zpub6rJJqJZcpaC7DrdsYiprLfUfvtaf11ZZWmrmYeWMkdZTx6tgfQLiBZuisraogskwBRLMGWfXoCyWRrXSypwPdNV2UWJXm5bDVQvBXvrzz9d");
+    auto pubKey4 = TWHDWalletGetPublicKeyFromExtended(zpub.get(), TWCurveSECP256k1, TWHDVersionZPUB, TWHDVersionZPRV, 0, 4);
+    auto pubKey11 = TWHDWalletGetPublicKeyFromExtended(zpub.get(), TWCurveSECP256k1, TWHDVersionZPUB, TWHDVersionZPRV, 0, 11);
+
+    auto address4 = WRAP(TWBech32Address, TWBech32AddressCreateWithPublicKey(TWHRPQtum, pubKey4));
+    auto address4String = WRAPS(TWBech32AddressDescription(address4.get()));
+
+    auto address11 = WRAP(TWBech32Address, TWBech32AddressCreateWithPublicKey(TWHRPQtum, pubKey11));
+    auto address11String = WRAPS(TWBech32AddressDescription(address11.get()));
+
+    assertStringsEqual(address4String, "qc1q3cvjmc2cgjkz9y58waj3r9ccchmrmrdzq03783");
+    assertStringsEqual(address11String, "qc1qrlk0ajg6khu2unsdppggs3pgpxxvdeymky58af");
+}
+
+TEST(Qtum, LockScripts) {
+    auto script = WRAP(TWBitcoinScript, TWBitcoinScriptBuildForAddress(STRING("MHhghmmCTASDnuwpgsPUNJVPTFaj61GzaG").get()));
+    auto scriptData = WRAPD(TWBitcoinScriptData(script.get()));
+    assertHexEqual(scriptData, "a9146b85b3dac9340f36b9d32bbacf2ffcb0851ef17987");
+}

--- a/tests/interface/TWQtumTests.cpp
+++ b/tests/interface/TWQtumTests.cpp
@@ -105,3 +105,17 @@ TEST(Qtum, LockScripts) {
     auto scriptData = WRAPD(TWBitcoinScriptData(script.get()));
     assertHexEqual(scriptData, "a9146b85b3dac9340f36b9d32bbacf2ffcb0851ef17987");
 }
+
+/*
+HD scheme that is used in qtum desktop wallet is "<MASTER KEY>/<COIN>/<INTERNAL>":
+m/88'/0'
+m/88'/1'
+The trust wallet use different approach "<MASTER KEY>/<PURPOSE>/<COIN>":
+m/44'/2301'
+m/49'/2301'
+m/84'/2301'
+The master key is used to derive the other keys, so the wallet should work but will not be compatible with qtum desktop wallet.
+The rules for creating send/receive Qtum transactions are the same as Bitcoin.
+The script address prefix for Qtum is not unique, it is the same as Litecoin.
+The default addresses in Qtum are the legacy addresses.
+*/


### PR DESCRIPTION
## Description

Added support for send/receive `Qtum` coins.
Support exist for `P2PKH` and `bech32`.
Support for `P2SH` added but disabled due to `Litecoin` and `Qtum` have the same prefix for it, more description in the commits.
Support for smart contracts not added, due to no such functionalities in the trust wallet.
Tested only with unit tests.


## Testing instructions

Run `./bootstrap.sh` to execute the unit tests for `Qtum`.

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
