### PR TITLE
Fix verifying ed25519 signature

### DIFF
--- a/src/PublicKey.cpp
+++ b/src/PublicKey.cpp
@@ -61,9 +61,9 @@ bool PublicKey::verify(const Data& signature, const Data& message) const {
     case TWPublicKeyTypeNIST256p1Extended:
         return ecdsa_verify_digest(&nist256p1, bytes.data(), signature.data(), message.data()) == 0;
     case TWPublicKeyTypeED25519:
-        return ed25519_sign_open(message.data(), message.size(), bytes.data() + 1, signature.data()) == 0;
+        return ed25519_sign_open(message.data(), message.size(), bytes.data(), signature.data()) == 0;
     case TWPublicKeyTypeED25519Blake2b:
-        return ed25519_sign_open_blake2b(message.data(), message.size(), bytes.data() + 1, signature.data()) == 0;
+        return ed25519_sign_open_blake2b(message.data(), message.size(), bytes.data(), signature.data()) == 0;
     }
 }
 

--- a/swift/Tests/PublicKeyTests.swift
+++ b/swift/Tests/PublicKeyTests.swift
@@ -8,10 +8,31 @@ import TrustWalletCore
 import XCTest
 
 class PublicKeyTests: XCTestCase {
-    func testCompressed() {
-        let privateKey = PrivateKey(data: Data(hexString: "afeefca74d9a325cf1d6b6911d61a65c32afa8e02bd5e78e2e4ac2910bab45f5")!)!
-        let publicKey = privateKey.getPublicKeySecp256k1(compressed: false)
 
+    let privateKey = PrivateKey(data: Data(hexString: "afeefca74d9a325cf1d6b6911d61a65c32afa8e02bd5e78e2e4ac2910bab45f5")!)!
+
+    func testCompressed() {
+        let publicKey = privateKey.getPublicKeySecp256k1(compressed: false)
         XCTAssertEqual(publicKey.compressed.data.hexString, "0399c6f51ad6f98c9c583f8e92bb7758ab2ca9a04110c0a1126ec43e5453d196c1")
+    }
+
+    func testVerify() {
+
+        let message = Hash.sha256(data: "hello".data(using: .utf8)!)
+        let sig1 = privateKey.sign(digest: message, curve: .ed25519)!
+        let result1 = privateKey.getPublicKeyEd25519()
+                            .verify(signature: sig1, message: message)
+
+        let sig2 = privateKey.sign(digest: message, curve: .ed25519Blake2bNano)!
+        let result2 = privateKey.getPublicKeyEd25519Blake2b()
+            .verify(signature: sig2, message: message)
+
+        let sig3 = privateKey.sign(digest: message, curve: .secp256k1)!
+        let result3 = privateKey.getPublicKeySecp256k1(compressed: true)
+                            .verify(signature: sig3, message: message)
+
+        XCTAssertTrue(result1)
+        XCTAssertTrue(result2)
+        XCTAssertTrue(result3)
     }
 }

--- a/tests/interface/TWPublicKeyTests.cpp
+++ b/tests/interface/TWPublicKeyTests.cpp
@@ -7,12 +7,16 @@
 #include "TWTestUtilities.h"
 
 #include "PublicKey.h"
+#include "PrivateKey.h"
+#include "HexCoding.h"
 
 #include <TrustWalletCore/TWHash.h>
 #include <TrustWalletCore/TWPrivateKey.h>
 #include <TrustWalletCore/TWPublicKey.h>
 
 #include <gtest/gtest.h>
+
+using namespace TW;
 
 TEST(PublicKeyTests, Compressed) {
     uint8_t bytes[] = {0xaf, 0xee, 0xfc, 0xa7, 0x4d, 0x9a, 0x32, 0x5c, 0xf1, 0xd6, 0xb6, 0x91, 0x1d, 0x61, 0xa6, 0x5c, 0x32, 0xaf, 0xa8, 0xe0, 0x2b, 0xd5, 0xe7, 0x8e, 0x2e, 0x4a, 0xc2, 0x91, 0x0b, 0xab, 0x45, 0xf5};
@@ -41,4 +45,22 @@ TEST(PublicKeyTests, Verify) {
 
     auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), false);
     ASSERT_TRUE(TWPublicKeyVerify(publicKey, signature.get(), digest.get()));
+}
+
+TEST(PublicKeyTests, VerifyEd25519) {
+    const auto key = PrivateKey(parse_hex("afeefca74d9a325cf1d6b6911d61a65c32afa8e02bd5e78e2e4ac2910bab45f5"));
+    auto privateKey = WRAP(TWPrivateKey, new TWPrivateKey{ key });
+
+    const char *message = "Hello";
+    auto messageData = WRAPD(TWDataCreateWithBytes((const uint8_t *)message, strlen(message)));
+    auto digest = WRAPD(TWHashSHA256(messageData.get()));
+
+    auto signature = WRAPD(TWPrivateKeySign(privateKey.get(), digest.get(), TWCurveED25519));
+    auto publicKey = TWPrivateKeyGetPublicKeyEd25519(privateKey.get());
+
+    auto signature2 = WRAPD(TWPrivateKeySign(privateKey.get(), digest.get(), TWCurveED25519Blake2bNano));
+    auto publicKey2 = TWPrivateKeyGetPublicKeyEd25519Blake2b(privateKey.get());
+
+    ASSERT_TRUE(TWPublicKeyVerify(publicKey, signature.get(), digest.get()));
+    ASSERT_TRUE(TWPublicKeyVerify(publicKey2, signature2.get(), digest.get()));
 }


### PR DESCRIPTION
Fix verifying ed25519 signature, this is introduced when we refactored public key type (https://github.com/TrustWallet/wallet-core/pull/378)