### PR TITLE
Improve AnySigner output message

### DIFF
--- a/src/proto/Any.proto
+++ b/src/proto/Any.proto
@@ -20,12 +20,10 @@ message SigningOutput {
         string description = 2;
     }
 
-    oneof output {
-        // Signing error
-        Error  error  = 1;
-        // Signing output as JSON
-        string json   = 2;
-        // Signing output encoded
-        string encoded = 3;
+    oneof result {
+        Error error = 1;
+        bool success = 2;
     }
+
+    string output = 4;
 }

--- a/tests/Any/SignerTests.cpp
+++ b/tests/Any/SignerTests.cpp
@@ -24,10 +24,9 @@ TEST(Signer, CosmosTransactionSign) {
     auto signer = Signer(input);
     auto output = signer.sign();
 
-    ASSERT_FALSE(output.has_error());
-    ASSERT_EQ("", output.encoded());
+    ASSERT_TRUE(output.success());
     ASSERT_EQ("{\"mode\":\"block\",\"tx\":{\"fee\":{\"amount\":[{\"amount\":\"5000\",\"denom\":\"uatom\"}],\"gas\":\"200000\"},\"memo\":\"Testing\",\"msg\":[{\"type\":\"cosmos-sdk/MsgSend\",\"value\":{\"amount\":[{\"amount\":\"995000\",\"denom\":\"uatom\"}],\"from_address\":\"cosmos1ufwv9ymhqaal6xz47n0jhzm2wf4empfqvjy575\",\"to_address\":\"cosmos135qla4294zxarqhhgxsx0sw56yssa3z0f78pm0\"}}],\"signatures\":[{\"pub_key\":{\"type\":\"tendermint/PubKeySecp256k1\",\"value\":\"A6EsukEXB53GhohQVeDpxtkeH8KQIayd/Co/ApYRYkTm\"},\"signature\":\"ULEpUqNzoAnYEx2x22F3ANAiPXquAU9+mqLWoAA/ZOUGTMsdb6vryzsW6AKX2Kqj1pGNdrTcQ58Z09JPyjpgEA==\"}],\"type\":\"cosmos-sdk/MsgSend\"}}",
-            output.json());
+            output.output());
 }
 
 TEST(Signer, BinanceTransactionSign) {
@@ -40,10 +39,9 @@ TEST(Signer, BinanceTransactionSign) {
     auto signer = Signer(input);
     auto output = signer.sign();
 
-    ASSERT_FALSE(output.has_error());
-    ASSERT_EQ("", output.json());
+    ASSERT_TRUE(output.success());
     ASSERT_EQ("ca01f0625dee0a4a2a2c87fa0a210a1412e654edef9e508b833736a987d069da5a89aedb12090a03424e4210cb8d5212210a1433bbf307b98146f13d20693cf946c2d77a4caf2812090a03424e4210cb8d52126d0a26eb5ae9872102e58176f271a9796b4288908be85094a2ac978e25535fd59a37b58626e3a84d9e1240015b4beb3d6ef366a7a92fd283f66b8f0d8cdb6b152a9189146b27f84f507f047e248517cf691a36ebc2b7f3b7f64e27585ce1c40f1928d119c31af428efcf3e1882671a0754657374696e672002",
-            output.encoded());
+            output.output());
 }
 
 TEST(Signer, EthereumTransactionSign) {
@@ -56,10 +54,9 @@ TEST(Signer, EthereumTransactionSign) {
     auto signer = Signer(input);
     auto output = signer.sign();
 
-    ASSERT_FALSE(output.has_error());
-    ASSERT_EQ("", output.json());
+    ASSERT_TRUE(output.success());;
     ASSERT_EQ("f86a8084d693a400825208947d8bf18c7ce84b3e175b339c4ca93aed1dd166f1870348bca5a160008025a0fe5802b49e04c6b1705088310e133605ed8b549811a18968ad409ea02ad79f21a05bf845646fb1e1b9365f63a7fd5eb5e984094e3ed35c3bed7361aebbcbf41f10",
-              output.encoded());
+              output.output());
 }
 
 TEST(Signer, NetworkNotSupported) {
@@ -72,7 +69,7 @@ TEST(Signer, NetworkNotSupported) {
     auto signer = Signer(input);
     auto output = signer.sign();
 
-    ASSERT_TRUE(output.has_error());
+    ASSERT_FALSE(output.success());
     ASSERT_EQ(SignerErrorCodeNotSupported, output.error().code());
     ASSERT_EQ("Network not supported", output.error().description());
 }
@@ -87,6 +84,6 @@ TEST(Signer, InvalidJsonFormat) {
     auto signer = Signer(input);
     auto output = signer.sign();
 
-    ASSERT_TRUE(output.has_error());
+    ASSERT_FALSE(output.success());
     ASSERT_EQ(SignerErrorCodeInvalidJson, output.error().code());
 }


### PR DESCRIPTION
## Description
I notice some inconsistencies between ios and android trust provider. This was due to the confusing output message, which I did myself (sorry). This PR is a simplification and improvement to AnySigner output message to remove any doubts about it's result.

## Testing instructions
Just run `./bootstrap.sh`

## Types of changes
 * Now `error` and `success` are grouped as `oneof`. If error was set, success is automatically false.
 * Now there is only one `output` property, which contains the signing result. Removed `json` and `encoded`.

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
