### PR TITLE
Bravo: Remove "Serializable" class as it is not used anymore

### DIFF
--- a/src/Bravo/Asset.h
+++ b/src/Bravo/Asset.h
@@ -9,7 +9,7 @@
 namespace TW::Bravo {
 
 // An asset class that can be used by Bravo, EOS, steem, et. al.
-class Asset: Serializable {
+class Asset {
 public:
     int64_t amount;
     uint64_t symbol = 0;

--- a/src/Bravo/Operation.h
+++ b/src/Bravo/Operation.h
@@ -12,7 +12,7 @@ namespace TW::Bravo {
 const static unsigned int MaxMemoSize = 2048;
 const static unsigned int MaxAccountNameSize = 16;
 
-class Operation : public Serializable {
+class Operation {
   public:
     virtual void serialize(Data& os) const = 0;
     virtual nlohmann::json serialize() const = 0;

--- a/src/Bravo/Serialization.h
+++ b/src/Bravo/Serialization.h
@@ -10,11 +10,6 @@
 #include <string>
 
 namespace TW::Bravo {
-class Serializable {
-public:
-    virtual void serialize(Data& os) const = 0;
-};
-
 inline void encodeVarInt64(uint64_t x, Data& os) {
     // 64-bit int would take at most 10 bytes as a varint
     static const int maxBytes = 10;
@@ -44,13 +39,13 @@ inline void encodeVarInt32(uint32_t x, Data& os) {
 
 inline void encodeString(const std::string& s, Data& os) {
     size_t size = s.size();
-    encodeVarInt32(static_cast<uint32_t>(size), os);
+    encodeVarInt64(size, os);
     os.insert(os.end(), s.data(), s.data() + size);
 }
 
 template<typename Collection>
 inline void encodeCollection(const Collection& collection, Data& os) {
-    encodeVarInt32(static_cast<uint32_t>(std::size(collection)), os);
+    encodeVarInt64(std::size(collection), os);
     for (const auto& item : collection) {
         item.serialize(os);
     }
@@ -58,7 +53,7 @@ inline void encodeCollection(const Collection& collection, Data& os) {
 
 template<typename Collection>
 inline void encodePointerCollection(const Collection& collection, Data& os) {
-    encodeVarInt32(static_cast<uint32_t>(std::size(collection)), os);
+    encodeVarInt64(std::size(collection), os);
     for (const auto& item : collection) {
         item->serialize(os);
     }

--- a/src/Bravo/Transaction.h
+++ b/src/Bravo/Transaction.h
@@ -12,7 +12,7 @@
 
 namespace TW::Bravo {
 
-class Signature : Serializable {
+class Signature {
   private:
     static const unsigned long DataSize = 65;
 
@@ -25,14 +25,14 @@ class Signature : Serializable {
 };
 
 /// for the future
-class FutureExtension : Serializable {
+class FutureExtension {
   public:
     virtual ~FutureExtension() = 0;
     virtual void serialize(Data& os) const = 0;
     virtual nlohmann::json serialize() const = 0;
 };
 
-class Transaction : Serializable {
+class Transaction {
   public:
     Transaction(const Data& referenceBlockId, int32_t referenceBlockTime);
 


### PR DESCRIPTION
## Description
While originally designing the Bravo/graphene code, we had created an interface class "Serializable". This class has no use anymore and hence we are removing it to clean up the codebase. Also, collection sizes are now encoded as uint64 instead of uint32.

## Testing instructions
Compiling and running existing tests should 

## Types of changes
* Non-breaking change which cleans up the code

## Checklist

- [ ] Prefix PR title with `[WIP]` if necessary.
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.