### PR TITLE
Filecoin support

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
@@ -82,5 +82,6 @@ class CoinAddressDerivationTests {
         POLKADOT -> assertEquals("1b97X8xTpFKMDzJpxiVhdYMNvekBDSfvGFf4DutxFkUjqfR", address)
         KAVA -> assertEquals("kava1drpa0x9ptz0fql3frv562rcrhj2nstuz3pas87", address)
         CARDANO -> assertEquals("Ae2tdPwUPEZJ2TwjFBMCnjz6t43pr4QVnBjCGSW8BMsttrt2WagC1D7LUWa", address)
+        FILECOIN -> assertEquals("f1zzykebxldfcakj5wdb5n3n7priul522fnmjzori", address)
     }
 }

--- a/coins.json
+++ b/coins.json
@@ -1306,5 +1306,26 @@
             "clientPublic": "", 
             "clientDocs": "https://cardanodocs.com/introduction/"
         }
+    },
+    {
+        "id": "filecoin",
+        "name": "Filecoin",
+        "symbol": "FIL",
+        "decimals": 8,
+        "blockchain": "Filecoin",
+        "derivationPath": "m/44'/461'/0'/0/0",
+        "curve": "secp256k1",
+        "publicKeyType": "secp256k1Extended",
+        "explorer": {
+            "url": "https://??",
+            "txPath": "/??",
+            "accountPath": "/??"
+        },
+        "info": {
+            "url": "https://filecoin.io/",
+            "client": "https://github.com/filecoin-project/lotus",
+            "clientPublic": "",
+            "clientDocs": "https://docs.lotu.sh"
+        }
     }
 ]

--- a/docs/coins.md
+++ b/docs/coins.md
@@ -41,6 +41,7 @@ This list is generated from [./coins.json](../coins.json)
 | 434     | Kusama           | KSM    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/kusama/info/logo.png" width="32" />       | <https://kusama.network>      |
 | 457     | Aeternity        | AE     | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/aeternity/info/logo.png" width="32" />    | <https://aeternity.com>       |
 | 459     | Kava             | KAVA   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/kava/info/logo.png" width="32" />         | <https://kava.io>             |
+| 461     | Filecoin         | FIL    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/filecoin/info/logo.png" width="32" />     | <https://filecoin.io/>        |
 | 500     | Theta            | THETA  | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/theta/info/logo.png" width="32" />        | <https://www.thetatoken.org>  |
 | 501     | Solana           | SOL    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/solana/info/logo.png" width="32" />       | <https://solana.com>          |
 | 714     | Binance          | BNB    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/info/logo.png" width="32" />      | <https://binance.org>         |

--- a/include/TrustWalletCore/TWBlockchain.h
+++ b/include/TrustWalletCore/TWBlockchain.h
@@ -43,6 +43,7 @@ enum TWBlockchain {
     TWBlockchainTON = 28,
     TWBlockchainPolkadot = 29,
     TWBlockchainCardano = 30,
+    TWBlockchainFilecoin = 31,
 };
 
 TW_EXTERN_C_END

--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -78,6 +78,7 @@ enum TWCoinType {
     TWCoinTypeAlgorand = 283,
     TWCoinTypeKusama = 434,
     TWCoinTypePolkadot = 354,
+    TWCoinTypeFilecoin = 461,
 };
 
 /// Returns the blockchain for a coin type.

--- a/include/TrustWalletCore/TWFilecoinAddress.h
+++ b/include/TrustWalletCore/TWFilecoinAddress.h
@@ -1,0 +1,42 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "TWBase.h"
+#include "TWData.h"
+#include "TWString.h"
+
+TW_EXTERN_C_BEGIN
+
+/// Represents a Filecoin address.
+TW_EXPORT_CLASS
+struct TWFilecoinAddress;
+
+/// Compares two addresses for equality.
+TW_EXPORT_STATIC_METHOD
+bool TWFilecoinAddressEqual(struct TWFilecoinAddress *_Nonnull lhs, struct TWFilecoinAddress *_Nonnull rhs);
+
+/// Determines if the string is a valid Filecoin address.
+TW_EXPORT_STATIC_METHOD
+bool TWFilecoinAddressIsValidString(TWString *_Nonnull string);
+
+/// Creates an address from a string representation.
+TW_EXPORT_STATIC_METHOD
+struct TWFilecoinAddress *_Nullable TWFilecoinAddressCreateWithString(TWString *_Nonnull string);
+
+/// Creates an address from a public key.
+TW_EXPORT_STATIC_METHOD
+struct TWFilecoinAddress *_Nonnull TWFilecoinAddressCreateWithPublicKey(struct TWPublicKey *_Nonnull publicKey);
+
+TW_EXPORT_METHOD
+void TWFilecoinAddressDelete(struct TWFilecoinAddress *_Nonnull address);
+
+/// Returns the address string representation.
+TW_EXPORT_PROPERTY
+TWString *_Nonnull TWFilecoinAddressDescription(struct TWFilecoinAddress *_Nonnull address);
+
+TW_EXTERN_C_END

--- a/include/TrustWalletCore/TWFilecoinProto.h
+++ b/include/TrustWalletCore/TWFilecoinProto.h
@@ -1,0 +1,12 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "TWData.h"
+
+typedef TWData *_Nonnull TW_Filecoin_Proto_SigningInput;
+typedef TWData *_Nonnull TW_Filecoin_Proto_SigningOutput;

--- a/include/TrustWalletCore/TWFilecoinSigner.h
+++ b/include/TrustWalletCore/TWFilecoinSigner.h
@@ -1,0 +1,23 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "TWBase.h"
+#include "TWData.h"
+#include "TWFilecoinProto.h"
+
+TW_EXTERN_C_BEGIN
+
+/// Helper class to sign Filecoin transactions.
+TW_EXPORT_CLASS
+struct TWFilecoinSigner;
+
+/// Signs a transaction.
+TW_EXPORT_STATIC_METHOD
+TW_Filecoin_Proto_SigningOutput TWFilecoinSignerSign(TW_Filecoin_Proto_SigningInput input);
+
+TW_EXTERN_C_END

--- a/src/Coin.cpp
+++ b/src/Coin.cpp
@@ -20,6 +20,7 @@
 #include "EOS/Address.h"
 #include "Ethereum/Address.h"
 #include "FIO/Address.h"
+#include "Filecoin/Address.h"
 #include "Groestlcoin/Address.h"
 #include "Harmony/Address.h"
 #include "Icon/Address.h"
@@ -185,6 +186,9 @@ bool TW::validateAddress(TWCoinType coin, const std::string& string) {
 
     case TWCoinTypeCardano:
         return Cardano::Address::isValid(string);
+
+    case TWCoinTypeFilecoin:
+        return Filecoin::Address::isValid(string);
     }
 }
 
@@ -323,6 +327,9 @@ std::string TW::deriveAddress(TWCoinType coin, const PublicKey& publicKey) {
 
     case TWCoinTypeCardano:
         return Cardano::Address(publicKey).string();
+
+    case TWCoinTypeFilecoin:
+        return Filecoin::Address(publicKey).string();
     }
 }
 

--- a/src/Filecoin/Address.cpp
+++ b/src/Filecoin/Address.cpp
@@ -1,0 +1,175 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Address.h"
+
+#include "../Base32.h"
+#include "../Data.h"
+
+using namespace TW;
+using namespace TW::Filecoin;
+
+static const char BASE32_ALPHABET_FILECOIN[] = "abcdefghijklmnopqrstuvwxyz234567";
+static constexpr size_t checksum_size = 4;
+
+bool Address::isValid(const Data& data) {
+    if (data.size() < 2) {
+        return false;
+    }
+    if (!get_type(data[0])) {
+        return false;
+    }
+    Type type = *get_type(data[0]);
+    if (type == Type::ID) {
+        // Verify varuint encoding
+        if (data.size() > 11)
+            return false;
+        if (data.size() == 11 && data[10] > 0x01)
+            return false;
+        int i;
+        for (i = 1; i < data.size(); i++)
+            if ((data[i] & 0x80) == 0)
+                break;
+        return i == data.size() - 1;
+    } else {
+        return data.size() == 1 + Address::payload_size(type);
+    }
+}
+
+static bool isValidID(const std::string& string) {
+    if (string.length() > 22)
+        return false;
+    for (int i = 2; i < string.length(); i++) {
+        if (string[i] < '0' || string[i] > '9') {
+            return false;
+        }
+    }
+    try {
+        size_t chars;
+        std::stoull(string.substr(2), &chars);
+        return chars > 0;
+    } catch (...) {
+        return false;
+    }
+}
+
+static bool isValidBase32(const std::string& string, Address::Type type) {
+    // Check if valid Base32.
+    uint8_t size = Address::payload_size(type);
+    Data decoded;
+    if (!Base32::decode(string.substr(2), decoded, BASE32_ALPHABET_FILECOIN)) {
+        return false;
+    }
+
+    // Check size
+    if (decoded.size() != size + 4) {
+        return false;
+    }
+
+    // Extract raw address.
+    Data address;
+    address.push_back(static_cast<uint8_t>(type));
+    address.insert(address.end(), decoded.data(), decoded.data() + size);
+
+    // Verify checksum.
+    Data should_sum = Hash::blake2b(address, checksum_size);
+    return std::memcmp(should_sum.data(), decoded.data() + size, checksum_size) == 0;
+}
+
+bool Address::isValid(const std::string& string) {
+    if (string.length() < 3) {
+        return false;
+    }
+    // Only main net addresses supported.
+    if (string[0] != PREFIX) {
+        return false;
+    }
+    // Get address type.
+    auto type = parse_type(string[1]);
+    if (!type) {
+        return false;
+    }
+
+    // ID addresses are special, they are just numbers.
+    return type == Type::ID ? isValidID(string) : isValidBase32(string, *type);
+}
+
+Address::Address(const std::string& string) {
+    if (!isValid(string))
+        throw std::invalid_argument("Invalid address data");
+
+    Type type = *(parse_type(string[1]));
+    // First byte is type
+    bytes.push_back(static_cast<uint8_t>(type));
+    if (type == Type::ID) {
+        uint64_t id = std::stoull(string.substr(2));
+        while (id >= 0x80) {
+            bytes.push_back(((uint8_t)id) | 0x80);
+            id >>= 7;
+        }
+        bytes.push_back((uint8_t)id);
+        return;
+    }
+
+    Data decoded;
+    if (!Base32::decode(string.substr(2), decoded, BASE32_ALPHABET_FILECOIN))
+        throw std::invalid_argument("Invalid address data");
+    uint8_t payload_size = Address::payload_size(type);
+
+    bytes.insert(bytes.end(), decoded.data(), decoded.data() + payload_size);
+}
+
+Address::Address(const Data& data) {
+    if (!isValid(data)) {
+        throw std::invalid_argument("Invalid address data");
+    }
+    bytes = data;
+}
+
+Address::Address(const PublicKey& publicKey) {
+    bytes.push_back(static_cast<uint8_t>(Type::SECP256K1));
+    Data hash = Hash::blake2b(publicKey.bytes, payload_size(Type::SECP256K1));
+    bytes.insert(bytes.end(), hash.begin(), hash.end());
+}
+
+std::string Address::string() const {
+    std::string s;
+    // Main net address prefix
+    s.push_back(PREFIX);
+    // Address type prefix
+    s.push_back(type_ascii(type()));
+
+    if (type() == Type::ID) {
+        uint64_t id = 0;
+        unsigned shift = 0;
+        for (int i = 1; i < bytes.size(); i++) {
+            if (bytes[i] < 0x80) {
+                id |= bytes[i] << shift;
+                break;
+            } else {
+                id |= ((uint64_t)(bytes[i] & 0x7F)) << shift;
+                shift += 7;
+            }
+        }
+        s.append(std::to_string(id));
+        return s;
+    }
+
+    uint8_t payload_size = Address::payload_size(type());
+    // Base32 encoded body
+    Data to_encode(payload_size + checksum_size);
+    // Copy address payload without prefix
+    std::copy(bytes.data() + 1, bytes.data() + payload_size + 1, to_encode.data());
+    // Append Blake2b checksum
+    Data bytes_vec;
+    bytes_vec.assign(std::begin(bytes), std::end(bytes));
+    Data sum = Hash::blake2b(bytes_vec, checksum_size);
+    assert(sum.size() == checksum_size);
+    std::copy(sum.begin(), sum.end(), to_encode.data() + payload_size);
+    s.append(Base32::encode(to_encode, BASE32_ALPHABET_FILECOIN));
+
+    return s;
+}

--- a/src/Filecoin/Address.h
+++ b/src/Filecoin/Address.h
@@ -1,0 +1,109 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "../PublicKey.h"
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace TW::Filecoin {
+
+class Address {
+  public:
+    enum class Type : uint8_t {
+        ID = 0,
+        SECP256K1 = 1,
+        ACTOR = 2,
+        BLS = 3,
+    };
+
+    /// Address data with address type prefix.
+    Data bytes;
+
+    /// Determines whether a collection of bytes makes a valid address.
+    static bool isValid(const Data& data);
+
+    /// Determines whether a string makes a valid encoded address.
+    static bool isValid(const std::string& string);
+
+    /// Initializes an address with a string representation.
+    explicit Address(const std::string& string);
+
+    /// Initializes an address with a collection of bytes.
+    explicit Address(const Data& data);
+
+    /// Initializes an address with a secp256k1 public key.
+    explicit Address(const PublicKey& publicKey);
+
+    /// Returns a string representation of the address.
+    [[nodiscard]] std::string string() const;
+
+    /// Returns the type of an address.
+    Type type() const { return *get_type(bytes[0]); }
+
+    /// Address prefix
+    static constexpr char PREFIX = 'f';
+
+  public:
+    /// Attempts to get the type by number.
+    static std::optional<Type> get_type(uint8_t raw) {
+        switch (raw) {
+        case 0:
+            return Type::ID;
+        case 1:
+            return Type::SECP256K1;
+        case 2:
+            return Type::ACTOR;
+        case 3:
+            return Type::BLS;
+        default:
+            return {};
+        }
+    }
+
+    /// Attempts to get the type by ASCII.
+    static std::optional<Type> parse_type(char c) {
+        if (c >= '0' && c <= '3') {
+            return static_cast<Type>(c - '0');
+        } else {
+            return {};
+        }
+    }
+
+    /// Returns ASCII character of type
+    static char type_ascii(Type t) { return '0' + static_cast<char>(t); }
+
+    // Returns the payload size (excluding any prefixes) of an address type.
+    // If the payload size is undefined/variable (e.g. ID)
+    // or the type is unknown, it returns zero.
+    static uint8_t payload_size(Type t) {
+        switch (t) {
+        case Type::SECP256K1:
+        case Type::ACTOR:
+            return 20;
+        case Type::BLS:
+            return 48;
+        default:
+            return 0;
+        }
+    }
+};
+
+inline bool operator==(const Address& lhs, const Address& rhs) {
+    return lhs.bytes == rhs.bytes;
+}
+
+} // namespace TW::Filecoin
+
+/// Wrapper for C interface.
+struct TWFilecoinAddress {
+    TW::Filecoin::Address impl;
+};

--- a/src/Filecoin/Signer.cpp
+++ b/src/Filecoin/Signer.cpp
@@ -1,0 +1,15 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Signer.h"
+
+using namespace TW;
+using namespace TW::Filecoin;
+
+void Signer::sign(const PrivateKey& privateKey, Transaction& transaction) const noexcept {
+    Data to_sign = Hash::blake2b(transaction.cid(), 32);
+    transaction.signature = privateKey.sign(to_sign, TWCurveSECP256k1);
+}

--- a/src/Filecoin/Signer.h
+++ b/src/Filecoin/Signer.h
@@ -1,0 +1,28 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "Transaction.h"
+#include "../Data.h"
+#include "../Hash.h"
+#include "../PrivateKey.h"
+
+namespace TW::Filecoin {
+
+/// Helper class that performs Filecoin transaction signing.
+class Signer {
+  public:
+    /// Signs the given transaction.
+    void sign(const PrivateKey& privateKey, Transaction& transaction) const noexcept;
+};
+
+} // namespace TW::Filecoin
+
+/// Wrapper for C interface.
+struct TWFilecoinSigner {
+    TW::Filecoin::Signer impl;
+};

--- a/src/Filecoin/Transaction.cpp
+++ b/src/Filecoin/Transaction.cpp
@@ -1,0 +1,54 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Transaction.h"
+
+using namespace TW;
+using namespace TW::Filecoin;
+
+// encode_varuint encodes a 256-bit number into a big endian encoding, omitting leading zeros.
+static Data encode_varuint(const uint256_t& value) {
+    Data data;
+    encode256BE(data, value, 256);
+    int i = 0;
+    for (i = 0; i < (int)data.size(); ++i)
+        if (data[i] != 0)
+            break;
+    Data small;
+    small.assign(data.begin() + i - 1, data.end());
+    return small;
+}
+
+Cbor::Encode Transaction::message() const {
+    return Cbor::Encode::array(
+        {Cbor::Encode::bytes(to.bytes), Cbor::Encode::bytes(from.bytes), Cbor::Encode::uint(nonce),
+         Cbor::Encode::bytes(encode_varuint(value)), Cbor::Encode::bytes(encode_varuint(gas_price)),
+         Cbor::Encode::bytes(encode_varuint(gas_limit)), Cbor::Encode::uint(0),
+         Cbor::Encode::bytes(Data())});
+}
+
+Data Transaction::cid() const {
+    Data cid = {
+        // CIDv1 with CBOR codec
+        0x01,
+        0x71,
+        // Blake2b-256 with 32 byte output
+        0xa0,
+        0xe4,
+        0x02,
+        0x20,
+    };
+    Data hash = Hash::blake2b(message().encoded(), 32);
+    cid.insert(cid.end(), hash.begin(), hash.end());
+    return cid;
+}
+
+Data Transaction::serialize() const {
+    Data enc_signature;
+    enc_signature.push_back(0x01); // Prepend IKTSecp256k1 type
+    enc_signature.insert(enc_signature.end(), signature.begin(), signature.end());
+    return Cbor::Encode::array({message(), Cbor::Encode::bytes(enc_signature)}).encoded();
+}

--- a/src/Filecoin/Transaction.cpp
+++ b/src/Filecoin/Transaction.cpp
@@ -5,14 +5,15 @@
 // file LICENSE at the root of the source code distribution tree.
 
 #include "Transaction.h"
+#include "../BinaryCoding.h"
 
 using namespace TW;
 using namespace TW::Filecoin;
 
-// encode_varuint encodes a 256-bit number into a big endian encoding, omitting leading zeros.
-static Data encode_varuint(const uint256_t& value) {
+// encode_varuint encodes a 64-bit number into a big endian encoding, omitting leading zeros.
+static Data encode_varuint(uint64_t value) {
     Data data;
-    encode256BE(data, value, 256);
+    encode64BE(value, data);
     int i = 0;
     for (i = 0; i < (int)data.size(); ++i)
         if (data[i] != 0)

--- a/src/Filecoin/Transaction.h
+++ b/src/Filecoin/Transaction.h
@@ -1,0 +1,56 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "Address.h"
+#include "../Cbor.h"
+#include "../uint256.h"
+
+namespace TW::Filecoin {
+
+class Transaction {
+  public:
+    // Recipient address
+    Address to;
+    // Sender address
+    Address from;
+    // Transaction nonce
+    uint64_t nonce;
+    // Transaction value
+    uint256_t value;
+    // Miner fee
+    uint256_t gas_price;
+    uint256_t gas_limit;
+    // Transaction type; 0 for simple transfers
+    uint64_t method;
+    // Transaction data; empty for simple transfers
+    Data params;
+    // secp256k1 signature data (excluding type byte)
+    Data signature;
+
+    Transaction(Address to, Address from, uint64_t nonce, uint256_t value, uint256_t gprice,
+                uint256_t glimit)
+        : to(std::move(to))
+        , from(std::move(from))
+        , nonce(nonce)
+        , value(std::move(value))
+        , gas_price(std::move(gprice))
+        , gas_limit(std::move(glimit))
+        , method(0) {}
+
+  public:
+    // message returns the CBOR encoding of the Filecoin Message to be signed.
+    Cbor::Encode message() const;
+
+    // cid returns the raw Filecoin message CID (excluding the signature).
+    Data cid() const;
+
+    // serialize returns the CBOR encoding of the Filecoin SignedMessage.
+    Data serialize() const;
+};
+
+} // namespace TW::Filecoin

--- a/src/Filecoin/Transaction.h
+++ b/src/Filecoin/Transaction.h
@@ -8,7 +8,6 @@
 
 #include "Address.h"
 #include "../Cbor.h"
-#include "../uint256.h"
 
 namespace TW::Filecoin {
 
@@ -21,10 +20,10 @@ class Transaction {
     // Transaction nonce
     uint64_t nonce;
     // Transaction value
-    uint256_t value;
+    uint64_t value;
     // Miner fee
-    uint256_t gas_price;
-    uint256_t gas_limit;
+    uint64_t gas_price;
+    uint64_t gas_limit;
     // Transaction type; 0 for simple transfers
     uint64_t method;
     // Transaction data; empty for simple transfers
@@ -32,14 +31,14 @@ class Transaction {
     // secp256k1 signature data (excluding type byte)
     Data signature;
 
-    Transaction(Address to, Address from, uint64_t nonce, uint256_t value, uint256_t gprice,
-                uint256_t glimit)
+    Transaction(Address to, Address from, uint64_t nonce, uint64_t value, uint64_t gprice,
+                uint64_t glimit)
         : to(std::move(to))
         , from(std::move(from))
         , nonce(nonce)
-        , value(std::move(value))
-        , gas_price(std::move(gprice))
-        , gas_limit(std::move(glimit))
+        , value(value)
+        , gas_price(gprice)
+        , gas_limit(glimit)
         , method(0) {}
 
   public:

--- a/src/interface/TWFilecoinAddress.cpp
+++ b/src/interface/TWFilecoinAddress.cpp
@@ -1,0 +1,56 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include <TrustWalletCore/TWFilecoinAddress.h>
+
+#include "../Filecoin/Address.h"
+
+#include <memory>
+
+using namespace TW::Filecoin;
+
+bool TWFilecoinAddressEqual(struct TWFilecoinAddress *_Nonnull lhs, struct TWFilecoinAddress *_Nonnull rhs) {
+    return lhs->impl == rhs->impl;
+}
+
+bool TWFilecoinAddressIsValid(TWData *_Nonnull data) {
+    std::vector<uint8_t> buf;
+    auto ptr = TWDataBytes(data);
+    buf.assign(ptr, ptr + TWDataSize(data));
+    return Address::isValid(buf);
+}
+
+bool TWFilecoinAddressIsValidString(TWString *_Nonnull string) {
+    auto s = reinterpret_cast<const std::string*>(string);
+    return Address::isValid(*s);
+}
+
+struct TWFilecoinAddress *_Nullable TWFilecoinAddressCreateWithString(TWString *_Nonnull string) {
+    auto s = reinterpret_cast<const std::string*>(string);
+    try {
+        const auto address = Address(*s);
+        return new TWFilecoinAddress{ std::move(address) };
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+struct TWFilecoinAddress *_Nonnull TWFilecoinAddressCreateWithPublicKey(struct TWPublicKey *_Nonnull publicKey) {
+    return new TWFilecoinAddress{ Address(publicKey->impl) };
+}
+
+void TWFilecoinAddressDelete(struct TWFilecoinAddress *_Nonnull address) {
+    delete address;
+}
+
+TWString *_Nonnull TWFilecoinAddressDescription(struct TWFilecoinAddress *_Nonnull address) {
+    const auto string = address->impl.string();
+    return TWStringCreateWithUTF8Bytes(string.c_str());
+}
+
+TWData *_Nonnull TWFilecoinAddressKeyHash(struct TWFilecoinAddress *_Nonnull address) {
+    return TWDataCreateWithBytes(address->impl.bytes.data(), address->impl.bytes.size());
+}

--- a/src/interface/TWFilecoinSigner.cpp
+++ b/src/interface/TWFilecoinSigner.cpp
@@ -1,0 +1,44 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include <TrustWalletCore/TWFilecoinSigner.h>
+
+#include "../Filecoin/Signer.h"
+#include "../Filecoin/Transaction.h"
+#include "../PrivateKey.h"
+#include "../proto/Filecoin.pb.h"
+
+using namespace TW;
+using namespace TW::Filecoin;
+
+TW_Filecoin_Proto_SigningOutput TWFilecoinSignerSign(TW_Filecoin_Proto_SigningInput data) {
+    Proto::SigningInput input;
+    input.ParseFromArray(TWDataBytes(data), static_cast<int>(TWDataSize(data)));
+
+    auto key = PrivateKey(Data(input.private_key().begin(), input.private_key().end()));
+    auto pubkey = key.getPublicKey(TWPublicKeyTypeSECP256k1Extended);
+    Address from(pubkey);
+    std::array<uint8_t, 32> pubkeyBytes = {};
+    std::copy(pubkey.bytes.begin(), pubkey.bytes.end(), pubkeyBytes.data());
+    Transaction transaction(
+        /* from */ from,
+        /* to */ Address(input.to_address()),
+        /* nonce */ input.nonce(),
+        /* value */ input.value(),
+        /* gas_price */ input.gas_price(),
+        /* gas_limit */ input.gas_limit()
+    );
+
+    Signer signer;
+    signer.sign(key, transaction);
+
+    auto protoOutput = Proto::SigningOutput();
+    auto encoded = transaction.serialize();
+    protoOutput.set_encoded(encoded.data(), encoded.size());
+
+    auto serialized = protoOutput.SerializeAsString();
+    return TWDataCreateWithBytes(reinterpret_cast<const uint8_t *>(serialized.data()), serialized.size());
+}

--- a/src/proto/Filecoin.proto
+++ b/src/proto/Filecoin.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package TW.Filecoin.Proto;
+option java_package = "wallet.core.jni.proto";
+
+// Input data necessary to create a signed transaction.
+message SigningInput {
+    // Private key of sender account.
+    bytes private_key = 1;
+
+    // Recipient's address.
+    string to_address = 2;
+
+    // Transaction nonce.
+    uint64 nonce = 3;
+
+    // Transfer value.
+    uint64 value = 4;
+
+    // Gas price.
+    uint64 gas_price = 5;
+
+    // Gas limit.
+    uint64 gas_limit = 6;
+}
+
+// Transaction signing output.
+message SigningOutput {
+    bytes encoded = 1;
+}

--- a/swift/Tests/CoinAddressDerivationTests.swift
+++ b/swift/Tests/CoinAddressDerivationTests.swift
@@ -187,6 +187,9 @@ class CoinAddressDerivationTests: XCTestCase {
                 case .cardano:
                     let expectedResult = "Ae2tdPwUPEZJ2TwjFBMCnjz6t43pr4QVnBjCGSW8BMsttrt2WagC1D7LUWa"
                     AssetCoinDerivation(coin, expectedResult, derivedAddress, address)
+                case .filecoin:
+                    let expectedResult = "f1zzykebxldfcakj5wdb5n3n7priul522fnmjzori"
+                    AssetCoinDerivation(coin, expectedResult, derivedAddress, address)
                 }
             }
         }

--- a/tests/Filecoin/AddressTests.cpp
+++ b/tests/Filecoin/AddressTests.cpp
@@ -1,0 +1,95 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "HexCoding.h"
+#include "Filecoin/Address.h"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace TW;
+using namespace TW::Filecoin;
+
+struct address_test {
+    std::string encoded;
+    const char *hex;
+};
+
+static const address_test valid_addresses[] = {
+    // ID addresses
+    {"f00",                    "0000"},
+    {"f01",                    "0001"},
+    {"f010",                   "000a"},
+    {"f0150",                  "009601"},
+    {"f0499",                  "00f303"},
+    {"f01024",                 "008008"},
+    {"f01729",                 "00c10d"},
+    {"f0999999",               "00bf843d"},
+    {"f018446744073709551615", "00ffffffffffffffffff01"},
+    // secp256k1 addresses
+    {"f15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq", "01ea0f0ea039b291a0f08fd179e0556a8c3277c0d3"},
+    {"f12fiakbhe2gwd5cnmrenekasyn6v5tnaxaqizq6a", "01d1500504e4d1ac3e89ac891a4502586fabd9b417"},
+    {"f1wbxhu3ypkuo6eyp6hjx6davuelxaxrvwb2kuwva", "01b06e7a6f0f551de261fe3a6fe182b422ee0bc6b6"},
+    {"f1xtwapqc6nh4si2hcwpr3656iotzmlwumogqbuaa", "01bcec07c05e69f92468e2b3e3bf77c874f2c5da8c"},
+    {"f1xcbgdhkgkwht3hrrnui3jdopeejsoatkzmoltqy", "01b882619d46558f3d9e316d11b48dcf211327026a"},
+    {"f17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy", "01fd1d0f4dfcd7e99afcb99a8326b7dc459d32c628"},
+    // Actor addresses
+    {"f24vg6ut43yw2h2jqydgbg2xq7x6f4kub3bg6as6i", "02e54dea4f9bc5b47d261819826d5e1fbf8bc5503b"},
+    {"f25nml2cfbljvn4goqtclhifepvfnicv6g7mfmmvq", "02eb58bd08a15a6ade19d0989674148fa95a8157c6"},
+    {"f2nuqrg7vuysaue2pistjjnt3fadsdzvyuatqtfei", "026d21137eb4c4814269e894d296cf6500e43cd714"},
+    {"f24dd4ox4c2vpf5vk5wkadgyyn6qtuvgcpxxon64a", "02e0c7c75f82d55e5ed55db28033630df4274a984f"},
+    {"f2gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y", "02316b4c1ff5d4afb7826ceab5bb0f2c3e0f364053"},
+    // BLS addresses
+    {"f3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss4a","03ad58df696e2d4e91ea86c881e938ba4ea81b395e12797b84b9cf314b9546705e839c7a99d606b247ddb4f9ac7a3414dd"},
+    {"f3wmuu6crofhqmm3v4enos73okk2l366ck6yc4owxwbdtkmpk42ohkqxfitcpa57pjdcftql4tojda2poeruwa","03b3294f0a2e29e0c66ebc235d2fedca5697bf784af605c75af608e6a63d5cd38ea85ca8989e0efde9188b382f9372460d"},
+    {"f3s2q2hzhkpiknjgmf4zq3ejab2rh62qbndueslmsdzervrhapxr7dftie4kpnpdiv2n6tvkr743ndhrsw6d3a","0396a1a3e4ea7a14d49985e661b22401d44fed402d1d0925b243c923589c0fbc7e32cd04e29ed78d15d37d3aaa3fe6da33"},
+    {"f3q22fijmmlckhl56rn5nkyamkph3mcfu5ed6dheq53c244hfmnq2i7efdma3cj5voxenwiummf2ajlsbxc65a","0386b454258c589475f7d16f5aac018a79f6c1169d20fc33921dd8b5ce1cac6c348f90a3603624f6aeb91b64518c2e8095"},
+    {"f3u5zgwa4ael3vuocgc5mfgygo4yuqocrntuuhcklf4xzg5tcaqwbyfabxetwtj4tsam3pbhnwghyhijr5mixa","03a7726b038022f75a384617585360cee629070a2d9d28712965e5f26ecc40858382803724ed34f2720336f09db631f074"},
+};
+
+static const std::string invalid_addresses[] = {
+    "",
+    "f0-1",                   // Negative :)
+    "f018446744073709551616", // Greater than max uint64_t
+    "f15ihq5ibzwki2b4ep2f46avlkr\0zhpqgtga7pdrq", // Embedded NUL
+    "t15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq",  // Test net
+    "a15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq",  // Unknown net
+    "f95ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq",  // Unknown address type
+    // Invalid checksum cases
+    "f15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7rdrr",
+    "f24vg6ut43yw2h2jqydgbg2xq7x6f4kub3bg6as66",
+    "f3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss44",
+};
+
+TEST(FilecoinAddress, IsValid) {
+    for (const auto& test : valid_addresses) {
+        ASSERT_TRUE(Address::isValid(test.encoded)) << "is_valid() != true: " << test.encoded << std::endl;
+        ASSERT_TRUE(Address::isValid(parse_hex(test.hex))) << "is_valid() != true: " << test.hex << std::endl;
+    }
+    for (const auto& address : invalid_addresses)
+        ASSERT_FALSE(Address::isValid(address)) << "is_valid() != false: " << address << std::endl;
+
+    ASSERT_FALSE(Address::isValid(parse_hex("00"))) << "Empty varuint";
+    ASSERT_FALSE(Address::isValid(parse_hex("00ff"))) << "Short varuint";
+    ASSERT_FALSE(Address::isValid(parse_hex("00ff00ff"))) << "Varuint with hole";
+    ASSERT_FALSE(Address::isValid(parse_hex("000101"))) << "Long varuint";
+    ASSERT_FALSE(Address::isValid(parse_hex("000000"))) << "Long varuint";
+    ASSERT_FALSE(Address::isValid(parse_hex("00ffffffffffffffffff02"))) << "Overflow";
+}
+
+TEST(FilecoinAddress, String) {
+    for (const auto& test : valid_addresses) {
+        Address a(parse_hex(test.hex));
+        ASSERT_EQ(a.string(), test.encoded) << "Address(" << test.hex << ")";
+    }
+}
+
+TEST(FilecoinAddress, FromString) {
+    for (const auto& test : valid_addresses) {
+        Address a(test.encoded);
+        ASSERT_EQ(hex(a.bytes), test.hex) << "Address(" << test.encoded << ")";
+    }
+}

--- a/tests/Filecoin/SignerTests.cpp
+++ b/tests/Filecoin/SignerTests.cpp
@@ -1,0 +1,44 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "HexCoding.h"
+#include "PrivateKey.h"
+#include "Filecoin/Address.h"
+#include "Filecoin/Signer.h"
+
+#include <gtest/gtest.h>
+
+namespace TW::Filecoin {
+
+TEST(FilecoinSigner, DerivePublicKey) {
+    const PrivateKey privateKey(parse_hex("1d969865e189957b9824bd34f26d5cbf357fda1a6d844cbf0c9ab1ed93fa7dbe"));
+    const PublicKey publicKey((privateKey.getPublicKey(TWPublicKeyTypeSECP256k1Extended)));
+    const Address address(publicKey);
+    ASSERT_EQ(address.string(), "f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq");
+}
+
+TEST(FilecoinSigner, Sign) {
+    const PrivateKey privateKey(parse_hex("1d969865e189957b9824bd34f26d5cbf357fda1a6d844cbf0c9ab1ed93fa7dbe"));
+    const PublicKey publicKey((privateKey.getPublicKey(TWPublicKeyTypeSECP256k1Extended)));
+    const Address fromAddress(publicKey);
+    const Address toAddress("f1rletqqhinhagw6nxjcr4kbfws25thgt7owzuruy");
+
+    Transaction tx(
+        toAddress, fromAddress,
+        0x1334565890, /*nonce*/
+        6000, /*value*/
+        2, /*gas_price*/
+        80 /*gas_limit*/
+    );
+
+    Signer signer;
+    signer.sign(privateKey, tx);
+
+    ASSERT_EQ(hex(tx.serialize()),
+        "828855018ac93840e869c06b79b748a3c504b696bb339a7f5501cf01bf485f61435e6770b52615bf455e043a23611b0000001334565890430017704200024200500040584201c1764de3891d32fcb0b372d1515cb480ef485ed9d8d3a78befd1530382163f3b00c7ad178a74fa8a2eb229bb06cae71cacf2fba1493ff22bb6c290d519b24a2c01");
+}
+
+} // namespace TW::Filecoin

--- a/tests/Filecoin/TransactionTests.cpp
+++ b/tests/Filecoin/TransactionTests.cpp
@@ -1,0 +1,36 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "HexCoding.h"
+#include "PrivateKey.h"
+#include "Filecoin/Address.h"
+#include "Filecoin/Transaction.h"
+
+#include <gtest/gtest.h>
+
+namespace TW::Filecoin {
+
+TEST(FilecoinTransaction, Serialize) {
+    const PrivateKey privateKey(parse_hex("2f0f1d2c8de955c7c3fb4d9cae02539fadcb13fa998ccd9a1e871bed95f1941e"));
+    const auto publicKey = privateKey.getPublicKey(TWPublicKeyTypeSECP256k1Extended);
+    const Address fromAddress(publicKey);
+    const Address toAddress("f1hvadvq4rd2pyayrigjx2nbqz2nvemqouslw4wxi");
+
+    Transaction tx(
+        toAddress, fromAddress,
+        0x1234567890, /*nonce*/
+        1000, /*value*/
+        1, /*gas_price*/
+        50 /*gas_limit*/
+    );
+
+    ASSERT_EQ(hex(tx.message().encoded()),
+        "8855013d403ac3911e9f806228326fa68619d36a4641d455013d413d4c3fe3d89f99495a48c6046224a71f0cd71b0000001234567890430003e84200014200320040");
+    ASSERT_EQ(hex(tx.cid()),
+        "0171a0e4022020421f7d6207c9575803d5d96387c399acbf4bdac3026196cb4d423bc8966bb1");
+}
+
+} // namespace TW::Filecoin


### PR DESCRIPTION
## Description

Adds support for Filecoin, implementing a secp256k1-based wallet.

## Changes

 - ~~Added light partial [CBOR](http://cbor.io/) implementation~~
 - Filecoin support (with secp256k1 wallet)

## Checklist

- [x] Support ID, SECP256K1, Actor and BLS Adresses.
- [x] Pass test vectors from Lotus
- [x] Add Signer & Transaction tests
- [ ] Send generated transaction to network
- [ ] Add token image
- [x] Wait for steps in #780 to be resolved
- [x] Update derivation path
- [x] Add iOS/Android tests
- [ ] Review from Trust Wallet team
- [ ] Update documentation as needed.

Closes #780.