### PR TITLE
Remove potential duplicated symbol error

### DIFF
--- a/include/TrustWalletCore/TWZilliqaSigner.h
+++ b/include/TrustWalletCore/TWZilliqaSigner.h
@@ -12,8 +12,6 @@
 
 TW_EXTERN_C_BEGIN
 
-const uint32_t TWZilliqaTxVersion = 65537;
-
 /// Helper class to sign Zilliqa transactions.
 TW_EXPORT_CLASS
 struct TWZilliqaSigner;

--- a/src/interface/TWZilliqaSigner.cpp
+++ b/src/interface/TWZilliqaSigner.cpp
@@ -8,7 +8,6 @@
 
 #include "../Zilliqa/Signer.h"
 #include "../proto/Zilliqa.pb.h"
-#include "../uint256.h"
 
 using namespace TW;
 using namespace TW::Zilliqa;

--- a/swift/Tests/Blockchains/ZilliqaTests.swift
+++ b/swift/Tests/Blockchains/ZilliqaTests.swift
@@ -39,7 +39,7 @@ class ZilliqaTests: XCTestCase {
 
         // 1 ZIL
         let input = ZilliqaSigningInput.with {
-            $0.version = TWZilliqaTxVersion
+            $0.version = 65537 // mainnet tx version
             $0.nonce = 2
             $0.toAddress = "zil10lx2eurx5hexaca0lshdr75czr025cevqu83uz"
             $0.amount = Data(hexString: "e8d4a51000")!


### PR DESCRIPTION
If you compile wallet core from source and archive a build, it might fail, this constant should be able to get from RPC