### PR TITLE
Add option to update Wallet Name

### DIFF
--- a/swift/Sources/Keystore/KeyStore.swift
+++ b/swift/Sources/Keystore/KeyStore.swift
@@ -241,6 +241,20 @@ public final class KeyStore {
     ///   - password: current password
     ///   - newPassword: new password
     public func update(wallet: Wallet, password: String, newPassword: String) throws {
+        try update(wallet: wallet, password: password, newPassword: newPassword, newName: wallet.key.name)
+    }
+    
+    /// Updates the name of an existing account.
+    ///
+    /// - Parameters:
+    ///   - wallet: wallet to update
+    ///   - password: current password
+    ///   - newName: new name
+    public func update(wallet: Wallet, password: String, newName: String) throws {
+        try update(wallet: wallet, password: password, newPassword: password, newName: newName)
+    }
+    
+    private func update(wallet: Wallet, password: String, newPassword: String, newName: String) throws {
         guard let index = wallets.firstIndex(of: wallet) else {
             fatalError("Missing wallet")
         }
@@ -258,10 +272,10 @@ public final class KeyStore {
         }
 
         if let mnemonic = checkMnemonic(privateKeyData),
-            let key = StoredKey.importHDWallet(mnemonic: mnemonic, name: wallet.key.name, password: newPassword, coin: coins[0]) {
+            let key = StoredKey.importHDWallet(mnemonic: mnemonic, name: newName, password: newPassword, coin: coins[0]) {
             wallets[index].key = key
         } else if let key = StoredKey.importPrivateKey(
-                privateKey: privateKeyData, name: wallet.key.name, password: newPassword, coin: coins[0]) {
+                privateKey: privateKeyData, name: newName, password: newPassword, coin: coins[0]) {
             wallets[index].key = key
         } else {
             throw Error.invalidKey

--- a/swift/Sources/Keystore/KeyStore.swift
+++ b/swift/Sources/Keystore/KeyStore.swift
@@ -253,7 +253,7 @@ public final class KeyStore {
     public func update(wallet: Wallet, password: String, newName: String) throws {
         try update(wallet: wallet, password: password, newPassword: password, newName: newName)
     }
-    
+
     private func update(wallet: Wallet, password: String, newPassword: String, newName: String) throws {
         guard let index = wallets.firstIndex(of: wallet) else {
             fatalError("Missing wallet")

--- a/swift/Sources/Keystore/KeyStore.swift
+++ b/swift/Sources/Keystore/KeyStore.swift
@@ -243,7 +243,7 @@ public final class KeyStore {
     public func update(wallet: Wallet, password: String, newPassword: String) throws {
         try update(wallet: wallet, password: password, newPassword: newPassword, newName: wallet.key.name)
     }
-    
+
     /// Updates the name of an existing account.
     ///
     /// - Parameters:

--- a/swift/Tests/Keystore/KeyStoreTests.swift
+++ b/swift/Tests/Keystore/KeyStoreTests.swift
@@ -106,7 +106,7 @@ class KeyStoreTests: XCTestCase {
         
         let data = wallet.key.decryptPrivateKey(password: "password")
         let mnemonic = String(data: data!, encoding: .ascii)
-        
+
         XCTAssertEqual(wallet.accounts.count, coins.count)
         XCTAssertNotNil(data)
         XCTAssertNotNil(mnemonic)

--- a/swift/Tests/Keystore/KeyStoreTests.swift
+++ b/swift/Tests/Keystore/KeyStoreTests.swift
@@ -94,6 +94,24 @@ class KeyStoreTests: XCTestCase {
         XCTAssertNotNil(data)
         XCTAssertNotNil(mnemonic)
         XCTAssert(HDWallet.isValid(mnemonic: mnemonic!))
+        XCTAssertEqual(wallet.key.name, "name")
+    }
+
+    func testUpdateName() throws {
+        let keyStore = try KeyStore(keyDirectory: keyDirectory)
+        let coins = [CoinType.ethereum, .callisto, .poanetwork]
+        let wallet = try keyStore.createWallet(name: "name", password: "password", coins: coins)
+        
+        try keyStore.update(wallet: wallet, password: "password", newName: "testname")
+        
+        let data = wallet.key.decryptPrivateKey(password: "password")
+        let mnemonic = String(data: data!, encoding: .ascii)
+        
+        XCTAssertEqual(wallet.accounts.count, coins.count)
+        XCTAssertNotNil(data)
+        XCTAssertNotNil(mnemonic)
+        XCTAssert(HDWallet.isValid(mnemonic: mnemonic!))
+        XCTAssertEqual(wallet.key.name, "testname")
     }
 
     func testAddAccounts() throws {

--- a/swift/Tests/Keystore/KeyStoreTests.swift
+++ b/swift/Tests/Keystore/KeyStoreTests.swift
@@ -101,9 +101,9 @@ class KeyStoreTests: XCTestCase {
         let keyStore = try KeyStore(keyDirectory: keyDirectory)
         let coins = [CoinType.ethereum, .callisto, .poanetwork]
         let wallet = try keyStore.createWallet(name: "name", password: "password", coins: coins)
-        
+
         try keyStore.update(wallet: wallet, password: "password", newName: "testname")
-        
+
         let data = wallet.key.decryptPrivateKey(password: "password")
         let mnemonic = String(data: data!, encoding: .ascii)
 


### PR DESCRIPTION
## Description

Currently, it's possible to update only wallet password, but it's not possible to update wallet name via KeyStore.

It's very similar operation as updating password (both of them are stored in StoredKey) so I reuse existing code for password updating in new private method to handle KeyStore update and create two public methods - one for updating password (compatible with previous code), the second one for updating the name.

## Testing instructions

* Create wallet
* Update name
* Check updated name

## Types of changes

* New feature (non-breaking change which adds functionality)

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.