### PR TITLE
Tezos delegation

### DIFF
--- a/include/TrustWalletCore/TWTezosProto.h
+++ b/include/TrustWalletCore/TWTezosProto.h
@@ -15,3 +15,4 @@ typedef TWData *_Nonnull TW_Tezos_Proto_Operation;
 typedef TWData *_Nonnull TW_Tezos_Proto_TransactionOperationData;
 typedef TWData *_Nonnull TW_Tezos_Proto_RevealOperationData;
 typedef TWData *_Nonnull TW_Tezos_Proto_OriginationOperationData;
+typedef TWData *_Nonnull TW_Tezos_Proto_DelegationOperationData;

--- a/src/Tezos/Forging.cpp
+++ b/src/Tezos/Forging.cpp
@@ -106,10 +106,24 @@ Data forgeOperation(const Operation& operation) {
       append(forged, forgeBool(false));
       append(forged, forgeBool(false));
       return forged;
+  } else if (operation.kind() == Operation_OperationKind_DELEGATION) {
+    auto delegate = operation.delegation_operation_data().delegate();
+    forged.push_back(0x09);
+    append(forged, forgedSource);
+    append(forged, forgedFee);
+    append(forged, forgedCounter);
+    append(forged, forgedGasLimit);
+    append(forged, forgedStorageLimit);
+    if (delegate.empty()) {
+      append(forged, forgeBool(true));
+      append(forged, forgePublicKeyHash(delegate));
+    } else {
+      append(forged, forgeBool(false));
+    }
   } else {
       auto forgedAmount = forgeZarith(operation.transaction_operation_data().amount());
       auto forgedDestination = Address(operation.transaction_operation_data().destination()).forge();
-      forged.push_back(0x08);
+      forged.push_back(0x10);
       append(forged, forgedSource);
       append(forged, forgedFee);
       append(forged, forgedCounter);

--- a/src/Tezos/Forging.cpp
+++ b/src/Tezos/Forging.cpp
@@ -79,7 +79,6 @@ Data forgeOperation(const Operation& operation) {
   auto forgedCounter = forgeZarith(operation.counter());
   auto forgedGasLimit = forgeZarith(operation.gas_limit());
   auto forgedStorageLimit = forgeZarith(operation.storage_limit());
-  printf("Hello, world\n");
 
   if (operation.kind() == Operation_OperationKind_REVEAL) {
       auto publicKey = PublicKey(operation.reveal_operation_data().public_key());
@@ -108,7 +107,6 @@ Data forgeOperation(const Operation& operation) {
       append(forged, forgeBool(false));
       return forged;
   } else if (operation.kind() == Operation_OperationKind_DELEGATION) {
-    printf("FOUND DELEGATION\n");
     auto delegate = operation.delegation_operation_data().delegate();
     forged.push_back(0x0a);
     append(forged, forgedSource);
@@ -139,14 +137,3 @@ Data forgeOperation(const Operation& operation) {
   }
   return Data();
 }
-
-////
-//// "7105102c032807994dd9b5edf219261896a559876ca16cbf9d31dbe3612b89f2
-//10
-//01315b1206ec00b1b1e64cc3b8b93059f58fa2fc3900e9
-//// "7105102c032807994dd9b5edf219261896a559876ca16cbf9d31dbe3612b89f2
-//0a
-//01315b1206ec00b1b1e64cc3b8b93059f58fa2fc3900e9
-//
-//0944904e00ff00c4650fd609f88c67356e5fe01e37cd3ff654b18c"
-//0944904e00ff00c4650fd609f88c67356e5fe01e37cd3ff654b18c"

--- a/src/Tezos/Forging.cpp
+++ b/src/Tezos/Forging.cpp
@@ -107,20 +107,20 @@ Data forgeOperation(const Operation& operation) {
       append(forged, forgeBool(false));
       return forged;
   } else if (operation.kind() == Operation_OperationKind_DELEGATION) {
-    auto delegate = operation.delegation_operation_data().delegate();
-    forged.push_back(0x0a);
-    append(forged, forgedSource);
-    append(forged, forgedFee);
-    append(forged, forgedCounter);
-    append(forged, forgedGasLimit);
-    append(forged, forgedStorageLimit);
-    if (!delegate.empty()) {
-      append(forged, forgeBool(true));
-      append(forged, forgePublicKeyHash(delegate));
-    } else {
-      append(forged, forgeBool(false));
-    }
-    return forged;
+      auto delegate = operation.delegation_operation_data().delegate();
+      forged.push_back(0x0a);
+      append(forged, forgedSource);
+      append(forged, forgedFee);
+      append(forged, forgedCounter);
+      append(forged, forgedGasLimit);
+      append(forged, forgedStorageLimit);
+      if (!delegate.empty()) {
+          append(forged, forgeBool(true));
+          append(forged, forgePublicKeyHash(delegate));
+      } else {
+          append(forged, forgeBool(false));
+      }
+      return forged;
   } else {
       auto forgedAmount = forgeZarith(operation.transaction_operation_data().amount());
       auto forgedDestination = Address(operation.transaction_operation_data().destination()).forge();

--- a/src/Tezos/Forging.cpp
+++ b/src/Tezos/Forging.cpp
@@ -79,6 +79,7 @@ Data forgeOperation(const Operation& operation) {
   auto forgedCounter = forgeZarith(operation.counter());
   auto forgedGasLimit = forgeZarith(operation.gas_limit());
   auto forgedStorageLimit = forgeZarith(operation.storage_limit());
+  printf("Hello, world\n");
 
   if (operation.kind() == Operation_OperationKind_REVEAL) {
       auto publicKey = PublicKey(operation.reveal_operation_data().public_key());
@@ -107,23 +108,25 @@ Data forgeOperation(const Operation& operation) {
       append(forged, forgeBool(false));
       return forged;
   } else if (operation.kind() == Operation_OperationKind_DELEGATION) {
+    printf("FOUND DELEGATION\n");
     auto delegate = operation.delegation_operation_data().delegate();
-    forged.push_back(0x09);
+    forged.push_back(0x0a);
     append(forged, forgedSource);
     append(forged, forgedFee);
     append(forged, forgedCounter);
     append(forged, forgedGasLimit);
     append(forged, forgedStorageLimit);
-    if (delegate.empty()) {
+    if (!delegate.empty()) {
       append(forged, forgeBool(true));
       append(forged, forgePublicKeyHash(delegate));
     } else {
       append(forged, forgeBool(false));
     }
+    return forged;
   } else {
       auto forgedAmount = forgeZarith(operation.transaction_operation_data().amount());
       auto forgedDestination = Address(operation.transaction_operation_data().destination()).forge();
-      forged.push_back(0x10);
+      forged.push_back(0x08);
       append(forged, forgedSource);
       append(forged, forgedFee);
       append(forged, forgedCounter);
@@ -136,3 +139,14 @@ Data forgeOperation(const Operation& operation) {
   }
   return Data();
 }
+
+////
+//// "7105102c032807994dd9b5edf219261896a559876ca16cbf9d31dbe3612b89f2
+//10
+//01315b1206ec00b1b1e64cc3b8b93059f58fa2fc3900e9
+//// "7105102c032807994dd9b5edf219261896a559876ca16cbf9d31dbe3612b89f2
+//0a
+//01315b1206ec00b1b1e64cc3b8b93059f58fa2fc3900e9
+//
+//0944904e00ff00c4650fd609f88c67356e5fe01e37cd3ff654b18c"
+//0944904e00ff00c4650fd609f88c67356e5fe01e37cd3ff654b18c"

--- a/src/proto/Tezos.proto
+++ b/src/proto/Tezos.proto
@@ -24,7 +24,7 @@ message OperationList {
 }
 
 // An operation that can be applied to the Tezos blockchain.
-// Next field: 11
+// Next field: 12
 message Operation {
   int64 counter = 1;
   string source = 2;
@@ -39,6 +39,7 @@ message Operation {
     REVEAL = 7;
     TRANSACTION = 8;
     ORIGINATION = 9;
+    DELEGATION = 10;
   }
   OperationKind kind = 7;
 
@@ -47,6 +48,7 @@ message Operation {
     RevealOperationData reveal_operation_data = 8;
     TransactionOperationData transaction_operation_data = 9;
     OriginationOperationData origination_operation_data = 10;
+    DelegationOperationData delegation_operation_data = 11;
   }
 }
 
@@ -68,4 +70,10 @@ message RevealOperationData {
 message OriginationOperationData {
   string manager_pubkey = 1;
   int64 balance = 2;
+}
+
+// Delegation operation specific data.
+// Next field: 2
+message DelegationOperationData {
+  string delegate = 1;
 }

--- a/tests/Tezos/OperationListTests.cpp
+++ b/tests/Tezos/OperationListTests.cpp
@@ -107,7 +107,7 @@ TEST(TezosOperationList, ForgeOperationList_Delegation_ClearDelegate) {
     delegationOperation.set_storage_limit(0);
     delegationOperation.set_kind(TW::Tezos::Proto::Operation::DELEGATION);
     delegationOperation.set_allocated_delegation_operation_data(delegationOperationData);
-    
+
     op_list.addOperation(delegationOperation);
 
     auto expected = "48b63d801fa824013a195f7885ba522503c59e0580f7663e15c52f03ccc935e60a01315b1206ec00b1b1e64cc3b8b93059f58fa2fc3900e90943904e0000";
@@ -132,7 +132,7 @@ TEST(TezosOperationList, ForgeOperationList_Delegation_AddDelegate) {
     
     op_list.addOperation(delegationOperation);
 
-    auto expected = "48b63d801fa824013a195f7885ba522503c59e0580f7663e15c52f03ccc935e60a01315b1206ec00b1b1e64cc3b8b93059f58fa2fc3900e90943904e0000";
+    auto expected = "7105102c032807994dd9b5edf219261896a559876ca16cbf9d31dbe3612b89f20a01315b1206ec00b1b1e64cc3b8b93059f58fa2fc3900e90944904e00ff00c4650fd609f88c67356e5fe01e37cd3ff654b18c";
     ASSERT_EQ(hex(op_list.forge()), hex(parse_hex(expected)));
 }
 

--- a/tests/Tezos/OperationListTests.cpp
+++ b/tests/Tezos/OperationListTests.cpp
@@ -92,6 +92,50 @@ TEST(TezosOperationList, ForgeOperationList_OriginationOnly) {
     ASSERT_EQ(hex(op_list.forge()), hex(parse_hex(expected)));
 }
 
+TEST(TezosOperationList, ForgeOperationList_Delegation_ClearDelegate) {
+    auto branch = "BLGJfQDFEYZBRLj5GSHskj8NPaRYhk7Kx5WAfdcDucD3q98WdeW";
+    auto op_list = TW::Tezos::OperationList(branch);
+
+    auto delegationOperationData = new TW::Tezos::Proto::DelegationOperationData();
+    delegationOperationData -> set_delegate("");
+
+    auto delegationOperation = TW::Tezos::Proto::Operation();
+    delegationOperation.set_source("KT1D5jmrBD7bDa3jCpgzo32FMYmRDdK2ihka");
+    delegationOperation.set_fee(1257);
+    delegationOperation.set_counter(67);
+    delegationOperation.set_gas_limit(10000);
+    delegationOperation.set_storage_limit(0);
+    delegationOperation.set_kind(TW::Tezos::Proto::Operation::DELEGATION);
+    delegationOperation.set_allocated_delegation_operation_data(delegationOperationData);
+    
+    op_list.addOperation(delegationOperation);
+
+    auto expected = "48b63d801fa824013a195f7885ba522503c59e0580f7663e15c52f03ccc935e60a01315b1206ec00b1b1e64cc3b8b93059f58fa2fc3900e90943904e0000";
+    ASSERT_EQ(hex(op_list.forge()), hex(parse_hex(expected)));
+}
+
+TEST(TezosOperationList, ForgeOperationList_Delegation_AddDelegate) {
+    auto branch = "BLa4GrVQTxUgQWbHv6cF7RXWSGzHGPbgecpQ795R3cLzw4cGfpD";
+    auto op_list = TW::Tezos::OperationList(branch);
+
+    auto delegationOperationData = new TW::Tezos::Proto::DelegationOperationData();
+    delegationOperationData -> set_delegate("tz1dYUCcrorfCoaQCtZaxi1ynGrP3prTZcxS");
+
+    auto delegationOperation = TW::Tezos::Proto::Operation();
+    delegationOperation.set_source("KT1D5jmrBD7bDa3jCpgzo32FMYmRDdK2ihka");
+    delegationOperation.set_fee(1257);
+    delegationOperation.set_counter(68);
+    delegationOperation.set_gas_limit(10000);
+    delegationOperation.set_storage_limit(0);
+    delegationOperation.set_kind(TW::Tezos::Proto::Operation::DELEGATION);
+    delegationOperation.set_allocated_delegation_operation_data(delegationOperationData);
+    
+    op_list.addOperation(delegationOperation);
+
+    auto expected = "48b63d801fa824013a195f7885ba522503c59e0580f7663e15c52f03ccc935e60a01315b1206ec00b1b1e64cc3b8b93059f58fa2fc3900e90943904e0000";
+    ASSERT_EQ(hex(op_list.forge()), hex(parse_hex(expected)));
+}
+
 TEST(TezosOperationList, ForgeOperationList_TransactionAndReveal) {
     auto branch = "BL8euoCWqNCny9AR3AKjnpi38haYMxjei1ZqNHuXMn19JSQnoWp";
     auto op_list = TW::Tezos::OperationList(branch);


### PR DESCRIPTION
## Description

Add a delegation operation for Tezos.

Delegations operations allow kt1 addresses to delegate their entire balance to tz1, tz2, and tz3 addresses which are registered as bakers.

## Testing instructions

Run ./bootstrap.sh

Forged an operation that set a delegate and cleared a delegate using a Tezos node and then created a unit test around it.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ X ] Prefix PR title with `[WIP]` if necessary.
- [ X ] Add tests to cover changes as needed.
- [ X ] Update documentation as needed.
