### PR TITLE
[WIP] [Test] Eth ABI header files can be now included multiple times

### DIFF
--- a/src/Ethereum/ABI/Array.h
+++ b/src/Ethereum/ABI/Array.h
@@ -15,18 +15,18 @@
 namespace TW::Ethereum {
 
 template <typename T>
-bool is_dynamic(std::vector<T>) {
+inline bool is_dynamic(std::vector<T>) {
     return true;
 }
 
 template <typename T>
-std::size_t size(const std::vector<T>& array) {
+inline std::size_t size(const std::vector<T>& array) {
     return 32 + std::accumulate(array.begin(), array.end(), 0u,
                                 [](size_t sum, auto x) { return sum + size(x); });
 }
 
 template <typename T>
-void encode(const std::vector<T>& array, Data& data) {
+inline void encode(const std::vector<T>& array, Data& data) {
     encode(uint256_t(array.size()), data);
 
     std::size_t headSize = 0;
@@ -55,7 +55,7 @@ void encode(const std::vector<T>& array, Data& data) {
 }
 
 template <typename T>
-std::string type_string(const std::vector<T>& array) {
+inline std::string type_string(const std::vector<T>& array) {
     return type_string(array[0]) + "[]";
 }
 

--- a/src/Ethereum/ABI/Bytes.cpp
+++ b/src/Ethereum/ABI/Bytes.cpp
@@ -1,0 +1,20 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Bytes.h"
+
+namespace TW::Ethereum {
+
+void encode(const Data& bytes, Data& data) {
+    encode(uint256_t(bytes.size()), data);
+
+    const auto count = std::min(std::size_t(32), bytes.size());
+    const auto padding = ((count + 31) / 32) * 32 - count;
+    data.insert(data.end(), bytes.begin(), bytes.begin() + count);
+    append(data, Data(padding));
+}
+
+} // namespace TW::Ethereum

--- a/src/Ethereum/ABI/Bytes.h
+++ b/src/Ethereum/ABI/Bytes.h
@@ -14,41 +14,34 @@ namespace TW::Ethereum {
 
 // dynamic bytes
 
-bool is_dynamic(Data) {
+inline bool is_dynamic(Data) {
     return true;
 }
 
-std::size_t size(const Data& bytes) {
+inline std::size_t size(const Data& bytes) {
     return 32 + ((bytes.size() + 31) / 32) * 32;
 }
 
-void encode(const Data& bytes, Data& data) {
-    encode(uint256_t(bytes.size()), data);
+void encode(const Data& bytes, Data& data);
 
-    const auto count = std::min(std::size_t(32), bytes.size());
-    const auto padding = ((count + 31) / 32) * 32 - count;
-    data.insert(data.end(), bytes.begin(), bytes.begin() + count);
-    append(data, Data(padding));
-}
-
-std::string type_string(const Data& data) {
+inline std::string type_string(const Data& data) {
     return "bytes";
 }
 
 // static bytes
 
 template <std::size_t N>
-bool is_dynamic(std::array<byte, N>) {
+inline bool is_dynamic(std::array<byte, N>) {
     return false;
 }
 
 template <std::size_t N>
-std::size_t size(const std::array<byte, N>& bytes) {
+inline std::size_t size(const std::array<byte, N>& bytes) {
     return ((bytes.size() + 31) / 32) * 32;
 }
 
 template <std::size_t N>
-void encode(const std::array<byte, N>& bytes, Data& data) {
+inline void encode(const std::array<byte, N>& bytes, Data& data) {
     const auto count = std::min(std::size_t(32), bytes.size());
     const auto padding = ((count + 31) / 32) * 32 - count;
     data.insert(data.end(), bytes.begin(), bytes.begin() + count);
@@ -56,26 +49,26 @@ void encode(const std::array<byte, N>& bytes, Data& data) {
 }
 
 template <std::size_t N>
-std::string type_string(const std::array<byte, N>& bytes) {
+inline std::string type_string(const std::array<byte, N>& bytes) {
     return "bytes" + std::to_string(N);
 }
 
 // string
 
-bool is_dynamic(std::string) {
+inline bool is_dynamic(std::string) {
     return true;
 }
 
-std::size_t size(const std::string& string) {
+inline std::size_t size(const std::string& string) {
     return string.size();
 }
 
-void encode(const std::string& string, Data& data) {
+inline void encode(const std::string& string, Data& data) {
     auto bytes = Data(string.begin(), string.end());
     encode(bytes, data);
 }
 
-std::string type_string(const std::string& data) {
+inline std::string type_string(const std::string& data) {
     return "string";
 }
 

--- a/src/Ethereum/ABI/Function.h
+++ b/src/Ethereum/ABI/Function.h
@@ -27,17 +27,17 @@ class Function {
 };
 
 template <typename... Params>
-bool is_dynamic(const Function<Params...>& f) {
+inline bool is_dynamic(const Function<Params...>& f) {
     return is_dynaic(f.parameters);
 }
 
 template <typename... Params>
-bool size(const Function<Params...>& f) {
+inline bool size(const Function<Params...>& f) {
     return 4 + size(f.parameters);
 }
 
 template <typename... Params>
-void encode(const Function<Params...>& f, Data& data) {
+inline void encode(const Function<Params...>& f, Data& data) {
     auto string = type_string(f);
     auto hash = Hash::keccak256(Data(string.begin(), string.end()));
     auto signature = Data(hash.begin(), hash.begin() + 4);
@@ -46,7 +46,7 @@ void encode(const Function<Params...>& f, Data& data) {
 }
 
 template <typename... Params>
-std::string type_string(const Function<Params...>& f) {
+inline std::string type_string(const Function<Params...>& f) {
     return f.name + "(" + type_string(f.parameters) + ")";
 }
 

--- a/src/Ethereum/ABI/Numbers.cpp
+++ b/src/Ethereum/ABI/Numbers.cpp
@@ -1,0 +1,23 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Numbers.h"
+
+namespace TW::Ethereum {
+
+void encode(uint256_t value, Data& data) {
+    Data bytes = store(value);
+
+    append(data, Data(encodedIntSize - bytes.size()));
+    append(data, bytes);
+}
+
+void encode(bool v, Data& data) {
+    append(data, Data(encodedIntSize - 1));
+    data.push_back(v ? 1 : 0);
+}
+
+} // namespace TW::Ethereum

--- a/src/Ethereum/ABI/Numbers.h
+++ b/src/Ethereum/ABI/Numbers.h
@@ -15,131 +15,123 @@ static constexpr std::size_t encodedIntSize = 32;
 
 // uint256_t
 
-bool is_dynamic(uint256_t) {
+inline bool is_dynamic(uint256_t) {
     return false;
 }
 
-std::size_t size(uint256_t) {
+inline std::size_t size(uint256_t) {
     return encodedIntSize;
 }
 
-void encode(uint256_t value, Data& data) {
-    Data bytes = store(value);
+void encode(uint256_t value, Data& data);
 
-    append(data, Data(encodedIntSize - bytes.size()));
-    append(data, bytes);
-}
-
-std::string type_string(uint256_t value) {
+inline std::string type_string(uint256_t value) {
     return "uint256";
 }
 
 // int256_t
 
-bool is_dynamic(int256_t) {
+inline bool is_dynamic(int256_t) {
     return false;
 }
 
-std::size_t size(int256_t) {
+inline std::size_t size(int256_t) {
     return encodedIntSize;
 }
 
-void encode(int256_t value, Data& data) {
+inline void encode(int256_t value, Data& data) {
     encode(static_cast<uint256_t>(value), data);
 }
 
-std::string type_string(int256_t value) {
+inline std::string type_string(int256_t value) {
     return "int256";
 }
 
 // bool
 
-bool is_dynamic(bool) {
+inline bool is_dynamic(bool) {
     return false;
 }
 
-std::size_t size(bool) {
+inline std::size_t size(bool) {
     return encodedIntSize;
 }
 
-void encode(bool v, Data& data) {
-    append(data, Data(encodedIntSize - 1));
-    data.push_back(v ? 1 : 0);
-}
+void encode(bool v, Data& data);
 
-std::string type_string(bool value) {
+inline std::string type_string(bool value) {
     return "bool";
 }
 
 // int32
 
-bool is_dynamic(int32_t) {
+inline bool is_dynamic(int32_t) {
     return false;
 }
 
-std::size_t size(int32_t) {
+inline std::size_t size(int32_t) {
     return encodedIntSize;
 }
 
-void encode(int32_t v, Data& data) {
+inline void encode(int32_t v, Data& data) {
     encode(static_cast<uint256_t>(v), data);
 }
 
-std::string type_string(int32_t value) {
+inline std::string type_string(int32_t value) {
     return "int32";
 }
 
 // uint32
 
-bool is_dynamic(uint32_t) {
+inline bool is_dynamic(uint32_t) {
     return false;
 }
 
-std::size_t size(uint32_t) {
+inline std::size_t size(uint32_t) {
     return encodedIntSize;
 }
 
-void encode(uint32_t v, Data& data) {
+inline void encode(uint32_t v, Data& data) {
     encode(static_cast<uint256_t>(v), data);
 }
 
-std::string type_string(uint32_t value) {
+inline std::string type_string(uint32_t value) {
     return "uint32";
 }
 
 // int64
 
-bool is_dynamic(int64_t) {
+inline bool is_dynamic(int64_t) {
     return false;
 }
 
-std::size_t size(int64_t) {
+inline std::size_t size(int64_t) {
     return encodedIntSize;
 }
 
-void encode(int64_t v, Data& data) {
+inline void encode(int64_t v, Data& data) {
     encode(static_cast<uint256_t>(v), data);
 }
 
-std::string type_string(int64_t value) {
+inline std::string type_string(int64_t value) {
     return "int64";
 }
 
 // uint64
 
-bool is_dynamic(uint64_t) {
+inline bool is_dynamic(uint64_t) {
     return false;
 }
 
-std::size_t size(uint64_t) {
+inline std::size_t size(uint64_t) {
     return encodedIntSize;
 }
 
-void encode(uint64_t v, Data& data) {
+inline void encode(uint64_t v, Data& data) {
     encode(static_cast<uint256_t>(v), data);
 }
 
-std::string type_string(uint64_t value) {
+inline std::string type_string(uint64_t value) {
     return "uint64";
 }
 

--- a/src/Ethereum/ABI/Tuple.h
+++ b/src/Ethereum/ABI/Tuple.h
@@ -17,53 +17,53 @@
 namespace TW::Ethereum {
 
 template <typename T, typename... Ts>
-auto head(std::tuple<T, Ts...> t) {
+inline auto head(std::tuple<T, Ts...> t) {
     return std::get<0>(t);
 }
 
 template <std::size_t... Ns, typename... Ts>
-auto tail_impl(std::index_sequence<Ns...>, std::tuple<Ts...> t) {
+inline auto tail_impl(std::index_sequence<Ns...>, std::tuple<Ts...> t) {
     return std::make_tuple(std::get<Ns + 1u>(t)...);
 }
 
 template <typename... Ts>
-auto tail(std::tuple<Ts...> t) {
+inline auto tail(std::tuple<Ts...> t) {
     return tail_impl(std::make_index_sequence<sizeof...(Ts) - 1u>(), t);
 }
 
-bool is_dynamic(const std::tuple<>& tuple) {
+inline bool is_dynamic(const std::tuple<>& tuple) {
     return false;
 }
 
 template <typename First, typename... T>
-bool is_dynamic(const std::tuple<First, T...>& tuple) {
+inline bool is_dynamic(const std::tuple<First, T...>& tuple) {
     return is_dynamic(head(tuple)) || is_dynamic(tail(tuple));
 }
 
-std::size_t head_size(const std::tuple<>& tuple) {
+inline std::size_t head_size(const std::tuple<>& tuple) {
     return 0;
 }
 
 template <typename First, typename... T>
-std::size_t head_size(const std::tuple<First, T...>& tuple) {
+inline std::size_t head_size(const std::tuple<First, T...>& tuple) {
     const auto s = is_dynamic(head(tuple)) ? 32 : size(head(tuple));
     return s + head_size(tail(tuple));
 }
 
-std::size_t size(const std::tuple<>& tuple) {
+inline std::size_t size(const std::tuple<>& tuple) {
     return 0;
 }
 
 template <typename First, typename... T>
-std::size_t size(const std::tuple<First, T...>& tuple) {
+inline std::size_t size(const std::tuple<First, T...>& tuple) {
     return size(head(tuple)) + size(tail(tuple));
 }
 
-void encode_small(const std::tuple<>& tuple, std::size_t headSize, std::size_t& offset,
+inline void encode_small(const std::tuple<>& tuple, std::size_t headSize, std::size_t& offset,
                   Data& data) {}
 
 template <typename First, typename... T>
-void encode_small(const std::tuple<First, T...>& tuple, std::size_t headSize, std::size_t& offset,
+inline void encode_small(const std::tuple<First, T...>& tuple, std::size_t headSize, std::size_t& offset,
                   Data& data) {
     auto value = head(tuple);
     if (is_dynamic(value)) {
@@ -76,10 +76,10 @@ void encode_small(const std::tuple<First, T...>& tuple, std::size_t headSize, st
     encode_small(tail(tuple), headSize, offset, data);
 }
 
-void encode_dynamic(const std::tuple<>& tuple, Data& data) {}
+inline void encode_dynamic(const std::tuple<>& tuple, Data& data) {}
 
 template <typename First, typename... T>
-void encode_dynamic(const std::tuple<First, T...>& tuple, Data& data) {
+inline void encode_dynamic(const std::tuple<First, T...>& tuple, Data& data) {
     auto value = head(tuple);
     if (is_dynamic(value)) {
         encode(value, data);
@@ -89,7 +89,7 @@ void encode_dynamic(const std::tuple<First, T...>& tuple, Data& data) {
 }
 
 template <typename... T>
-void encode(const std::tuple<T...>& tuple, Data& data) {
+inline void encode(const std::tuple<T...>& tuple, Data& data) {
     std::size_t headSize = head_size(tuple);
 
     std::size_t dynamicOffset = 0;
@@ -97,12 +97,12 @@ void encode(const std::tuple<T...>& tuple, Data& data) {
     encode_dynamic(tuple, data);
 }
 
-std::string type_string(const std::tuple<>& tuple) {
+inline std::string type_string(const std::tuple<>& tuple) {
     return "";
 }
 
 template <typename... T>
-std::string type_string(const std::tuple<T...>& tuple) {
+inline std::string type_string(const std::tuple<T...>& tuple) {
     std::string string = type_string(head(tuple));
     if (std::tuple_size<std::tuple<T...>>::value > 1) {
         string += "," + type_string(tail(tuple));


### PR DESCRIPTION
Eth ABI header files can be now included multiple times, contain only inline implementation.
Most methods have been turned into inline (one-liner), very few longer methods moved to .cpp files.