### PR TITLE
Fix thunder token mainnet chain id

### DIFF
--- a/include/TrustWalletCore/TWEthereumChainID.h
+++ b/include/TrustWalletCore/TWEthereumChainID.h
@@ -20,7 +20,7 @@ enum TWEthereumChainID {
     TWEthereumChainIDEthereumClassic = 61,
     TWEthereumChainIDEthersocial = 31102,
     TWEthereumChainIDVeChain = 74,
-    TWEthereumChainIDThunderToken = 18,
+    TWEthereumChainIDThunderToken = 108,
     TWEthereumChainIDTomoChain = 88,
     TWEthereumChainIDXDai = 100,
     TWEthereumChainIDDEXON = 237,


### PR DESCRIPTION
According to https://chainid.network/, we should use 108, not 18