### PR TITLE
Ethereum ABI: Fix address parameter padding.

### DIFF
--- a/src/Ethereum/ABI/ParamAddress.h
+++ b/src/Ethereum/ABI/ParamAddress.h
@@ -12,14 +12,24 @@
 
 namespace TW::Ethereum::ABI {
 
-/// 160-bit Address parameter, "address"
-class ParamAddress: public ParamByteArrayFix
+/// 160-bit Address parameter, "address".  Padded to the right, treated like ParamUInt160
+class ParamAddress: public ParamUIntN
 {
 public:
-    static const size_t bytes = 160/8;
-    ParamAddress(): ParamByteArrayFix(bytes) {}
-    ParamAddress(const Data& val): ParamByteArrayFix(bytes, val) {}
+    static const size_t bytes = 20;
+    static const size_t bits = bytes * 8;
+    ParamAddress(): ParamUIntN(bits) {}
+    ParamAddress(const Data& val): ParamUIntN(bits, TW::load(val)) {}
     virtual std::string getType() const { return "address"; };
+    // get the value as (20-byte) byte array (as opposed to uint256_t)
+    Data getData() const {
+        Data data = TW::store(getVal());
+        if (data.size() >= bytes) { return data; }
+        // need to pad
+        Data padded(bytes - data.size());
+        TW::append(padded, data);
+        return padded;
+    }
 };
 
 } // namespace TW::Ethereum::ABI

--- a/src/interface/TWEthereumAbiFunction.cpp
+++ b/src/interface/TWEthereumAbiFunction.cpp
@@ -282,7 +282,7 @@ TWData *_Nonnull TWEthereumAbiFunctionGetParamAddress(struct TWEthereumAbiFuncti
     if (!function.getParam(idx, param, isOutput)) {
         return TWDataCreateWithBytes(valData.data(), valData.size());
     }
-    valData = (std::dynamic_pointer_cast<ParamAddress>(param))->getVal();
+    valData = (std::dynamic_pointer_cast<ParamAddress>(param))->getData();
     return TWDataCreateWithBytes(valData.data(), valData.size());
 }
 

--- a/tests/Ethereum/AbiTests.cpp
+++ b/tests/Ethereum/AbiTests.cpp
@@ -386,7 +386,7 @@ TEST(EthereumAbi, ParamAddress) {
     Data val1(parse_hex(val1Str));
     {
         auto param = ParamAddress(val1);
-        EXPECT_EQ(val1, param.getVal());
+        EXPECT_EQ(val1, param.getData());
 
         EXPECT_EQ("address", param.getType());
         EXPECT_FALSE(param.isDynamic());
@@ -396,10 +396,24 @@ TEST(EthereumAbi, ParamAddress) {
         auto param = ParamAddress(val1);
         Data encoded;
         param.encode(encoded);
-        EXPECT_EQ("f784682c82526e245f50975190ef0fff4e4fc077000000000000000000000000", hex(encoded));
+        EXPECT_EQ("000000000000000000000000f784682c82526e245f50975190ef0fff4e4fc077", hex(encoded));
         size_t offset = 0;
         EXPECT_TRUE(param.decode(encoded, offset));
-        EXPECT_EQ(val1, param.getVal());
+        EXPECT_EQ(val1, param.getData());
+    }
+    {
+        auto param = ParamAddress(parse_hex("0000000000000000000000000000000000000012"));
+        EXPECT_EQ("0000000000000000000000000000000000000012", hex(param.getData()));
+        Data encoded;
+        param.encode(encoded);
+        EXPECT_EQ("0000000000000000000000000000000000000000000000000000000000000012", hex(encoded));
+    }
+    {
+        auto param = ParamAddress(parse_hex("4300000000000000000000000000000000000000"));
+        EXPECT_EQ("4300000000000000000000000000000000000000", hex(param.getData()));
+        Data encoded;
+        param.encode(encoded);
+        EXPECT_EQ("0000000000000000000000004300000000000000000000000000000000000000", hex(encoded));
     }
 }
 
@@ -506,15 +520,15 @@ TEST(EthereumAbi, ParamArrayAddress) {
         param.encode(encoded);
         EXPECT_EQ(
             "0000000000000000000000000000000000000000000000000000000000000002"
-            "f784682c82526e245f50975190ef0fff4e4fc077000000000000000000000000"
-            "2e00cd222cb42b616d86d037cc494e8ab7f5c9a3000000000000000000000000",
+            "000000000000000000000000f784682c82526e245f50975190ef0fff4e4fc077"
+            "0000000000000000000000002e00cd222cb42b616d86d037cc494e8ab7f5c9a3",
             hex(encoded));
         size_t offset = 0;
         EXPECT_TRUE(param.decode(encoded, offset));
         EXPECT_EQ(2, param.getVal().size());
         EXPECT_EQ(
             "2e00cd222cb42b616d86d037cc494e8ab7f5c9a3", 
-            hex((std::dynamic_pointer_cast<ParamAddress>(param.getVal()[1]))->getVal()));
+            hex((std::dynamic_pointer_cast<ParamAddress>(param.getVal()[1]))->getData()));
     }
 }
 


### PR DESCRIPTION
## Description

Change padding of Address type ABI parameter; treated as UInt160, not ByteArray20; padded to the right, not left.
Fixes #756 .

## Testing instructions

Unit tests, *Abi*.

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
