### PR TITLE
Add clang compiler check in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
+if (NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
+    message(FATAL_ERROR "You should use clang compiler")
+endif()
+
 if ("$ENV{PREFIX}" STREQUAL "")
     set(PREFIX "${CMAKE_SOURCE_DIR}/build/local")
 else()


### PR DESCRIPTION
## Description
For now project cannot be compile with GNU. For make more clarify compile error.
I propose add this check. When support another compilers will be added, this check can be deleted or changed.

Now the error looks like this:
![Selection_534](https://user-images.githubusercontent.com/20345096/56042986-fae54700-5d44-11e9-8fff-38a0b3924835.png)
With my changes:
![Selection_537](https://user-images.githubusercontent.com/20345096/56043017-07699f80-5d45-11e9-945f-466aad76b6ac.png)

[Compilers ID](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html)
<!--- Describe your changes in detail -->

## Testing instructions

Build on Linux with GNU Compiler 

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Prefix PR title with `[WIP]` if necessary.
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
