### PR TITLE
ZCash: move prefix check more upstream, add C++ class level unit tests.

### DIFF
--- a/src/Coin.cpp
+++ b/src/Coin.cpp
@@ -142,8 +142,7 @@ bool TW::validateAddress(TWCoinType coin, const std::string &string) {
 
     case TWCoinTypeZelcash:
     case TWCoinTypeZcash:
-        return Zcash::TAddress::isValid(string, {{Zcash::TAddress::staticPrefix, p2pkh},
-                                                 {Zcash::TAddress::staticPrefix, p2sh}});
+        return Zcash::TAddress::isValid(string);
 
     case TWCoinTypeZilliqa:
         return Zilliqa::Address::isValid(string);

--- a/src/Zcash/TAddress.cpp
+++ b/src/Zcash/TAddress.cpp
@@ -6,7 +6,4 @@
 
 #include "TAddress.h"
 
-#include "../Base58.h"
-
 using namespace TW::Zcash;
-

--- a/src/Zcash/TAddress.h
+++ b/src/Zcash/TAddress.h
@@ -18,6 +18,18 @@ namespace TW::Zcash {
 class TAddress : public TW::Base58Address<22> {
   public:
     static const byte staticPrefix = 0x1c;
+    static const byte p2pkh = 0xB8; // p2pkhPrefix(TWCoinType::TWCoinTypeZcash);
+    static const byte p2sh = 0xBD; // p2shPrefix(TWCoinType::TWCoinTypeZcash);
+
+    /// Determines whether a string makes a valid ZCash address.
+    static bool isValid(const std::string& string) {
+        return TW::Base58Address<size>::isValid(string, {{staticPrefix, p2pkh}, {staticPrefix, p2sh}});
+    }
+
+    /// Determines whether a string makes a valid ZCash address, with possible prefixes.
+    static bool isValid(const std::string& string, const std::vector<Data>& validPrefixes) {
+        return TW::Base58Address<size>::isValid(string, validPrefixes);
+    }
 
     /// Initializes a  address with a string representation.
     explicit TAddress(const std::string& string) : TW::Base58Address<size>(string) {}
@@ -25,8 +37,8 @@ class TAddress : public TW::Base58Address<22> {
     /// Initializes a  address with a collection of bytes.
     explicit TAddress(const Data& data) : TW::Base58Address<size>(data) {}
 
-    /// Initializes a  address with a public key and a prefix.
-    TAddress(const PublicKey& publicKey, uint8_t prefix) : TW::Base58Address<size>(publicKey, {staticPrefix, prefix}) {}
+    /// Initializes a  address with a public key and a prefix (2nd byte).
+    TAddress(const PublicKey& publicKey, uint8_t prefix = p2pkh) : TW::Base58Address<size>(publicKey, {staticPrefix, prefix}) {}
 
   private:
     TAddress() = default;

--- a/tests/Zcash/AddressTests.cpp
+++ b/tests/Zcash/AddressTests.cpp
@@ -1,0 +1,67 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Zcash/TAddress.h"
+#include "HexCoding.h"
+#include "PrivateKey.h"
+
+#include <gtest/gtest.h>
+
+namespace TW::Zcash {
+
+TEST(ZcashAddress, FromPrivateKey) {
+    const auto privateKey =  PrivateKey(parse_hex("2d8f68944bdbfbc0769542fba8fc2d2a3de67393334471624364c7006da2aa54"));
+    const auto publicKey = privateKey.getPublicKey(TWPublicKeyTypeSECP256k1);
+    const auto address = TAddress(publicKey);
+
+    EXPECT_EQ(address.string(), "t1Wg9uPPAfwhBWeRjtDPa5ZHNzyBx9rJVKY");
+    EXPECT_EQ(address.bytes[0], 0x1c);
+    EXPECT_EQ(address.bytes[1], 0xb8);
+}
+
+TEST(ZcashAddress, FromPublicKey) {
+    const auto privateKey = PrivateKey(parse_hex("BE88DF1D0BF30A923CB39C3BB953178BAAF3726E8D3CE81E7C8462E046E0D835"));
+    const auto publicKey = privateKey.getPublicKey(TWPublicKeyTypeSECP256k1);
+    const auto address = TAddress(publicKey);
+
+    EXPECT_EQ(address.string(), "t1gaySCXCYtXE3ygP38YuWtVZczsEbdjG49");
+    EXPECT_EQ(address.bytes[0], 0x1c);
+    EXPECT_EQ(address.bytes[1], 0xb8);
+}
+
+TEST(ZcashAddress, Valid) {
+    EXPECT_TRUE(TAddress::isValid(std::string("t1RygJmrLdNGgi98gUgEJDTVaELTAYWoMBy")));
+    EXPECT_TRUE(TAddress::isValid(std::string("t1TWk2mmvESDnE4dmCfT7MQ97ij6ZqLpNVU")));
+    EXPECT_TRUE(TAddress::isValid(std::string("t3RD6RFKhWSotNbPEY4Vw7Ku9QCfKkzrbBL")));
+}
+
+TEST(ZcashAddress, Invalid) {
+    EXPECT_FALSE(TAddress::isValid(std::string("abc")));
+    EXPECT_FALSE(TAddress::isValid(std::string("0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed")));
+    EXPECT_FALSE(TAddress::isValid(std::string("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W")));
+    EXPECT_FALSE(TAddress::isValid(std::string("t1RygJmrLdNGgi98+UgEJDTVaELTAYWoMBy"))); // Invalid Base58
+    EXPECT_FALSE(TAddress::isValid(std::string("t1RygJmrLdNGgi98gUgEJDTVaELTAYW"))); // too short
+    EXPECT_FALSE(TAddress::isValid(std::string("t1RygJmrLdNGgi98gUgEJDTVaELTAYWoMBz"))); // bad checksum
+    EXPECT_FALSE(TAddress::isValid(std::string("TJRyWwFs9wTFGZg3JbrVriFbNfCug5tDeC"))); // too short
+    EXPECT_FALSE(TAddress::isValid(std::string("2NRbuP5YfzRNEa1RibT5kXay1VgvQHnydZY1"))); // invalid prefix
+}
+
+TEST(ZcashAddress, InitWithString) {
+    {
+        const auto address = TAddress("t1Wg9uPPAfwhBWeRjtDPa5ZHNzyBx9rJVKY");
+        EXPECT_EQ(address.string(), "t1Wg9uPPAfwhBWeRjtDPa5ZHNzyBx9rJVKY");
+        EXPECT_EQ(address.bytes[0], 0x1c);
+        EXPECT_EQ(address.bytes[1], 0xb8);
+    }
+    {
+        const auto address = TAddress("t3RD6RFKhWSotNbPEY4Vw7Ku9QCfKkzrbBL");
+        EXPECT_EQ(address.string(), "t3RD6RFKhWSotNbPEY4Vw7Ku9QCfKkzrbBL");
+        EXPECT_EQ(address.bytes[0], 0x1c);
+        EXPECT_EQ(address.bytes[1], 0xbd);
+    }
+}
+
+} // namespace TW::Zcash


### PR DESCRIPTION
## Description

Minor refactoring: move address prefix check more upstream, from Coin.cpp to Zcash::TAddress.
Add C++ class level unit tests for address (were missing).

## Testing instructions

Unit tests.

## Types of changes

* Minor refactoring, no behaviour change

## Checklist

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
