### PR TITLE
[WIP] PrivateKey supports extended keys.

### DIFF
--- a/coins.json
+++ b/coins.json
@@ -1265,7 +1265,7 @@
         "id": "cardano", 
         "name": "Cardano", 
         "symbol": "ADA", 
-        "decimals": 8, 
+        "decimals": 6, 
         "blockchain": "Cardano", 
         "derivationPath": "m/44'/1815'/0'", 
         "curve": "ed25519", 

--- a/coins.json
+++ b/coins.json
@@ -1260,5 +1260,28 @@
             "clientPublic": "", 
             "clientDocs": "https://polkadot.js.org/api/substrate/rpc.html"
         }
+    },
+    {
+        "id": "cardano", 
+        "name": "Cardano", 
+        "symbol": "ADA", 
+        "decimals": 8, 
+        "blockchain": "Cardano", 
+        "derivationPath": "m/44'/1815'/0'", 
+        "curve": "ed25519", 
+        "publicKeyType": "ed25519", 
+        "explorer": {
+            "url": "https://cardanoexplorer.com", 
+            "txPath": "/tx/",
+            "accountPath": "/address/",
+            "sampleTx": "b7a6c5cadab0f64bdc89c77ee4a351463aba5c33f2cef6bbd6542a74a90a3af3",
+            "sampleAccount": "DdzFFzCqrhstpwKc8WMvPwwBb5oabcTW9zc5ykA37wJR4tYQucvsR9dXb2kEGNXkFJz2PtrpzfRiZkx8R1iNo8NYqdsukVmv7EAybFwC"
+        },
+        "info": {
+            "url": "https://www.cardano.org", 
+            "client": "https://github.com/input-output-hk/cardano-sl", 
+            "clientPublic": "", 
+            "clientDocs": "https://cardanodocs.com/introduction/"
+        }
     }
 ]

--- a/docs/coins.md
+++ b/docs/coins.md
@@ -50,6 +50,7 @@ This list is generated from [./coins.json](../coins.json)
 | 1023    | Harmony          | ONE    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/harmony/info/logo.png" width="32" />      | <https://harmony.one>         |
 | 1024    | Ontology         | ONT    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ontology/info/logo.png" width="32" />     | <https://ont.io>              |
 | 1729    | Tezos            | XTZ    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tezos/info/logo.png" width="32" />        | <https://tezos.com>           |
+| 1815    | Cardano          | ADA    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/cardano/info/logo.png" width="32" />      | <https://www.cardano.org>     |
 | 2017    | Kin              | KIN    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/kin/info/logo.png" width="32" />          | <https://www.kin.org>         |
 | 2301    | Qtum             | QTUM   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/qtum/info/logo.png" width="32" />         | <https://qtum.org>            |
 | 2718    | Nebulas          | NAS    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/nebulas/info/logo.png" width="32" />      | <https://nebulas.io>          |

--- a/include/TrustWalletCore/TWBlockchain.h
+++ b/include/TrustWalletCore/TWBlockchain.h
@@ -42,6 +42,7 @@ enum TWBlockchain {
     TWBlockchainAlgorand = 27,
     TWBlockchainTON = 28,
     TWBlockchainPolkadot = 29,
+    TWBlockchainCardano = 30,
 };
 
 TW_EXTERN_C_END

--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -76,6 +76,7 @@ enum TWCoinType {
     TWCoinTypeAlgorand = 283,
     TWCoinTypeKusama = 434,
     TWCoinTypePolkadot = 354,
+    TWCoinTypeCardano = 1815,
 };
 
 /// Returns the blockchain for a coin type.

--- a/src/Cardano/Address.cpp
+++ b/src/Cardano/Address.cpp
@@ -1,0 +1,107 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Address.h"
+#include "Cbor.h"
+#include "../Data.h"
+#include "../Base58.h"
+#include "../Crc.h"
+#include "../HexCoding.h"
+//#include "../Hash.h"
+
+#include <array>
+#include <iostream>
+#include <vector>
+
+using namespace TW;
+using namespace TW::Cardano;
+using namespace std;
+
+bool Address::isValid(const std::string& string) {
+    try {
+        Data base58decoded = Base58::bitcoin.decode(string);
+        //std::cerr << base58decoded.size() << " " << (int)base58decoded[0] << " " << (int)base58decoded[0]/32 << std::endl;
+
+        //cerr << Cbor::Decode(base58decoded).dumpToString() << endl;
+        auto elems = Cbor::Decode(base58decoded).getArrayElements();
+        if (elems.size() < 2) { return false; }
+        auto array0 = elems[0];
+        auto tag = array0.getTagValue();
+        if (tag != 24) {
+            // wrong tag value
+            return false;
+        }
+        Data addressAsArray = array0.getTagElement().getStringData();
+        // debug
+        uint64_t crcPresent = (uint32_t)elems[1].getValue();
+        uint32_t crcComputed = TW::Crc::crc32(addressAsArray);
+        if (crcPresent != crcComputed) {
+            // CRC mismatch
+            return false;
+        }
+        return true;
+    } catch (exception& ex) {
+        return false;
+    }
+}
+
+Address::Address(const std::string& string) {
+    try
+    {
+        if (!isValid(string)) {
+            throw std::invalid_argument("Invalid address string");
+        }
+        Data base58decoded = Base58::bitcoin.decode(string);
+        auto elems = Cbor::Decode(base58decoded).getArrayElements();
+        if (elems.size() >= 2) { // checked in isValid
+            auto array0 = elems[0];
+            auto tag = array0.getTagValue();
+            if (tag == 24) { // checked in isValid
+                Data addressAsArray = array0.getTagElement().getStringData();
+                // debug
+                uint64_t crcPresent = (uint32_t)elems[1].getValue();
+                uint32_t crcComputed = TW::Crc::crc32(addressAsArray);
+                if (crcPresent == crcComputed) { // checked in isValid
+                    // parse 2nd CBOR
+                    auto elems2 = Cbor::Decode(addressAsArray).getArrayElements();
+                    if (elems2.size() < 3) {
+                        // a 3-elem array is expected
+                        throw std::invalid_argument("Invalid address string, inner array too short");
+                    }
+                    // store values
+                    root = elems2[0].getStringData();
+                    attrs = elems2[1].getData();
+                    type = (TW::byte)(elems2[2].getValue());
+                }
+            }
+        }
+    } catch (exception& ex) {
+        throw std::invalid_argument("Invalid address string EXcEP");
+    }
+}
+
+string Address::string() const {
+    // put together string represenatation (CBOR encopde, Base58 encode)
+    // inner data: pubkey, attrs, type
+    Cbor::Encode cbor1;
+    cbor1.addArray(vector<Cbor::Encode>{
+        Cbor::Encode().addString(root),
+        Cbor::Encode(attrs),
+        Cbor::Encode().addPInt(type),
+    });
+    auto cborbase = cbor1.getData();
+    
+    // crc checksum 
+    auto crc = TW::Crc::crc32(cborbase);
+    // second pack: tag, base, crc
+    Cbor::Encode cbor2;
+    cbor2.addArray(vector<Cbor::Encode>{
+        Cbor::Encode().addTag(24, Cbor::Encode().addString(cborbase)),
+        Cbor::Encode().addPInt(crc),
+    });
+    auto cbor2Data = cbor2.getData();
+    return Base58::bitcoin.encode(cbor2Data);
+}

--- a/src/Cardano/Address.h
+++ b/src/Cardano/Address.h
@@ -16,17 +16,6 @@ namespace TW::Cardano {
 /// Cardano address.  Type is 0.
 class Address {
   public:
-    /*
-    /// Base32 encoded address string length.
-    static const size_t encodedSize = 58;
-
-    /// Sha512/256 checksum size.
-    static const size_t checksumSize = 4;
-    /// Address data consisting of public key.
-
-    std::array<byte, PublicKey::ed25519Size> bytes;
-    */
-
     /// root key
     Data root;
 
@@ -39,21 +28,21 @@ class Address {
     /// Determines whether a string makes a valid address.
     static bool isValid(const std::string& string);
 
-    static std::string build();
-
     /// Initializes a Cardano address with a string representation.
     explicit Address(const std::string& string);
 
-    /*
-    /// Initializes a Cardano address with a public key.
-    explicit Address(const PublicKey& publicKey);
-    */
+    /// Initializes a V2, public key type Cardano address from an extended public key.
+    ///explicit Address(const PublicKey& publicKey);
+    explicit Address(const TW::Data& xPublicKey);
 
     /// Returns a string representation of the address.
     std::string string() const;
+
+    /// compute hash of public key, for address root
+    static TW::Data keyHash(const TW::Data& xpub);
 };
 
-/*
+/* TODO
 inline bool operator==(const Address& lhs, const Address& rhs) {
     return lhs.bytes == rhs.bytes;
 }

--- a/src/Cardano/Address.h
+++ b/src/Cardano/Address.h
@@ -1,0 +1,67 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "Data.h"
+//#include "../PublicKey.h"
+
+#include <string>
+
+namespace TW::Cardano {
+
+/// Cardano address.  Type is 0.
+class Address {
+  public:
+    /*
+    /// Base32 encoded address string length.
+    static const size_t encodedSize = 58;
+
+    /// Sha512/256 checksum size.
+    static const size_t checksumSize = 4;
+    /// Address data consisting of public key.
+
+    std::array<byte, PublicKey::ed25519Size> bytes;
+    */
+
+    /// root key
+    Data root;
+
+    /// Additional info, CBOR-encoded
+    Data attrs;
+
+    /// Type; 0: public key.
+    TW::byte type;
+
+    /// Determines whether a string makes a valid address.
+    static bool isValid(const std::string& string);
+
+    static std::string build();
+
+    /// Initializes a Cardano address with a string representation.
+    explicit Address(const std::string& string);
+
+    /*
+    /// Initializes a Cardano address with a public key.
+    explicit Address(const PublicKey& publicKey);
+    */
+
+    /// Returns a string representation of the address.
+    std::string string() const;
+};
+
+/*
+inline bool operator==(const Address& lhs, const Address& rhs) {
+    return lhs.bytes == rhs.bytes;
+}
+*/
+
+} // namespace TW::Cardano
+
+/// Wrapper for C interface.
+struct TWCardanoAddress {
+    TW::Cardano::Address impl;
+};

--- a/src/Cardano/Cbor.cpp
+++ b/src/Cardano/Cbor.cpp
@@ -1,0 +1,302 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Cbor.h"
+
+#include <iostream>
+#include <sstream>
+
+namespace TW::Cardano::Cbor {
+
+using namespace std;
+
+Encode Encode::addPInt(uint64_t value) {
+    appendValue(0, value);
+    return *this;
+}
+
+Encode Encode::addString(const Data& string) {
+    appendValue(2, string.size());
+    append(data, string);
+    return *this;
+}
+
+Encode Encode::addArray(const vector<Encode>& elems) {
+    auto n = elems.size();
+    appendValue(4, n);
+    for (int i = 0; i < n; ++i) {
+        append(data, elems[i].getData());
+    }
+    return *this;
+}
+
+Encode Encode::addMap(const vector<std::pair<Encode, Encode>>& elems) {
+    auto n = elems.size();
+    appendValue(5, n);
+    for (int i = 0; i < n; ++i) {
+        append(data, elems[i].first.getData());
+        append(data, elems[i].second.getData());
+    }
+    return *this;
+}
+
+Encode Encode::addTag(uint64_t value, const Encode& elem) {
+    appendValue(6, value);
+    append(data, elem.getData());
+    return *this;
+}
+
+void Encode::appendValue(byte majorType, uint64_t value) {
+    byte byteCount = 0;
+    byte minorType = 0;
+    if (value < 24) {
+        byteCount = 1;
+        minorType = (byte)value;
+    } else if (value <= 0xFF) {
+        byteCount = 1 + 1;
+        minorType = 24;
+    } else if (value <= 0xFFFF) {
+        byteCount = 1 + 2;
+        minorType = 25;
+    } else if (value <= 0xFFFFFFFF) {
+        byteCount = 1 + 4;
+        minorType = 26;
+    } else {
+        byteCount = 1 + 8;
+        minorType = 27;
+    }
+    // add bytes
+    //cerr << "appendValue " << (int)majorType << " " << (int)minorType << endl;
+    TW::append(data, (majorType << 5) | (minorType & 0x1F));
+    Data valBytes = Data(byteCount - 1);
+    for (int i = 0; i < valBytes.size(); ++i) {
+        valBytes[valBytes.size() - 1 - i] = (byte)(value & 0xFF);
+        value = value >> 8;
+    }
+    TW::append(data, valBytes);
+}
+
+
+Decode::Decode(const TW::byte* ndata, uint32_t nlen) {
+    base = ndata;
+    startIdx = 0;
+    totlen = nlen;
+}
+
+Decode::Decode(const Data& input) {
+    base = (const TW::byte*)input.data();
+    startIdx = 0;
+    totlen = input.size();
+}
+
+Decode Decode::skip(uint32_t offset) const {
+    Decode skipped = Decode(base, totlen);
+    skipped.startIdx = startIdx + offset;
+    return skipped;
+}
+
+void Decode::getTypes(TW::byte& majorType, TW::byte& byteCount, uint64_t& value) const {
+    majorType = byte(0) >> 5;
+    TW::byte minorType = (TW::byte)((uint8_t)byte(0) & 0x1F);
+    if (minorType < 24) {
+        // direct value
+        byteCount = 1;
+        value = minorType;
+        return;
+    }
+    if (minorType == 24) {
+        byteCount = 1 + 1;
+        value = byte(1);
+        return;
+    }
+    if (minorType == 25) {
+        byteCount = 1 + 2;
+        value = 0x100 * (uint16_t)byte(1) + (uint16_t)byte(2);
+        return;
+    }
+    if (minorType == 26) {
+        byteCount = 1 + 4;
+        value = 0x1000000 * (uint32_t)byte(1) + 0x10000 * (uint32_t)byte(2) + 0x100 * (uint32_t)byte(3) + (uint32_t)byte(4);
+        return;
+    }
+    throw std::invalid_argument("CBOR longer values not supported");
+}
+
+uint32_t Decode::getSimpleTotalLen() const {
+    TW::byte majorType;
+    TW::byte byteCount;
+    uint64_t value;
+    getTypes(majorType, byteCount, value);
+    //cerr << "major, bytecnt, val  " << (int)majorType << " " << (int)byteCount << " " << (uint32_t)value << endl;
+    switch (majorType) {
+        case 0:
+        case 1:
+            // simple types
+            return byteCount;
+        case 2:
+        case 3:
+            // string
+            return (uint32_t)byteCount + (uint32_t)value;
+        case 5:
+            {
+                auto elems = getMapElements();
+                uint32_t len = byteCount;
+                for (int i = 0; i < elems.size(); ++i) {
+                    len += elems[i].first.getSimpleTotalLen() + elems[i].second.getSimpleTotalLen();
+                }
+                return len;
+            }
+        case 6: // tag
+            {
+                uint32_t dataLen = skip(byteCount).getSimpleTotalLen();
+                return byteCount + dataLen;
+            }
+        default:
+            //cerr << "majorType " << (int)majorType << endl;
+            throw std::invalid_argument("CBOR length type not supported");
+    }
+}
+
+uint64_t Decode::getValue() const {
+    TW::byte majorType;
+    TW::byte byteCount;
+    uint64_t value;
+    getTypes(majorType, byteCount, value);
+    if (majorType != 0 && majorType != 1) {
+        throw std::invalid_argument("CBOR data type not a value-type");
+    }
+    return value;
+}
+
+Data Decode::getStringData() const {
+    TW::byte majorType;
+    TW::byte byteCount;
+    uint64_t value;
+    getTypes(majorType, byteCount, value);
+    if (majorType != 2 && majorType != 3) {
+        throw std::invalid_argument("CBOR data type not string");
+    }
+    uint32_t len = value;
+    if (length() < (uint32_t)byteCount + (uint32_t)len) {
+        throw std::invalid_argument("CBOR string data too short");
+    }
+    return data(base + (startIdx + byteCount), value); 
+}
+
+vector<Decode> Decode::getCompoundElements(uint32_t countMultiplier, TW::byte expectedType) const {
+    TW::byte majorType;
+    TW::byte byteCount;
+    uint64_t value;
+    getTypes(majorType, byteCount, value);
+    if (majorType != expectedType) {
+        throw std::invalid_argument("CBOR data type not array");
+    }
+    vector<Decode> elems;
+    uint32_t count = (uint32_t)(value * countMultiplier);
+    // process elements
+    uint32_t idx = byteCount;
+    for (int i = 0; i < count; ++i) {
+        uint32_t elemLen = skip(idx).getSimpleTotalLen();
+        if (idx + elemLen > length()) {
+            throw std::invalid_argument("CBOR array data too short");
+        }
+        elems.push_back(Decode(base + (startIdx + idx), elemLen));
+        idx += elemLen;
+    }
+    return elems;
+}
+
+vector<pair<Decode, Decode>> Decode::getMapElements() const {
+    auto elems = getCompoundElements(2, 5);
+    vector<pair<Decode, Decode>> map;
+    for (int i = 0; i < elems.size(); i += 2) {
+        map.push_back(make_pair(elems[i], elems[i+1]));
+    }
+    return map;
+}
+
+uint64_t Decode::getTagValue() const {
+    TW::byte majorType;
+    TW::byte byteCount;
+    uint64_t value;
+    getTypes(majorType, byteCount, value);
+    if (majorType != 6) {
+        throw std::invalid_argument("CBOR data type not tag");
+    }
+    return value;
+}
+
+Decode Decode::getTagElement() const {
+    TW::byte majorType;
+    TW::byte byteCount;
+    uint64_t value;
+    getTypes(majorType, byteCount, value);
+    if (majorType != 6) {
+        throw std::invalid_argument("CBOR data type not tag");
+    }
+    return skip(byteCount);
+}
+
+string Decode::dumpToString() const {
+    stringstream s;
+    s << "["<< length() << "] ";
+    TW::byte majorType;
+    TW::byte byteCount;
+    uint64_t value;
+    getTypes(majorType, byteCount, value);
+    switch (majorType) {
+        case 0: // pint
+            s << "pint " << (int)byteCount << " (" << value << ")";
+            break;
+
+        case 1: // nint
+            s << "nint " << (int)byteCount << " (" << value << ")";
+            break;
+
+        case 2: // string
+            s << "string " << (int)byteCount << "+" << value;
+            break;
+
+        case 3: // string
+            s << "utf string " << (int)byteCount << "+" << value;
+            break;
+
+        case 4: // array
+            {
+                s << "array " << (int)byteCount << " " << value << " (";
+                vector<Decode> elems = getArrayElements();
+                for (int i = 0; i < elems.size(); ++i) {
+                    if (i > 0) s << ", ";
+                    s << elems[i].dumpToString();
+                }
+                s << ")";
+            }
+            break;
+
+        case 5: // map
+            {
+                s << "map " << (int)byteCount << " " << value << " (";
+                auto elems = getMapElements();
+                for (int i = 0; i < elems.size(); ++i) {
+                    if (i > 0) s << ", ";
+                    s << elems[i].first.dumpToString() << ": " << elems[i].second.dumpToString();
+                }
+                s << ")";
+            }
+            break;
+
+        case 6: // tag
+            s << "tag " << (int)byteCount << " " << value << " (" << getTagElement().dumpToString() << ")";
+            break;
+
+        default:
+            //cerr << "majorType " << (int)majorType << endl;
+            throw std::invalid_argument("CBOR analyze type not supported");
+    }
+    return s.str();
+}
+
+} // namespace TW::Cardano

--- a/src/Cardano/Cbor.h
+++ b/src/Cardano/Cbor.h
@@ -1,0 +1,69 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "Data.h"
+
+#include <string>
+#include <vector>
+
+namespace TW::Cardano::Cbor {
+
+// CBOR-encoded data, encoder
+class Encode {
+public:
+    Encode() {}
+    // Create from raw content
+    Encode(const TW::Data& rawData) { data = rawData; }
+    TW::Data getData() const { return data; }
+    // builder/adder methods
+    Encode addPInt(uint64_t value);
+    Encode addString(const Data& string);
+    Encode addArray(const std::vector<Encode>& elems);
+    Encode addMap(const std::vector<std::pair<Encode, Encode>>& elems);
+    Encode addTag(uint64_t value, const Encode& elem);
+protected:
+    void appendValue(byte majorType, uint64_t value);
+private:
+    TW::Data data;
+};
+
+// CBOR-encoded data, decoder.  Read-only data or data slice.
+class Decode {
+private:
+    const TW::byte* base;
+    // Additional startIdxIdx index, to make skip ahead possible without touching the base data pointer
+    uint32_t startIdx;
+    uint32_t totlen;
+public: // constructors
+    Decode(const TW::byte* ndata, uint32_t nlen);
+    Decode(const Data& input);
+    // Skip ahead: from other Decode data with offset
+    Decode skip(uint32_t offset) const;
+public: // accessors
+    uint32_t length() const { return totlen - startIdx; }
+    TW::byte byte(uint32_t idx) const {
+        if (startIdx + idx >= totlen) { throw std::invalid_argument("CBOR data too short"); }
+        return base[startIdx + idx];
+    }
+    TW::Data getData() const { return TW::data(base + startIdx, totlen - startIdx); }
+public: // decoding helpers
+    void getTypes(TW::byte& majorType, TW::byte& byteCount, uint64_t& value) const;
+    uint32_t getSimpleTotalLen() const;
+    std::vector<Decode> getCompoundElements(uint32_t countMultiplier, TW::byte expectedType) const;
+public: // decoding
+    // Get the value of a simple type
+    uint64_t getValue() const;
+    TW::Data getStringData() const;
+    std::vector<Decode> getArrayElements() const { return getCompoundElements(1, 4); }
+    std::vector<std::pair<Decode, Decode>> getMapElements() const;
+    uint64_t getTagValue() const;
+    Decode getTagElement() const;
+    std::string dumpToString() const;
+};
+
+} // namespace TW::Cardano

--- a/src/Coin.cpp
+++ b/src/Coin.cpp
@@ -180,6 +180,9 @@ bool TW::validateAddress(TWCoinType coin, const std::string& string) {
 
     case TWCoinTypePolkadot:
         return Polkadot::Address::isValid(string);
+
+    case TWCoinTypeCardano:
+        return true; // TODO
     }
 }
 
@@ -314,6 +317,9 @@ std::string TW::deriveAddress(TWCoinType coin, const PublicKey& publicKey) {
 
     case TWCoinTypePolkadot:
         return Polkadot::Address(publicKey).string();
+
+    case TWCoinTypeCardano:
+        return "adaddr";
     }
 }
 

--- a/src/Crc.cpp
+++ b/src/Crc.cpp
@@ -6,6 +6,8 @@
 
 #include "Crc.h"
 
+#include <boost/crc.hpp>  // for boost::crc_32_type
+
 #include <string>
 
 using namespace TW;
@@ -28,4 +30,19 @@ uint16_t Crc::crc16(uint8_t* bytes, uint32_t length) {
     }
 
     return crc & 0xffff;
+}
+
+uint32_t Crc::crc32(const Data& data)
+{
+    boost::crc_32_type result;
+    result.process_bytes((const void*)data.data(), data.size());
+    return (uint32_t)result.checksum();
+}
+
+uint32_t Crc::crc32C(const Data& data)
+{
+    using crc_32c_type = boost::crc_optimal<32, 0x1EDC6F41, 0xFFFFFFFF, 0xFFFFFFFF, true, true>;
+    crc_32c_type result;
+    result.process_bytes((const void*)data.data(), data.size());
+    return (uint32_t)result.checksum();
 }

--- a/src/Crc.h
+++ b/src/Crc.h
@@ -15,4 +15,8 @@ namespace TW::Crc {
 /// Initial value changed to 0x0000 to match Stellar
 uint16_t crc16(uint8_t* bytes, uint32_t length);
 
+uint32_t crc32(const TW::Data& data);
+
+uint32_t crc32C(const TW::Data& data);
+
 } // namespace TW::Crc

--- a/src/PublicKey.h
+++ b/src/PublicKey.h
@@ -11,7 +11,6 @@
 
 #include <TrustWalletCore/TWPublicKeyType.h>
 
-#include <array>
 #include <cassert>
 #include <stdexcept>
 #include <vector>
@@ -32,7 +31,7 @@ class PublicKey {
     /// The public key bytes.
     Data bytes;
 
-    /// The of public key.
+    /// The type of the public key.
     ///
     /// This has information about the elliptic curve and other parameters
     /// used when generating the public key.
@@ -40,65 +39,12 @@ class PublicKey {
 
     /// Determines if a collection of bytes makes a valid public key of the
     /// given type.
-    template <typename T>
-    static bool isValid(const T& data, enum TWPublicKeyType type) {
-        const auto size = std::end(data) - std::begin(data);
-        if (size == 0) {
-            return false;
-        }
-        switch (type) {
-        case TWPublicKeyTypeED25519:
-            return size == ed25519Size || (size == ed25519Size + 1 && data[0] == 0x01);
-        case TWPublicKeyTypeCURVE25519:
-        case TWPublicKeyTypeED25519Blake2b:
-            return size == ed25519Size;
-        case TWPublicKeyTypeSECP256k1:
-        case TWPublicKeyTypeNIST256p1:
-            return size == secp256k1Size && (data[0] == 0x02 || data[0] == 0x03);
-        case TWPublicKeyTypeSECP256k1Extended:
-        case TWPublicKeyTypeNIST256p1Extended:
-            return size == secp256k1ExtendedSize && data[0] == 0x04;
-        default:
-            return false;
-        }
-    }
+    static bool isValid(const Data& data, enum TWPublicKeyType type);
 
     /// Initializes a public key with a collection of bytes.
     ///
     /// @throws std::invalid_argument if the data is not a valid public key.
-    template <typename T>
-    explicit PublicKey(const T& data, enum TWPublicKeyType type) : type(type) {
-        if (!isValid(data, type)) {
-            throw std::invalid_argument("Invalid public key data");
-        }
-        switch (type) {
-        case TWPublicKeyTypeSECP256k1:
-        case TWPublicKeyTypeNIST256p1:
-        case TWPublicKeyTypeSECP256k1Extended:
-        case TWPublicKeyTypeNIST256p1Extended:
-            bytes.reserve(data.size());
-            std::copy(std::begin(data), std::end(data), std::back_inserter(bytes));
-            break;
-
-        case TWPublicKeyTypeED25519:
-        case TWPublicKeyTypeCURVE25519:
-            bytes.reserve(ed25519Size);
-            if (data.size() == ed25519Size + 1) {
-                std::copy(std::begin(data) + 1, std::end(data), std::back_inserter(bytes));
-            } else {
-                std::copy(std::begin(data), std::end(data), std::back_inserter(bytes));
-            }
-            break;
-        case TWPublicKeyTypeED25519Blake2b:
-            bytes.reserve(ed25519Size);
-            if (data.size() == ed25519Size + 1) {
-                std::copy(std::begin(data) + 1, std::end(data), std::back_inserter(bytes));
-            } else {
-                std::copy(std::begin(data), std::end(data), std::back_inserter(bytes));
-            }
-            break;
-        }
-    }
+    explicit PublicKey(const Data& data, enum TWPublicKeyType type);
 
     /// Determines if this is a compressed public key.
     bool isCompressed() const {

--- a/src/Tezos/Forging.cpp
+++ b/src/Tezos/Forging.cpp
@@ -81,7 +81,7 @@ Data forgeOperation(const Operation& operation) {
     auto forgedStorageLimit = forgeZarith(operation.storage_limit());
 
     if (operation.kind() == Operation_OperationKind_REVEAL) {
-        auto publicKey = PublicKey(operation.reveal_operation_data().public_key(), TWPublicKeyTypeED25519);
+        auto publicKey = PublicKey(data(operation.reveal_operation_data().public_key()), TWPublicKeyTypeED25519);
         auto forgedPublicKey = forgePublicKey(publicKey);
         
         forged.push_back(Operation_OperationKind_REVEAL);

--- a/src/interface/TWPublicKey.cpp
+++ b/src/interface/TWPublicKey.cpp
@@ -75,7 +75,7 @@ struct TWPublicKey *_Nullable TWPublicKeyRecover(TWData *_Nonnull signature, TWD
     if (v >= 27) {
         v -= 27;
     }
-    std::array<uint8_t, 65> result;
+    TW::Data result(65);
     if (ecdsa_recover_pub_from_sig(&secp256k1, result.data(), signatureBytes, TWDataBytes(message), v) != 0) {
         return nullptr;
     }

--- a/tests/Cardano/AddressTests.cpp
+++ b/tests/Cardano/AddressTests.cpp
@@ -1,0 +1,65 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Cardano/Address.h"
+
+#include "HexCoding.h"
+#include "PublicKey.h"
+#include "PrivateKey.h"
+#include "Base58.h"
+#include "HDWallet.h"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace TW;
+using namespace TW::Cardano;
+using namespace std;
+
+TEST(CardanoAddress, Validation) {
+    // valid V1 address
+    ASSERT_TRUE(Address::isValid("DdzFFzCqrhssmYoG5Eca1bKZFdGS8d6iag1mU4wbLeYcSPVvBNF2wRG8yhjzQqErbg63N6KJA4DHqha113tjKDpGEwS5x1dT2KfLSbSJ"));
+    // valid V2 address
+    ASSERT_TRUE(Address::isValid("Ae2tdPwUPEZ18ZjTLnLVr9CEvUEUX4eW1LBHbxxxJgxdAYHrDeSCSbCxrvx"));
+
+    // invalid checksum
+    ASSERT_FALSE(Address::isValid("Ae2tdPwUPEZ18ZjTLnLVr9CEvUEUX4eW1LBHbxxxJgxdAYHrDeSCSbCxrvm"));
+    // random
+    ASSERT_FALSE(Address::isValid("hasoiusaodiuhsaijnnsajnsaiussai"));
+    // empty
+    ASSERT_FALSE(Address::isValid(""));
+}
+
+TEST(CardanoAddress, FromString) {
+    {
+        auto address = Address("Ae2tdPwUPEZ18ZjTLnLVr9CEvUEUX4eW1LBHbxxxJgxdAYHrDeSCSbCxrvx");
+        ASSERT_EQ(address.string(), "Ae2tdPwUPEZ18ZjTLnLVr9CEvUEUX4eW1LBHbxxxJgxdAYHrDeSCSbCxrvx");
+    }
+    {
+        auto address = Address("DdzFFzCqrhssmYoG5Eca1bKZFdGS8d6iag1mU4wbLeYcSPVvBNF2wRG8yhjzQqErbg63N6KJA4DHqha113tjKDpGEwS5x1dT2KfLSbSJ");
+        ASSERT_EQ(address.string(), "DdzFFzCqrhssmYoG5Eca1bKZFdGS8d6iag1mU4wbLeYcSPVvBNF2wRG8yhjzQqErbg63N6KJA4DHqha113tjKDpGEwS5x1dT2KfLSbSJ");
+    }
+}
+
+/*
+TEST(CardanoAddress, DeriveDummy) {
+    auto mnemo = "crowd captain hungry tray powder motor coast oppose month shed parent mystery torch resemble index";
+    auto wallet = HDWallet(mnemo, "");
+    cerr << hex(wallet.getMasterKey(TWCurve::TWCurveED25519).bytes) << endl;
+}
+
+TEST(CardanoAddress, FromPrivateKey) {
+    auto privateKey = PrivateKey(parse_hex("526d96fffdbfe787b2f00586298538f9a019e97f6587964dc61aae9ad1d7fa23"));
+    auto address = Address(privateKey.getPublicKey(TWPublicKeyTypeED25519));
+    ASSERT_EQ(address.string(), "JBCQYJ2FREG667NAN7BFKH4RFIKPT7CYDQJNW3SNN5Z7F7ILFLKQ346TSU");
+}
+
+TEST(AlgorandAddress, FromPublicKey) {
+    auto publicKey = PublicKey(parse_hex("c2b423afa8b0095e5ae105668b91b2132db4dadbf38acfc64908d3476a00191f"), TWPublicKeyTypeED25519);
+    auto address = Address(publicKey);
+    ASSERT_EQ(address.string(), "YK2CHL5IWAEV4WXBAVTIXENSCMW3JWW36OFM7RSJBDJUO2QADEP5QYVO5I");
+}
+*/

--- a/tests/Cardano/AddressTests.cpp
+++ b/tests/Cardano/AddressTests.cpp
@@ -45,21 +45,31 @@ TEST(CardanoAddress, FromString) {
 }
 
 /*
-TEST(CardanoAddress, DeriveDummy) {
-    auto mnemo = "crowd captain hungry tray powder motor coast oppose month shed parent mystery torch resemble index";
-    auto wallet = HDWallet(mnemo, "");
-    cerr << hex(wallet.getMasterKey(TWCurve::TWCurveED25519).bytes) << endl;
+TEST(CardanoAddress, MnemonicToKeys) {
+    auto mnemonic = "cost dash dress stove morning robust group affair stomach vacant route volume yellow salute laugh";
+
+    auto wallet = HDWallet(mnemonic, "");
+    auto seed = wallet.seed;
+    cerr << "seed " << (int)wallet.seedSize << " " << hex(seed) << endl;
+}
+*/
+
+TEST(CardanoAddress, KeyHash) {
+    auto xpub = parse_hex("e6f04522f875c1563682ca876ddb04c2e2e3ae718e3ff9f11c03dd9f9dccf69869272d81c376382b8a87c21370a7ae9618df8da708d1a9490939ec54ebe43000");
+    auto hash = Address::keyHash(xpub);
+    ASSERT_EQ("a1eda96a9952a56c983d9f49117f935af325e8a6c9d38496e945faa8", hex(hash));
 }
 
+TEST(CardanoAddress, FromXPublicKey) {
+    auto publicKey = parse_hex("e6f04522f875c1563682ca876ddb04c2e2e3ae718e3ff9f11c03dd9f9dccf69869272d81c376382b8a87c21370a7ae9618df8da708d1a9490939ec54ebe43000");
+    auto address = Address(publicKey);
+    ASSERT_EQ(address.string(), "Ae2tdPwUPEZCxt4UV1Uj2AMMRvg5pYPypqZowVptz3GYpK4pkcvn3EjkuNH");
+}
+
+/*
 TEST(CardanoAddress, FromPrivateKey) {
     auto privateKey = PrivateKey(parse_hex("526d96fffdbfe787b2f00586298538f9a019e97f6587964dc61aae9ad1d7fa23"));
     auto address = Address(privateKey.getPublicKey(TWPublicKeyTypeED25519));
     ASSERT_EQ(address.string(), "JBCQYJ2FREG667NAN7BFKH4RFIKPT7CYDQJNW3SNN5Z7F7ILFLKQ346TSU");
-}
-
-TEST(AlgorandAddress, FromPublicKey) {
-    auto publicKey = PublicKey(parse_hex("c2b423afa8b0095e5ae105668b91b2132db4dadbf38acfc64908d3476a00191f"), TWPublicKeyTypeED25519);
-    auto address = Address(publicKey);
-    ASSERT_EQ(address.string(), "YK2CHL5IWAEV4WXBAVTIXENSCMW3JWW36OFM7RSJBDJUO2QADEP5QYVO5I");
 }
 */

--- a/tests/Cardano/TWCoinTypeTests.cpp
+++ b/tests/Cardano/TWCoinTypeTests.cpp
@@ -1,0 +1,34 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here MAY BE LOST.
+// Generated one-time (codegen/bin/cointests)
+//
+
+#include "../interface/TWTestUtilities.h"
+#include <TrustWalletCore/TWCoinTypeConfiguration.h>
+#include <gtest/gtest.h>
+
+
+TEST(TWCardanoCoinType, TWCoinType) {
+    auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeCardano));
+    auto txId = TWStringCreateWithUTF8Bytes("b7a6c5cadab0f64bdc89c77ee4a351463aba5c33f2cef6bbd6542a74a90a3af3");
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeCardano, txId));
+    auto accId = TWStringCreateWithUTF8Bytes("DdzFFzCqrhstpwKc8WMvPwwBb5oabcTW9zc5ykA37wJR4tYQucvsR9dXb2kEGNXkFJz2PtrpzfRiZkx8R1iNo8NYqdsukVmv7EAybFwC");
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeCardano, accId));
+    auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeCardano));
+    auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeCardano));
+
+    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeCardano), 8);
+    ASSERT_EQ(TWBlockchainCardano, TWCoinTypeBlockchain(TWCoinTypeCardano));
+    ASSERT_EQ(0x0, TWCoinTypeP2shPrefix(TWCoinTypeCardano));
+    ASSERT_EQ(0x0, TWCoinTypeStaticPrefix(TWCoinTypeCardano));
+    assertStringsEqual(symbol, "ADA");
+    assertStringsEqual(txUrl, "https://cardanoexplorer.com/tx/b7a6c5cadab0f64bdc89c77ee4a351463aba5c33f2cef6bbd6542a74a90a3af3");
+    assertStringsEqual(accUrl, "https://cardanoexplorer.com/address/DdzFFzCqrhstpwKc8WMvPwwBb5oabcTW9zc5ykA37wJR4tYQucvsR9dXb2kEGNXkFJz2PtrpzfRiZkx8R1iNo8NYqdsukVmv7EAybFwC");
+    assertStringsEqual(id, "cardano");
+    assertStringsEqual(name, "Cardano");
+}

--- a/tests/Cardano/TWCoinTypeTests.cpp
+++ b/tests/Cardano/TWCoinTypeTests.cpp
@@ -22,7 +22,7 @@ TEST(TWCardanoCoinType, TWCoinType) {
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeCardano));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeCardano));
 
-    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeCardano), 8);
+    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeCardano), 6);
     ASSERT_EQ(TWBlockchainCardano, TWCoinTypeBlockchain(TWCoinTypeCardano));
     ASSERT_EQ(0x0, TWCoinTypeP2shPrefix(TWCoinTypeCardano));
     ASSERT_EQ(0x0, TWCoinTypeStaticPrefix(TWCoinTypeCardano));

--- a/tests/Polkadot/TWCoinTypeTests.cpp
+++ b/tests/Polkadot/TWCoinTypeTests.cpp
@@ -15,11 +15,10 @@
 
 TEST(TWPolkadotCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypePolkadot));
-    // TODO: update block explorer url
-    //auto txId = TWStringCreateWithUTF8Bytes("t123");
-    //auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypePolkadot, txId));
-    //auto accId = TWStringCreateWithUTF8Bytes("a12");
-    //auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypePolkadot, accId));
+    auto txId = TWStringCreateWithUTF8Bytes("t123");
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypePolkadot, txId));
+    auto accId = TWStringCreateWithUTF8Bytes("a12");
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypePolkadot, accId));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypePolkadot));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypePolkadot));
 
@@ -28,8 +27,8 @@ TEST(TWPolkadotCoinType, TWCoinType) {
     ASSERT_EQ(0x0, TWCoinTypeP2shPrefix(TWCoinTypePolkadot));
     ASSERT_EQ(0x0, TWCoinTypeStaticPrefix(TWCoinTypePolkadot));
     assertStringsEqual(symbol, "DOT");
-    //assertStringsEqual(txUrl, "https://??/??t123");
-    //assertStringsEqual(accUrl, "https://??/??a12");
+    assertStringsEqual(txUrl, "https://??/??t123");
+    assertStringsEqual(accUrl, "https://??/??a12");
     assertStringsEqual(id, "polkadot");
     assertStringsEqual(name, "Polkadot");
 }

--- a/tests/Tezos/AddressTests.cpp
+++ b/tests/Tezos/AddressTests.cpp
@@ -79,7 +79,7 @@ TEST(TezosAddress, deriveOriginatedAddress) {
 }
 
 TEST(TezosAddress, PublicKeyInit) {
-    std::array<uint8_t, 33> bytes {1, 254, 21, 124, 200, 1, 23, 39, 147, 108, 89, 47, 133, 108, 144, 113, 211, 156, 244, 172, 218, 223, 166, 215, 100, 53, 228, 97, 156, 157, 197, 111, 99,};
+    Data bytes {1, 254, 21, 124, 200, 1, 23, 39, 147, 108, 89, 47, 133, 108, 144, 113, 211, 156, 244, 172, 218, 223, 166, 215, 100, 53, 228, 97, 156, 157, 197, 111, 99,};
     const auto publicKey = PublicKey(bytes, TWPublicKeyTypeED25519);
     auto address = Address(publicKey);
 


### PR DESCRIPTION
## Description

PrivateKey support extended keys (32 byte key, 32 extended, 32 codechain).  Use Data type instead of byte array in PrivateKey and PublicKey.

<!--- Describe your changes in detail -->

## Testing instructions

All unit tests.

## Types of changes

* Minor New feature (non-breaking change which adds functionality)

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
