### PR TITLE
New runnable docker image

### DIFF
--- a/docker/wallet-core-run/Dockerfile
+++ b/docker/wallet-core-run/Dockerfile
@@ -1,0 +1,18 @@
+# Docker image with a built, runnable version of wallet-core
+FROM trustwallet/wallet-core
+
+ENV CC=/usr/bin/clang
+ENV CXX=/usr/bin/clang++
+# Prepare fresh git repo
+RUN cd /wallet-core && git checkout master && git pull
+
+# Build: generate, cmake, and make
+# rbenv trick is needed as Ruby is installed to non-standard location
+RUN cd /wallet-core \
+    && eval "$(/root/.rbenv/bin/rbenv init -)" \
+    && echo PATH $PATH \
+    && ./tools/generate-files \
+    && cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Debug \
+    && make -Cbuild
+
+CMD ["/bin/bash"]

--- a/docker/wallet-core/Dockerfile
+++ b/docker/wallet-core/Dockerfile
@@ -1,12 +1,11 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ARG CLANG_VERSION=7.0.1
 ARG CMAKE_VERSION=3.13.4
 ARG PROTOBUF_VERSION=3.9.0
 
 # Install the basics
-RUN apt-get update && apt-get install -y curl python-software-properties build-essential xz-utils libreadline-dev
-
+RUN apt-get update && apt-get install -y curl build-essential xz-utils libreadline-dev
 
 # Install all required packages
 RUN apt-get install -y \
@@ -62,10 +61,9 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ENV CC=/usr/bin/clang
 ENV CXX=/usr/bin/clang++
 RUN git clone https://github.com/TrustWallet/wallet-core.git
-# Prepare dependencies, with cleanuo
+# Prepare dependencies
 RUN cd /wallet-core \
     && export PREFIX=/usr/local \
-    && tools/install-dependencies \
-    && rm -Rf /wallet-core/build/protobuf
+    && tools/install-dependencies
 
 CMD ["/bin/bash"]

--- a/docker/wallet-core/Dockerfile
+++ b/docker/wallet-core/Dockerfile
@@ -7,8 +7,6 @@ ARG PROTOBUF_VERSION=3.9.0
 # Install the basics
 RUN apt-get update && apt-get install -y curl python-software-properties build-essential xz-utils libreadline-dev
 
-# Make latest NodeJS available
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 
 # Install all required packages
 RUN apt-get install -y \
@@ -19,7 +17,6 @@ RUN apt-get install -y \
     libssl-dev \
     libtool \
     ninja-build \
-    nodejs \
     pkg-config \
     unzip
 
@@ -43,15 +40,17 @@ RUN curl -fSsL https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_
     && mv boost_1_66_0/boost /usr/include \
     && rm -rf boost*
 
-# Install CMake
+# Install CMake, binaries from GitHub
 ENV CMAKE_VERSION=$CMAKE_VERSION
 RUN cd /usr/local/src \
-    && curl -fSsOL https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz \
-    && tar xvf cmake-$CMAKE_VERSION.tar.gz \
-    && cd cmake-$CMAKE_VERSION \
-    && ./bootstrap --system-curl \
-    && make \
-    && make install \
+    && curl -fSsOL https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz \
+    && ls -l cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz \
+    && tar xf cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz \
+    && cd cmake-$CMAKE_VERSION-Linux-x86_64 \
+    && cp -r bin /usr/ \
+    && cp -r share /usr/ \
+    && cp -r doc /usr/share/ \
+    && cp -r man /usr/share/ \
     && cd .. \
     && rm -rf cmake*
 RUN cmake --version
@@ -62,9 +61,11 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 # Clone repo
 ENV CC=/usr/bin/clang
 ENV CXX=/usr/bin/clang++
-RUN git clone https://github.com/TrustWallet/wallet-core.git \
-    && cd wallet-core \
+RUN git clone https://github.com/TrustWallet/wallet-core.git
+# Prepare dependencies, with cleanuo
+RUN cd /wallet-core \
     && export PREFIX=/usr/local \
-    && tools/install-dependencies
+    && tools/install-dependencies \
+    && rm -Rf /wallet-core/build/protobuf
 
 CMD ["/bin/bash"]

--- a/tools/docker-build
+++ b/tools/docker-build
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# This script builds the Docker image(s)
+
+docker build -t trustwallet/wallet-core:latest ./docker/wallet-core
+docker build -t trustwallet/wallet-core-run:latest ./docker/wallet-core-run

--- a/tools/install-dependencies
+++ b/tools/install-dependencies
@@ -70,6 +70,8 @@ cd protobuf-$PROTOBUF_VERSION
 ./configure --prefix="$PREFIX"
 make -j4
 make install
+# after install, cleanup to save space (docker)
+make clean
 "$PREFIX/bin/protoc" --version
 
 if [ -x "$(command -v swift)" ]; then


### PR DESCRIPTION
## Description

- New docker image, with built, runnable version of the library; called wallet-core-run
- Docker image optimizations:
-- Update docker image base to Ubuntu 18.04 (from 16.04)
-- CMake: install binaries, do not build, to speed up creation
-- Remove Nodejs.

Now it is possible to do:
- docker run -i -t trustwallet/wallet-core-run:latest
- cd wallet-core && ./build/tests/tests tests

## Testing instructions

- docker build -t trustwallet/wallet-core-run:latest ./docker/wallet-core-run
- docker run -i -t trustwallet/wallet-core-run:latest
- cd wallet-core && ./build/tests/tests tests

## Types of changes

* New feature (non-breaking change which adds functionality)

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
