### PR TITLE
Fix build protobuf in docker

### DIFF
--- a/tools/install-dependencies
+++ b/tools/install-dependencies
@@ -68,6 +68,7 @@ tar xzf protobuf-java-$PROTOBUF_VERSION.tar.gz
 # Build Protobuf
 cd protobuf-$PROTOBUF_VERSION
 ./configure --prefix="$PREFIX"
+make clean
 make -j4
 make install
 "$PREFIX/bin/protoc" --version


### PR DESCRIPTION
Without this, the error message is: "error: cannot install 'libprotoc.la' to a directory not ending in /usr/local/lib"

https://github.com/protocolbuffers/protobuf/issues/148