### PR TITLE
Walletconsole: Fix public key type derivation for coins.

### DIFF
--- a/tests/WalletConsoleTests.cpp
+++ b/tests/WalletConsoleTests.cpp
@@ -278,3 +278,17 @@ TEST(WalletConsole, fileWriteRead) {
     string res3 = outputss.str().substr(pos3);
     EXPECT_TRUE(res3.find("not") != string::npos);
 }
+
+// used to fail due to incorrect public key type, see https://github.com/trustwallet/wallet-core/issues/767
+TEST(WalletConsole, harmonyAddressDerivation) {
+    cmd.executeLine("coin harmony");
+    cmd.executeLine("newKey");
+    cmd.executeLine("pubPri #");
+    auto pos0 = outputss.str().length();
+    cmd.executeLine("addrPub #");
+    string res1 = outputss.str().substr(pos0);
+    // should contain harmony address, no error
+    EXPECT_TRUE(res1.find(" one") != string::npos);
+    EXPECT_TRUE(res1.find("Result") != string::npos);
+    EXPECT_TRUE(res1.find("rror") == string::npos);
+}

--- a/walletconsole/lib/Coins.cpp
+++ b/walletconsole/lib/Coins.cpp
@@ -77,7 +77,7 @@ void Coins::scanCoinRange(int from, int to) {
         string name = TWStringUTF8Bytes(WRAPS(TWCoinTypeConfigurationGetName(c)).get());
         Util::toLower(name);
         int curve = (int)TWCoinTypeCurve(c);
-        int pubKeyType = pubKeyTypeFromCurve(curve);
+        int pubKeyType = (int)TW::publicKeyType(c);
         string derivPath = TW::derivationPath(c).string();
         Coin coin = Coin{c, id, name, symbol, curve, pubKeyType, derivPath};
         _coinsByNum[c] = coin;
@@ -85,19 +85,6 @@ void Coins::scanCoinRange(int from, int to) {
         _coinsByName[name] = coin;
         _coinsBySymbol[symbol] = coin;
     }
-}
-
-int Coins::pubKeyTypeFromCurve(int cc) {
-    TWCurve c = (TWCurve)cc;
-    TWPublicKeyType t;
-    switch (c) {
-        case TWCurveSECP256k1: t = TWPublicKeyTypeSECP256k1; break;
-        case TWCurveED25519: t = TWPublicKeyTypeED25519; break;
-        case TWCurveED25519Blake2bNano: t = TWPublicKeyTypeED25519Blake2b; break;
-        case TWCurveCurve25519: t = TWPublicKeyTypeCURVE25519; break;
-        case TWCurveNIST256p1: t = TWPublicKeyTypeNIST256p1; break;
-    }
-    return (int)t;
 }
 
 } // namespace TW::WalletConsole


### PR DESCRIPTION
## Description

Public key type was incorrectly derived from curve, which did not account for non-compressed/compressed variation.  Now it is obtained directly.
Fixes #767 .

## Testing instructions

In walletconsole:
```
> coin harmony
> newKey
> pubPri #
> addrPub #
```

Expected: no error.  Current:  Error while executing command, address may only be an extended SECP256k1 public key

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
