### PR TITLE
Minor update to codegen to ignore .DS_Store files

### DIFF
--- a/codegen/bin/codegen
+++ b/codegen/bin/codegen
@@ -63,7 +63,7 @@ end.parse!
 entities = []
 files = []
 Dir.foreach(options.input) do |item|
-  next if ['.', '..'].include?(item)
+  next if ['.', '..', '.DS_Store'].include?(item)
 
   entity = Parser.new(path: File.expand_path(File.join(options.input, item))).parse
   next if entity.nil?


### PR DESCRIPTION
codegen, while iterating over options.input, ignores files named '.DS_Store'.

## Description
.DS_Store files are auto-generated inside a directory by macOS when that directory is opened in Finder. If codegen, while parsing it's input directory, encounters this file, it exits with an error such as follows:

> Found a class NimiqSigner
    Found an enum HRP
    Found a class GroestlcoinTransactionSigner
     ...wallet-core/codegen/lib/parser.rb:23:in 'skip_until': invalid byte sequence in UTF-8 (ArgumentError)
	from .../wallet-core/codegen/lib/parser.rb:23:in 'parse'
	from ../codegen/bin/codegen:68:in 'block in \<main>'
	from ../codegen/bin/codegen:65:in 'foreach'
	from ../codegen/bin/codegen:65:in '\<main>'

My edit simply skips this file when parsing all the files in the input.

## Testing instructions
I'm uncertain of the exact circumstances under which Finder creates a .DS_Store. But for testing, one may copy an existing .DS_Store from another directory to the default input directory (include/TrustWalletCore/) and then run codegen/bin/codegen to reproduce this error.

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Prefix PR title with `[WIP]` if necessary.
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
