### PR TITLE
Add source of the node

### DIFF
--- a/include/TrustWalletCore/TWCoinTypeConfiguration.h
+++ b/include/TrustWalletCore/TWCoinTypeConfiguration.h
@@ -31,4 +31,7 @@ TWString *_Nonnull TWCoinTypeConfigurationGetID(enum TWCoinType type);
 TW_EXPORT_STATIC_METHOD
 TWString *_Nonnull TWCoinTypeConfigurationGetName(enum TWCoinType type);
 
+TW_EXPORT_STATIC_METHOD
+TWString *_Nullable TWCoinTypeConfigurationGetNodeSource(enum TWCoinType type);
+
 TW_EXTERN_C_END

--- a/src/interface/TWCoinTypeConfiguration.cpp
+++ b/src/interface/TWCoinTypeConfiguration.cpp
@@ -304,4 +304,48 @@ TWString *_Nonnull TWCoinTypeConfigurationGetName(enum TWCoinType type) {
     return TWStringCreateWithUTF8Bytes(string.c_str());
 }
 
+TWString *_Nullable TWCoinTypeConfigurationGetNodeSource(enum TWCoinType type) {
+    string string;
+    switch (type) {
+    case TWCoinTypeBitcoin:
+    case TWCoinTypeBitcoinCash:
+    case TWCoinTypeDash:
+    case TWCoinTypeDogecoin:
+    case TWCoinTypeDecred:
+    case TWCoinTypeLitecoin:
+    case TWCoinTypeGroestlcoin:
+    case TWCoinTypeZcash:
+    case TWCoinTypeZcoin:
+    case TWCoinTypeViacoin:
+    case TWCoinTypeLux:
+    case TWCoinTypeQtum: string = "https://github.com/trezor/blockbook"; break;
+    case TWCoinTypeICON: string = "https://github.com/icon-project/icon-rpc-server"; break;
+    case TWCoinTypeNEO: string = "https://github.com/neo-project/neo"; break;
+    case TWCoinTypeStellar: string = "https://github.com/stellar/go"; break;
+    case TWCoinTypeEthereum:
+    case TWCoinTypeCallisto:
+    case TWCoinTypePoa:
+    case TWCoinTypeEthereumClassic:
+    case TWCoinTypeGo:
+    case TWCoinTypeXDai:
+    case TWCoinTypeTomoChain:
+    case TWCoinTypeThunderToken: string = "https://github.com/ethereum/go-ethereum"; break;
+    case TWCoinTypeWanChain: string = "https://github.com/wanchain/go-wanchain"; break;
+    case TWCoinTypeKIN: string = "https://github.com/kinecosystem/go"; break;
+    case TWCoinTypeIOST: string = "https://github.com/iost-official/go-iost"; break;
+    case TWCoinTypeOntology: string = "https://github.com/ontio/ontology"; break;
+    case TWCoinTypeTheta: string = "https://github.com/thetatoken/theta-protocol-ledger"; break;
+    case TWCoinTypeTron: string = "https://github.com/tronprotocol/java-tron"; break;
+    case TWCoinTypeAion: string = "https://github.com/aionnetwork/aion"; break;
+    case TWCoinTypeVeChain: string = "https://github.com/vechain/thor"; break;
+    case TWCoinTypeRipple: string = "https://github.com/ripple"; break;
+    case TWCoinTypeTezos: string = "https://gitlab.com/tezos/tezos"; break;
+    case TWCoinTypeNimiq: string = "https://github.com/nimiq-network/core"; break;
+    case TWCoinTypeBinance: string = "https://github.com/binance-chain/"; break;
+    case TWCoinTypeCosmos: string = "https://github.com/cosmos/cosmos-sdk"; break;
+    default: string = "";
+    }
+    return TWStringCreateWithUTF8Bytes(string.c_str());
+}
+
 #pragma clang diagnostic pop

--- a/swift/Tests/ConfigurationTests.swift
+++ b/swift/Tests/ConfigurationTests.swift
@@ -1,0 +1,16 @@
+//
+//  ConfigurationTests.swift
+//  TrustWalletCoreTests
+//
+//  Created by Viktor on 4/13/19.
+//
+
+import XCTest
+import TrustWalletCore
+
+class ConfigurationTests: XCTestCase {
+
+    func testNodeSource() {
+        XCTAssertEqual("https://github.com/ethereum/go-ethereum", CoinTypeConfiguration.getNodeSource(type: .ethereum))
+    }
+}

--- a/tests/interface/TWCoinTypeConfigTests.cpp
+++ b/tests/interface/TWCoinTypeConfigTests.cpp
@@ -375,10 +375,17 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetName) {
     auto value26 = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeGroestlcoin));
     assertStringsEqual(value26, "Groestlcoin");
 
-
     auto value27 = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeLux));
     assertStringsEqual(value27, "Lux");
 
     auto value28 = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeQtum));
     assertStringsEqual(value28, "Qtum");
+}
+
+TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetNodeSource) {
+    auto value1 = WRAPS(TWCoinTypeConfigurationGetNodeSource(TWCoinTypeEthereum));
+    assertStringsEqual(value1, "https://github.com/ethereum/go-ethereum");
+
+    auto value2 = WRAPS(TWCoinTypeConfigurationGetNodeSource(TWCoinTypeBitcoin));
+    assertStringsEqual(value2, "https://github.com/trezor/blockbook");
 }


### PR DESCRIPTION
Adding the required parameter to specify the source of the node to run.

- if we need manually to run node ourselves
- provide users the ability to run their own in the future, the source would be useful for them to do it
