### PR TITLE
Filecoin address class and tests

### DIFF
--- a/src/Filecoin/Address.cpp
+++ b/src/Filecoin/Address.cpp
@@ -59,7 +59,7 @@ Address::Address(const PublicKey& publicKey) {
 
 std::string Address::string() const {
     std::array<byte, encodedSize> encoded;
-    encoded[0] = 'f';
+    encoded[0] = FilecoinMainnetPrefix;
     encoded[1] = '1';
     std::array<byte, payloadSize+1> check;
     check[0] = 1;

--- a/src/Filecoin/Address.cpp
+++ b/src/Filecoin/Address.cpp
@@ -1,0 +1,74 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "../HexCoding.h"
+#include "../Hash.h"
+#include "Address.h"
+
+#include <TrezorCrypto/base32.h>
+
+#include <array>
+#include <iostream>
+
+using namespace TW;
+using namespace TW::Filecoin;
+
+bool Address::isValid(const std::string& string) {
+    if (string.size() != encodedSize) {
+        return false;
+    }
+    const size_t dataSize = payloadSize + checksumSize;
+    std::array<byte, dataSize> decoded;
+    // base32 decode
+    if (base32_decode(string.data()+2, string.size()-2, decoded.data(), dataSize, BASE32_ALPHABET_RFC4648) == nullptr) {
+        return false;
+    }
+    std::array<byte, payloadSize+1> check;
+    std::copy(decoded.data(), decoded.data()+payloadSize, check.data()+1);
+    check[0] = 1;
+    // compute checksum
+    auto hash = TW::Hash::blake2b(check.data(), check.data()+payloadSize+1, checksumSize);
+    // compare checksum
+    if (!std::equal(decoded.end() - checksumSize, decoded.end(), hash.begin())) {
+        return false;
+    }
+    return true;
+}
+
+Address::Address(const std::string& string) {
+    if (!isValid(string)) {
+        throw std::invalid_argument("Invalid address string");
+    }
+
+    const size_t dataSize = payloadSize + checksumSize;
+    std::array<byte, dataSize> decoded;
+    base32_decode(string.data()+2, string.size()-2, decoded.data(), dataSize, BASE32_ALPHABET_RFC4648);
+    std::copy(decoded.begin(), decoded.begin() + payloadSize, bytes.begin());
+}
+
+Address::Address(const PublicKey& publicKey) {
+    if (publicKey.type != TWPublicKeyTypeSECP256k1) {
+        throw std::invalid_argument("Invalid public key type");
+    }
+    auto hash = TW::Hash::blake2b(publicKey.bytes.data(), publicKey.bytes.data()+PublicKey::secp256k1Size, payloadSize);
+    std::copy(hash.begin(), hash.end(), bytes.data());
+}
+
+std::string Address::string() const {
+    std::array<byte, encodedSize> encoded;
+    encoded[0] = 'f';
+    encoded[1] = '1';
+    std::array<byte, payloadSize+1> check;
+    check[0] = 1;
+
+    std::copy(bytes.data(), bytes.data()+payloadSize, check.data()+1);
+    base32_encode(bytes.data(), payloadSize, reinterpret_cast<char*>(encoded.data()+2), encodedSize-2-7+1, BASE32_ALPHABET_RFC4648_LOWERCASE);
+    // compute checksum
+    auto hash = TW::Hash::blake2b(check.data(), check.data()+payloadSize+1, checksumSize);
+    base32_encode(hash.data(), checksumSize, reinterpret_cast<char*>(encoded.data()+2+32), 7+1, BASE32_ALPHABET_RFC4648_LOWERCASE);
+
+    return std::string(encoded.begin(), encoded.begin() + encodedSize);
+}

--- a/src/Filecoin/Address.h
+++ b/src/Filecoin/Address.h
@@ -1,0 +1,51 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "../Data.h"
+#include "../PublicKey.h"
+
+#include <string>
+
+namespace TW::Filecoin {
+
+class Address {
+  public:
+    const char* BASE32_ALPHABET_RFC4648_LOWERCASE = "abcdefghijklmnopqrstuvwxyz23456789";
+    /// 'f'/'t'+ protocol + base32 encoded address string length + checksum.
+    static const size_t encodedSize = 41;
+    static const size_t payloadSize = 20;
+
+    /// blake2b 4 bytes checksum size.
+    static const size_t checksumSize = 4;
+
+    /// Address data consisting of hashed public key.
+    std::array<byte, PublicKey::secp256k1Size> bytes;
+
+    /// Determines whether a string makes a valid address.
+    static bool isValid(const std::string& string);
+
+    /// Initializes a Filecoin address with a string representation.
+    explicit Address(const std::string& string);
+
+    /// Initializes a Filecoin address with a public key.
+    explicit Address(const PublicKey& publicKey);
+
+    /// Returns a string representation of the address.
+    std::string string() const;
+};
+
+inline bool operator==(const Address& lhs, const Address& rhs) {
+    return lhs.bytes == rhs.bytes;
+}
+
+} // namespace TW::Filecoin
+
+/// Wrapper for C interface.
+struct TWFilecoinAddress {
+    TW::Filecoin::Address impl;
+};

--- a/src/Filecoin/Address.h
+++ b/src/Filecoin/Address.h
@@ -15,7 +15,6 @@ namespace TW::Filecoin {
 
 class Address {
   public:
-    const char* BASE32_ALPHABET_RFC4648_LOWERCASE = "abcdefghijklmnopqrstuvwxyz23456789";
     /// 'f'/'t'+ protocol + base32 encoded address string length + checksum.
     static const size_t encodedSize = 41;
     static const size_t payloadSize = 20;

--- a/src/Filecoin/Address.h
+++ b/src/Filecoin/Address.h
@@ -15,6 +15,9 @@ namespace TW::Filecoin {
 
 class Address {
   public:
+    const char FilecoinMainnetPrefix = 'f';
+    const char FilecoinTestnetPrefix = 't';
+
     /// 'f'/'t'+ protocol + base32 encoded address string length + checksum.
     static const size_t encodedSize = 41;
     static const size_t payloadSize = 20;

--- a/tests/Filecoin/AddressTests.cpp
+++ b/tests/Filecoin/AddressTests.cpp
@@ -1,0 +1,45 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "HexCoding.h"
+#include "Filecoin/Address.h"
+#include "PublicKey.h"
+#include "PrivateKey.h"
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace TW;
+using namespace TW::Filecoin;
+
+TEST(FilecoinAddress, Validation) {
+    // empty address
+    ASSERT_FALSE(Address::isValid(""));
+    // invalid checksum
+    ASSERT_FALSE(Address::isValid("t15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pppp"));
+    // wrong length
+    ASSERT_FALSE(Address::isValid("t15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq "));
+    // Stellar address
+    ASSERT_FALSE(Address::isValid("t15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7p"));
+
+    ASSERT_TRUE(Address::isValid("f17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy"));
+}
+
+TEST(FilecoinAddress, FromPrivateKey) {
+    auto privateKey = PrivateKey(parse_hex("24dee5d2ceda995013f3227628a75f57185c9b9a52b1415a7b87aecf340b923a")); //pirvate key in base64 "JN7l0s7amVAT8yJ2KKdfVxhcm5pSsUFae4euzzQLkjo="
+    auto address = Address(privateKey.getPublicKey(TWPublicKeyTypeSECP256k1));
+    ASSERT_EQ(address.string(), "f1gd53ycqr7kc7rub2dbi2cumx5e4nqbi4tu3mhuy");
+}
+
+TEST(FilecoinAddress, FromPublicKey) {
+    auto publicKey = PublicKey(parse_hex("03cef0bb63eca86361e50fbf85e89282d91f6caa4e4137c556cd112b3bcfa9e82e"), TWPublicKeyTypeSECP256k1);
+    auto address = Address(publicKey);
+    ASSERT_EQ(address.string(), "f1gd53ycqr7kc7rub2dbi2cumx5e4nqbi4tu3mhuy");
+}
+
+TEST(FilecoinAddress, FromString) {
+    auto address = Address("f15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq");
+    ASSERT_EQ(address.string(), "f15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq");
+}

--- a/trezor-crypto/include/TrezorCrypto/base32.h
+++ b/trezor-crypto/include/TrezorCrypto/base32.h
@@ -32,6 +32,7 @@ extern "C" {
 #endif
 
 extern const char *BASE32_ALPHABET_RFC4648;
+extern const char *BASE32_ALPHABET_RFC4648_LOWERCASE;
 
 char *base32_encode(const uint8_t *in, size_t inlen, char *out, size_t outlen, const char *alphabet);
 void base32_encode_unsafe(const uint8_t *in, size_t inlen, uint8_t *out);

--- a/trezor-crypto/src/base32.c
+++ b/trezor-crypto/src/base32.c
@@ -25,6 +25,7 @@
 #include <string.h>
 
 const char *BASE32_ALPHABET_RFC4648 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ23456789";
+const char *BASE32_ALPHABET_RFC4648_LOWERCASE = "abcdefghijklmnopqrstuvwxyz23456789";
 
 static inline void base32_5to8(const uint8_t *in, uint8_t length, uint8_t *out);
 static inline bool base32_8to5(const uint8_t *in, uint8_t length, uint8_t *out, const char *alphabet);


### PR DESCRIPTION
## Description

Filecoin Address class and tests in the change
The filecoin wallet address is constructed with network symbol, protocol, hashed public key and the checksum.
In Address bytes it stores the hashed public key in binary, so two wallet address is comparable.

## Testing instructions

The AddressTests.cpp define the test data.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
