### PR TITLE
Move logic in CoinType+Address.swift to C++ side

### DIFF
--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -13,6 +13,7 @@
 #include "TWPurpose.h"
 #include "TWString.h"
 #include "TWHDVersion.h"
+#include "TWHRP.h"
 
 TW_EXTERN_C_BEGIN
 
@@ -112,5 +113,8 @@ TWString *_Nonnull TWCoinTypeDeriveAddress(enum TWCoinType coin, struct TWPrivat
 /// Derives the address for a particular coin from the public key.
 TW_EXPORT_METHOD
 TWString *_Nonnull TWCoinTypeDeriveAddressFromPublicKey(enum TWCoinType coin, struct TWPublicKey *_Nonnull publicKey);
+
+TW_EXPORT_PROPERTY
+enum TWHRP TWCoinTypeHRP(enum TWCoinType coin);
 
 TW_EXTERN_C_END

--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -114,6 +114,7 @@ TWString *_Nonnull TWCoinTypeDeriveAddress(enum TWCoinType coin, struct TWPrivat
 TW_EXPORT_METHOD
 TWString *_Nonnull TWCoinTypeDeriveAddressFromPublicKey(enum TWCoinType coin, struct TWPublicKey *_Nonnull publicKey);
 
+/// HRP for this coin type
 TW_EXPORT_PROPERTY
 enum TWHRP TWCoinTypeHRP(enum TWCoinType coin);
 

--- a/src/IOST/Account.cpp
+++ b/src/IOST/Account.cpp
@@ -1,5 +1,6 @@
 #include "Account.h"
 #include "../Base58.h"
+#include "../Base58Address.h"
 
 using namespace TW;
 using namespace TW::IOST;
@@ -16,12 +17,13 @@ bool isAccountValid(const std::string& account) {
     return true;
 }
 
+bool isBase58AddressValid(const std::string& address) {
+    auto decoded = Base58::bitcoin.decode(address);
+    return decoded.size() == Base58Address<32>::size;
+}
+
 bool Account::isValid(const std::string& s) {
-    if (s.size() == 44) {
-        return true;
-    } else {
-        return isAccountValid(s);
-    }
+    return isAccountValid(s) ? true : isBase58AddressValid(s);
 }
 
 std::string Account::encodePubKey(const PublicKey& publicKey) {

--- a/src/IOST/Account.cpp
+++ b/src/IOST/Account.cpp
@@ -4,16 +4,24 @@
 using namespace TW;
 using namespace TW::IOST;
 
-bool Account::isValid(const std::string& s) {
-    if (s.size() < 5 || s.size() > 11) { 
-        return false; 
+bool isAccountValid(const std::string& account) {
+    if (account.size() < 5 || account.size() > 11) {
+        return false;
     }
-    for (char ch : s) {
+    for (char ch : account) {
         if ((ch < 'a' || ch > 'z') && (ch < '0' || ch > '9') && ch != '_') {
             return false;
         }
     }
     return true;
+}
+
+bool Account::isValid(const std::string& s) {
+    if (s.size() == 44) {
+        return true;
+    } else {
+        return isAccountValid(s);
+    }
 }
 
 std::string Account::encodePubKey(const PublicKey& publicKey) {

--- a/src/Zilliqa/Address.h
+++ b/src/Zilliqa/Address.h
@@ -20,11 +20,7 @@
 namespace TW::Zilliqa {
 
 static bool isValidAddress(const std::string &address) {
-    if (address.rfind("0x", 0) == 0) {
-        return true;
-    } else {
-        return Cosmos::Address::isValid(address, HRP_ZILLIQA);
-    }
+    return Cosmos::Address::isValid(address, HRP_ZILLIQA);
 }
 
 static Cosmos::Address Address(const PublicKey &publicKey) {

--- a/src/Zilliqa/Address.h
+++ b/src/Zilliqa/Address.h
@@ -20,7 +20,11 @@
 namespace TW::Zilliqa {
 
 static bool isValidAddress(const std::string &address) {
-    return Cosmos::Address::isValid(address, HRP_ZILLIQA);
+    if (address.rfind("0x", 0) == 0) {
+        return true;
+    } else {
+        return Cosmos::Address::isValid(address, HRP_ZILLIQA);
+    }
 }
 
 static Cosmos::Address Address(const PublicKey &publicKey) {

--- a/src/interface/TWCoinType.cpp
+++ b/src/interface/TWCoinType.cpp
@@ -5,6 +5,7 @@
 // file LICENSE at the root of the source code distribution tree.
 
 #include <TrustWalletCore/TWCoinType.h>
+#include <TrustWalletCore/TWHRP.h>
 
 #include "../Coin.h"
 
@@ -46,4 +47,31 @@ TWString *_Nonnull TWCoinTypeDeriveAddress(enum TWCoinType coin, struct TWPrivat
 TWString *_Nonnull TWCoinTypeDeriveAddressFromPublicKey(enum TWCoinType coin, struct TWPublicKey *_Nonnull publicKey) {
     const auto string = TW::deriveAddress(coin, publicKey->impl);
     return TWStringCreateWithUTF8Bytes(string.c_str());
+}
+
+enum TWHRP TWCoinTypeHRP(enum TWCoinType coin) {
+    switch (coin) {
+        case TWCoinTypeBitcoin:
+            return TWHRPBitcoin;
+        case TWCoinTypeBitcoinCash:
+            return TWHRPBitcoinCash;
+        case TWCoinTypeBinance:
+            return TWHRPBinance;
+        case TWCoinTypeCosmos:
+            return TWHRPCosmos;
+        case TWCoinTypeDigiByte:
+            return TWHRPDigiByte;
+        case TWCoinTypeLitecoin:
+            return TWHRPLitecoin;
+        case TWCoinTypeGroestlcoin:
+            return TWHRPGroestlcoin;
+        case TWCoinTypeViacoin:
+            return TWHRPViacoin;
+        case TWCoinTypeQtum:
+            return TWHRPQtum;
+        case TWCoinTypeZilliqa:
+            return TWHRPZilliqa;
+        default:
+            return TWHRPUnknown;
+    }
 }

--- a/swift/Sources/Addresses/CoinType+Address.swift
+++ b/swift/Sources/Addresses/CoinType+Address.swift
@@ -130,34 +130,6 @@ public extension CoinType {
             return Set()
         }
     }
-
-    /// HRP for this coin type.
-    var hrp: HRP {
-        switch self {
-        case .bitcoin:
-            return .bitcoin
-        case .bitcoinCash:
-            return .bitcoinCash
-        case .binance:
-            return .binance
-        case .cosmos:
-            return .cosmos
-        case .digiByte:
-            return .digiByte
-        case .litecoin:
-            return .litecoin
-        case .groestlcoin:
-            return .groestlcoin
-        case .viacoin:
-            return .viacoin
-        case .qtum:
-            return .qtum
-        case .zilliqa:
-            return .zilliqa
-        default:
-            return HRP.unknown
-        }
-    }
 }
 
 extension IOSTAccount: Address {}

--- a/swift/Sources/Addresses/CoinType+Address.swift
+++ b/swift/Sources/Addresses/CoinType+Address.swift
@@ -28,7 +28,7 @@ public extension CoinType {
             } else {
                 return BitcoinAddress(string: string)
             }
-        case .dash, .dogecoin, .zcoin, .lux, .monetaryUnit:
+        case .dash, .dogecoin, .zcoin, .lux, .monetaryUnit, .ravencoin:
             return BitcoinAddress(string: string)
         case .callisto, .ellaism, .ethereum, .ethereumClassic,
              .ethersocial, .goChain, .poanetwork, .theta,
@@ -90,8 +90,6 @@ public extension CoinType {
             return SemuxAddress(string: string)
         case .ark:
             return ARKAddress(string: string)
-        case .ravencoin:
-            return BitcoinAddress(string: string)
         case .waves:
             return WavesAddress(string: string)
         }

--- a/swift/Sources/Addresses/CoinType+Address.swift
+++ b/swift/Sources/Addresses/CoinType+Address.swift
@@ -9,26 +9,30 @@ import Foundation
 public extension CoinType {
     /// Converts a string to an address for this coin type.
     func address(string: String) -> Address? {
+        guard self.validate(address: string) else {
+            return nil
+        }
+
         switch self {
         case .binance, .cosmos:
-            if let addr = CosmosAddress(string: string), addr.hrp == hrp { return addr }
+            return CosmosAddress(string: string)
         case .bitcoin, .litecoin, .viacoin, .qtum, .digiByte:
-            if let addr = SegwitAddress(string: string), addr.hrp == hrp {
-                return addr
-            } else if let addr = BitcoinAddress(string: string), prefixSet.contains(addr.prefix) { return addr }
+            if let segwitAddress = SegwitAddress(string: string) {
+                return segwitAddress
+            } else {
+                return BitcoinAddress(string: string)
+            }
         case .bitcoinCash:
-            if let addr = BitcoinCashAddress(string: string) {
-                return addr
-            } else if let addr = BitcoinAddress(string: string), prefixSet.contains(addr.prefix) { return addr }
+            if let bitcoinCashAddress = BitcoinCashAddress(string: string) {
+                return bitcoinCashAddress
+            } else {
+                return BitcoinAddress(string: string)
+            }
         case .dash, .dogecoin, .zcoin, .lux, .monetaryUnit:
-            if let addr = BitcoinAddress(string: string), prefixSet.contains(addr.prefix) { return addr }
-        case .callisto, .ellaism,
-             .ethereum, .ethereumClassic,
-             .ethersocial, .goChain,
-             .poanetwork, .theta,
-             .thunderToken, .tomoChain,
-             .veChain, .xdai,
-             .dexon:
+            return BitcoinAddress(string: string)
+        case .callisto, .ellaism, .ethereum, .ethereumClassic,
+             .ethersocial, .goChain, .poanetwork, .theta,
+             .thunderToken, .tomoChain, .veChain, .xdai, .dexon:
             return EthereumAddress(string: string)
         case .wanchain:
             return WanchainAddress(string: string)
@@ -42,8 +46,7 @@ public extension CoinType {
             return TezosAddress(string: string)
         case .tron:
             return TronAddress(string: string)
-        case .zelcash,
-             .zcash:
+        case .zelcash, .zcash:
             return ZcashTAddress(string: string)
         case .nimiq:
             return NimiqAddress(string: string)
@@ -60,8 +63,8 @@ public extension CoinType {
         case .iocoin:
             return IocoinAddress(string: string)
         case .groestlcoin:
-            if let addr = SegwitAddress(string: string), addr.hrp == hrp {
-                return addr
+            if let segwitAddress = SegwitAddress(string: string) {
+                return segwitAddress
             } else {
                 return GroestlcoinAddress(string: string)
             }
@@ -88,46 +91,9 @@ public extension CoinType {
         case .ark:
             return ARKAddress(string: string)
         case .ravencoin:
-            if let addr = BitcoinAddress(string: string), prefixSet.contains(addr.prefix) { return addr }
+            return BitcoinAddress(string: string)
         case .waves:
             return WavesAddress(string: string)
-        }
-        return .none
-    }
-
-    /// Set of valid prefixes for this coin type.
-    var prefixSet: Set<UInt8> {
-        switch self {
-        case .bitcoin,
-             .bitcoinCash:
-            return Set([P2SHPrefix.bitcoin.rawValue, P2PKHPrefix.bitcoin.rawValue])
-        case .litecoin:
-            return Set([P2SHPrefix.litecoin.rawValue, P2PKHPrefix.litecoin.rawValue])
-        case .lux:
-            return Set([P2SHPrefix.s.rawValue, P2PKHPrefix.litecoin.rawValue])
-        case .groestlcoin:
-            return Set([P2SHPrefix.bitcoin.rawValue, P2PKHPrefix.groestlcoin.rawValue])
-        case .dash:
-            return Set([P2SHPrefix.dash.rawValue, P2PKHPrefix.dash.rawValue])
-        case .zcoin:
-            return Set([P2SHPrefix.zcoin.rawValue, P2PKHPrefix.zcoin.rawValue])
-        case .zelcash,
-             .zcash:
-            return Set([P2SHPrefix.zcashT.rawValue, P2PKHPrefix.zcashT.rawValue])
-        case .qtum:
-            return Set([P2PKHPrefix.qtum.rawValue])
-        case .dogecoin:
-            return Set([P2SHPrefix.dogecoin.rawValue, P2PKHPrefix.d.rawValue])
-        case .digiByte:
-            return Set([P2SHPrefix.bitcoin.rawValue, P2SHPrefix.s.rawValue, P2PKHPrefix.d.rawValue])
-        case .viacoin:
-            return Set([P2SHPrefix.viacoin.rawValue, P2PKHPrefix.viacoin.rawValue])
-        case .monetaryUnit:
-            return Set([P2SHPrefix.monetaryUnit.rawValue, P2PKHPrefix.monetaryUnit.rawValue])
-        case .ravencoin:
-            return Set([P2SHPrefix.ravencoin.rawValue, P2PKHPrefix.ravencoin.rawValue])
-        default:
-            return Set()
         }
     }
 }

--- a/swift/Tests/Addresses/BitcoinAddressTests.swift
+++ b/swift/Tests/Addresses/BitcoinAddressTests.swift
@@ -14,11 +14,34 @@ class BitcoinAddressTests: XCTestCase {
         XCTAssertNil(BitcoinAddress(string: "175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W"))
     }
 
+    func testInvalidByCoinType() {
+        XCTAssertNil(CoinType.bitcoin.address(string: "abc"))
+        XCTAssertNil(CoinType.bitcoin.address(string: "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"))
+        XCTAssertNil(CoinType.bitcoin.address(string: "175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W"))
+        XCTAssertNil(CoinType.bitcoin.address(string: "bx1q03h6k5lt6pzfjaanz5mlnmuc7aha2t3nkz7gh0"))
+        XCTAssertNil(CoinType.bitcoin.address(string: "bc1q03h6k5lt6pzfjaanz5mlnmuc7aha2t3nkz7gh0x"))
+    }
+
     func testInitWithString() {
         let address = BitcoinAddress(string: "1AC4gh14wwZPULVPCdxUkgqbtPvC92PQPN")
-
-        XCTAssertNotNil(address)
         XCTAssertEqual(address!.description, "1AC4gh14wwZPULVPCdxUkgqbtPvC92PQPN")
+
+        let address2 = BitcoinAddress(string: "396BPtVBUXqigCS2RCbUs4LFuA4QWW9djN")
+        XCTAssertEqual(address2!.description, "396BPtVBUXqigCS2RCbUs4LFuA4QWW9djN")
+
+        let address3 = SegwitAddress(string: "bc1q03h6k5lt6pzfjaanz5mlnmuc7aha2t3nkz7gh0")
+        XCTAssertEqual(address3!.description, "bc1q03h6k5lt6pzfjaanz5mlnmuc7aha2t3nkz7gh0")
+    }
+
+    func testInitWithStringByCoinType() {
+        let address1 = CoinType.bitcoin.address(string: "1AC4gh14wwZPULVPCdxUkgqbtPvC92PQPN")
+        XCTAssertEqual(address1!.description, "1AC4gh14wwZPULVPCdxUkgqbtPvC92PQPN")
+
+        let address2 = CoinType.bitcoin.address(string: "396BPtVBUXqigCS2RCbUs4LFuA4QWW9djN")
+        XCTAssertEqual(address2!.description, "396BPtVBUXqigCS2RCbUs4LFuA4QWW9djN")
+
+        let address3 = CoinType.bitcoin.address(string: "bc1q03h6k5lt6pzfjaanz5mlnmuc7aha2t3nkz7gh0")
+        XCTAssertEqual(address3!.description, "bc1q03h6k5lt6pzfjaanz5mlnmuc7aha2t3nkz7gh0")
     }
 
     func testFromPrivateKey() {

--- a/swift/Tests/Blockchains/ZilliqaTests.swift
+++ b/swift/Tests/Blockchains/ZilliqaTests.swift
@@ -11,10 +11,12 @@ class ZilliqaTests: XCTestCase {
 
     func testConfig() {
         XCTAssertEqual(coin.hrp, .zilliqa)
-        let address1 = coin.address(string: "0x7FCcaCf066a5F26Ee3AFfc2ED1FA9810Deaa632C")
-        let address2 = coin.address(string: "zil10lx2eurx5hexaca0lshdr75czr025cevqu83uz")
 
-        XCTAssertEqual(address1?.description, address2?.description)
+        let address1 = coin.address(string: "0x7FCcaCf066a5F26Ee3AFfc2ED1FA9810Deaa632C")
+        XCTAssertNil(address1)
+
+        let address2 = coin.address(string: "zil10lx2eurx5hexaca0lshdr75czr025cevqu83uz")
+        XCTAssertEqual("zil10lx2eurx5hexaca0lshdr75czr025cevqu83uz", address2?.description)
     }
 
     func testAddress() {

--- a/tests/IOST/AddressTests.cpp
+++ b/tests/IOST/AddressTests.cpp
@@ -1,0 +1,20 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "IOST/Account.h"
+
+#include <gtest/gtest.h>
+
+using namespace TW;
+using namespace TW::IOST;
+
+TEST(IOSTAddress, ValidateAccount) {
+    // https://www.iostabc.com/tx/DnR4QuRDJAjUZ2qfJK9MT92p95BBub2FnyigeXn2Z1es
+    ASSERT_TRUE(Account::isValid("12345xusong"));
+
+    ASSERT_FALSE(Account::isValid("1234"));
+    ASSERT_FALSE(Account::isValid("12345xusong6"));
+}

--- a/tests/IOST/AddressTests.cpp
+++ b/tests/IOST/AddressTests.cpp
@@ -14,8 +14,13 @@ using namespace TW::IOST;
 TEST(IOSTAddress, ValidateAccount) {
     // https://www.iostabc.com/tx/DnR4QuRDJAjUZ2qfJK9MT92p95BBub2FnyigeXn2Z1es
     ASSERT_TRUE(Account::isValid("12345xusong"));
+    ASSERT_TRUE(Account::isValid("12345"));
+    ASSERT_TRUE(Account::isValid("1234_xuson"));
     ASSERT_TRUE(Account::isValid("EKRQPgX7nKt8hJABwm9m3BKWGj7kcSECkJnCBauHQWin"));
 
     ASSERT_FALSE(Account::isValid("1234"));
+    ASSERT_FALSE(Account::isValid("1234_xusonG"));
     ASSERT_FALSE(Account::isValid("12345xusong6"));
+    ASSERT_FALSE(Account::isValid("bc1quvuarfksewfeuevuc6tn0kfyptgjvwsvrprk9d"));
+    ASSERT_FALSE(Account::isValid("DJRFZNg8jkUtjcpo2zJd92FUAzwRjitw6f"));
 }

--- a/tests/IOST/AddressTests.cpp
+++ b/tests/IOST/AddressTests.cpp
@@ -14,6 +14,7 @@ using namespace TW::IOST;
 TEST(IOSTAddress, ValidateAccount) {
     // https://www.iostabc.com/tx/DnR4QuRDJAjUZ2qfJK9MT92p95BBub2FnyigeXn2Z1es
     ASSERT_TRUE(Account::isValid("12345xusong"));
+    ASSERT_TRUE(Account::isValid("EKRQPgX7nKt8hJABwm9m3BKWGj7kcSECkJnCBauHQWin"));
 
     ASSERT_FALSE(Account::isValid("1234"));
     ASSERT_FALSE(Account::isValid("12345xusong6"));

--- a/tests/interface/TWHRPTests.cpp
+++ b/tests/interface/TWHRPTests.cpp
@@ -7,6 +7,7 @@
 #include "TWTestUtilities.h"
 
 #include <TrustWalletCore/TWHRP.h>
+#include <TrustWalletCore/TWCoinType.h>
 
 #include <gtest/gtest.h>
 
@@ -34,4 +35,62 @@ TEST(TWHRP, HRPForString) {
     ASSERT_EQ(hrpForString("grs"), TWHRPGroestlcoin);
     ASSERT_EQ(hrpForString("qc"), TWHRPQtum);
     ASSERT_EQ(hrpForString("zil"), TWHRPZilliqa);
+}
+
+TEST(TWHPR, HPRByCoinType) {
+    ASSERT_EQ(TWHRPBitcoin, TWCoinTypeHRP(TWCoinTypeBitcoin));
+    ASSERT_EQ(TWHRPBitcoinCash, TWCoinTypeHRP(TWCoinTypeBitcoinCash));
+    ASSERT_EQ(TWHRPBinance, TWCoinTypeHRP(TWCoinTypeBinance));
+    ASSERT_EQ(TWHRPCosmos, TWCoinTypeHRP(TWCoinTypeCosmos));
+    ASSERT_EQ(TWHRPDigiByte, TWCoinTypeHRP(TWCoinTypeDigiByte));
+    ASSERT_EQ(TWHRPLitecoin, TWCoinTypeHRP(TWCoinTypeLitecoin));
+    ASSERT_EQ(TWHRPGroestlcoin, TWCoinTypeHRP(TWCoinTypeGroestlcoin));
+    ASSERT_EQ(TWHRPViacoin, TWCoinTypeHRP(TWCoinTypeViacoin));
+    ASSERT_EQ(TWHRPQtum, TWCoinTypeHRP(TWCoinTypeQtum));
+    ASSERT_EQ(TWHRPZilliqa, TWCoinTypeHRP(TWCoinTypeZilliqa));
+
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeAion));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeBravoCoin));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeCallisto));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeDash));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeDecred));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeDogecoin));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeEllaism));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeEOS));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeEthereum));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeEthereumClassic));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeEthersocial));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeGoChain));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeICON));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeIOST));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeIocoin));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeIoTeX));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeKin));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeNULS));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeLux));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeNano));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeNEO));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeNimiq));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeOntology));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypePOANetwork));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeXRP));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeSteem));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeStellar));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeTezos));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeTheta));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeThunderToken));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeTomoChain));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeTron));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeVeChain));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeWanchain));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeXDai));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeZcash));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeZcoin));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeSemux));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeDEXON));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeZelcash));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeARK));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeMonetaryUnit));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeRavencoin));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeWaves));
 }


### PR DESCRIPTION
## Description
* implement code generation for `hrp` in `CoinType.swift`
* refactor address() in CoinType.swift to use the existing validation `TW::validateAddress()` in `Coin.cpp`