### PR TITLE
Fix method keystore.updateWallet for multiple accounts wallets

### DIFF
--- a/swift/Sources/Keystore/KeyStore.swift
+++ b/swift/Sources/Keystore/KeyStore.swift
@@ -251,7 +251,7 @@ public final class KeyStore {
         defer {
             privateKeyData.resetBytes(in: 0 ..< privateKeyData.count)
         }
-        
+
         let coins = wallet.accounts.map({ $0.coin })
         guard !coins.isEmpty else {
             throw Error.accountNotFound

--- a/swift/Sources/Keystore/KeyStore.swift
+++ b/swift/Sources/Keystore/KeyStore.swift
@@ -257,9 +257,11 @@ public final class KeyStore {
             throw Error.accountNotFound
         }
 
-        if let mnemonic = checkMnemonic(privateKeyData), let key = StoredKey.importHDWallet(mnemonic: mnemonic, name: wallet.key.name, password: newPassword, coin: coins[0]) {
+        if let mnemonic = checkMnemonic(privateKeyData),
+            let key = StoredKey.importHDWallet(mnemonic: mnemonic, name: wallet.key.name, password: newPassword, coin: coins[0]) {
             wallets[index].key = key
-        } else if let key = StoredKey.importPrivateKey(privateKey: privateKeyData, name: wallet.key.name, password: newPassword, coin: coins[0]) {
+        } else if let key = StoredKey.importPrivateKey(
+                privateKey: privateKeyData, name: wallet.key.name, password: newPassword, coin: coins[0]) {
             wallets[index].key = key
         } else {
             throw Error.invalidKey

--- a/swift/Sources/Keystore/KeyStore.swift
+++ b/swift/Sources/Keystore/KeyStore.swift
@@ -264,7 +264,7 @@ public final class KeyStore {
         } else {
             throw Error.invalidKey
         }
-        
+
         _ = try wallets[index].getAccounts(password: newPassword, coins: coins)
     }
 

--- a/swift/Sources/Keystore/KeyStore.swift
+++ b/swift/Sources/Keystore/KeyStore.swift
@@ -251,18 +251,21 @@ public final class KeyStore {
         defer {
             privateKeyData.resetBytes(in: 0 ..< privateKeyData.count)
         }
-
-        guard let coin = wallet.key.account(index: 0)?.coin else {
+        
+        let coins = wallet.accounts.map({ $0.coin })
+        guard !coins.isEmpty else {
             throw Error.accountNotFound
         }
 
-        if let mnemonic = checkMnemonic(privateKeyData), let key = StoredKey.importHDWallet(mnemonic: mnemonic, name: wallet.key.name, password: newPassword, coin: coin) {
+        if let mnemonic = checkMnemonic(privateKeyData), let key = StoredKey.importHDWallet(mnemonic: mnemonic, name: wallet.key.name, password: newPassword, coin: coins[0]) {
             wallets[index].key = key
-        } else if let key = StoredKey.importPrivateKey(privateKey: privateKeyData, name: wallet.key.name, password: newPassword, coin: coin) {
+        } else if let key = StoredKey.importPrivateKey(privateKey: privateKeyData, name: wallet.key.name, password: newPassword, coin: coins[0]) {
             wallets[index].key = key
         } else {
             throw Error.invalidKey
         }
+        
+        _ = try wallets[index].getAccounts(password: newPassword, coins: coins)
     }
 
     /// Deletes an account including its key if the password is correct.

--- a/swift/Tests/Keystore/KeyStoreTests.swift
+++ b/swift/Tests/Keystore/KeyStoreTests.swift
@@ -82,13 +82,17 @@ class KeyStoreTests: XCTestCase {
 
     func testUpdateKey() throws {
         let keyStore = try KeyStore(keyDirectory: keyDirectory)
-        let wallet = keyStore.keyWallet!
-        try keyStore.update(wallet: wallet, password: "testpassword", newPassword: "password")
-        let data = wallet.key.decryptPrivateKey(password: "password")
-        let privateKey = PrivateKey(data: data!)
-
+        let wallet = try keyStore.createWallet(name: "name", password: "password", coins: [.ethereum, .callisto, .poanetwork])
+        
+        try keyStore.update(wallet: wallet, password: "password", newPassword: "testpassword")
+        
+        let data = wallet.key.decryptPrivateKey(password: "testpassword")
+        let mnemonic = String(data: data!, encoding: .ascii)
+        
+        XCTAssertEqual(wallet.accounts.count, 3)
         XCTAssertNotNil(data)
-        XCTAssertNotNil(privateKey)
+        XCTAssertNotNil(mnemonic)
+        XCTAssert(HDWallet.isValid(mnemonic: mnemonic!))
     }
 
     func testAddAccounts() throws {

--- a/swift/Tests/Keystore/KeyStoreTests.swift
+++ b/swift/Tests/Keystore/KeyStoreTests.swift
@@ -83,12 +83,12 @@ class KeyStoreTests: XCTestCase {
     func testUpdateKey() throws {
         let keyStore = try KeyStore(keyDirectory: keyDirectory)
         let wallet = try keyStore.createWallet(name: "name", password: "password", coins: [.ethereum, .callisto, .poanetwork])
-        
+
         try keyStore.update(wallet: wallet, password: "password", newPassword: "testpassword")
-        
+
         let data = wallet.key.decryptPrivateKey(password: "testpassword")
         let mnemonic = String(data: data!, encoding: .ascii)
-        
+
         XCTAssertEqual(wallet.accounts.count, 3)
         XCTAssertNotNil(data)
         XCTAssertNotNil(mnemonic)

--- a/swift/Tests/Keystore/KeyStoreTests.swift
+++ b/swift/Tests/Keystore/KeyStoreTests.swift
@@ -82,14 +82,15 @@ class KeyStoreTests: XCTestCase {
 
     func testUpdateKey() throws {
         let keyStore = try KeyStore(keyDirectory: keyDirectory)
-        let wallet = try keyStore.createWallet(name: "name", password: "password", coins: [.ethereum, .callisto, .poanetwork])
+        let coins = [CoinType.ethereum, .callisto, .poanetwork]
+        let wallet = try keyStore.createWallet(name: "name", password: "password", coins: coins)
 
         try keyStore.update(wallet: wallet, password: "password", newPassword: "testpassword")
 
         let data = wallet.key.decryptPrivateKey(password: "testpassword")
         let mnemonic = String(data: data!, encoding: .ascii)
 
-        XCTAssertEqual(wallet.accounts.count, 3)
+        XCTAssertEqual(wallet.accounts.count, coins.count)
         XCTAssertNotNil(data)
         XCTAssertNotNil(mnemonic)
         XCTAssert(HDWallet.isValid(mnemonic: mnemonic!))


### PR DESCRIPTION
## Description

Triggering method updateWallet(wallet: Wallet, password: String, newPassword: String) to update wallet password caused also removing all wallet accounts except the first one. 

## Testing instructions

1. Create a Wallet with support for multiple coins
2. Update wallet password

Excepted result: 
The same wallet with changed password

Current behavior:
Wallet for first coin with changed password

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.