### PR TITLE
HDWallet: New method to derive address directly from wallet.

### DIFF
--- a/include/TrustWalletCore/TWHDWallet.h
+++ b/include/TrustWalletCore/TWHDWallet.h
@@ -57,6 +57,10 @@ struct TWPrivateKey *_Nonnull TWHDWalletGetMasterKey(struct TWHDWallet *_Nonnull
 TW_EXPORT_METHOD
 struct TWPrivateKey *_Nonnull TWHDWalletGetKeyForCoin(struct TWHDWallet *_Nonnull wallet, enum TWCoinType coin);
 
+/// Generates the default address for the specified coin (without exposing intermediary private key).
+TW_EXPORT_METHOD
+TWString *_Nonnull TWHDWalletGetAddressForCoin(struct TWHDWallet *_Nonnull wallet, enum TWCoinType coin);
+
 /// Generates the private key for the specified derivation path.
 TW_EXPORT_METHOD
 struct TWPrivateKey *_Nonnull TWHDWalletGetKey(struct TWHDWallet *_Nonnull wallet, TWString *_Nonnull derivationPath);

--- a/src/Bitcoin/SegwitAddress.cpp
+++ b/src/Bitcoin/SegwitAddress.cpp
@@ -51,7 +51,7 @@ bool SegwitAddress::isValid(const std::string& string, const std::string& hrp) {
 SegwitAddress::SegwitAddress(const PublicKey& publicKey, int witver, std::string hrp)
     : hrp(std::move(hrp)), witnessVersion(witver), witnessProgram() {
     if (publicKey.type != TWPublicKeyTypeSECP256k1) {
-        throw std::invalid_argument("SegwitAddressneeds a compressed SECP256k1 public key.");
+        throw std::invalid_argument("SegwitAddress needs an extended SECP256k1 public key.");
     }
     witnessProgram.resize(20);
     ecdsa_get_pubkeyhash(publicKey.compressed().bytes.data(), HASHER_SHA2_RIPEMD,

--- a/src/Bitcoin/SegwitAddress.cpp
+++ b/src/Bitcoin/SegwitAddress.cpp
@@ -51,7 +51,7 @@ bool SegwitAddress::isValid(const std::string& string, const std::string& hrp) {
 SegwitAddress::SegwitAddress(const PublicKey& publicKey, int witver, std::string hrp)
     : hrp(std::move(hrp)), witnessVersion(witver), witnessProgram() {
     if (publicKey.type != TWPublicKeyTypeSECP256k1) {
-        throw std::invalid_argument("SegwitAddress needs an extended SECP256k1 public key.");
+        throw std::invalid_argument("SegwitAddress needs a compressed SECP256k1 public key.");
     }
     witnessProgram.resize(20);
     ecdsa_get_pubkeyhash(publicKey.compressed().bytes.data(), HASHER_SHA2_RIPEMD,

--- a/src/interface/TWHDWallet.cpp
+++ b/src/interface/TWHDWallet.cpp
@@ -49,6 +49,13 @@ struct TWPrivateKey *_Nonnull TWHDWalletGetKeyForCoin(struct TWHDWallet *wallet,
     return new TWPrivateKey{ wallet->impl.getKey(derivationPath) };
 }
 
+TWString *_Nonnull TWHDWalletGetAddressForCoin(struct TWHDWallet *wallet, TWCoinType coin) {
+    auto derivationPath = TW::derivationPath(coin);
+    PrivateKey privateKey = wallet->impl.getKey(derivationPath);
+    std::string address = deriveAddress(coin, privateKey);
+    return TWStringCreateWithUTF8Bytes(address.c_str());
+}
+
 struct TWPrivateKey *_Nonnull TWHDWalletGetKey(struct TWHDWallet *_Nonnull wallet, TWString *_Nonnull derivationPath) {
     auto& s = *reinterpret_cast<const std::string*>(derivationPath);
     return new TWPrivateKey{ wallet->impl.getKey( TW::DerivationPath(s)) };

--- a/tests/interface/TWHDWalletTests.cpp
+++ b/tests/interface/TWHDWalletTests.cpp
@@ -95,7 +95,16 @@ TEST(HDWallet, Derive) {
     assertHexEqual(publicKey0Data, "0414acbe5a06c68210fcbb77763f9612e45a526990aeb69d692d705f276f558a5ae68268e9389bb099ed5ac84d8d6861110f63644f6e5b447e3f86b4bab5dee011");
 }
 
-TEST(HDWallet, DeriveBitcoin) {
+TEST(HDWallet, DeriveBitcoinNonextended) {
+    auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), passphrase.get()));
+    auto key = WRAP(TWPrivateKey, TWHDWalletGetKeyForCoin(wallet.get(), TWCoinTypeBitcoin));
+    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(key.get(), false);
+    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey));
+
+    assertHexEqual(publicKeyData, "047ea5dff03f677502c4a1d73c5ac897200e56b155e876774c8fba0cc22f80b9414ec07cda7b1c9a84c2e04ea2746c21afacc5e91b47427c453c3f1a4a3e983ce5");
+}
+
+TEST(HDWallet, DeriveBitcoinExtended) {
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), passphrase.get()));
     auto key = WRAP(TWPrivateKey, TWHDWalletGetKeyForCoin(wallet.get(), TWCoinTypeBitcoin));
     auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(key.get(), true);

--- a/tests/interface/TWHDWalletTests.cpp
+++ b/tests/interface/TWHDWalletTests.cpp
@@ -98,10 +98,19 @@ TEST(HDWallet, Derive) {
 TEST(HDWallet, DeriveBitcoin) {
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), passphrase.get()));
     auto key = WRAP(TWPrivateKey, TWHDWalletGetKeyForCoin(wallet.get(), TWCoinTypeBitcoin));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(key.get(), false);
+    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(key.get(), true);
     auto publicKeyData = WRAPD(TWPublicKeyData(publicKey));
 
-    assertHexEqual(publicKeyData, "047ea5dff03f677502c4a1d73c5ac897200e56b155e876774c8fba0cc22f80b9414ec07cda7b1c9a84c2e04ea2746c21afacc5e91b47427c453c3f1a4a3e983ce5");
+    assertHexEqual(publicKeyData, "037ea5dff03f677502c4a1d73c5ac897200e56b155e876774c8fba0cc22f80b941");
+
+    auto address = WRAPS(TWCoinTypeDeriveAddressFromPublicKey(TWCoinTypeBitcoin, publicKey));
+    assertStringsEqual(address, "bc1qumwjg8danv2vm29lp5swdux4r60ezptzz7ce85");
+}
+
+TEST(HDWallet, DeriveAddressBitcoin) {
+    auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), passphrase.get()));
+    auto address = WRAP(TWString, TWHDWalletGetAddressForCoin(wallet.get(), TWCoinTypeBitcoin));
+    assertStringsEqual(address, "bc1qumwjg8danv2vm29lp5swdux4r60ezptzz7ce85");
 }
 
 TEST(HDWallet, DeriveEthereum) {
@@ -113,6 +122,12 @@ TEST(HDWallet, DeriveEthereum) {
     auto address = WRAPS(TWCoinTypeDeriveAddressFromPublicKey(TWCoinTypeEthereum, publicKey));
 
     assertHexEqual(publicKeyData, "0414acbe5a06c68210fcbb77763f9612e45a526990aeb69d692d705f276f558a5ae68268e9389bb099ed5ac84d8d6861110f63644f6e5b447e3f86b4bab5dee011");
+    assertStringsEqual(address, "0x27Ef5cDBe01777D62438AfFeb695e33fC2335979");
+}
+
+TEST(HDWallet, DeriveAddressEthereum) {
+    auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), passphrase.get()));
+    auto address = WRAP(TWString, TWHDWalletGetAddressForCoin(wallet.get(), TWCoinTypeEthereum));
     assertStringsEqual(address, "0x27Ef5cDBe01777D62438AfFeb695e33fC2335979");
 }
 

--- a/tests/interface/TWHDWalletTests.cpp
+++ b/tests/interface/TWHDWalletTests.cpp
@@ -102,6 +102,7 @@ TEST(HDWallet, DeriveBitcoinNonextended) {
     auto publicKeyData = WRAPD(TWPublicKeyData(publicKey));
 
     assertHexEqual(publicKeyData, "047ea5dff03f677502c4a1d73c5ac897200e56b155e876774c8fba0cc22f80b9414ec07cda7b1c9a84c2e04ea2746c21afacc5e91b47427c453c3f1a4a3e983ce5");
+    // Note: address derivation does not work with nonextended public key
 }
 
 TEST(HDWallet, DeriveBitcoinExtended) {


### PR DESCRIPTION
## Description

New shortcut method TWHDWalletGetAddressForCoin() to derive an address from HD wallet directly, without need to handle private key.
Fixes #740 .

## Testing instructions

Unit tests

## Types of changes

* Small new feature (non-breaking change which adds functionality)

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
