### PR TITLE
Add -fno-aligned-allocation to Podspec

### DIFF
--- a/TrustWalletCore.podspec
+++ b/TrustWalletCore.podspec
@@ -155,7 +155,8 @@ Pod::Spec.new do |s|
     'GCC_WARN_UNUSED_FUNCTION' => 'NO',
     'GCC_WARN_64_TO_32_BIT_CONVERSION' => 'NO',
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
-    'OTHER_CFLAGS' => '-DHAVE_PTHREAD=1'
+    'OTHER_CFLAGS' => '-DHAVE_PTHREAD=1',
+    'OTHER_CPLUSPLUSFLAGS' => '$(OTHER_CFLAGS) -fno-aligned-allocation'
   }
   s.pod_target_xcconfig = {
     'SYSTEM_HEADER_SEARCH_PATHS' => '$(inherited) /usr/local/include'


### PR DESCRIPTION
## Description

This PR adds fix applied by @alejandro-isaza for not compatible "aligned allocation"  https://github.com/TrustWallet/wallet-core/commit/b1b876baa123cb7a7ca3cb52b7fd22246ad88e1d also to static Podspec file. 

Previously this flag `-fno-aligned-allocation` was added only to ios.toolchain.cmake that is not used in case when we have TrustWalletCore pod installed directly from GitHub, like:
`pod 'TrustWalletCore', :git => 'git@github.com:TrustWallet/wallet-core.git', :branch => 'master'`

Without proposed change, it's not possible to archive successfully the project. It finishes with a lot of similar errors:
```
Pods/TrustWalletCore/src/interface/TWBitcoinTransactionSigner.cpp:24:12: aligned allocation function of type 'void *(unsigned long, enum std::align_val_t)' is only available on iOS 11 or newer

return new TWBitcoinTransactionSigner{ TransactionSigner<Transaction>(std::move(input)) };
    ^~~
```

## Testing instructions

Use TrustWalletCore declaration GitHub source:
`pod 'TrustWalletCore', :git => 'git@github.com:TrustWallet/wallet-core.git', :branch => 'master'`

Try to archive the project with and without the fix.

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.