### PR TITLE
Rename TransactionSigner to AnySigner

### DIFF
--- a/include/TrustWalletCore/TWAnySigner.h
+++ b/include/TrustWalletCore/TWAnySigner.h
@@ -12,11 +12,11 @@
 TW_EXTERN_C_BEGIN
 
 TW_EXPORT_CLASS
-struct TWTransactionSigner;
+struct TWAnySigner;
 
 /// Signs a transaction.
 TW_EXPORT_STATIC_METHOD
-TW_Signer_Proto_SigningOutput TWTransactionSignerSign(TW_Signer_Proto_SigningInput input);
+TW_Signer_Proto_SigningOutput TWAnySignerSign(TW_Signer_Proto_SigningInput input);
 
 
 TW_EXTERN_C_END

--- a/src/AnySigner.cpp
+++ b/src/AnySigner.cpp
@@ -7,7 +7,7 @@
 #include "Data.h"
 #include "Coin.h"
 #include "PrivateKey.h"
-#include "TransactionSigner.h"
+#include "AnySigner.h"
 #include "HexCoding.h"
 #include "Cosmos/Signer.h"
 #include "Binance/Signer.h"
@@ -22,7 +22,7 @@ using namespace TW;
 using namespace TW::Signer;
 using namespace google::protobuf;
 
-Proto::SigningOutput TransactionSigner::sign() const noexcept {
+Proto::SigningOutput AnySigner::sign() const noexcept {
     const auto coinType = (TWCoinType) input.coin_type();
     const auto transaction = input.transaction();
     const auto privateKeyData = parse_hex(input.private_key());
@@ -73,7 +73,7 @@ Proto::SigningOutput TransactionSigner::sign() const noexcept {
     return output;
 }
 
-void TransactionSigner::parse(const std::string& transaction, Message* message,
+void AnySigner::parse(const std::string& transaction, Message* message,
                    Proto::SigningOutput& output) const noexcept {
     util::JsonParseOptions options;
     options.case_insensitive_enum_parsing = true;

--- a/src/AnySigner.h
+++ b/src/AnySigner.h
@@ -15,9 +15,9 @@ enum SignerErrorCode {
 
 namespace TW {
 /// Helper class to perform json signing
-class TransactionSigner {
+class AnySigner {
 public:
-    explicit TransactionSigner(const Signer::Proto::SigningInput& input) : input(input) {}
+    explicit AnySigner(const Signer::Proto::SigningInput& input) : input(input) {}
 
     Signer::Proto::SigningOutput sign() const noexcept;
 private:
@@ -29,7 +29,7 @@ private:
 }
 
 /// Wrapper for C interface.
-struct TWSigner {
-    TW::TransactionSigner impl;
+struct TWAnySigner {
+    TW::AnySigner impl;
 };
 

--- a/src/interface/TWAnySigner.cpp
+++ b/src/interface/TWAnySigner.cpp
@@ -4,19 +4,19 @@
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
 
-#include <TrustWalletCore/TWTransactionSigner.h>
+#include <TrustWalletCore/TWAnySigner.h>
 
-#include "TransactionSigner.h"
+#include "AnySigner.h"
 
 using namespace TW;
 using namespace TW::Signer;
 
-TW_Signer_Proto_SigningOutput TWTransactionSignerSign(TW_Signer_Proto_SigningInput data)
+TW_Signer_Proto_SigningOutput TWAnySignerSign(TW_Signer_Proto_SigningInput data)
 {
     Proto::SigningInput input;
     input.ParseFromArray(TWDataBytes(data), static_cast<int>(TWDataSize(data)));
 
-    auto signer = new TWSigner{ TransactionSigner(input) };
+    auto signer = new TWAnySigner{ AnySigner(input) };
     Proto::SigningOutput output = signer->impl.sign();
 
     auto serialized = output.SerializeAsString();

--- a/tests/AnySignerTests.cpp
+++ b/tests/AnySignerTests.cpp
@@ -4,7 +4,7 @@
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
 
-#include "TransactionSigner.h"
+#include "AnySigner.h"
 #include "Coin.h"
 #include "Base64.h"
 
@@ -21,7 +21,7 @@ TEST(Signer, CosmosTransactionSign) {
     input.set_transaction(transaction);
     input.set_coin_type(TWCoinTypeCosmos);
 
-    auto signer = TransactionSigner(input);
+    auto signer = AnySigner(input);
     auto output = signer.sign();
 
     ASSERT_FALSE(output.has_error());
@@ -37,7 +37,7 @@ TEST(Signer, BinanceTransactionSign) {
     input.set_transaction(transaction);
     input.set_coin_type(TWCoinTypeBinance);
 
-    auto signer = TransactionSigner(input);
+    auto signer = AnySigner(input);
     auto output = signer.sign();
 
     ASSERT_FALSE(output.has_error());
@@ -53,7 +53,7 @@ TEST(Signer, EthereumTransactionSign) {
     input.set_transaction(transaction);
     input.set_coin_type(TWCoinTypeEthereum);
 
-    auto signer = TransactionSigner(input);
+    auto signer = AnySigner(input);
     auto output = signer.sign();
 
     ASSERT_FALSE(output.has_error());
@@ -69,7 +69,7 @@ TEST(Signer, NetworkNotSupported) {
     input.set_transaction(transaction);
     input.set_coin_type(TWCoinTypeBitcoinCash);
 
-    auto signer = TransactionSigner(input);
+    auto signer = AnySigner(input);
     auto output = signer.sign();
 
     ASSERT_TRUE(output.has_error());
@@ -84,7 +84,7 @@ TEST(Signer, InvalidJsonFormat) {
     input.set_transaction(transaction);
     input.set_coin_type(TWCoinTypeCosmos);
 
-    auto signer = TransactionSigner(input);
+    auto signer = AnySigner(input);
     auto output = signer.sign();
 
     ASSERT_TRUE(output.has_error());


### PR DESCRIPTION
After `pod install` all files are in a flat folder, there is a file already called `TransactionSigner.h`, This fixes potential conflicts