### PR TITLE
support Ethersocial Network

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
@@ -33,6 +33,7 @@ class CoinAddressDerivationTests {
         DASH -> assertEquals("XqHiz8EXYbTAtBEYs4pWTHh7ipEDQcNQeT", address)
         ETHEREUM -> assertEquals("0x8f348F300873Fd5DA36950B2aC75a26584584feE", address)
         ETHEREUMCLASSIC -> assertEquals("0x078bA3228F3E6C08bEEac9A005de0b7e7089aD1c", address)
+        ETHERSOCIAL -> assertEquals("0x182dd55D97C1F8D3781CDaDFC275948Ac38Ea1fe", address)
         GO -> assertEquals("0x5940ce4A14210d4Ccd0ac206CE92F21828016aC2", address)
         GROESTLCOIN -> assertEquals("grs1qexwmshts5pdpeqglkl39zyl6693tmfwp0cue4j", address)
         ICON -> assertEquals("hx18b380b53c23dc4ee9f6666bc20d1be02f3fe106", address)

--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -31,6 +31,7 @@ enum TWCoinType {
     TWCoinTypeDogecoin = 3,
     TWCoinTypeEthereum = 60,
     TWCoinTypeEthereumClassic = 61,
+    TWCoinTypeEthersocial = 31102,
     TWCoinTypeGo = 6060,
     TWCoinTypeGroestlcoin = 17,
     TWCoinTypeICON = 74,

--- a/include/TrustWalletCore/TWEthereumChainID.h
+++ b/include/TrustWalletCore/TWEthereumChainID.h
@@ -17,6 +17,7 @@ enum TWEthereumChainID {
     TWEthereumChainIDPOA = 99,
     TWEthereumChainIDCallisto = 820,
     TWEthereumChainIDEthereumClassic = 61,
+    TWEthereumChainIDEthersocial = 31102,
     TWEthereumChainIDVeChain = 74,
     TWEthereumChainIDThunderToken = 18,
     TWEthereumChainIDTomoChain = 88,

--- a/src/Coin.cpp
+++ b/src/Coin.cpp
@@ -72,6 +72,7 @@ bool TW::validateAddress(TWCoinType coin, const std::string& string) {
     case TWCoinTypeCallisto:
     case TWCoinTypeEthereum:
     case TWCoinTypeEthereumClassic:
+    case TWCoinTypeEthersocial:
     case TWCoinTypeGo:
     case TWCoinTypePoa:
     case TWCoinTypeThunderToken:
@@ -148,6 +149,7 @@ TWPurpose TW::purpose(TWCoinType coin) {
     case TWCoinTypeDecred:
     case TWCoinTypeEthereum:
     case TWCoinTypeEthereumClassic:
+    case TWCoinTypeEthersocial:
     case TWCoinTypeGo:
     case TWCoinTypeICON:
     case TWCoinTypeIOST:
@@ -191,6 +193,7 @@ TWCurve TW::curve(TWCoinType coin) {
     case TWCoinTypeDogecoin:
     case TWCoinTypeEthereum:
     case TWCoinTypeEthereumClassic:
+    case TWCoinTypeEthersocial:
     case TWCoinTypeGo:
     case TWCoinTypeGroestlcoin:
     case TWCoinTypeICON:
@@ -257,6 +260,7 @@ TWHDVersion TW::xpubVersion(TWCoinType coin) {
     case TWCoinTypeCallisto:
     case TWCoinTypeEthereum:
     case TWCoinTypeEthereumClassic:
+    case TWCoinTypeEthersocial:
     case TWCoinTypeGo:
     case TWCoinTypeICON:
     case TWCoinTypeIOST:
@@ -308,6 +312,7 @@ TWHDVersion TW::xprvVersion(TWCoinType coin) {
     case TWCoinTypeCallisto:
     case TWCoinTypeEthereum:
     case TWCoinTypeEthereumClassic:
+    case TWCoinTypeEthersocial:
     case TWCoinTypeGo:
     case TWCoinTypeICON:
     case TWCoinTypeIOST:
@@ -343,6 +348,7 @@ DerivationPath TW::derivationPath(TWCoinType coin) {
     case TWCoinTypeDogecoin:
     case TWCoinTypeEthereum:
     case TWCoinTypeEthereumClassic:
+    case TWCoinTypeEthersocial:
     case TWCoinTypeGo:
     case TWCoinTypeGroestlcoin:
     case TWCoinTypeICON:
@@ -416,6 +422,7 @@ PublicKeyType TW::publicKeyType(TWCoinType coin) {
     case TWCoinTypeCallisto:
     case TWCoinTypeEthereum:
     case TWCoinTypeEthereumClassic:
+    case TWCoinTypeEthersocial:
     case TWCoinTypeGo:
     case TWCoinTypePoa:
     case TWCoinTypeThunderToken:
@@ -476,6 +483,7 @@ std::string TW::deriveAddress(TWCoinType coin, const PublicKey& publicKey) {
     case TWCoinTypeCallisto:
     case TWCoinTypeEthereum:
     case TWCoinTypeEthereumClassic:
+    case TWCoinTypeEthersocial:
     case TWCoinTypeGo:
     case TWCoinTypePoa:
     case TWCoinTypeThunderToken:
@@ -547,6 +555,7 @@ Hash::Hasher TW::publicKeyHasher(TWCoinType coin) {
     case TWCoinTypeDogecoin:
     case TWCoinTypeEthereum:
     case TWCoinTypeEthereumClassic:
+    case TWCoinTypeEthersocial:
     case TWCoinTypeGo:
     case TWCoinTypeGroestlcoin:
     case TWCoinTypeICON:
@@ -593,6 +602,7 @@ Hash::Hasher TW::base58Hasher(TWCoinType coin) {
     case TWCoinTypeDogecoin:
     case TWCoinTypeEthereum:
     case TWCoinTypeEthereumClassic:
+    case TWCoinTypeEthersocial:
     case TWCoinTypeGo:
     case TWCoinTypeICON:
     case TWCoinTypeIOST:

--- a/src/interface/TWCoinTypeConfiguration.cpp
+++ b/src/interface/TWCoinTypeConfiguration.cpp
@@ -26,6 +26,7 @@ TWString *_Nullable TWCoinTypeConfigurationGetSymbol(enum TWCoinType type) {
     case TWCoinTypeDecred: string = "DCR"; break;
     case TWCoinTypeDogecoin: string = "DOGE"; break;
     case TWCoinTypeEthereumClassic:  string = "ETC"; break;
+    case TWCoinTypeEthersocial:  string = "ESN"; break;
     case TWCoinTypeGo:  string =  "GO"; break;
     case TWCoinTypeGroestlcoin: string = "GRS"; break;
     case TWCoinTypeICON:  string =  "ICX"; break;
@@ -65,6 +66,7 @@ int TWCoinTypeConfigurationGetDecimals(enum TWCoinType type) {
     case TWCoinTypeEthereum:
     case TWCoinTypeCallisto:
     case TWCoinTypeEthereumClassic:
+    case TWCoinTypeEthersocial:
     case TWCoinTypeICON:
     case TWCoinTypeGo:
     case TWCoinTypePoa:
@@ -127,6 +129,7 @@ TWString *_Nullable TWCoinTypeConfigurationGetTransactionURL(enum TWCoinType typ
     case TWCoinTypeDogecoin:
     case TWCoinTypeEthereum:
     case TWCoinTypeEthereumClassic:
+    case TWCoinTypeEthersocial:
     case TWCoinTypeGo:
     case TWCoinTypeGroestlcoin:
     case TWCoinTypeKIN:
@@ -187,6 +190,7 @@ const char *explorerURLForCoinType(enum TWCoinType type) {
     case TWCoinTypeDecred: return "https://mainnet.decred.org";
     case TWCoinTypeDogecoin: return "https://live.blockcypher.com/doge";
     case TWCoinTypeEthereumClassic: return "https://gastracker.io";
+    case TWCoinTypeEthersocial: return "https://ethersocial.net";
     case TWCoinTypeGo: return "https://explorer.gochain.io";
     case TWCoinTypeGroestlcoin: return "https://blockbook.groestlcoin.org";
     case TWCoinTypeICON: return "https://tracker.icon.foundation";
@@ -231,6 +235,7 @@ TWString *_Nonnull TWCoinTypeConfigurationGetID(enum TWCoinType type) {
     case TWCoinTypeDecred: string = "decred"; break;
     case TWCoinTypeDogecoin: string = "doge"; break;
     case TWCoinTypeEthereumClassic:  string = "classic"; break;
+    case TWCoinTypeEthersocial:  string = "ethersocial"; break;
     case TWCoinTypeGo:  string =  "gochain"; break;
     case TWCoinTypeGroestlcoin: string = "groestlcoin"; break;
     case TWCoinTypeICON:  string =  "icon"; break;
@@ -276,6 +281,7 @@ TWString *_Nonnull TWCoinTypeConfigurationGetName(enum TWCoinType type) {
     case TWCoinTypeDecred: string = "Decred"; break;
     case TWCoinTypeDogecoin: string = "Dogecoin"; break;
     case TWCoinTypeEthereumClassic:  string = "Ethereum Classic"; break;
+    case TWCoinTypeEthersocial:  string = "Ethersocial"; break;
     case TWCoinTypeGo:  string =  "GoChain"; break;
     case TWCoinTypeGroestlcoin: string =  "Groestlcoin"; break;
     case TWCoinTypeICON:  string =  "ICON"; break;

--- a/swift/Sources/Addresses/CoinType+Address.swift
+++ b/swift/Sources/Addresses/CoinType+Address.swift
@@ -25,6 +25,7 @@ public extension CoinType {
         case .callisto,
              .ethereum,
              .ethereumClassic,
+             .ethersocial,
              .go,
              .poa,
              .theta,

--- a/swift/Sources/ChainID.swift
+++ b/swift/Sources/ChainID.swift
@@ -13,4 +13,5 @@ public enum ChainID: UInt32 {
     case veChain = 74
     case thunderToken = 18
     case tomoChain = 88
+    case ethersocial = 31102
 }

--- a/swift/Tests/CoinAddressDerivationTests.swift
+++ b/swift/Tests/CoinAddressDerivationTests.swift
@@ -49,6 +49,9 @@ class CoinAddressDerivationTests: XCTestCase {
                 case .ethereumClassic:
                     let expectedResult = "0x078bA3228F3E6C08bEEac9A005de0b7e7089aD1c"
                     AssetCoinDerivation(coin, expectedResult, derivedAddress, address)
+                case .ethersocial:
+                    let expectedResult = "0x182dd55D97C1F8D3781CDaDFC275948Ac38Ea1fe"
+                    AssetCoinDerivation(coin, expectedResult, derivedAddress, address)
                 case .go:
                     let expectedResult = "0x5940ce4A14210d4Ccd0ac206CE92F21828016aC2"
                     AssetCoinDerivation(coin, expectedResult, derivedAddress, address)

--- a/swift/Tests/Keystore/WalletTests.swift
+++ b/swift/Tests/Keystore/WalletTests.swift
@@ -15,6 +15,7 @@ class WalletTests: XCTestCase {
         _ = try wallet.getAccount(password: "password", coin: .ethereum)
         _ = try wallet.getAccount(password: "password", coin: .callisto)
         _ = try wallet.getAccount(password: "password", coin: .poa)
+        _ = try wallet.getAccount(password: "password", coin: .ethersocial)
 
         XCTAssertEqual(wallet.key.accountCount, 3)
     }

--- a/swift/Tests/SlipTests.swift
+++ b/swift/Tests/SlipTests.swift
@@ -28,5 +28,6 @@ class SlipTests: XCTestCase {
         XCTAssertEqual(CoinType.xdai.rawValue, 700)
         XCTAssertEqual(CoinType.lux.rawValue, 3003)
         XCTAssertEqual(CoinType.qtum.rawValue, 2301)
+        XCTAssertEqual(CoinType.ethersocial.rawValue, 31102)
     }
 }

--- a/tests/CoinTests.cpp
+++ b/tests/CoinTests.cpp
@@ -121,6 +121,7 @@ TEST(Coin, DeriveAddress) {
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeDecred, privateKey), "Dsp4u8xxTHSZU2ELWTQLQP77xJhgeWrTsGK");
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeEthereum, privateKey), "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F");
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeEthereumClassic, privateKey), "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F");
+    EXPECT_EQ(TW::deriveAddress(TWCoinTypeEthersocial, privateKey), "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F");
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeGo, privateKey), "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F");
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeGroestlcoin, privateKey), "grs1qhkfq3zahaqkkzx5mjnamwjsfpq2jk7z0jsaf3d");
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeICON, privateKey), "hx4728fc65c31728f0d3538b8783b5394b31a136b9");

--- a/tests/interface/TWCoinTypeConfigTests.cpp
+++ b/tests/interface/TWCoinTypeConfigTests.cpp
@@ -91,6 +91,9 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetSymbol) {
 
     auto value27 = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeQtum));
     assertStringsEqual(value27, "QTUM");
+
+    auto value28 = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeEthersocial));
+    assertStringsEqual(value28, "ESN");
 }
 
 TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetDecimals) {
@@ -101,6 +104,7 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetDecimals) {
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeDash), 8);
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeDecred), 8);
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeEthereumClassic), 18);
+    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeEthersocial), 18);
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeGo), 18);
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeGroestlcoin), 8);
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeICON), 18);
@@ -217,6 +221,9 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetTransactionURL) {
 
     auto value31 = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeQtum, txId));
     assertStringsEqual(value31, "https://qtum.info/tx/123");
+
+    auto value32 = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeEthersocial, txId));
+    assertStringsEqual(value32, "https://ethersocial.net/tx/123");
 }
 
 TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetID) {
@@ -297,6 +304,9 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetID) {
 
     auto value27 = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeQtum));
     assertStringsEqual(value27, "qtum");
+
+    auto value28 = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeEthersocial));
+    assertStringsEqual(value28, "ethersocial");
 }
 
 TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetName) {
@@ -381,4 +391,7 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetName) {
 
     auto value28 = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeQtum));
     assertStringsEqual(value28, "Qtum");
+
+    auto value29 = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeEthersocial));
+    assertStringsEqual(value29, "Ethersocial");
 }


### PR DESCRIPTION
## Description
add Ethersocial Network (ESN) support

- Homepage: https://ethersocial.org/
- Block Explorer : https://ethersocial.net
- API node: https://api.esn.gonspool.com
- BIP44 / Chainid `31102` ( satoshilabs/slips#277 )
- Ticker: ESN
- CMC: https://coinmarketcap.com/currencies/ethersocial/

## Testing instructions
`./bootstrap.sh` or `make -C build tests`

## Types of changes
Ethersocial Network support added

## Checklist

- [x] Add tests to cover changes as needed.
