### PR TITLE
Fix JS Bech32Address and HDWallet tests

### DIFF
--- a/js/cpp/TWNapi.h
+++ b/js/cpp/TWNapi.h
@@ -16,7 +16,7 @@
 
 #include <TrustWalletCore/TWBitcoinOpCodes.h>
 #include <TrustWalletCore/TWBitcoinScript.h>
-#include <TrustWalletCore/TWBech32Address.h>
+#include <TrustWalletCore/TWSegwitAddress.h>
 
 #include <napi.h>
 

--- a/js/tests/blockchain/bitcoin/SegwitAddress.test.ts
+++ b/js/tests/blockchain/bitcoin/SegwitAddress.test.ts
@@ -2,14 +2,14 @@ import { expect } from 'chai';
 import 'mocha';
 
 import { fromHexString } from '../../Utils';
-import { PublicKey, Bech32Address, HRP } from '../../../lib';
+import { PublicKey, SegwitAddress, HRP } from '../../../lib';
 
-describe('Bech32Address', () => {
+describe('SegwitAddress', () => {
 
     it('test from public', () => {
         const data = fromHexString('0x02f1e733ed6030cc569c4323a34b17e192d58107d9ffbce71c8420b779f484dba1');
         const publicKey = PublicKey.createWithData(data);
-        const address = Bech32Address.createWithPublicKey(HRP.BITCOIN, publicKey);
+        const address = SegwitAddress.createWithPublicKey(HRP.BITCOIN, publicKey);
         expect(address.description()).to.equal('bc1qrq6gs660qewd282en83n6em9s4rlslj3cd2wmg');
     });
 

--- a/js/tests/utils/HDWallet.test.ts
+++ b/js/tests/utils/HDWallet.test.ts
@@ -64,8 +64,8 @@ describe('Bech32Address', () => {
 
     it('test PublicKey from X', () => {
         const xpub = 'xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj';
-        const xpubAddr2 = HDWallet.getPublicKeyFromExtended(xpub, CoinType.BITCOIN, HDVersion.XPUB, HDVersion.XPRV, 0, 2);
-        const xpubAddr9 = HDWallet.getPublicKeyFromExtended(xpub, CoinType.BITCOIN, HDVersion.XPUB, HDVersion.XPRV, 0, 9);
+        const xpubAddr2 = HDWallet.getPublicKeyFromExtended(xpub, 'm/44\'/145\'/0\'/0/2');
+        const xpubAddr9 = HDWallet.getPublicKeyFromExtended(xpub, 'm/44\'/145\'/0\'/0/9');
 
         expect(bufToHex(xpubAddr2.data()), '0x0338994349b3a804c44bbec55c2824443ebb9e475dfdad14f4b1a01a97d42751b3');
         expect(bufToHex(xpubAddr9.data()), '0x03786c1d274f2c804ff9a57d8e7289c281d4aef15e17187ad9f9c3722d81a6ae66');


### PR DESCRIPTION
## Description

- Change `Bech32Address` imports and tests
- Fix HDWallet test
