### PR TITLE
Support for Bitshares

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
@@ -80,5 +80,6 @@ class CoinAddressDerivationTests {
         MONETARYUNIT -> assertEquals("7W3QRu8FttKzmYtRbXNKopeHweAKWuun2q", address)
         RAVENCOIN -> assertEquals("RHoCwPc2FCQqwToYnSiAb3SrCET4zEHsbS", address)
         WAVES -> assertEquals("3P63vkaHhyE9pPv9EfsjwGKqmZYcCRHys4n", address)
+        BITSHARES -> assertEquals("BTS58ARYk4isf7dm9HN8fjanEfmi9jCLJozVzeYNCWo8asZyb82uC", address)
     }
 }

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bitshares/TestBitsharesSigning.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bitshares/TestBitsharesSigning.kt
@@ -1,0 +1,180 @@
+package com.trustwallet.core.app.blockchains.bitshares
+
+import android.util.Log
+import androidx.annotation.IntegerRes
+import com.google.common.base.Utf8
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonObject
+import com.google.gson.reflect.TypeToken
+import com.google.protobuf.ByteString
+import com.google.protobuf.UInt64Value
+import com.trustwallet.core.app.utils.*
+import org.junit.Assert.*
+import org.junit.Test
+import wallet.core.jni.proto.Bravo
+import org.json.JSONObject
+import wallet.core.jni.*
+import wallet.core.jni.proto.Bitshares
+import wallet.core.jni.proto.EOS
+import java.math.BigInteger
+import java.util.*
+
+
+class TestBitShares {
+
+    init {
+        System.loadLibrary("TrustWalletCore")
+    }
+
+
+    @Test
+    fun testAddresses() {
+        assertTrue(CoinType.BITSHARES.validate("BTS52K5kMmwiRyNQYAf7ymCMz6hieE8siyrqNt1t57ac9hvBrRdaa"))
+        var addr = listOf(
+            "52K5kMmwiRyNQYAf7ymCMz6hieE8siyrqNt1t57ac9hvBrRdaa",
+            "BTS52K5kMmwiRyNQYAf7ymCMz6hieE8siyrqNt1t57ac9hvBrRd",
+            "BTS52K5kMmwiRyNQYAf7ymCMz6hieE8siyrqNt1t57ac9hvBrRdaaaa",
+            "BITS52K5kMmwiRyNQYAf7ymCMz6hieE8siyrqNt1t57ac9hvBrRdaa"
+        )
+        addr.forEach {
+            assertFalse(CoinType.STEEM.validate(it))
+        }
+    }
+
+    fun getAssetBuilder(amt: Long, assetID: Long): Bitshares.Asset.Builder {
+        val asset: Bitshares.Asset.Builder = Bitshares.Asset.newBuilder();
+        asset.apply {
+            amount = amt
+            assetId = assetID
+        }
+        return asset;
+    }
+
+    fun getFeeBuilder(amt: Long, assetID: Long): Bitshares.Asset.Builder {
+        val asset: Bitshares.Asset.Builder = Bitshares.Asset.newBuilder();
+        asset.apply {
+            amount = amt
+            assetId = assetID
+        }
+        return asset;
+    }
+
+    fun signingInput(): Bitshares.SigningInput.Builder {
+        val signingInput: Bitshares.SigningInput.Builder = Bitshares.SigningInput.newBuilder()
+
+        signingInput.apply {
+            chainId = ByteString.copyFrom(ByteArray(32))
+            senderId = 12
+            recipientId = 16
+            asset = getAssetBuilder(511, 0).build()
+            fee = getFeeBuilder(2, 0).build()
+            referenceBlockId = ByteString.copyFrom("0000086bf9e7704509aa41311a66fa0a1b479c6b".toHexByteArray())
+            referenceBlockTime = 1552464180
+            privateKey = ByteString.copyFrom(Hash.sha256("A".toByteArray()))
+        }
+        return signingInput;
+    }
+
+
+    // ensure valid input is signed
+    @Test
+    fun testSigning() {
+
+        val result = BitsharesSigner.sign(signingInput().build())
+        assertTrue("Error signing: " + result.error, result.success)
+        assertEquals(1, result.objectsCount)
+
+        val signingOutput: Bitshares.SigningOutput = result.getObjects(0).unpack(Bitshares.SigningOutput::class.java)
+        val jsonObj = JSONObject(signingOutput.jsonEncoded)
+        assertNotNull(jsonObj)
+
+        val signatures = jsonObj.getJSONArray("signatures")
+        assertNotNull("Error parsing JSON result", signatures)
+
+        val signatureValue: String = signatures.get(0) as String;
+        assertNotNull("Error parsing JSON result", signatureValue)
+        assertEquals(
+            "1f0ee91e5f9cdd04629d4db71a6d5f0d75c282669bbaf84c184b6c18f04fe75dfb560969a9d8360f31bdd93b90c40dfe5fed601094433962205b4c49e925b51b24",
+            signatureValue
+        )
+
+    }
+
+    // ensure invalid inputs are not signed
+    @Test
+    fun testFailures() {
+        var badinput = signingInput()
+        badinput.asset = getAssetBuilder(0, 0).build();
+        var result = BitsharesSigner.sign(badinput.build())
+        assertFalse("Expected error but signing suceeded!", result.success)
+
+
+        badinput = signingInput()
+        badinput.fee = getFeeBuilder(-1, 0).build()
+        result = BitsharesSigner.sign(badinput.build())
+        assertFalse("Expected error but signing suceeded!", result.success)
+
+
+        badinput = signingInput()
+        badinput.senderId = badinput.recipientId
+        result = BitsharesSigner.sign(badinput.build())
+        assertFalse("Expected error but signing suceeded!", result.success)
+
+        badinput = signingInput()
+        badinput.referenceBlockId = ByteString.copyFrom("0000086bf9e7704509aa41311a66fa0a1b479c".toHexByteArray())
+        result = BitsharesSigner.sign(badinput.build())
+        assertFalse("Expected error but signing suceeded!", result.success)
+    }
+
+
+    @Test
+    fun testMemo() {
+        val message = "Hello, world!"
+        var inputWithMemo = signingInput() //signingInput
+        val senderPublicKey = PrivateKey(Hash.sha256("A".toByteArray())).getPublicKeySecp256k1(true)
+        val recipientPublicKey = PrivateKey(Hash.sha256("B".toByteArray())).getPublicKeySecp256k1(true)
+
+        inputWithMemo.memo = message
+        inputWithMemo.recipientPublicKey = ByteString.copyFrom(recipientPublicKey.data())
+
+        val result = BitsharesSigner.sign(inputWithMemo.build());
+        assertTrue("Error signing: " + result.error, result.success)
+
+
+        assertEquals(1, result.objectsCount)
+
+        val signingOutput: Bitshares.SigningOutput = result.getObjects(0).unpack(Bitshares.SigningOutput::class.java)
+
+        val memoJSON = Gson().fromJson(signingOutput.jsonEncoded, JsonObject::class.java)
+                                .getAsJsonArray("operations")
+                                    .get(0).getAsJsonArray().get(1).getAsJsonObject().get("memo")
+            .getAsJsonObject()
+        val nonce = memoJSON.get("nonce").toString().toULong()
+        val encryptedData = memoJSON.get("message").asString.toHexByteArray()
+
+        assertEquals(memoJSON.get("to").asString, BitsharesAddress(recipientPublicKey).description())
+        assertEquals(memoJSON.get("from").asString, BitsharesAddress(senderPublicKey).description())
+
+        if (nonce > Long.MAX_VALUE.toULong()) {
+            Log.e("Bitshares", "nonce bigger than long max.")
+        }
+
+        if (encryptedData == null || nonce == null) {
+            fail("Failed to extract encrypted message")
+            return
+        }
+
+        val sharedSecretHex =
+            "05c160e88379eabeaac0ac98afd22486a1e1ec7982cebad6073d68647f8cdea8e61cb714f314a2ad2d9d6eb74cde6f1e7150823b361032c8b598dcd68957f474"
+        val keyPlusIV = Hash.sha512(("" + nonce + sharedSecretHex).toByteArray())
+        val decrypted = AES.cbcdecrypt(keyPlusIV.copyOfRange(0, 32), encryptedData, keyPlusIV.copyOfRange(32, 48))
+        assertNotNull(decrypted)
+        val messageData = message.toByteArray()
+
+        assertEquals(
+            Numeric.toHexString(messageData),
+            Numeric.toHexString(decrypted.copyOfRange(4, messageData.size + 4))
+        )
+    }
+}

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bitshares/TestBitsharesSigning.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bitshares/TestBitsharesSigning.kt
@@ -92,7 +92,7 @@ class TestBitShares {
         val signatures = jsonObj.getJSONArray("signatures")
         assertNotNull("Error parsing JSON result", signatures)
 
-        val signatureValue: String = signatures.get(0) as String;
+        val signatureValue = signatures.getString(0)
         assertNotNull("Error parsing JSON result", signatureValue)
         assertEquals(
             "1f0ee91e5f9cdd04629d4db71a6d5f0d75c282669bbaf84c184b6c18f04fe75dfb560969a9d8360f31bdd93b90c40dfe5fed601094433962205b4c49e925b51b24",
@@ -107,24 +107,25 @@ class TestBitShares {
         var badinput = signingInput()
         badinput.asset = getAssetBuilder(0, 0).build();
         var result = BitsharesSigner.sign(badinput.build())
-        assertFalse("Expected error but signing suceeded!", result.success)
+        val errorMessage = "Expected error but signing suceeded!"
+        assertFalse(errorMessage, result.success)
 
 
         badinput = signingInput()
         badinput.fee = getFeeBuilder(-1, 0).build()
         result = BitsharesSigner.sign(badinput.build())
-        assertFalse("Expected error but signing suceeded!", result.success)
+        assertFalse(errorMessage, result.success)
 
 
         badinput = signingInput()
         badinput.senderId = badinput.recipientId
         result = BitsharesSigner.sign(badinput.build())
-        assertFalse("Expected error but signing suceeded!", result.success)
+        assertFalse(errorMessage, result.success)
 
         badinput = signingInput()
         badinput.referenceBlockId = ByteString.copyFrom("0000086bf9e7704509aa41311a66fa0a1b479c".toHexByteArray())
         result = BitsharesSigner.sign(badinput.build())
-        assertFalse("Expected error but signing suceeded!", result.success)
+        assertFalse(errorMessage, result.success)
     }
 
 

--- a/coins.json
+++ b/coins.json
@@ -660,5 +660,16 @@
         "curve": "ed25519",
         "publicKeyType": "curve25519",
         "explorer": "https://wavesexplorer.com/tx/"
+    },
+    {
+        "id": "bitshares",
+        "name": "Bitshares",
+        "symbol": "BTS",
+        "decimals": 5,
+        "derivationPath": "m/44'/308'/0'/0/0",
+        "curve": "secp256k1",
+        "publicKeyType": "secp256k1",
+        "transactionPath": "/tx/",
+        "explorer": "https://cryptofresh.com"
     }
 ]

--- a/coins.json
+++ b/coins.json
@@ -666,10 +666,10 @@
         "name": "Bitshares",
         "symbol": "BTS",
         "decimals": 5,
+        "blockchain": "EOS",
         "derivationPath": "m/44'/308'/0'/0/0",
         "curve": "secp256k1",
         "publicKeyType": "secp256k1",
-        "transactionPath": "/tx/",
-        "explorer": "https://cryptofresh.com"
+        "explorer": "https://cryptofresh.com/tx/"
     }
 ]

--- a/include/TrustWalletCore/TWBitsharesAddress.h
+++ b/include/TrustWalletCore/TWBitsharesAddress.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "TWBase.h"
+#include "TWData.h"
+#include "TWString.h"
+
+
+TW_EXTERN_C_BEGIN
+
+struct TWPublicKey;
+
+/// Represents a Bravo address.
+TW_EXPORT_CLASS
+struct TWBitsharesAddress;
+
+/// Compares two addresses for equality.
+TW_EXPORT_STATIC_METHOD
+bool TWBitsharesAddressEqual(struct TWBitsharesAddress *_Nonnull lhs, struct TWBitsharesAddress *_Nonnull rhs);
+
+/// Determines if the string is a valid address.
+TW_EXPORT_STATIC_METHOD
+bool TWBitsharesAddressIsValidString(TWString *_Nonnull string);
+
+/// Creates an address from a string representaion.
+TW_EXPORT_STATIC_METHOD
+struct TWBitsharesAddress *_Nullable TWBitsharesAddressCreateWithString(TWString *_Nonnull string);
+
+/// Creates an address from a public key.
+TW_EXPORT_STATIC_METHOD
+struct TWBitsharesAddress *_Nonnull TWBitsharesAddressCreateWithPublicKey(struct TWPublicKey *_Nonnull publicKey);
+
+/// Creates an address from a key hash.
+TW_EXPORT_STATIC_METHOD
+struct TWBitsharesAddress *_Nullable TWBitsharesAddressCreateWithKeyHash(TWData *_Nonnull keyHash);
+
+TW_EXPORT_METHOD
+void TWBitsharesAddressDelete(struct TWBitsharesAddress *_Nonnull address);
+
+/// Returns the address string representation.
+TW_EXPORT_PROPERTY
+TWString *_Nonnull TWBitsharesAddressDescription(struct TWBitsharesAddress *_Nonnull address);
+
+TW_EXTERN_C_END

--- a/include/TrustWalletCore/TWBitsharesAddress.h
+++ b/include/TrustWalletCore/TWBitsharesAddress.h
@@ -1,3 +1,9 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
 #pragma once
 
 #include "TWBase.h"

--- a/include/TrustWalletCore/TWBitsharesAddress.h
+++ b/include/TrustWalletCore/TWBitsharesAddress.h
@@ -15,7 +15,7 @@ TW_EXTERN_C_BEGIN
 
 struct TWPublicKey;
 
-/// Represents a Bravo address.
+/// Represents a Bitshares address.
 TW_EXPORT_CLASS
 struct TWBitsharesAddress;
 
@@ -34,10 +34,6 @@ struct TWBitsharesAddress *_Nullable TWBitsharesAddressCreateWithString(TWString
 /// Creates an address from a public key.
 TW_EXPORT_STATIC_METHOD
 struct TWBitsharesAddress *_Nonnull TWBitsharesAddressCreateWithPublicKey(struct TWPublicKey *_Nonnull publicKey);
-
-/// Creates an address from a key hash.
-TW_EXPORT_STATIC_METHOD
-struct TWBitsharesAddress *_Nullable TWBitsharesAddressCreateWithKeyHash(TWData *_Nonnull keyHash);
 
 TW_EXPORT_METHOD
 void TWBitsharesAddressDelete(struct TWBitsharesAddress *_Nonnull address);

--- a/include/TrustWalletCore/TWBitsharesProto.h
+++ b/include/TrustWalletCore/TWBitsharesProto.h
@@ -1,0 +1,13 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "TWData.h"
+
+typedef TWData *_Nonnull TW_Bitshares_Proto_Asset;
+typedef TWData *_Nonnull TW_Bitshares_Proto_SigningInput;
+typedef TWData *_Nonnull TW_Bitshares_Proto_SigningOutput;

--- a/include/TrustWalletCore/TWBitsharesSigner.h
+++ b/include/TrustWalletCore/TWBitsharesSigner.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "TWBase.h"
+
+#include "TWBitsharesProto.h"
+#include "TWCommonProto.h"
+
+TW_EXTERN_C_BEGIN
+
+/// Represents a Bitshares Signer.
+TW_EXPORT_CLASS
+struct TWBitsharesSigner;
+
+TW_EXPORT_STATIC_METHOD
+TW_Proto_Result TWBitsharesSignerSign(TW_Bitshares_Proto_SigningInput input);
+
+TW_EXTERN_C_END

--- a/include/TrustWalletCore/TWBitsharesSigner.h
+++ b/include/TrustWalletCore/TWBitsharesSigner.h
@@ -1,3 +1,9 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
 #pragma once
 
 #include "TWBase.h"

--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -26,6 +26,7 @@ enum TWCoinType {
     TWCoinTypeBinance = 714,
     TWCoinTypeBitcoin = 0,
     TWCoinTypeBitcoinCash = 145,
+    TWCoinTypeBitshares = 308,
     TWCoinTypeBravoCoin = 282,
     TWCoinTypeCallisto = 820,
     TWCoinTypeCosmos = 118,

--- a/src/Bitshares/AES.cpp
+++ b/src/Bitshares/AES.cpp
@@ -1,0 +1,49 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "AES.h"
+
+#include <TrezorCrypto/aes.h>
+
+using namespace TW::Bitshares;
+using Data = TW::Data;
+
+Data TW::Bitshares::aesEncrypt(const uint8_t *message, size_t messageLength, const uint8_t *key, const uint8_t *initializationVector) {
+    if (messageLength > static_cast<size_t>(INT_MAX)) {
+        throw std::invalid_argument("Message size must be smaller than " + std::to_string(INT_MAX));
+    }
+
+    // create context
+    aes_encrypt_ctx context;
+    if (aes_encrypt_key256(key, &context) == EXIT_FAILURE) {
+        throw std::runtime_error("Encryption error: Error initializing the key");
+    }
+
+    size_t fullBlockBytes = (messageLength / 16) * 16;        // no. of bytes that make up the full 16-byte blocks
+    size_t remainingBytes = messageLength % 16;
+
+    size_t outputSize = fullBlockBytes + 16;
+    Data output(outputSize);
+
+    // create a non-const copy of the iv
+    Data iv(initializationVector, initializationVector + 16);
+
+    // encrypt the full blocks at a go
+    if (fullBlockBytes) {
+        if (aes_cbc_encrypt(message, output.data(), static_cast<int>(fullBlockBytes), iv.data(), &context) == EXIT_FAILURE) {
+            throw std::runtime_error("Encryption error: Error encrypting the message");
+        }
+    }
+
+    // create a __PKCS#5-padded__ buffer for the remaining bytes and encrypt that too
+    Data lastBlock(16, static_cast<unsigned char>(16 - remainingBytes));
+    std::memcpy(lastBlock.data(), message + fullBlockBytes, remainingBytes);
+    if (aes_cbc_encrypt(lastBlock.data(), output.data() + fullBlockBytes, 16, iv.data(), &context) == EXIT_FAILURE) {
+        throw std::runtime_error("Encryption error: Error encrypting the message");
+    }
+
+    return output;
+}

--- a/src/Bitshares/AES.h
+++ b/src/Bitshares/AES.h
@@ -1,0 +1,21 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "../Data.h"
+
+namespace TW::Bitshares {
+// Encrypts message using AES-256 in CBC mode and PKCS#5 padding
+// The key must be 256 bits long and the IV 128 bits.
+TW::Data aesEncrypt(const uint8_t *message, size_t messageLength, const uint8_t *key, const uint8_t *initializationVector);
+
+// A templated wrapper for the above funciton
+template <typename T1, typename T2, typename T3>
+TW::Data aesEncrypt(const T1& message, const T2& key, const T3& initializationVector) {
+    return aesEncrypt(reinterpret_cast<const uint8_t*>(message.data()), message.size(), reinterpret_cast<const uint8_t*>(key.data()), reinterpret_cast<const uint8_t*>(initializationVector.data()));
+}
+} // namespace TW::Bitshares

--- a/src/Bitshares/Address.h
+++ b/src/Bitshares/Address.h
@@ -1,0 +1,21 @@
+// Copyright � 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "../Bravo/Address.h"
+
+namespace TW {
+namespace Bitshares {
+    const std::string AddressPrefix = "BTS";
+}}
+
+// Bitshares address class is similar to Bravo. 
+// Just creating TWBitsharesAddress struct for C interface 
+
+struct TWBitsharesAddress {
+	TW::Bravo::Address impl;
+};

--- a/src/Bitshares/Address.h
+++ b/src/Bitshares/Address.h
@@ -8,14 +8,12 @@
 
 #include "../Bravo/Address.h"
 
-namespace TW {
-namespace Bitshares {
-    const std::string AddressPrefix = "BTS";
-}}
+namespace TW::Bitshares {
+const std::string AddressPrefix = "BTS";
+}
 
 // Bitshares address class is similar to Bravo. 
 // Just creating TWBitsharesAddress struct for C interface 
-
 struct TWBitsharesAddress {
 	TW::Bravo::Address impl;
 };

--- a/src/Bitshares/Address.h
+++ b/src/Bitshares/Address.h
@@ -15,5 +15,5 @@ const std::string AddressPrefix = "BTS";
 // Bitshares address class is similar to Bravo. 
 // Just creating TWBitsharesAddress struct for C interface 
 struct TWBitsharesAddress {
-	TW::Bravo::Address impl;
+    TW::Bravo::Address impl;
 };

--- a/src/Bitshares/Asset.h
+++ b/src/Bitshares/Asset.h
@@ -11,24 +11,25 @@
 #include "ObjectId.h"
 #include "../Bravo/Serialization.h"
 
-namespace TW {
-namespace Bitshares {
-    class Asset {
-    public:
-        int64_t amount;
-        ObjectId id;
+namespace TW::Bitshares {
+class Asset {
+public:
+    int64_t amount;
+    ObjectId id;
 
-        Asset(int64_t amount, uint64_t assetId) : amount(amount), id({1, 3, assetId}) { }
+    Asset(int64_t amount, uint64_t assetId) : amount(amount), id({1, 3, assetId}) { }
 
-        void serialize(Data& os) const {
-            encode64LE(amount, os);
-            Bravo::encodeVarInt64(id.instance, os);
-        }
+    void serialize(Data& os) const noexcept {
+        encode64LE(amount, os);
+        Bravo::encodeVarInt64(id.instance, os);
+    }
 
-        nlohmann::json serialize() const {
-            nlohmann::json obj;
-            obj["amount"] = amount;
-            obj["asset_id"] = id.string();
-        }
-    };
-}} // namespace
+    nlohmann::json serialize() const noexcept {
+        nlohmann::json obj;
+        obj["amount"] = amount;
+        obj["asset_id"] = id.string();
+
+        return obj;
+    }
+};
+} // namespace TW::Bitshares

--- a/src/Bitshares/Asset.h
+++ b/src/Bitshares/Asset.h
@@ -1,0 +1,34 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include "ObjectId.h"
+#include "../Bravo/Serialization.h"
+
+namespace TW {
+namespace Bitshares {
+    class Asset {
+    public:
+        int64_t amount;
+        ObjectId id;
+
+        Asset(int64_t amount, uint64_t assetId) : amount(amount), id({1, 3, assetId}) { }
+
+        void serialize(Data& os) const {
+            encode64LE(amount, os);
+            Bravo::encodeVarInt64(id.instance, os);
+        }
+
+        nlohmann::json serialize() const {
+            nlohmann::json obj;
+            obj["amount"] = amount;
+            obj["asset_id"] = id.string();
+        }
+    };
+}} // namespace

--- a/src/Bitshares/Memo.cpp
+++ b/src/Bitshares/Memo.cpp
@@ -1,0 +1,87 @@
+#include "Memo.h"
+
+#include <stdexcept>
+
+#include <TrezorCrypto/ecdsa.h>
+#include <TrezorCrypto/secp256k1.h>
+#include <TrezorCrypto/rand.h>
+#include <TrezorCrypto/aes.h>
+#include <boost/lexical_cast.hpp>
+
+#include "../Hash.h"
+#include "../HexCoding.h"
+
+using namespace TW::Bitshares;
+using Data = TW::Data;
+
+Memo::Memo(const PrivateKey& senderKey, const PublicKey& recipientKey, const std::string& message)
+        : to(recipientKey), from(senderKey.getPublicKey(PublicKeyType::secp256k1)) {
+    if (recipientKey.type() != PublicKeyType::secp256k1) {
+        throw std::invalid_argument("Recipient's public key is not a secp25k1 public key.");
+    }
+
+    if (message.empty()) {
+        throw std::invalid_argument("Message is empty.");
+    }
+
+    random_buffer(static_cast<uint8_t *>(&nonce), sizeof(nonce));
+    Data secret = getSharedSecret(senderKey, recipientKey);
+
+    // The first 32 bytes will be used as encryption key and the next 32 as the IV
+    Data encryptionKeyPlusIV = Hash::sha512(boost::lexical_cast<std::string>(nonce) + hex(secret));
+
+    // Encrypted Message = AES(4-byte Checksum + Original Message)
+    Data input = Hash::sha256(message);
+    input.resize(4);
+    input.insert(input.end, message.begin(), message.end());
+
+    aesEncrypt( message,
+                encryptionKeyPlusIV.data(),
+                encryptionKeyPlusIV.data() + 32);
+}
+
+Data Memo::getSharedSecret(const PrivateKey& senderKey, const PublicKey& recipientKey) {
+    Data dhKey(PublicKey::secp256k1Size);
+
+    if (ecdh_multiply(&secp256k1, senderKey.bytes.data(), recipientKey.bytes.data(), dhKey.data()) != 0) {
+        throw std::runtime_error("Could not derive a shared secret");
+    }
+
+    Data result(Hash::sha512Size);
+    sha512_Raw(dhKey.data() + 1, dhKey.size() - 1, result.data());
+
+    return result;
+}
+
+Data aesEncrypt(const uint8_t *message, size_t messageLength, const uint8_t *key, const uint8_t *initializationVector) {
+    // need a non-const copy
+    Data iv(initializationVector, initializationVector + 32);
+
+    aes_encrypt_ctx context;
+
+    if (aes_encrypt_key256(key, &context) == EXIT_FAILURE) {
+        throw std::runtime_error("Encryption error: Error initializing the key");
+    }
+
+    size_t fullBlocksCount = messageLength / 16;
+    size_t remainingBytes = messageLength % 16;
+
+    size_t outputSize = (fullBlocksCount + (remainingBytes ? 1 : 0)) * 16;
+    Data output(outputSize);
+
+    // encrypt the full blocks at a go
+    if (aes_cbc_encrypt(message, output.data(), fullBlocksCount * 16, iv.data(), &context) == EXIT_FAILURE) {
+        throw std::runtime_error("Encryption error: Error encrypting the message");
+    }
+
+    // create a 0-padded buffer for the remaining bytes and encrypt that too
+    if (remainingBytes) {
+        Data lastBlock(message + (fullBlocksCount * 16), remainingBytes);
+        std::memcpy(lastBlock.data(), message + (fullBlocksCount * 16), remainingBytes);
+        (aes_cbc_encrypt(lastBlock.data(), output.data() + (fullBlocksCount * 16), 16, iv.data(), &context) == EXIT_FAILURE) {
+            throw std::runtime_error("Encryption error: Error encrypting the message");
+        }
+    }
+
+    return output;
+}

--- a/src/Bitshares/Memo.cpp
+++ b/src/Bitshares/Memo.cpp
@@ -10,12 +10,16 @@
 
 #include "../Hash.h"
 #include "../HexCoding.h"
+#include "../Bravo/Serialization.h"
+
+#include "Address.h"
 
 using namespace TW::Bitshares;
 using Data = TW::Data;
+using json = nlohmann::json;
 
 Memo::Memo(const PrivateKey& senderKey, const PublicKey& recipientKey, const std::string& message)
-        : to(recipientKey), from(senderKey.getPublicKey(PublicKeyType::secp256k1)) {
+        : from(senderKey.getPublicKey(PublicKeyType::secp256k1)), to(recipientKey) {
     if (recipientKey.type() != PublicKeyType::secp256k1) {
         throw std::invalid_argument("Recipient's public key is not a secp25k1 public key.");
     }
@@ -24,7 +28,7 @@ Memo::Memo(const PrivateKey& senderKey, const PublicKey& recipientKey, const std
         throw std::invalid_argument("Message is empty.");
     }
 
-    random_buffer(static_cast<uint8_t *>(&nonce), sizeof(nonce));
+    random_buffer(reinterpret_cast<uint8_t *>(&nonce), sizeof(nonce));
     Data secret = getSharedSecret(senderKey, recipientKey);
 
     // The first 32 bytes will be used as encryption key and the next 32 as the IV
@@ -33,7 +37,7 @@ Memo::Memo(const PrivateKey& senderKey, const PublicKey& recipientKey, const std
     // Encrypted Message = AES(4-byte Checksum + Original Message)
     Data input = Hash::sha256(message);
     input.resize(4);
-    input.insert(input.end, message.begin(), message.end());
+    input.insert(input.end(), message.begin(), message.end());
 
     aesEncrypt( message,
                 encryptionKeyPlusIV.data(),
@@ -53,7 +57,8 @@ Data Memo::getSharedSecret(const PrivateKey& senderKey, const PublicKey& recipie
     return result;
 }
 
-Data aesEncrypt(const uint8_t *message, size_t messageLength, const uint8_t *key, const uint8_t *initializationVector) {
+/// Function that encrypts the given 
+Data TW::Bitshares::aesEncrypt(const uint8_t *message, size_t messageLength, const uint8_t *key, const uint8_t *initializationVector) {
     // need a non-const copy
     Data iv(initializationVector, initializationVector + 32);
 
@@ -76,12 +81,29 @@ Data aesEncrypt(const uint8_t *message, size_t messageLength, const uint8_t *key
 
     // create a 0-padded buffer for the remaining bytes and encrypt that too
     if (remainingBytes) {
-        Data lastBlock(message + (fullBlocksCount * 16), remainingBytes);
+        Data lastBlock(message + (fullBlocksCount * 16), message + (fullBlocksCount * 16) + remainingBytes);
         std::memcpy(lastBlock.data(), message + (fullBlocksCount * 16), remainingBytes);
-        (aes_cbc_encrypt(lastBlock.data(), output.data() + (fullBlocksCount * 16), 16, iv.data(), &context) == EXIT_FAILURE) {
+        if (aes_cbc_encrypt(lastBlock.data(), output.data() + (fullBlocksCount * 16), 16, iv.data(), &context) == EXIT_FAILURE) {
             throw std::runtime_error("Encryption error: Error encrypting the message");
         }
     }
 
     return output;
+}
+
+void Memo::serialize(Data& os) const noexcept {
+    append(os, from.bytes);
+    append(os, to.bytes);
+    encode64LE(nonce, os);
+    Bravo::encodeVarInt64(encryptedMessage.size(), os);
+    append(os, encryptedMessage);
+}
+
+json Memo::serialize() const noexcept {
+    json obj;
+    obj["from"] = Bravo::Address(from, AddressPrefix).string();
+    obj["to"] = Bravo::Address(to, AddressPrefix).string();
+    obj["nonce"] = nonce;
+    obj["message"] = hex(encryptedMessage);
+    return obj;
 }

--- a/src/Bitshares/Memo.cpp
+++ b/src/Bitshares/Memo.cpp
@@ -7,6 +7,7 @@
 #include <TrezorCrypto/rand.h>
 #include <TrezorCrypto/aes.h>
 #include <boost/lexical_cast.hpp>
+#include <TrustWalletCore/TWPublicKeyType.h>
 
 #include "../Hash.h"
 #include "../HexCoding.h"
@@ -19,8 +20,8 @@ using Data = TW::Data;
 using json = nlohmann::json;
 
 Memo::Memo(const PrivateKey& senderKey, const PublicKey& recipientKey, const std::string& message, uint64_t nonce)
-        : from(senderKey.getPublicKey(PublicKeyType::secp256k1)), to(recipientKey) {
-    if (recipientKey.type() != PublicKeyType::secp256k1) {
+        : from(senderKey.getPublicKey(TWPublicKeyTypeSECP256k1)), to(recipientKey) {
+    if (recipientKey.type != TWPublicKeyTypeSECP256k1) {
         throw std::invalid_argument("Recipient's public key is not a secp25k1 public key.");
     }
 

--- a/src/Bitshares/Memo.cpp
+++ b/src/Bitshares/Memo.cpp
@@ -73,7 +73,7 @@ Data TW::Bitshares::aesEncrypt(const uint8_t *message, size_t messageLength, con
     size_t fullBlockBytes = (messageLength / 16) * 16;        // no. of bytes that make up the full 16-byte blocks
     size_t remainingBytes = messageLength % 16;
 
-    size_t outputSize = fullBlockBytes + (remainingBytes ? 16 : 0);
+    size_t outputSize = fullBlockBytes + 16;
     Data output(outputSize);
 
     // create a non-const copy of the iv
@@ -87,12 +87,10 @@ Data TW::Bitshares::aesEncrypt(const uint8_t *message, size_t messageLength, con
     }
 
     // create a __PKCS#5-padded__ buffer for the remaining bytes and encrypt that too
-    if (remainingBytes) {
-        Data lastBlock(16, static_cast<unsigned char>(16 - remainingBytes));
-        std::memcpy(lastBlock.data(), message + fullBlockBytes, remainingBytes);
-        if (aes_cbc_encrypt(lastBlock.data(), output.data() + fullBlockBytes, 16, iv.data(), &context) == EXIT_FAILURE) {
-            throw std::runtime_error("Encryption error: Error encrypting the message");
-        }
+    Data lastBlock(16, static_cast<unsigned char>(16 - remainingBytes));
+    std::memcpy(lastBlock.data(), message + fullBlockBytes, remainingBytes);
+    if (aes_cbc_encrypt(lastBlock.data(), output.data() + fullBlockBytes, 16, iv.data(), &context) == EXIT_FAILURE) {
+        throw std::runtime_error("Encryption error: Error encrypting the message");
     }
 
     return output;

--- a/src/Bitshares/Memo.cpp
+++ b/src/Bitshares/Memo.cpp
@@ -1,3 +1,9 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
 #include "Memo.h"
 
 #include <stdexcept>

--- a/src/Bitshares/Memo.cpp
+++ b/src/Bitshares/Memo.cpp
@@ -59,33 +59,37 @@ Data Memo::getSharedSecret(const PrivateKey& senderKey, const PublicKey& recipie
 }
 
 Data TW::Bitshares::aesEncrypt(const uint8_t *message, size_t messageLength, const uint8_t *key, const uint8_t *initializationVector) {
+    if (messageLength > static_cast<size_t>(INT_MAX)) {
+        throw std::invalid_argument("Message size must be smaller than " + std::to_string(INT_MAX));
+    }
+
     // create context
     aes_encrypt_ctx context;
     if (aes_encrypt_key256(key, &context) == EXIT_FAILURE) {
         throw std::runtime_error("Encryption error: Error initializing the key");
     }
 
-    size_t fullBlocksCount = messageLength / 16;
+    size_t fullBlockBytes = (messageLength / 16) * 16;        // no. of bytes that make up the full 16-byte blocks
     size_t remainingBytes = messageLength % 16;
 
-    size_t outputSize = (fullBlocksCount + (remainingBytes ? 1 : 0)) * 16;
+    size_t outputSize = fullBlockBytes + (remainingBytes ? 16 : 0);
     Data output(outputSize);
 
     // create a non-const copy of the iv
     Data iv(initializationVector, initializationVector + 16);
 
     // encrypt the full blocks at a go
-    if (fullBlocksCount) {
-        if (aes_cbc_encrypt(message, output.data(), fullBlocksCount * 16, iv.data(), &context) == EXIT_FAILURE) {
+    if (fullBlockBytes) {
+        if (aes_cbc_encrypt(message, output.data(), static_cast<int>(fullBlockBytes), iv.data(), &context) == EXIT_FAILURE) {
             throw std::runtime_error("Encryption error: Error encrypting the message");
         }
     }
 
     // create a __PKCS#5-padded__ buffer for the remaining bytes and encrypt that too
     if (remainingBytes) {
-        Data lastBlock(16, 16 - remainingBytes);
-        std::memcpy(lastBlock.data(), message + (fullBlocksCount * 16), remainingBytes);
-        if (aes_cbc_encrypt(lastBlock.data(), output.data() + (fullBlocksCount * 16), 16, iv.data(), &context) == EXIT_FAILURE) {
+        Data lastBlock(16, static_cast<unsigned char>(16 - remainingBytes));
+        std::memcpy(lastBlock.data(), message + fullBlockBytes, remainingBytes);
+        if (aes_cbc_encrypt(lastBlock.data(), output.data() + fullBlockBytes, 16, iv.data(), &context) == EXIT_FAILURE) {
             throw std::runtime_error("Encryption error: Error encrypting the message");
         }
     }

--- a/src/Bitshares/Memo.h
+++ b/src/Bitshares/Memo.h
@@ -7,19 +7,19 @@
 #pragma once
 
 #include <string>
+#include <nlohmann/json.hpp>
 
 #include "../PublicKey.h"
 #include "../PrivateKey.h"
 #include "../Data.h"
 
-namespace TW {
-namespace Bitshares {
+namespace TW::Bitshares {
 
 TW::Data aesEncrypt(const uint8_t *message, size_t messageLength, const uint8_t *key, const uint8_t *initializationVector);
 
 template <typename T>
 TW::Data aesEncrypt(const T& message, const uint8_t *key, const uint8_t *initializationVector) {
-    return aesEncrypt(message.data(), message.size(), key, initializationVector);
+    return aesEncrypt(reinterpret_cast<const uint8_t*>(message.data()), message.size(), key, initializationVector);
 }
 
 class Memo {
@@ -31,6 +31,9 @@ public:
     Memo(const PrivateKey& senderKey, const PublicKey& recipientKey, const std::string& message);
 
     static Data getSharedSecret(const PrivateKey& senderKey, const PublicKey& recipientKey);
+
+        void serialize(Data& os) const noexcept;
+        nlohmann::json serialize() const noexcept;
 };
 
-}} // namespace
+} // namespace TW::Bitshares

--- a/src/Bitshares/Memo.h
+++ b/src/Bitshares/Memo.h
@@ -14,16 +14,6 @@
 #include "../Data.h"
 
 namespace TW::Bitshares {
-
-// Encrypts message using AES-256 in CBC mode and PKCS#5 padding
-// The key must be 256 bits long and the IV 128 bits.
-TW::Data aesEncrypt(const uint8_t *message, size_t messageLength, const uint8_t *key, const uint8_t *initializationVector);
-
-template <typename T>
-TW::Data aesEncrypt(const T& message, const uint8_t *key, const uint8_t *initializationVector) {
-    return aesEncrypt(reinterpret_cast<const uint8_t*>(message.data()), message.size(), key, initializationVector);
-}
-
 class Memo {
 public:
     PublicKey from, to;
@@ -38,5 +28,4 @@ public:
 
     static Data getSharedSecret(const PrivateKey& senderKey, const PublicKey& recipientKey);
 };
-
 } // namespace TW::Bitshares

--- a/src/Bitshares/Memo.h
+++ b/src/Bitshares/Memo.h
@@ -1,0 +1,36 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include <string>
+
+#include "../PublicKey.h"
+#include "../PrivateKey.h"
+#include "../Data.h"
+
+namespace TW {
+namespace Bitshares {
+
+TW::Data aesEncrypt(const uint8_t *message, size_t messageLength, const uint8_t *key, const uint8_t *initializationVector);
+
+template <typename T>
+TW::Data aesEncrypt(const T& message, const uint8_t *key, const uint8_t *initializationVector) {
+    return aesEncrypt(message.data(), message.size(), key, initializationVector);
+}
+
+class Memo {
+public:
+    PublicKey from, to;
+    uint64_t nonce;
+    Data encryptedMessage;
+
+    Memo(const PrivateKey& senderKey, const PublicKey& recipientKey, const std::string& message);
+
+    static Data getSharedSecret(const PrivateKey& senderKey, const PublicKey& recipientKey);
+};
+
+}} // namespace

--- a/src/Bitshares/Memo.h
+++ b/src/Bitshares/Memo.h
@@ -15,6 +15,8 @@
 
 namespace TW::Bitshares {
 
+// Encrypts message using AES-256 in CBC mode and PKCS#5 padding
+// The key must be 256 bits long and the IV 128 bits.
 TW::Data aesEncrypt(const uint8_t *message, size_t messageLength, const uint8_t *key, const uint8_t *initializationVector);
 
 template <typename T>
@@ -28,12 +30,13 @@ public:
     uint64_t nonce;
     Data encryptedMessage;
 
-    Memo(const PrivateKey& senderKey, const PublicKey& recipientKey, const std::string& message);
+    // Nonce should not be set manually except for debugging
+    Memo(const PrivateKey& senderKey, const PublicKey& recipientKey, const std::string& message, uint64_t nonce = 0);
+
+    void serialize(Data& os) const noexcept;
+    nlohmann::json serialize() const noexcept;
 
     static Data getSharedSecret(const PrivateKey& senderKey, const PublicKey& recipientKey);
-
-        void serialize(Data& os) const noexcept;
-        nlohmann::json serialize() const noexcept;
 };
 
 } // namespace TW::Bitshares

--- a/src/Bitshares/ObjectId.h
+++ b/src/Bitshares/ObjectId.h
@@ -6,33 +6,32 @@
 
 #pragma once
 
-namespace TW {
-namespace Bitshares {
-    struct ObjectId {
-        uint8_t spaceId, typeId;
-        uint64_t instance;
+namespace TW::Bitshares {
+struct ObjectId {
+    uint8_t spaceId, typeId;
+    uint64_t instance;
 
-        ObjectId(uint8_t spaceId, uint8_t typeId, uint64_t instance): spaceId(spaceId), 
-                                                                        typeId(typeId),
-                                                                        instance(instance) { }
+    ObjectId(uint8_t spaceId, uint8_t typeId, uint64_t instance): spaceId(spaceId), 
+                                                                    typeId(typeId),
+                                                                    instance(instance) { }
 
-        std::string string() const {
-            return std::to_string(spaceId) + "."
-                    + std::to_string(typeId) + "."
-                    + std::to_string(instance);
-        }
-
-        friend bool operator==(const ObjectId& lhs, const ObjectId rhs);
-        friend bool operator!=(const ObjectId& lhs, const ObjectId rhs);
-    };
-
-    inline bool operator==(const ObjectId& lhs, const ObjectId rhs) {
-        return lhs.spaceId == rhs.spaceId 
-                && lhs.typeId == rhs.typeId 
-                && lhs.instance == rhs.instance;
+    std::string string() const {
+        return std::to_string(spaceId) + "."
+                + std::to_string(typeId) + "."
+                + std::to_string(instance);
     }
 
-    inline bool operator!=(const ObjectId& lhs, const ObjectId rhs) {
-        return ! (lhs == rhs);
-    }
-}} // namespace
+    friend bool operator==(const ObjectId& lhs, const ObjectId rhs);
+    friend bool operator!=(const ObjectId& lhs, const ObjectId rhs);
+};
+
+inline bool operator==(const ObjectId& lhs, const ObjectId rhs) {
+    return lhs.spaceId == rhs.spaceId 
+            && lhs.typeId == rhs.typeId 
+            && lhs.instance == rhs.instance;
+}
+
+inline bool operator!=(const ObjectId& lhs, const ObjectId rhs) {
+    return ! (lhs == rhs);
+}
+} // namespace TW::Bitshares

--- a/src/Bitshares/ObjectId.h
+++ b/src/Bitshares/ObjectId.h
@@ -6,16 +6,33 @@
 
 #pragma once
 
-#include "../Bravo/Serialization.h"
-
 namespace TW {
 namespace Bitshares {
-    struct ObjectId: Bravo::Serializable {
+    struct ObjectId {
         uint8_t spaceId, typeId;
         uint64_t instance;
 
-        void serialize(const Data& os) {
-            Bravo::encodeVarInt64(os, instance);
+        ObjectId(uint8_t spaceId, uint8_t typeId, uint64_t instance): spaceId(spaceId), 
+                                                                        typeId(typeId),
+                                                                        instance(instance) { }
+
+        std::string string() const {
+            return std::to_string(spaceId) + "."
+                    + std::to_string(typeId) + "."
+                    + std::to_string(instance);
         }
+
+        friend bool operator==(const ObjectId& lhs, const ObjectId rhs);
+        friend bool operator!=(const ObjectId& lhs, const ObjectId rhs);
     };
+
+    inline bool operator==(const ObjectId& lhs, const ObjectId rhs) {
+        return lhs.spaceId == rhs.spaceId 
+                && lhs.typeId == rhs.typeId 
+                && lhs.instance == rhs.instance;
+    }
+
+    inline bool operator!=(const ObjectId& lhs, const ObjectId rhs) {
+        return ! (lhs == rhs);
+    }
 }} // namespace

--- a/src/Bitshares/ObjectId.h
+++ b/src/Bitshares/ObjectId.h
@@ -1,0 +1,21 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "../Bravo/Serialization.h"
+
+namespace TW {
+namespace Bitshares {
+    struct ObjectId: Bravo::Serializable {
+        uint8_t spaceId, typeId;
+        uint64_t instance;
+
+        void serialize(const Data& os) {
+            Bravo::encodeVarInt64(os, instance);
+        }
+    };
+}} // namespace

--- a/src/Bitshares/Operation.cpp
+++ b/src/Bitshares/Operation.cpp
@@ -1,3 +1,9 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
 #include "Operation.h"
 
 #include <stdexcept>

--- a/src/Bitshares/Operation.cpp
+++ b/src/Bitshares/Operation.cpp
@@ -33,6 +33,7 @@ void TransferOperation::validate() {
 }
 
 void TransferOperation::serialize(Data& os) const noexcept {
+    Bravo::encodeVarInt64(operationId(), os);
     fee.serialize(os);
     Bravo::encodeVarInt64(from.instance, os);
     Bravo::encodeVarInt64(to.instance, os);

--- a/src/Bitshares/Operation.cpp
+++ b/src/Bitshares/Operation.cpp
@@ -11,16 +11,9 @@
 using namespace TW::Bitshares;
 using json = nlohmann::json;
 
-TransferOperation::TransferOperation(uint64_t senderId, 
-                                    uint64_t recipientId,
-                                    const Asset& amount,
-                                    const Asset& fee,
-                                    Memo *memo) 
-                                    : from({1, 2, senderId}),
-                                      to({1, 2, recipientId}),
-                                      memo(memo),
-                                      amount(amount),
-                                      fee(fee) {
+TransferOperation::TransferOperation(uint64_t senderId, uint64_t recipientId, const Asset &amount,
+                                     const Asset &fee, Memo *memo)
+    : from({1, 2, senderId}), to({1, 2, recipientId}), memo(memo), amount(amount), fee(fee) {
     validate();
 }
 

--- a/src/Bitshares/Operation.cpp
+++ b/src/Bitshares/Operation.cpp
@@ -60,5 +60,5 @@ json TransferOperation::serialize() const noexcept {
     }
 
     obj["extensions"] = json::array();
-    return json::array({OperationId, obj});
+    return json::array({operationId(), obj});
 }

--- a/src/Bitshares/Operation.cpp
+++ b/src/Bitshares/Operation.cpp
@@ -1,0 +1,39 @@
+#include "Operation.h"
+
+#include <stdexcept>
+
+using namespace TW::Bitshares;
+using json = nlohmann::json;
+
+TransferOperation::TransferOperation(uint64_t senderId, 
+                                    uint64_t recipientId,
+                                    const Asset& amount,
+                                    const Asset& fee,
+                                    const Memo& memo) 
+                                    : from({1, 2, senderId}),
+                                      to({1, 2, recipientId}),
+                                      amount(amount),
+                                      fee(fee),
+                                      memo( memo) 
+{
+    validate();
+}
+
+void TransferOperation::validate() {
+    if (fee.amount < 0) {
+        throw std::invalid_argument("Fee cannot be negative.");
+    }
+
+    if (from == to) {
+        throw std::invalid_argument("Sender and recipient cannot be the same.");
+    }
+
+    if (amount.amount <= 0) {
+        throw std::invalid_argument("Amount in a transfer operation must be positive.");
+    }
+}
+
+void TransferOperation::serialize(Data& os) const noexcept override {
+
+}
+json TransferOperation::serialize() const noexcept override;

--- a/src/Bitshares/Operation.h
+++ b/src/Bitshares/Operation.h
@@ -1,0 +1,35 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include "Asset.h"
+#include "Memo.h"
+#include "../Bravo/Operation.h"
+
+namespace TW {
+namespace Bitshares {
+    class TransferOperation: public Bravo::Operation {
+    public:
+        TransferOperation(uint64_t senderId, 
+                            uint64_t recipientId, 
+                            const Asset& amount, 
+                            const Asset& fee,
+                            const Memo& memo);
+
+        void serialize(Data& os) const noexcept override;
+        nlohmann::json serialize() const noexcept override;
+		void validate();
+        static const int OperationId = 0;
+
+    private:
+        ObjectId from, to;
+        Memo memo;
+        Asset amount, fee;
+    }
+}} // namespace

--- a/src/Bitshares/Operation.h
+++ b/src/Bitshares/Operation.h
@@ -12,24 +12,23 @@
 #include "Memo.h"
 #include "../Bravo/Operation.h"
 
-namespace TW {
-namespace Bitshares {
-    class TransferOperation: public Bravo::Operation {
-    public:
-        TransferOperation(uint64_t senderId, 
-                            uint64_t recipientId, 
-                            const Asset& amount, 
-                            const Asset& fee,
-                            const Memo& memo);
+namespace TW::Bitshares {
+class TransferOperation: public Bravo::Operation {
+public:
+    TransferOperation(uint64_t senderId, 
+                        uint64_t recipientId, 
+                        const Asset& amount, 
+                        const Asset& fee,
+                        Memo *memo);
 
-        void serialize(Data& os) const noexcept override;
-        nlohmann::json serialize() const noexcept override;
-		void validate();
-        static const int OperationId = 0;
+    void serialize(Data& os) const noexcept override;
+    nlohmann::json serialize() const noexcept override;
+    void validate();
+    static const int OperationId = 0;
 
-    private:
-        ObjectId from, to;
-        Memo memo;
-        Asset amount, fee;
-    }
-}} // namespace
+private:
+    ObjectId from, to;
+    std::unique_ptr<Memo> memo;
+    Asset amount, fee;
+};
+} // namespace TW::Bitshares

--- a/src/Bitshares/Operation.h
+++ b/src/Bitshares/Operation.h
@@ -19,12 +19,12 @@ public:
                         uint64_t recipientId, 
                         const Asset& amount, 
                         const Asset& fee,
-                        Memo *memo);
+                        Memo *memo = nullptr);
 
     void serialize(Data& os) const noexcept override;
     nlohmann::json serialize() const noexcept override;
     void validate();
-    static const int OperationId = 0;
+    static constexpr int operationId() { return 0; };
 
 private:
     ObjectId from, to;

--- a/src/Coin.cpp
+++ b/src/Coin.cpp
@@ -36,6 +36,7 @@
 #include "Semux/Address.h"
 #include "ARK/Address.h"
 #include "Waves/Address.h"
+#include "Bitshares/Address.h"
 
 #include <TrustWalletCore/TWHRP.h>
 #include <TrustWalletCore/TWP2PKHPrefix.h>
@@ -61,6 +62,9 @@ bool TW::validateAddress(TWCoinType coin, const std::string& string) {
     case TWCoinTypeBitcoinCash:
         return Bitcoin::CashAddress::isValid(string) ||
                Bitcoin::Address::isValid(string, {{TWP2PKHPrefixBitcoin}, {TWP2SHPrefixBitcoin}});
+
+    case TWCoinTypeBitshares:
+        return Bravo::Address::isValid(string, {Bitshares::AddressPrefix});
 
     case TWCoinTypeBravoCoin:
         return Bravo::Address::isValid(string);
@@ -202,6 +206,9 @@ std::string TW::deriveAddress(TWCoinType coin, const PublicKey& publicKey) {
 
     case TWCoinTypeBitcoinCash:
         return Bitcoin::CashAddress(publicKey).string();
+
+    case TWCoinTypeBitshares:
+        return Bravo::Address(publicKey, {Bitshares::AddressPrefix}).string();
 
     case TWCoinTypeBravoCoin:
         return Bravo::Address(publicKey).string();

--- a/src/interface/TWBitsharesAddress.cpp
+++ b/src/interface/TWBitsharesAddress.cpp
@@ -1,0 +1,64 @@
+// Copyright � 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include <TrustWalletCore/TWBitsharesAddress.h>
+
+#include "../Data.h"
+#include "../Bitshares/Address.h"
+#include "../Bravo/Address.h"
+
+#include <TrustWalletCore/TWPublicKey.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace TW;
+using namespace TW::Bitshares;
+using Address = Bravo::Address;
+
+bool TWBitsharesAddressEqual(struct TWBitsharesAddress *_Nonnull lhs, struct TWBitsharesAddress *_Nonnull rhs) {
+	return lhs->impl == rhs->impl;
+}
+
+bool TWBitsharesAddressIsValidString(TWString *_Nonnull string) {
+	auto s = reinterpret_cast<const std::string *>(string);
+	return Address::isValid(*s, { AddressPrefix });
+}
+
+struct TWBitsharesAddress *_Nullable TWBitsharesAddressCreateWithString(TWString *_Nonnull string) {
+	auto s = reinterpret_cast<const std::string*>(string);
+
+	try {
+		return new TWBitsharesAddress{ Address(*s, { AddressPrefix }) };
+	}
+	catch (...) {
+		return nullptr;
+	}
+}
+
+struct TWBitsharesAddress *_Nonnull TWBitsharesAddressCreateWithPublicKey(struct TWPublicKey *_Nonnull publicKey) {
+		return new TWBitsharesAddress{ Address(publicKey->impl, AddressPrefix) };
+}
+
+struct TWBitsharesAddress *_Nullable TWBitsharesAddressCreateWithKeyHash(TWData *_Nonnull keyHash) {
+	auto d = reinterpret_cast<const Data *>(keyHash);
+	try {
+		return new TWBitsharesAddress{ Address(*d, AddressPrefix) };
+	}
+	catch (...) {
+		return nullptr;
+	}
+}
+
+void TWBitsharesAddressDelete(struct TWBitsharesAddress *_Nonnull address) {
+	delete address;
+}
+
+TWString *_Nonnull TWBitsharesAddressDescription(struct TWBitsharesAddress *_Nonnull address) {
+	const auto string = address->impl.string();
+	return TWStringCreateWithUTF8Bytes(string.c_str());
+}

--- a/src/interface/TWBitsharesAddress.cpp
+++ b/src/interface/TWBitsharesAddress.cpp
@@ -1,4 +1,4 @@
-// Copyright � 2017-2019 Trust Wallet.
+// Copyright © 2017-2019 Trust Wallet.
 //
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the

--- a/src/interface/TWBitsharesAddress.cpp
+++ b/src/interface/TWBitsharesAddress.cpp
@@ -6,9 +6,9 @@
 
 #include <TrustWalletCore/TWBitsharesAddress.h>
 
-#include "../Data.h"
 #include "../Bitshares/Address.h"
 #include "../Bravo/Address.h"
+#include "../Data.h"
 
 #include <TrustWalletCore/TWPublicKey.h>
 
@@ -20,45 +20,36 @@ using namespace TW;
 using namespace TW::Bitshares;
 using Address = Bravo::Address;
 
-bool TWBitsharesAddressEqual(struct TWBitsharesAddress *_Nonnull lhs, struct TWBitsharesAddress *_Nonnull rhs) {
-	return lhs->impl == rhs->impl;
+bool TWBitsharesAddressEqual(struct TWBitsharesAddress *_Nonnull lhs,
+                             struct TWBitsharesAddress *_Nonnull rhs) {
+    return lhs->impl == rhs->impl;
 }
 
 bool TWBitsharesAddressIsValidString(TWString *_Nonnull string) {
-	auto s = reinterpret_cast<const std::string *>(string);
-	return Address::isValid(*s, { AddressPrefix });
+    auto s = reinterpret_cast<const std::string *>(string);
+    return Address::isValid(*s, {AddressPrefix});
 }
 
 struct TWBitsharesAddress *_Nullable TWBitsharesAddressCreateWithString(TWString *_Nonnull string) {
-	auto s = reinterpret_cast<const std::string*>(string);
+    auto s = reinterpret_cast<const std::string *>(string);
 
-	try {
-		return new TWBitsharesAddress{ Address(*s, { AddressPrefix }) };
-	}
-	catch (...) {
-		return nullptr;
-	}
+    try {
+        return new TWBitsharesAddress{Address(*s, {AddressPrefix})};
+    } catch (...) {
+        return nullptr;
+    }
 }
 
-struct TWBitsharesAddress *_Nonnull TWBitsharesAddressCreateWithPublicKey(struct TWPublicKey *_Nonnull publicKey) {
-		return new TWBitsharesAddress{ Address(publicKey->impl, AddressPrefix) };
-}
-
-struct TWBitsharesAddress *_Nullable TWBitsharesAddressCreateWithKeyHash(TWData *_Nonnull keyHash) {
-	auto d = reinterpret_cast<const Data *>(keyHash);
-	try {
-		return new TWBitsharesAddress{ Address(*d, AddressPrefix) };
-	}
-	catch (...) {
-		return nullptr;
-	}
+struct TWBitsharesAddress *_Nonnull TWBitsharesAddressCreateWithPublicKey(
+    struct TWPublicKey *_Nonnull publicKey) {
+    return new TWBitsharesAddress{Address(publicKey->impl, AddressPrefix)};
 }
 
 void TWBitsharesAddressDelete(struct TWBitsharesAddress *_Nonnull address) {
-	delete address;
+    delete address;
 }
 
 TWString *_Nonnull TWBitsharesAddressDescription(struct TWBitsharesAddress *_Nonnull address) {
-	const auto string = address->impl.string();
-	return TWStringCreateWithUTF8Bytes(string.c_str());
+    const auto string = address->impl.string();
+    return TWStringCreateWithUTF8Bytes(string.c_str());
 }

--- a/src/interface/TWBitsharesSigner.cpp
+++ b/src/interface/TWBitsharesSigner.cpp
@@ -1,0 +1,64 @@
+#include <TrustWalletCore/TWBitsharesSigner.h>
+
+#include "../Bravo/Signer.h"
+#include "../Bitshares/Operation.h"
+#include "../proto/Bitshares.pb.h"
+#include "../proto/Common.pb.h"
+
+using namespace TW::Bitshares;
+
+static TW_Proto_Result createErrorResult(const std::string& description) {
+
+    auto result = TW::Proto::Result();
+    result.set_success(false);
+    result.set_error(description);
+    auto serialized = result.SerializeAsString();
+    return TWDataCreateWithBytes(reinterpret_cast<const uint8_t *>(serialized.data()), serialized.size());
+}
+
+TW_Proto_Result TWBitsharesSignerSign(TW_Bitshares_Proto_SigningInput input) {
+    Proto::SigningInput in;
+    bool success = in.ParseFromArray(TWDataBytes(input), static_cast<int>(TWDataSize(input)));
+
+    if (!success) {
+        return createErrorResult("Error parsing the input.");
+    }
+
+    try {
+        auto privateKey = TW::PrivateKey(TW::Data(in.private_key().begin(), in.private_key().end()));
+
+        // create a memo;
+        Memo *memo = nullptr;
+        const std::string& memoContents = in.memo();
+        if (memoContents.size()) {
+            auto publicKey = TW::PublicKey(TW::Data(in.recipient_public_key().begin(), in.recipient_public_key().end()));
+            memo = new Memo(privateKey, publicKey, memoContents);
+        }
+
+        // create a transfer operation
+        Asset asset {in.asset().amount(), in.asset().asset_id()};
+        Asset fee {in.fee().amount(), in.fee().asset_id()};
+        auto op = new TransferOperation(in.sender_id(), in.recipient_id(), asset, fee, memo);
+
+        // create a Transaction and add the transfer operation
+        TW::Bravo::Transaction tx{ TW::Data(in.reference_block_id().begin(), in.reference_block_id().end()), 
+                                in.reference_block_time() };
+        tx.addOperation(op);
+
+        // sign the transaction with a Signer
+        auto chainId = TW::Data(in.chain_id().begin(), in.chain_id().end());
+        TW::Bravo::Signer(chainId).sign(privateKey, tx);
+
+        // add transaction's json encoding to Signing Output and return that
+        Proto::SigningOutput out;
+        out.set_json_encoded(tx.serialize().dump());
+
+        auto result = TW::Proto::Result();
+        result.set_success(true);
+        result.add_objects()->PackFrom(out);
+        auto serialized = result.SerializeAsString();
+        return TWDataCreateWithBytes(reinterpret_cast<const uint8_t *>(serialized.data()), serialized.size());
+    } catch (const std::exception& e) {
+        return createErrorResult(e.what());
+    }
+}

--- a/src/interface/TWBitsharesSigner.cpp
+++ b/src/interface/TWBitsharesSigner.cpp
@@ -31,7 +31,7 @@ TW_Proto_Result TWBitsharesSignerSign(TW_Bitshares_Proto_SigningInput input) {
         Memo *memo = nullptr;
         const std::string& memoContents = in.memo();
         if (memoContents.size()) {
-            auto publicKey = TW::PublicKey(TW::Data(in.recipient_public_key().begin(), in.recipient_public_key().end()));
+            auto publicKey = TW::PublicKey(TW::Data(in.recipient_public_key().begin(), in.recipient_public_key().end()), TWPublicKeyTypeSECP256k1);
             memo = new Memo(privateKey, publicKey, memoContents);
         }
 

--- a/src/interface/TWBitsharesSigner.cpp
+++ b/src/interface/TWBitsharesSigner.cpp
@@ -1,3 +1,9 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
 #include <TrustWalletCore/TWBitsharesSigner.h>
 
 #include "../Bravo/Signer.h"

--- a/src/proto/Bitshares.proto
+++ b/src/proto/Bitshares.proto
@@ -1,0 +1,51 @@
+syntax = "proto3";
+
+package TW.Bitshares.Proto;
+option java_package = "wallet.core.jni.proto";
+
+// An asset's data.
+message Asset {
+    sint64 amount = 1;
+    uint64 asset_id = 2;
+}
+
+// Input data necessary to create a signed transaction.
+message SigningInput {
+    // Chain id (256-bit number)
+    bytes chain_id = 1;
+
+    // Sender's user id
+    uint64 sender_id = 2;
+
+    // Recipient's user id
+    uint64 recipient_id = 3;
+
+    // Asset to transfer
+    Asset asset = 4;
+
+    // Asset to send as fee
+    Asset fee = 5;
+
+    // Memo to attach to the transaction
+    string memo = 6;
+
+    // Recipient's public key's raw bytes
+    // Used for encrypting the memo.
+    // Can be left empty if memo is also empty
+    bytes recipient_public_key = 7;
+
+    // Reference Block Id (160-bits)
+    bytes reference_block_id = 8;
+
+    // Timestamp on the reference block
+    sfixed32 reference_block_time = 9;
+
+    // Sender's private key's raw bytes
+    bytes private_key = 10;
+}
+
+// Transaction signing output.
+message SigningOutput {
+    // JSON of the signed transaction.
+    string json_encoded = 1;
+}

--- a/swift/Sources/Addresses/CoinType+Address.swift
+++ b/swift/Sources/Addresses/CoinType+Address.swift
@@ -92,6 +92,8 @@ public extension CoinType {
             return ARKAddress(string: string)
         case .waves:
             return WavesAddress(string: string)
+        case .bitshares:
+            return BitsharesAddress(string: string)
         }
     }
 }

--- a/swift/Tests/Blockchains/BitsharesTests.swift
+++ b/swift/Tests/Blockchains/BitsharesTests.swift
@@ -86,7 +86,7 @@ class BitsharesTests: XCTestCase {
     }
     
     func testMemos() throws {
-        let message = "Hello world!"
+        let message = "Hello, world!"
         var inputWithMemo = signingInput
         let senderPublicKey = PrivateKey(data: Hash.sha256(data: "A".data(using: .utf8)!))!.getPublicKeySecp256k1(compressed: true)
         let recipientPublicKey = PrivateKey(data: Hash.sha256(data: "B".data(using: .utf8)!))!.getPublicKeySecp256k1(compressed: true)
@@ -120,6 +120,10 @@ class BitsharesTests: XCTestCase {
         let keyPlusIV = Hash.sha512(data: ("\(nonce)" + sharedSecretHex).data(using: .utf8)!)
         let decrypted = AES.cbcdecrypt(key: keyPlusIV[0..<32], data: encryptedData, iv: keyPlusIV[32..<48])
         XCTAssertNotNil(decrypted)
-        XCTAssertEqual(decrypted!.dropFirst(4), message.data(using: .utf8)!)
+        let messageData = message.data(using: .utf8)!
+        
+        // check decrypted bytes against the original message's bytes
+        // skip the checksum bytes (first 4) and the padding bytes
+        XCTAssertEqual(decrypted![4..<messageData.count + 4], messageData)
     }
 }

--- a/swift/Tests/Blockchains/BitsharesTests.swift
+++ b/swift/Tests/Blockchains/BitsharesTests.swift
@@ -1,3 +1,9 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
 import XCTest
 import TrustWalletCore
 

--- a/swift/Tests/Blockchains/BitsharesTests.swift
+++ b/swift/Tests/Blockchains/BitsharesTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+import TrustWalletCore
+
+class BitsharesTests: XCTestCase {
+    override func setUp() {
+        continueAfterFailure = false
+    }
+
+    func testAddresses() {
+        XCTAssertTrue(CoinType.bitshares.validate(address: "BTS52K5kMmwiRyNQYAf7ymCMz6hieE8siyrqNt1t57ac9hvBrRdaa"))
+        for addr in [
+            "52K5kMmwiRyNQYAf7ymCMz6hieE8siyrqNt1t57ac9hvBrRdaa",
+            "BTS52K5kMmwiRyNQYAf7ymCMz6hieE8siyrqNt1t57ac9hvBrRd",
+            "BTS52K5kMmwiRyNQYAf7ymCMz6hieE8siyrqNt1t57ac9hvBrRdaaaa",
+            "BITS52K5kMmwiRyNQYAf7ymCMz6hieE8siyrqNt1t57ac9hvBrRdaa",
+            ] {
+            XCTAssertFalse(CoinType.steem.validate(address: addr))
+        }
+    }
+    
+    
+    let signingInput: BitsharesSigningInput = {
+        let asset = BitsharesAsset.with {
+            $0.amount = 511;
+            $0.assetID = 0;
+        }
+        
+        let fee = BitsharesAsset.with {
+            $0.amount = 2;
+            $0.assetID = 0;
+        }
+
+        return BitsharesSigningInput.with {
+            $0.chainID = Data(repeating: 0, count: 32);
+            $0.senderID = 12;
+            $0.recipientID = 16;
+            $0.asset = asset;
+            $0.fee = fee;
+            $0.referenceBlockID = Data(hexString: "0000086bf9e7704509aa41311a66fa0a1b479c6b")!;
+            $0.referenceBlockTime = 1552464180;
+            $0.privateKey = Hash.sha256(data: "A".data(using: .utf8)!)
+        }
+        
+    }()
+
+    // ensure valid input is signed
+    func testSigning() throws {
+        let result = BitsharesSigner.sign(input: signingInput);
+        XCTAssertTrue(result.success, "Error signing: \(result.error)")
+        XCTAssertEqual(result.objects.count, 1)
+
+        let signingOutput = try BitsharesSigningOutput(unpackingAny: result.objects[0])
+        
+        let signedJSON = signingOutput.jsonEncoded
+        let data = signedJSON.data(using: .utf8)
+        XCTAssertNotNil(data)
+        
+        let jsonArray = try JSONSerialization.jsonObject(with: data!, options : .allowFragments) as? [String: Any]
+        XCTAssertNotNil(jsonArray, "Error parsing JSON result")
+        let signature = (jsonArray!["signatures"] as? [Any])?.first as? String
+        XCTAssertNotNil(signature, "Error parsing JSON result")
+        XCTAssertEqual(signature!, "1f0ee91e5f9cdd04629d4db71a6d5f0d75c282669bbaf84c184b6c18f04fe75dfb560969a9d8360f31bdd93b90c40dfe5fed601094433962205b4c49e925b51b24")
+    }
+    
+    // ensure invalid inputs are not signed
+    func testSigningFailures() throws {
+        var badInput = signingInput
+        badInput.asset.amount = 0
+        var result = BitsharesSigner.sign(input: badInput);
+        XCTAssertFalse(result.success, "Expected error but signing suceeded!")
+        
+        badInput = signingInput
+        badInput.fee.amount = -1;
+        result = BitsharesSigner.sign(input: badInput);
+        XCTAssertFalse(result.success, "Expected error but signing suceeded!")
+
+        badInput = signingInput
+        badInput.senderID = badInput.recipientID
+        result = BitsharesSigner.sign(input: badInput);
+        XCTAssertFalse(result.success, "Expected error but signing suceeded!")
+
+        badInput = signingInput
+        badInput.referenceBlockID = Data(hexString: "0000086bf9e7704509aa41311a66fa0a1b479c")!;
+        result = BitsharesSigner.sign(input: badInput);
+        XCTAssertFalse(result.success, "Expected error but signing suceeded!")
+    }
+    
+    func testMemos() throws {
+        let message = "Hello world!"
+        var inputWithMemo = signingInput
+        let senderPublicKey = PrivateKey(data: Hash.sha256(data: "A".data(using: .utf8)!))!.getPublicKeySecp256k1(compressed: true)
+        let recipientPublicKey = PrivateKey(data: Hash.sha256(data: "B".data(using: .utf8)!))!.getPublicKeySecp256k1(compressed: true)
+        inputWithMemo.memo = message
+        inputWithMemo.recipientPublicKey = recipientPublicKey.data
+        
+        let result = BitsharesSigner.sign(input: inputWithMemo);
+        XCTAssertTrue(result.success, "Error signing: \(result.error)")
+        XCTAssertEqual(result.objects.count, 1)
+        
+        let signingOutput = try BitsharesSigningOutput(unpackingAny: result.objects[0])
+        
+        let signedJSON = signingOutput.jsonEncoded
+        let data = signedJSON.data(using: .utf8)
+        XCTAssertNotNil(data)
+        
+        let jsonArray = try JSONSerialization.jsonObject(with: data!, options : .allowFragments) as? [String: Any]
+        XCTAssertNotNil(jsonArray, "Error parsing JSON result")
+        let memoJSON = (((jsonArray!["operations"] as? [Any])?.first as? [Any])?[1] as? [String: Any])?["memo"] as? [String: Any]
+        XCTAssertNotNil(memoJSON, "Error parsing JSON result")
+        
+        XCTAssertEqual(memoJSON!["to"] as! String, BitsharesAddress(publicKey: recipientPublicKey).description)
+        XCTAssertEqual(memoJSON!["from"] as! String, BitsharesAddress(publicKey: senderPublicKey).description)
+        
+        guard let encryptedHex = memoJSON!["message"] as? String, let encryptedData = Data(hexString: encryptedHex), let nonce = memoJSON!["nonce"] as? UInt64 else {
+            XCTFail("Failed to extract encrypted message")
+            return
+        }
+        
+        let sharedSecretHex = "05c160e88379eabeaac0ac98afd22486a1e1ec7982cebad6073d68647f8cdea8e61cb714f314a2ad2d9d6eb74cde6f1e7150823b361032c8b598dcd68957f474"
+        let keyPlusIV = Hash.sha512(data: ("\(nonce)" + sharedSecretHex).data(using: .utf8)!)
+        let decrypted = AES.cbcdecrypt(key: keyPlusIV[0..<32], data: encryptedData, iv: keyPlusIV[32..<48])
+        XCTAssertNotNil(decrypted)
+        XCTAssertEqual(decrypted!.dropFirst(4), message.data(using: .utf8)!)
+    }
+}

--- a/swift/Tests/Blockchains/BitsharesTests.swift
+++ b/swift/Tests/Blockchains/BitsharesTests.swift
@@ -23,27 +23,26 @@ class BitsharesTests: XCTestCase {
             XCTAssertFalse(CoinType.steem.validate(address: addr))
         }
     }
-    
-    
+
     let signingInput: BitsharesSigningInput = {
         let asset = BitsharesAsset.with {
-            $0.amount = 511;
-            $0.assetID = 0;
+            $0.amount = 511
+            $0.assetID = 0
         }
         
         let fee = BitsharesAsset.with {
-            $0.amount = 2;
-            $0.assetID = 0;
+            $0.amount = 2
+            $0.assetID = 0
         }
 
         return BitsharesSigningInput.with {
-            $0.chainID = Data(repeating: 0, count: 32);
-            $0.senderID = 12;
-            $0.recipientID = 16;
-            $0.asset = asset;
-            $0.fee = fee;
-            $0.referenceBlockID = Data(hexString: "0000086bf9e7704509aa41311a66fa0a1b479c6b")!;
-            $0.referenceBlockTime = 1552464180;
+            $0.chainID = Data(repeating: 0, count: 32)
+            $0.senderID = 12
+            $0.recipientID = 16
+            $0.asset = asset
+            $0.fee = fee
+            $0.referenceBlockID = Data(hexString: "0000086bf9e7704509aa41311a66fa0a1b479c6b")!
+            $0.referenceBlockTime = 1552464180
             $0.privateKey = Hash.sha256(data: "A".data(using: .utf8)!)
         }
         
@@ -51,7 +50,7 @@ class BitsharesTests: XCTestCase {
 
     // ensure valid input is signed
     func testSigning() throws {
-        let result = BitsharesSigner.sign(input: signingInput);
+        let result = BitsharesSigner.sign(input: signingInput)
         XCTAssertTrue(result.success, "Error signing: \(result.error)")
         XCTAssertEqual(result.objects.count, 1)
 
@@ -61,7 +60,7 @@ class BitsharesTests: XCTestCase {
         let data = signedJSON.data(using: .utf8)
         XCTAssertNotNil(data)
         
-        let jsonArray = try JSONSerialization.jsonObject(with: data!, options : .allowFragments) as? [String: Any]
+        let jsonArray = try JSONSerialization.jsonObject(with: data!, options: .allowFragments) as? [String: Any]
         XCTAssertNotNil(jsonArray, "Error parsing JSON result")
         let signature = (jsonArray!["signatures"] as? [Any])?.first as? String
         XCTAssertNotNil(signature, "Error parsing JSON result")
@@ -72,22 +71,22 @@ class BitsharesTests: XCTestCase {
     func testSigningFailures() throws {
         var badInput = signingInput
         badInput.asset.amount = 0
-        var result = BitsharesSigner.sign(input: badInput);
+        var result = BitsharesSigner.sign(input: badInput)
         XCTAssertFalse(result.success, "Expected error but signing suceeded!")
         
         badInput = signingInput
-        badInput.fee.amount = -1;
-        result = BitsharesSigner.sign(input: badInput);
+        badInput.fee.amount = -1
+        result = BitsharesSigner.sign(input: badInput)
         XCTAssertFalse(result.success, "Expected error but signing suceeded!")
 
         badInput = signingInput
         badInput.senderID = badInput.recipientID
-        result = BitsharesSigner.sign(input: badInput);
+        result = BitsharesSigner.sign(input: badInput)
         XCTAssertFalse(result.success, "Expected error but signing suceeded!")
 
         badInput = signingInput
-        badInput.referenceBlockID = Data(hexString: "0000086bf9e7704509aa41311a66fa0a1b479c")!;
-        result = BitsharesSigner.sign(input: badInput);
+        badInput.referenceBlockID = Data(hexString: "0000086bf9e7704509aa41311a66fa0a1b479c")!
+        result = BitsharesSigner.sign(input: badInput)
         XCTAssertFalse(result.success, "Expected error but signing suceeded!")
     }
     
@@ -99,7 +98,7 @@ class BitsharesTests: XCTestCase {
         inputWithMemo.memo = message
         inputWithMemo.recipientPublicKey = recipientPublicKey.data
         
-        let result = BitsharesSigner.sign(input: inputWithMemo);
+        let result = BitsharesSigner.sign(input: inputWithMemo)
         XCTAssertTrue(result.success, "Error signing: \(result.error)")
         XCTAssertEqual(result.objects.count, 1)
         
@@ -109,25 +108,31 @@ class BitsharesTests: XCTestCase {
         let data = signedJSON.data(using: .utf8)
         XCTAssertNotNil(data)
         
-        let jsonArray = try JSONSerialization.jsonObject(with: data!, options : .allowFragments) as? [String: Any]
+        let jsonArray = try JSONSerialization.jsonObject(with: data!, options: .allowFragments) as? [String: Any]
         XCTAssertNotNil(jsonArray, "Error parsing JSON result")
-        let memoJSON = (((jsonArray!["operations"] as? [Any])?.first as? [Any])?[1] as? [String: Any])?["memo"] as? [String: Any]
-        XCTAssertNotNil(memoJSON, "Error parsing JSON result")
-        
-        XCTAssertEqual(memoJSON!["to"] as! String, BitsharesAddress(publicKey: recipientPublicKey).description)
-        XCTAssertEqual(memoJSON!["from"] as! String, BitsharesAddress(publicKey: senderPublicKey).description)
-        
-        guard let encryptedHex = memoJSON!["message"] as? String, let encryptedData = Data(hexString: encryptedHex), let nonce = memoJSON!["nonce"] as? UInt64 else {
+        guard let memoJSON = (((jsonArray!["operations"] as? [Any])?.first as? [Any])?[1] as? [String: Any])?["memo"] as? [String: Any] else {
+            XCTFail("Error parsing JSON result")
+            return
+        }
+
+        guard let to = memoJSON["to"] as? String, let from = memoJSON["from"] as? String else {
+            XCTFail("Failed to extract memo fields.")
+            return
+        }
+        XCTAssertEqual(to, BitsharesAddress(publicKey: recipientPublicKey).description)
+        XCTAssertEqual(from, BitsharesAddress(publicKey: senderPublicKey).description)
+
+        guard let encryptedHex = memoJSON["message"] as? String, let encryptedData = Data(hexString: encryptedHex), let nonce = memoJSON["nonce"] as? UInt64 else {
             XCTFail("Failed to extract encrypted message")
             return
         }
-        
+
         let sharedSecretHex = "05c160e88379eabeaac0ac98afd22486a1e1ec7982cebad6073d68647f8cdea8e61cb714f314a2ad2d9d6eb74cde6f1e7150823b361032c8b598dcd68957f474"
         let keyPlusIV = Hash.sha512(data: ("\(nonce)" + sharedSecretHex).data(using: .utf8)!)
         let decrypted = AES.cbcdecrypt(key: keyPlusIV[0..<32], data: encryptedData, iv: keyPlusIV[32..<48])
         XCTAssertNotNil(decrypted)
         let messageData = message.data(using: .utf8)!
-        
+
         // check decrypted bytes against the original message's bytes
         // skip the checksum bytes (first 4) and the padding bytes
         XCTAssertEqual(decrypted![4..<messageData.count + 4], messageData)

--- a/swift/Tests/CoinAddressDerivationTests.swift
+++ b/swift/Tests/CoinAddressDerivationTests.swift
@@ -181,6 +181,9 @@ class CoinAddressDerivationTests: XCTestCase {
                 case .waves:
                     let expectedResult = "3P63vkaHhyE9pPv9EfsjwGKqmZYcCRHys4n"
                     AssetCoinDerivation(coin, expectedResult, derivedAddress, address)
+                case .bitshares:
+                    let expectedResult = "BTS58ARYk4isf7dm9HN8fjanEfmi9jCLJozVzeYNCWo8asZyb82uC"
+                    AssetCoinDerivation(coin, expectedResult, derivedAddress, address)
                 }
             }
         }

--- a/tests/Bitshares/AddressTests.cpp
+++ b/tests/Bitshares/AddressTests.cpp
@@ -1,0 +1,30 @@
+#include "Bravo/Address.h"
+#include "Bitshares/Address.h"
+
+#include <gtest/gtest.h>
+
+using Address = TW::Bravo::Address;
+
+static const std::string bitsharesPrefix = TW::Bitshares::AddressPrefix;
+static const std::vector<std::string> validPrefixes = {bitsharesPrefix};
+
+TEST(BitsharesAddress, Invalid) {
+    ASSERT_FALSE(Address::isValid("BTS5LZBF18uucMKVyKMQ7r6qnXBWn9StM5AJYHs1kidPeyNexuBUmm", validPrefixes));
+    ASSERT_FALSE(Address::isValid("BTS115LZBF18uucMKVyKMQ7r6qnXBWn9StM5AJYHs1kidPeyNexuBUm", validPrefixes));
+}
+
+TEST(BitsharesAddress, Base58) {
+    ASSERT_EQ(
+        Address("BTS5LZBF18uucMKVyKMQ7r6qnXBWn9StM5AJYHs1kidPeyNexuBUm", validPrefixes).string(),
+        "BTS5LZBF18uucMKVyKMQ7r6qnXBWn9StM5AJYHs1kidPeyNexuBUm"
+    );
+    ASSERT_EQ(
+        Address("BTS8Z6A8JeF4JMRaVAVcBxCE5NhtXz1WVHr6u1ckUnqqyc7HiTF4n", validPrefixes).string(),
+        "BTS8Z6A8JeF4JMRaVAVcBxCE5NhtXz1WVHr6u1ckUnqqyc7HiTF4n"
+    );
+}
+
+TEST(BitsharesAddress, IsValid) {
+    ASSERT_TRUE(Address::isValid("BTS4yPnD1zXSqyK4LFHkt1d5m5LZq2oaMFGYjosVXURUfqaUAXTKQ", validPrefixes));
+    ASSERT_TRUE(Address::isValid("BTS67eD8Rx4us2bjjxyc1ciWzP1MQJd8CvQDmiiqRnu5659LXMJiv", validPrefixes));
+}

--- a/tests/Bitshares/AddressTests.cpp
+++ b/tests/Bitshares/AddressTests.cpp
@@ -1,3 +1,9 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
 #include "Bravo/Address.h"
 #include "Bitshares/Address.h"
 

--- a/tests/Bitshares/AssetTests.cpp
+++ b/tests/Bitshares/AssetTests.cpp
@@ -1,0 +1,31 @@
+#include <stdexcept>
+#include <iostream>
+
+#include "Bitshares/Asset.h"
+#include "HexCoding.h"
+
+#include <gtest/gtest.h>
+
+using namespace TW;
+using namespace TW::Bitshares;
+
+TEST(BitsharesAsset, Serialization) {
+    Data buf;
+    Asset(2, 0).serialize(buf);
+    ASSERT_EQ(
+        hex(buf),
+        "020000000000000000"
+    );
+
+    buf.clear();
+    Asset(511, 256).serialize(buf);
+    ASSERT_EQ(
+        hex(buf),
+        "ff010000000000008002"
+    );
+
+    ASSERT_EQ(
+        Asset(511, 256).serialize().dump(),
+        "{\"amount\":511,\"asset_id\":\"1.3.256\"}"
+    );
+}

--- a/tests/Bitshares/AssetTests.cpp
+++ b/tests/Bitshares/AssetTests.cpp
@@ -1,3 +1,9 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
 #include <stdexcept>
 #include <iostream>
 

--- a/tests/Bitshares/MemoTests.cpp
+++ b/tests/Bitshares/MemoTests.cpp
@@ -13,8 +13,8 @@ TEST(BitsharesMemo, Invalid) {
     PrivateKey pk1{Hash::sha256(std::string("A"))};
     PrivateKey pk2{Hash::sha256(std::string("B"))};
 
-    ASSERT_THROW(Memo(pk1, pk2.getPublicKey(PublicKeyType::secp256k1Extended), "Hello, world!"), std::invalid_argument);
-    ASSERT_THROW(Memo(pk1, pk2.getPublicKey(PublicKeyType::secp256k1), ""), std::invalid_argument);
+    ASSERT_THROW(Memo(pk1, pk2.getPublicKey(TWPublicKeyTypeSECP256k1Extended), "Hello, world!"), std::invalid_argument);
+    ASSERT_THROW(Memo(pk1, pk2.getPublicKey(TWPublicKeyTypeSECP256k1), ""), std::invalid_argument);
 }
 
 TEST(BitsharesMemo, Serialization) {
@@ -23,7 +23,7 @@ TEST(BitsharesMemo, Serialization) {
 
     Memo *memo = nullptr;
 
-    ASSERT_NO_THROW(memo = new Memo(pk1, pk2.getPublicKey(PublicKeyType::secp256k1), "Hello, world! How are you doing?", 1));
+    ASSERT_NO_THROW(memo = new Memo(pk1, pk2.getPublicKey(TWPublicKeyTypeSECP256k1), "Hello, world! How are you doing?", 1));
 
     Data buf;
     memo->serialize(buf);

--- a/tests/Bitshares/MemoTests.cpp
+++ b/tests/Bitshares/MemoTests.cpp
@@ -1,0 +1,41 @@
+#include <stdexcept>
+#include <iostream>
+
+#include "Bitshares/Memo.h"
+#include "HexCoding.h"
+
+#include <gtest/gtest.h>
+
+using namespace TW;
+using namespace TW::Bitshares;
+
+TEST(BitsharesMemo, Invalid) {
+    PrivateKey pk1{Hash::sha256(std::string("A"))};
+    PrivateKey pk2{Hash::sha256(std::string("B"))};
+
+    ASSERT_THROW(Memo(pk1, pk2.getPublicKey(PublicKeyType::secp256k1Extended), "Hello, world!"), std::invalid_argument);
+    ASSERT_THROW(Memo(pk1, pk2.getPublicKey(PublicKeyType::secp256k1), ""), std::invalid_argument);
+}
+
+TEST(BitsharesMemo, Serialization) {
+    PrivateKey pk1{Hash::sha256(std::string("A"))};
+    PrivateKey pk2{Hash::sha256(std::string("B"))};
+
+    Memo *memo = nullptr;
+
+    ASSERT_NO_THROW(memo = new Memo(pk1, pk2.getPublicKey(PublicKeyType::secp256k1), "Hello, world! How are you doing?", 1));
+
+    Data buf;
+    memo->serialize(buf);
+    ASSERT_EQ(
+        hex(buf),
+        "0211c34c5d6472f63143085e0d0d78e1691b51d8244f759bc2ef2a50adb49404a902b08d858f075fb92b580a011d580ee2098a397177a46ab8bc67ed049b57c166380100000000000000305578960ffe4d94864bdbb6ab330814860924919b2b843077d0b1dba13f682c7474434c00262fccc5b079f963f6bc818f"
+    );
+
+    ASSERT_EQ(
+        memo->serialize().dump(),
+        "{\"from\":\"BTS52K5kMmwiRyNQYAf7ymCMz6hieE8siyrqNt1t57ac9hvBrRdaa\",\"message\":\"5578960ffe4d94864bdbb6ab330814860924919b2b843077d0b1dba13f682c7474434c00262fccc5b079f963f6bc818f\",\"nonce\":1,\"to\":\"BTS6EFA9Ge5KQaCS2jGZVf7xHZ6hzcH7uvikf5oR7YnYKemkucxB4\"}"
+    );
+
+    delete memo;
+}

--- a/tests/Bitshares/MemoTests.cpp
+++ b/tests/Bitshares/MemoTests.cpp
@@ -1,3 +1,9 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
 #include <stdexcept>
 #include <iostream>
 

--- a/tests/Bitshares/OperationTests.cpp
+++ b/tests/Bitshares/OperationTests.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 
 #include "Bitshares/Operation.h"
+#include "Bravo/Signer.h"
 #include "HexCoding.h"
 
 #include <gtest/gtest.h>
@@ -27,7 +28,7 @@ TEST(BitsharesOperation, Serialization) {
     op->serialize(buf);
     ASSERT_EQ(
         hex(buf),
-        "0200000000000000000c10ff0100000000000000010211c34c5d6472f63143085e0d0d78e1691b51d8244f759bc2ef2a50adb49404a902b08d858f075fb92b580a011d580ee2098a397177a46ab8bc67ed049b57c166380100000000000000203ccc8d3cfc1d68b4a2b18a4f51c3979c9ecad1cdc301f7b4a492c7a997e69fc800"
+        "000200000000000000000c10ff0100000000000000010211c34c5d6472f63143085e0d0d78e1691b51d8244f759bc2ef2a50adb49404a902b08d858f075fb92b580a011d580ee2098a397177a46ab8bc67ed049b57c166380100000000000000203ccc8d3cfc1d68b4a2b18a4f51c3979c9ecad1cdc301f7b4a492c7a997e69fc800"
     );
 
     ASSERT_EQ(
@@ -35,5 +36,21 @@ TEST(BitsharesOperation, Serialization) {
         "[0,{\"amount\":{\"amount\":511,\"asset_id\":\"1.3.0\"},\"extensions\":[],\"fee\":{\"amount\":2,\"asset_id\":\"1.3.0\"},\"from\":\"1.2.12\",\"memo\":{\"from\":\"BTS52K5kMmwiRyNQYAf7ymCMz6hieE8siyrqNt1t57ac9hvBrRdaa\",\"message\":\"3ccc8d3cfc1d68b4a2b18a4f51c3979c9ecad1cdc301f7b4a492c7a997e69fc8\",\"nonce\":1,\"to\":\"BTS6EFA9Ge5KQaCS2jGZVf7xHZ6hzcH7uvikf5oR7YnYKemkucxB4\"},\"to\":\"1.2.16\"}]"
     );
 
-    delete op;
+    // Test if TransferOperation works properly with Bravo Transactions as well
+    auto transaction = Bravo::Transaction(parse_hex("0000086bf9e7704509aa41311a66fa0a1b479c6b"), 1552464180);
+    transaction.addOperation(op);
+    op = nullptr;
+    Bravo::Signer(Data(32)).sign(pk1, transaction);
+
+    buf.clear();
+    transaction.serialize(buf);
+    ASSERT_EQ(
+        hex(buf),
+        "6b08f9e770458cbb885c01000200000000000000000c10ff0100000000000000010211c34c5d6472f63143085e0d0d78e1691b51d8244f759bc2ef2a50adb49404a902b08d858f075fb92b580a011d580ee2098a397177a46ab8bc67ed049b57c166380100000000000000203ccc8d3cfc1d68b4a2b18a4f51c3979c9ecad1cdc301f7b4a492c7a997e69fc80000"
+    );
+
+    ASSERT_EQ(
+        transaction.getSignatures().back().string(),
+        "1f7653bbcebb0be719e2fc29c77147570645eaa544eb82c9c36e48938b5feb5bea6e7e7758aa3e13ea1f7ff51692f30cbaa22e04fd77bbf01df9b92ce5faa688e6"
+    );
 }

--- a/tests/Bitshares/OperationTests.cpp
+++ b/tests/Bitshares/OperationTests.cpp
@@ -20,7 +20,7 @@ TEST(BitsharesOperation, Serialization) {
     PrivateKey pk1{Hash::sha256(std::string("A"))};
     PrivateKey pk2{Hash::sha256(std::string("B"))};
 
-    Memo *memo = new Memo(pk1, pk2.getPublicKey(PublicKeyType::secp256k1), "Hello, world!", 1);
+    Memo *memo = new Memo(pk1, pk2.getPublicKey(TWPublicKeyTypeSECP256k1), "Hello, world!", 1);
     TransferOperation *op = nullptr;
     ASSERT_NO_THROW(op = new TransferOperation(12, 16, Asset(511, 0), Asset(2, 0), memo));
 

--- a/tests/Bitshares/OperationTests.cpp
+++ b/tests/Bitshares/OperationTests.cpp
@@ -1,3 +1,9 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
 #include <stdexcept>
 #include <iostream>
 

--- a/tests/CoinAddressDerivationTests.cpp
+++ b/tests/CoinAddressDerivationTests.cpp
@@ -66,6 +66,7 @@ TEST(Coin, DeriveAddress) {
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeSemux, privateKey), "0x1574f7f969f41e030a75677af25bd9373b9c87f1");
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeZilliqa, privateKey), "zil1j2cvtd7j9n7fnxfv2r3neucjw8tp4xz9sp07v4");    
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeRavencoin, privateKey), "RSZYjMDCP4q3t7NAFXPPnqEGrMZn971pdB");    
+    EXPECT_EQ(TW::deriveAddress(TWCoinTypeBitshares, privateKey), "BTS5TrYnZP1RkDSUMzBY4GanCy6AP68kCMdkAb5EACkAwkdgRLShz");
 }
 
 } // namespace TW

--- a/tests/CoinAddressValidationTests.cpp
+++ b/tests/CoinAddressValidationTests.cpp
@@ -258,4 +258,11 @@ TEST(Coin, ValidateAddressWaves) {
     EXPECT_FALSE(validateAddress(TWCoinTypeWaves, "3P7WTh6kLKa8pAy4ynrSHm8TN8PVrdR7M1Q"));
 }
 
+TEST(Coin, ValidateAddressBitshares) {
+    EXPECT_TRUE(validateAddress(TWCoinTypeBitshares, "BTS67eD8Rx4us2bjjxyc1ciWzP1MQJd8CvQDmiiqRnu5659LXMJiv"));
+    EXPECT_TRUE(validateAddress(TWCoinTypeBitshares, "BTS4yPnD1zXSqyK4LFHkt1d5m5LZq2oaMFGYjosVXURUfqaUAXTKQ"));
+    EXPECT_FALSE(validateAddress(TWCoinTypeBitshares, "BTS5LZBF18uucMKVyKMQ7r6qnXBWn9StM5AJYHs1kidPeyNexuBUmm"));
+    EXPECT_FALSE(validateAddress(TWCoinTypeBitshares, "BTS115LZBF18uucMKVyKMQ7r6qnXBWn9StM5AJYHs1kidPeyNexuBUm"));
+}
+
 } // namespace TW

--- a/tests/interface/TWCoinTypeConfigTests.cpp
+++ b/tests/interface/TWCoinTypeConfigTests.cpp
@@ -136,6 +136,9 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetSymbol) {
 
     auto waves = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeWaves));
     assertStringsEqual(waves, "WAVES");
+
+    auto bts = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeBitshares));
+    assertStringsEqual(bts, "BTS");
 }
 
 TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetDecimals) {
@@ -183,6 +186,7 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetDecimals) {
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeARK), 8);
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeMonetaryUnit), 8);
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeWaves), 8);
+    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeBitshares), 5);
 }
 
 TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetTransactionURL) {
@@ -322,6 +326,9 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetTransactionURL) {
 
     auto waves = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeWaves, txId));
     assertStringsEqual(waves, "https://wavesexplorer.com/tx/123");
+
+    auto bts = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeBitshares, txId));
+    assertStringsEqual(bts, "https://cryptofresh.com/tx/123");
 }
 
 TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetID) {
@@ -453,6 +460,9 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetID) {
 
     auto waves = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeWaves));
     assertStringsEqual(waves, "waves");
+
+    auto bts = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeBitshares));
+    assertStringsEqual(bts, "bitshares");
 }
 
 TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetName) {
@@ -587,6 +597,9 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeConfigurationGetName) {
 
     auto waves = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeWaves));
     assertStringsEqual(waves, "Waves");
+
+    auto bts = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeBitshares));
+    assertStringsEqual(bts, "Bitshares");
 }
 
 TEST(TWCoinTypeConfiguration, TWCoinTypeBlockchain) {

--- a/tests/interface/TWCoinTypeConfigTests.cpp
+++ b/tests/interface/TWCoinTypeConfigTests.cpp
@@ -615,6 +615,7 @@ TEST(TWCoinTypeConfiguration, TWCoinTypeBlockchain) {
     ASSERT_EQ(TWBlockchainEOS, TWCoinTypeBlockchain(TWCoinTypeEOS));
     ASSERT_EQ(TWBlockchainSteem, TWCoinTypeBlockchain(TWCoinTypeSteem));
     ASSERT_EQ(TWBlockchainEOS, TWCoinTypeBlockchain(TWCoinTypeBravoCoin));
+    ASSERT_EQ(TWBlockchainEOS, TWCoinTypeBlockchain(TWCoinTypeBitshares));
     ASSERT_EQ(TWBlockchainNano, TWCoinTypeBlockchain(TWCoinTypeNano));
     ASSERT_EQ(TWBlockchainSemux, TWCoinTypeBlockchain(TWCoinTypeSemux));
     ASSERT_EQ(TWBlockchainZilliqa, TWCoinTypeBlockchain(TWCoinTypeZilliqa));


### PR DESCRIPTION
## Description

Adds support for [BitShares](bitshares.org) blockchain. While this is a graphene based blockchain as well, it differs in its implementation from Steem, Bravo and, EOS hence some of the code is new.

## Testing instructions

We have added tests in src/tests as well as swift and kotlin tests in their respective directories

## Types of changes

* New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [ ] Update documentation as needed.