### PR TITLE
Cosmos support - Add cosmos address validation with different prefixes

### DIFF
--- a/tests/Cosmos/AddressTests.cpp
+++ b/tests/Cosmos/AddressTests.cpp
@@ -32,7 +32,7 @@ TEST(Address, FromKeyHash) {
     ASSERT_EQ(address.string(), "bnb1grpf0955h0ykzq3ar5nmum7y6gdfl6lxfn46h2");
 }
 
-TEST(Address, FromKeyHashCosmos) {
+TEST(Address, Cosmos_FromKeyHash) {
     auto privateKey = PrivateKey(parse_hex("80e81ea269e66a0a05b11236df7919fb7fbeedba87452d667489d7403a02f005"));
     auto publicKeyData = privateKey.getPublicKey(TWPublicKeyTypeSECP256k1);
     ASSERT_EQ(hex(publicKeyData.bytes.begin(), publicKeyData.bytes.end()), "0257286ec3f37d33557bbbaa000b27744ac9023aa9967cae75a181d1ff91fa9dc5");
@@ -42,4 +42,17 @@ TEST(Address, FromKeyHashCosmos) {
     ASSERT_EQ(address.string(), "cosmos1hsk6jryyqjfhp5dhc55tc9jtckygx0eph6dd02");
 }
 
+TEST(Address, Cosmos_Valid) {
+    ASSERT_TRUE(Address::isValid("cosmos1hsk6jryyqjfhp5dhc55tc9jtckygx0eph6dd02"));
+    ASSERT_TRUE(Address::isValid("cosmospub1addwnpepqftjsmkr7d7nx4tmhw4qqze8w39vjq364xt8etn45xqarlu3l2wu2n7pgrq"));
+    ASSERT_TRUE(Address::isValid("cosmosvaloper1sxx9mszve0gaedz5ld7qdkjkfv8z992ax69k08"));
+    ASSERT_TRUE(Address::isValid("cosmosvalconspub1zcjduepqjnnwe2jsywv0kfc97pz04zkm7tc9k2437cde2my3y5js9t7cw9mstfg3sa"));
+}
+
+TEST(Address, Cosmos_Invalid) {
+    ASSERT_FALSE(Address::isValid("cosmos1xsk6jryyqjfhp5dhc55tc9jtckygx0eph6dd02"));
+    ASSERT_FALSE(Address::isValid("cosmospub1xddwnpepqftjsmkr7d7nx4tmhw4qqze8w39vjq364xt8etn45xqarlu3l2wu2n7pgrq"));
+    ASSERT_FALSE(Address::isValid("cosmosvaloper1xxx9mszve0gaedz5ld7qdkjkfv8z992ax69k08"));
+    ASSERT_FALSE(Address::isValid("cosmosvalconspub1xcjduepqjnnwe2jsywv0kfc97pz04zkm7tc9k2437cde2my3y5js9t7cw9mstfg3sa"));
+}
 } // namespace TW::Cosmos


### PR DESCRIPTION
## Description
Add tests for validating various Cosmos addresses

## Issue
https://github.com/TrustWallet/wallet-core/issues/255