### PR TITLE
Fix generate-files on Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG CMAKE_VERSION=3.13.4
 ARG PROTOBUF_VERSION=3.9.0
 
 # Install the basics
-RUN apt-get update && apt-get install -y curl python-software-properties build-essential xz-utils libreadline-dev nano
+RUN apt-get update && apt-get install -y curl python-software-properties build-essential xz-utils libreadline-dev
 
 # Make latest NodeJS available
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG CMAKE_VERSION=3.13.4
 ARG PROTOBUF_VERSION=3.9.0
 
 # Install the basics
-RUN apt-get update && apt-get install -y curl python-software-properties build-essential xz-utils libreadline-dev
+RUN apt-get update && apt-get install -y curl python-software-properties build-essential xz-utils libreadline-dev nano
 
 # Make latest NodeJS available
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -

--- a/protobuf-plugin/CMakeLists.txt
+++ b/protobuf-plugin/CMakeLists.txt
@@ -22,3 +22,5 @@ target_link_libraries(protoc-gen-c-typedef protobuf -lprotoc -pthread)
 
 add_executable(protoc-gen-swift-typealias swift_typealias.cc ${PROTO_SRCS} ${PROTO_HDRS})
 target_link_libraries(protoc-gen-swift-typealias protobuf -lprotoc -pthread)
+
+install(TARGETS protoc-gen-c-typedef protoc-gen-swift-typealias DESTINATION bin)

--- a/tools/generate-files
+++ b/tools/generate-files
@@ -12,8 +12,17 @@ set -e
 
 ROOT="$PWD"
 PREFIX="${PREFIX:-$ROOT/build/local}"
+if [ ! -d $PREFIX ]
+then
+    echo $PREFIX does not exist, fallback to /usr/local
+    PREFIX=/usr/local
+fi
+echo "PREFIX: $PREFIX"
 PATH="$PREFIX/bin":$PATH
+LD_LIBRARY_PATH="$PREFIX/lib":$LD_LIBRARY_PATH
+# protoc executable (protobuf compiler)
 PROTOC="$PREFIX/bin/protoc"
+$PROTOC --version
 
 # Clean
 rm -rf swift/Sources/Generated
@@ -40,12 +49,8 @@ fi
 "$PROTOC" -I=$PREFIX/include -I=src/Zilliqa/Protobuf --cpp_out=src/Zilliqa/Protobuf src/Zilliqa/Protobuf/*.proto
 
 # Generate Proto interface file
-pushd protobuf-plugin
-cmake -H. -Bbuild
-make -Cbuild
-popd
-"$PROTOC" -I=$PREFIX/include -I=src/proto --plugin=protobuf-plugin/build/protoc-gen-c-typedef --c-typedef_out include/TrustWalletCore src/proto/*.proto
-"$PROTOC" -I=$PREFIX/include -I=src/proto --plugin=protobuf-plugin/build/protoc-gen-swift-typealias --swift-typealias_out swift/Sources/Generated/Protobuf src/proto/*.proto
+"$PROTOC" -I=$PREFIX/include -I=src/proto --plugin=$PREFIX/bin/protoc-gen-c-typedef --c-typedef_out include/TrustWalletCore src/proto/*.proto
+"$PROTOC" -I=$PREFIX/include -I=src/proto --plugin=$PREFIX/bin/protoc-gen-swift-typealias --swift-typealias_out swift/Sources/Generated/Protobuf src/proto/*.proto
 
 # Generate Xcode project
 if [ -x "$(command -v xcodegen)" ]; then

--- a/tools/generate-files
+++ b/tools/generate-files
@@ -27,10 +27,10 @@ then
     fi
 fi
 echo "PREFIX: $PREFIX"
-PATH="$PREFIX/bin":$PATH
+export PATH="$PREFIX/bin":$PATH
 # library paths, for protobuf plugins
-LD_LIBRARY_PATH="$PREFIX/lib":$LD_LIBRARY_PATH
-DYLD_LIBRARY_PATH="$PREFIX/lib":$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH="$PREFIX/lib":$LD_LIBRARY_PATH
+export DYLD_LIBRARY_PATH="$PREFIX/lib":$LD_LIBRARY_PATH
 # protoc executable (protobuf compiler)
 PROTOC="$PREFIX/bin/protoc"
 which $PROTOC

--- a/tools/generate-files
+++ b/tools/generate-files
@@ -10,18 +10,30 @@
 
 set -e
 
-ROOT="$PWD"
-PREFIX="${PREFIX:-$ROOT/build/local}"
-if [ ! -d $PREFIX ]
+# This script works in both Docker and normal build environments.
+# Protobuf and co. tools are taken from: $PREFIX if provided, or from $PWD/build/local if exists, or from /usr/bin
+if [ -z $PREFIX ]
 then
-    echo $PREFIX does not exist, fallback to /usr/local
-    PREFIX=/usr/local
+    # PREFIX not set
+    ROOT="$PWD"
+    PREFIX="$ROOT/build/local"
+    if  [ ! -d $PREFIX ] || \
+        [ ! -d $PREFIX/include ] || \
+        [ ! -f $PREFIX/bin/protoc ] || \
+        [ ! -f $PREFIX/bin/protoc-gen-c-typedef ]
+    then
+        echo $PREFIX does not exist or not complete, fallback to /usr/local
+        PREFIX=/usr/local
+    fi
 fi
 echo "PREFIX: $PREFIX"
 PATH="$PREFIX/bin":$PATH
+# library paths, for protobuf plugins
 LD_LIBRARY_PATH="$PREFIX/lib":$LD_LIBRARY_PATH
+DYLD_LIBRARY_PATH="$PREFIX/lib":$LD_LIBRARY_PATH
 # protoc executable (protobuf compiler)
 PROTOC="$PREFIX/bin/protoc"
+which $PROTOC
 $PROTOC --version
 
 # Clean

--- a/tools/install-dependencies
+++ b/tools/install-dependencies
@@ -4,6 +4,7 @@ set -e
 
 ROOT="$PWD"
 PREFIX="${PREFIX:-$ROOT/build/local}"
+echo "PREFIX: $PREFIX"
 
 # Setup up folders
 export PATH="$PREFIX/bin":$PATH
@@ -89,5 +90,11 @@ if [ -x "$(command -v swift)" ]; then
     cp -f "$SWIFT_PROTOBUF_DIR/swift-protobuf-$SWIFT_PROTOBUF_VERSION/.build/release/protoc-gen-swift" "$PREFIX/bin" | true
     $PREFIX/bin/protoc-gen-swift --version
 fi
+
+# Protobuf plugins
+cd "$ROOT/protobuf-plugin"
+cmake -H. -Bbuild -DCMAKE_INSTALL_PREFIX=$PREFIX
+make -Cbuild
+make -Cbuild install
 
 cd "$ROOT"


### PR DESCRIPTION
Fix generate-files on Docker.  In addition:
- All dependency binary compilation&install is done by tools/install-dependencies
- On Docker, /usr/local is used to place results, on non-Docker, local build dir
- Binaries are taken from $PREFIX variable
- moved protobuf-plugin compilation to install-dependencies.
Fixes #751 .

## Description

see above

## Testing instructions

docker -i -t trustwallet/wallet-core /bin/bash
cd wallet-core
./tools/generate-files

Note that ./tools/install-dependencies is not needed, but should also work now.

## Types of changes

<!-- * Bug fix (non-breaking change which fixes an issue) -->

## Checklist

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
