### PR TITLE
CBOR implementation and tests.

### DIFF
--- a/src/Cbor.cpp
+++ b/src/Cbor.cpp
@@ -128,7 +128,7 @@ void Encode::appendValue(byte majorType, uint64_t value) {
         minorType = 27;
     }
     // add bytes
-    TW::append(data, (majorType << 5) | (minorType & 0x1F));
+    TW::append(data, (byte)((majorType << 5) | (minorType & 0x1F)));
     Data valBytes = Data(byteCount - 1);
     for (int i = 0; i < valBytes.size(); ++i) {
         valBytes[valBytes.size() - 1 - i] = (byte)(value & 0xFF);
@@ -139,7 +139,7 @@ void Encode::appendValue(byte majorType, uint64_t value) {
 
 void Encode::appendIndefinite(byte majorType) {
     byte minorType = 31;
-    TW::append(data, (majorType << 5) | (minorType & 0x1F));
+    TW::append(data, (byte)((majorType << 5) | (minorType & 0x1F)));
 }
 
 
@@ -349,7 +349,7 @@ bool Decode::isValid() const {
         case MT_bytes:
         case MT_string:
             {
-                uint32_t len = typeDesc.byteCount + typeDesc.value;
+                uint32_t len = (uint32_t)(typeDesc.byteCount + typeDesc.value);
                 return (startIdx + len <= totlen);
             }
 

--- a/src/Cbor.cpp
+++ b/src/Cbor.cpp
@@ -14,11 +14,6 @@ namespace TW::Cbor {
 using namespace std;
 
 
-Encode::Encode(const TW::Data& rawData)
-{
-    data = rawData;
-}
-
 TW::Data Encode::encoded() const {
     if (openIndefCount > 0) {
         throw invalid_argument("CBOR Unclosed indefinite lenght building");

--- a/src/Cbor.cpp
+++ b/src/Cbor.cpp
@@ -138,21 +138,24 @@ void Encode::appendIndefinite(byte majorType) {
 }
 
 
-Decode::Decode(const TW::byte* ndata, uint32_t nlen) {
-    base = ndata;
-    startIdx = 0;
-    totlen = nlen;
+Decode::Decode(const Data& input) {
+    // copy input data
+    origData = input;
+    dataPtr = origData.data();
+    dataLen = origData.size();
+    subStart = 0;
+    subLen = dataLen;
 }
 
-Decode::Decode(const TW::byte* ndata, uint32_t nlen, uint32_t nStartIdx) {
-    base = ndata;
-    startIdx = nStartIdx;
-    totlen = nlen;
+Decode::Decode(const TW::byte* nDataPtr, uint32_t nDataLen, uint32_t nSubStart, uint32_t nSubLen) {
+    dataPtr = nDataPtr;
+    dataLen = nDataLen;
+    subStart = nSubStart;
+    subLen = nSubLen;
 }
 
-Decode Decode::skip(uint32_t offset) const {
-    Decode skipped = Decode(base, totlen, startIdx + offset);
-    return skipped;
+Decode Decode::skipClone(uint32_t offset) const {
+    return Decode(dataPtr, dataLen, subStart + offset, subLen - offset);
 }
 
 Decode::TypeDesc Decode::getTypeDesc() const {
@@ -223,7 +226,7 @@ uint32_t Decode::getTotalLen() const {
             return getCompoundLength(2);
         case MT_tag:
             {
-                uint32_t dataLen = skip(typeDesc.byteCount).getTotalLen();
+                uint32_t dataLen = skipClone(typeDesc.byteCount).getTotalLen();
                 return typeDesc.byteCount + dataLen;
             }
         default:
@@ -253,7 +256,7 @@ Data Decode::getBytes() const {
     if (length() < (uint32_t)typeDesc.byteCount + (uint32_t)len) {
         throw std::invalid_argument("CBOR bytes/string data too short");
     }
-    return data(base + (startIdx + typeDesc.byteCount), typeDesc.value); 
+    return data(dataPtr + (subStart + typeDesc.byteCount), len); 
 }
 
 bool Decode::isBreak() const {
@@ -269,7 +272,7 @@ uint32_t Decode::getCompoundLength(uint32_t countMultiplier) const {
     // process elements
     len += typeDesc.byteCount;
     for (int i = 0; i < count || typeDesc.isIndefiniteValue; ++i) {
-        Decode nextElem = skip(len);
+        Decode nextElem = skipClone(len);
         if (typeDesc.isIndefiniteValue && nextElem.isBreak()) {
             // end of indefinite-length
             len += 1; // account for break
@@ -294,7 +297,7 @@ vector<Decode> Decode::getCompoundElements(uint32_t countMultiplier, TW::byte ex
     // process elements
     uint32_t idx = typeDesc.byteCount;
     for (int i = 0; i < count || typeDesc.isIndefiniteValue; ++i) {
-        Decode nextElem = skip(idx);
+        Decode nextElem = skipClone(idx);
         if (typeDesc.isIndefiniteValue && nextElem.isBreak()) {
             // end of indefinite-length
             break;
@@ -303,7 +306,7 @@ vector<Decode> Decode::getCompoundElements(uint32_t countMultiplier, TW::byte ex
         if (idx + elemLen > length()) {
             throw std::invalid_argument("CBOR array data too short");
         }
-        elems.push_back(Decode(base, startIdx + idx + elemLen, startIdx + idx));
+        elems.push_back(Decode(dataPtr, dataLen, subStart + idx, elemLen));
         idx += elemLen;
     }
     return elems;
@@ -331,7 +334,7 @@ Decode Decode::getTagElement() const {
     if (typeDesc.majorType != MT_tag) {
         throw std::invalid_argument("CBOR data type not tag");
     }
-    return skip(typeDesc.byteCount);
+    return skipClone(typeDesc.byteCount);
 }
 
 bool Decode::isValid() const {
@@ -341,13 +344,13 @@ bool Decode::isValid() const {
             case MT_uint:
             case MT_negint:
             case MT_special:
-                return (startIdx + typeDesc.byteCount <= totlen);
+                return (typeDesc.byteCount <= subLen);
 
             case MT_bytes:
             case MT_string:
                 {
                     auto len = (uint32_t)(typeDesc.byteCount + typeDesc.value);
-                    return (startIdx + len <= totlen);
+                    return (len <= subLen);
                 }
 
             case MT_array:
@@ -355,12 +358,12 @@ bool Decode::isValid() const {
                 {
                     uint32_t countMultiplier = (typeDesc.majorType == MT_map) ? 2 : 1;
                     uint32_t len = getCompoundLength(countMultiplier);
-                    if (len > totlen) return false;
+                    if (len > subLen) { return false; }
                     auto count = typeDesc.isIndefiniteValue ? 0 : countMultiplier * typeDesc.value;
                     uint32_t idx = typeDesc.byteCount;
                     for (int i = 0; i < count || typeDesc.isIndefiniteValue; ++i)
                     {
-                        Decode nextElem = skip(idx);
+                        Decode nextElem = skipClone(idx);
                         if (typeDesc.isIndefiniteValue && nextElem.isBreak()) { break; }
                         if (!nextElem.isValid()) { return false; }
                         idx += nextElem.getTotalLen();
@@ -369,7 +372,7 @@ bool Decode::isValid() const {
                 }
 
             case MT_tag:
-                return skip(typeDesc.byteCount).isValid();
+                return skipClone(typeDesc.byteCount).isValid();
 
             default:
                 return false;

--- a/src/Cbor.cpp
+++ b/src/Cbor.cpp
@@ -1,0 +1,458 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Cbor.h"
+#include "HexCoding.h"
+
+#include <sstream>
+
+namespace TW::Cbor {
+
+using namespace std;
+
+
+Encode::Encode(const TW::Data& rawData)
+{
+    // check validity, may throw
+    Decode check(rawData);
+    if (!check.isValid()) { throw invalid_argument("Invalid CBOR data"); }
+    data = rawData;
+}
+
+Encode Encode::uint(uint64_t value) {
+    Encode e;
+    e.appendValue(Decode::MT_uint, value);
+    return e;
+}
+
+Encode Encode::negInt(uint64_t value) {
+    Encode e;
+    if (value == 0) {
+        e.appendValue(Decode::MT_uint, 0);
+    } else {
+        e.appendValue(Decode::MT_negint, value - 1);
+    }
+    return e;
+}
+
+Encode Encode::string(const std::string& str) {
+    Encode e;
+    e.appendValue(Decode::MT_string, str.size());
+    append(e.data, TW::data(str));
+    return e;
+}
+
+Encode Encode::bytes(const Data& str) {
+    Encode e;
+    e.appendValue(Decode::MT_bytes, str.size());
+    append(e.data, str);
+    return e;
+}
+
+Encode Encode::array(const vector<Encode>& elems) {
+    Encode e;
+    auto n = elems.size();
+    e.appendValue(Decode::MT_array, n);
+    for (int i = 0; i < n; ++i) {
+        append(e.data, elems[i].encoded());
+    }
+    return e;
+}
+
+Encode Encode::map(const vector<std::pair<Encode, Encode>>& elems) {
+    Encode e;
+    auto n = elems.size();
+    e.appendValue(Decode::MT_map, n);
+    for (int i = 0; i < n; ++i) {
+        append(e.data, elems[i].first.encoded());
+        append(e.data, elems[i].second.encoded());
+    }
+    return e;
+}
+
+Encode Encode::tag(uint64_t value, const Encode& elem) {
+    Encode e;
+    e.appendValue(Decode::MT_tag, value);
+    append(e.data, elem.encoded());
+    return e;
+}
+
+Encode Encode::indefArray() {
+    Encode e;
+    e.appendIndefinite(Decode::MT_array);
+    e.indefElemCount.push_back(0);
+    return e;
+}
+
+Encode Encode::addIDArrayElem(const Encode& elem) {
+    if (indefElemCount.size() <= 0) {
+        throw invalid_argument("CBOR Not inside undefined-length array");
+    }
+    append(data, elem.encoded());
+    // increase counter
+    indefElemCount[indefElemCount.size() - 1] = indefElemCount[indefElemCount.size() - 1] + 1;
+    return *this;
+}
+
+Encode Encode::closeIndefArray() {
+    if (indefElemCount.size() <= 0) {
+        throw invalid_argument("CBOR Not inside undefined-length array");
+    }
+    // add closing break command
+    append(data, 0xFF);
+    // close counter
+    indefElemCount.erase(indefElemCount.begin() + (indefElemCount.size() - 1));
+    return *this;
+}
+
+void Encode::appendValue(byte majorType, uint64_t value) {
+    byte byteCount = 0;
+    byte minorType = 0;
+    if (value < 24) {
+        byteCount = 1;
+        minorType = (byte)value;
+    } else if (value <= 0xFF) {
+        byteCount = 1 + 1;
+        minorType = 24;
+    } else if (value <= 0xFFFF) {
+        byteCount = 1 + 2;
+        minorType = 25;
+    } else if (value <= 0xFFFFFFFF) {
+        byteCount = 1 + 4;
+        minorType = 26;
+    } else {
+        byteCount = 1 + 8;
+        minorType = 27;
+    }
+    // add bytes
+    TW::append(data, (majorType << 5) | (minorType & 0x1F));
+    Data valBytes = Data(byteCount - 1);
+    for (int i = 0; i < valBytes.size(); ++i) {
+        valBytes[valBytes.size() - 1 - i] = (byte)(value & 0xFF);
+        value = value >> 8;
+    }
+    TW::append(data, valBytes);
+}
+
+void Encode::appendIndefinite(byte majorType) {
+    byte minorType = 31;
+    TW::append(data, (majorType << 5) | (minorType & 0x1F));
+}
+
+
+Decode::Decode(const TW::byte* ndata, uint32_t nlen) {
+    base = ndata;
+    startIdx = 0;
+    totlen = nlen;
+}
+
+Decode::Decode(const TW::byte* ndata, uint32_t nlen, uint32_t nStartIdx) {
+    base = ndata;
+    startIdx = nStartIdx;
+    totlen = nlen;
+}
+
+Decode Decode::skip(uint32_t offset) const {
+    Decode skipped = Decode(base, totlen, startIdx + offset);
+    return skipped;
+}
+
+Decode::TypeDesc Decode::getTypeDesc() const {
+    TypeDesc typeDesc;
+    typeDesc.isIndefiniteValue = false;
+    typeDesc.majorType = (MajorType)(byte(0) >> 5);
+    TW::byte minorType = (TW::byte)((uint8_t)byte(0) & 0x1F);
+    if (minorType < 24) {
+        // direct value
+        typeDesc.byteCount = 1;
+        typeDesc.value = minorType;
+        return typeDesc;
+    }
+    if (minorType == 24) {
+        typeDesc.byteCount = 1 + 1;
+        typeDesc.value = byte(1);
+        return typeDesc;
+    }
+    if (minorType == 25) {
+        typeDesc.byteCount = 1 + 2;
+        typeDesc.value = 0x100 * (uint16_t)byte(1) + (uint16_t)byte(2);
+        return typeDesc;
+    }
+    if (minorType == 26) {
+        typeDesc.byteCount = 1 + 4;
+        typeDesc.value = 0x1000000 * (uint32_t)byte(1) + 0x10000 * (uint32_t)byte(2) + 0x100 * (uint32_t)byte(3) + (uint32_t)byte(4);
+        return typeDesc;
+    }
+    if (minorType == 27) {
+        typeDesc.byteCount = 1 + 8;
+        typeDesc.value =
+            0x100000000000000 * (uint64_t)byte(1) +
+            0x001000000000000 * (uint64_t)byte(2) +
+            0x000010000000000 * (uint64_t)byte(3) +
+            0x000000100000000 * (uint64_t)byte(4) +
+            0x000000001000000 * (uint64_t)byte(5) +
+            0x000000000010000 * (uint64_t)byte(6) +
+            0x000000000000100 * (uint64_t)byte(7) +
+                                (uint64_t)byte(8);
+        return typeDesc;
+    }
+    if (minorType >= 28 && minorType <= 30) {
+        throw std::invalid_argument("CBOR unassigned type not supported");
+    }
+    // minorType == 31
+    // stop code
+    typeDesc.byteCount = 1;
+    typeDesc.value = 0;
+    typeDesc.isIndefiniteValue = true;
+    return typeDesc;
+}
+
+uint32_t Decode::getTotalLen() const {
+    TypeDesc typeDesc = getTypeDesc();
+    switch (typeDesc.majorType) {
+        case MT_uint:
+        case MT_negint:
+        case MT_special:
+            // simple types
+            return typeDesc.byteCount;
+        case MT_bytes:
+        case MT_string:
+            return (uint32_t)typeDesc.byteCount + (uint32_t)typeDesc.value;
+        case MT_array:
+            return getCompoundLength(1);
+        case MT_map:
+            return getCompoundLength(2);
+        case MT_tag:
+            {
+                uint32_t dataLen = skip(typeDesc.byteCount).getTotalLen();
+                return typeDesc.byteCount + dataLen;
+            }
+        default:
+            throw std::invalid_argument("CBOR length type not supported");
+    }
+}
+
+uint64_t Decode::getValue() const {
+    TypeDesc typeDesc = getTypeDesc();
+    if (typeDesc.majorType != MT_uint && typeDesc.majorType != MT_negint) {
+        throw std::invalid_argument("CBOR data type not a value-type");
+    }
+    return typeDesc.value;
+}
+
+std::string Decode::getString() const {
+    Data strData = getBytes();
+    return std::string((const char*)strData.data(), strData.size()); 
+}
+
+Data Decode::getBytes() const {
+    TypeDesc typeDesc = getTypeDesc();
+    if (typeDesc.majorType != MT_bytes && typeDesc.majorType != MT_string) {
+        throw std::invalid_argument("CBOR data type not bytes/string");
+    }
+    uint32_t len = typeDesc.value;
+    if (length() < (uint32_t)typeDesc.byteCount + (uint32_t)len) {
+        throw std::invalid_argument("CBOR bytes/string data too short");
+    }
+    return data(base + (startIdx + typeDesc.byteCount), typeDesc.value); 
+}
+
+bool Decode::isBreak() const {
+    TypeDesc typeDesc = getTypeDesc();
+    if (typeDesc.majorType == MT_special && typeDesc.isIndefiniteValue) { return true; }
+    return false;
+}
+
+uint32_t Decode::getCompoundLength(uint32_t countMultiplier) const {
+    uint32_t len = 0;
+    TypeDesc typeDesc = getTypeDesc();
+    uint32_t count = typeDesc.isIndefiniteValue ? 0 : (uint32_t)(typeDesc.value * countMultiplier);
+    // process elements
+    len += typeDesc.byteCount;
+    for (int i = 0; i < count || typeDesc.isIndefiniteValue; ++i) {
+        Decode nextElem = skip(len);
+        if (typeDesc.isIndefiniteValue && nextElem.isBreak()) {
+            // end of indefinite-length
+            len += 1; // account for break
+            break;
+        }
+        uint32_t elemLen = nextElem.getTotalLen();
+        if (len + elemLen > length()) {
+            throw std::invalid_argument("CBOR array data too short");
+        }
+        len += elemLen;
+    }
+    return len;
+}
+
+vector<Decode> Decode::getCompoundElements(uint32_t countMultiplier, TW::byte expectedType) const {
+    TypeDesc typeDesc = getTypeDesc();
+    if (typeDesc.majorType != expectedType) {
+        throw std::invalid_argument("CBOR data type mismatch");
+    }
+    vector<Decode> elems;
+    uint32_t count = typeDesc.isIndefiniteValue ? 0 : (uint32_t)(typeDesc.value * countMultiplier);
+    // process elements
+    uint32_t idx = typeDesc.byteCount;
+    for (int i = 0; i < count || typeDesc.isIndefiniteValue; ++i) {
+        Decode nextElem = skip(idx);
+        if (typeDesc.isIndefiniteValue && nextElem.isBreak()) {
+            // end of indefinite-length
+            break;
+        }
+        uint32_t elemLen = nextElem.getTotalLen();
+        if (idx + elemLen > length()) {
+            throw std::invalid_argument("CBOR array data too short");
+        }
+        elems.push_back(Decode(base, startIdx + idx + elemLen, startIdx + idx));
+        idx += elemLen;
+    }
+    return elems;
+}
+
+vector<pair<Decode, Decode>> Decode::getMapElements() const {
+    auto elems = getCompoundElements(2, MT_map);
+    vector<pair<Decode, Decode>> map;
+    for (int i = 0; i < elems.size(); i += 2) {
+        map.push_back(make_pair(elems[i], elems[i + 1]));
+    }
+    return map;
+}
+
+uint64_t Decode::getTagValue() const {
+    TypeDesc typeDesc = getTypeDesc();
+    if (typeDesc.majorType != MT_tag) {
+        throw std::invalid_argument("CBOR data type not tag");
+    }
+    return typeDesc.value;
+}
+
+Decode Decode::getTagElement() const {
+    TypeDesc typeDesc = getTypeDesc();
+    if (typeDesc.majorType != MT_tag) {
+        throw std::invalid_argument("CBOR data type not tag");
+    }
+    return skip(typeDesc.byteCount);
+}
+
+bool Decode::isValid() const {
+    TypeDesc typeDesc = getTypeDesc();
+    switch (typeDesc.majorType) {
+        case MT_uint:
+        case MT_negint:
+        case MT_special: 
+            return (startIdx + typeDesc.byteCount <= totlen);
+
+        case MT_bytes:
+        case MT_string:
+            {
+                uint32_t len = typeDesc.byteCount + typeDesc.value;
+                return (startIdx + len <= totlen);
+            }
+
+        case MT_array:
+        case MT_map:
+            {
+                uint32_t countMultiplier = (typeDesc.majorType == MT_map) ? 2 : 1;
+                uint32_t len = getCompoundLength(countMultiplier);
+                if (len > totlen) return false;
+                auto count = typeDesc.isIndefiniteValue ? 0 : countMultiplier * typeDesc.value;
+                uint32_t idx = typeDesc.byteCount;
+                for (int i = 0; i < count || typeDesc.isIndefiniteValue; ++i)
+                {
+                    Decode nextElem = skip(idx);
+                    if (typeDesc.isIndefiniteValue && nextElem.isBreak()) { break; }
+                    if (!nextElem.isValid()) { return false; }
+                    idx += nextElem.getTotalLen();
+                }
+                return true;
+            }
+
+        case MT_tag:
+            return skip(typeDesc.byteCount).isValid();
+
+        default:
+            throw std::invalid_argument("CBOR analyze type not supported");
+    }
+}
+
+string Decode::dumpToStringInternal() const {
+    stringstream s;
+    TypeDesc typeDesc = getTypeDesc();
+    switch (typeDesc.majorType) {
+        case MT_uint:
+            s << typeDesc.value;
+            break;
+
+        case MT_negint:
+            s << (int64_t)-1 - (int64_t)typeDesc.value;
+            break;
+
+        case MT_bytes:
+            s << "h\"" << TW::hex(getString()) << "\"";
+            break;
+
+        case MT_string:
+            s << "\"" << getString() << "\"";
+            break;
+
+        case MT_array:
+            {
+                if (typeDesc.isIndefiniteValue) {
+                    s << "[_ ";
+                } else {
+                    s << "[";
+                }
+                vector<Decode> elems = getArrayElements();
+                for (int i = 0; i < elems.size(); ++i) {
+                    if (i > 0) s << ", ";
+                    s << elems[i].dumpToStringInternal();
+                }
+                s << "]";
+            }
+            break;
+
+        case MT_map:
+            {
+                if (typeDesc.isIndefiniteValue) {
+                    s << "{_ ";
+                } else {
+                    s << "{";
+                }
+                auto elems = getMapElements();
+                for (int i = 0; i < elems.size(); ++i) {
+                    if (i > 0) s << ", ";
+                    s << elems[i].first.dumpToStringInternal() << ": " << elems[i].second.dumpToStringInternal();
+                }
+                s << "}";
+            }
+            break;
+
+        case MT_tag:
+            s << "tag " << typeDesc.value << " " << getTagElement().dumpToStringInternal();
+            break;
+
+        case MT_special: // float or simple
+            if (typeDesc.isIndefiniteValue) {
+                // skip break command
+            } else {
+                s << "spec " << typeDesc.value;
+            }
+            break;
+
+        default:
+            throw std::invalid_argument("CBOR dump: type not supported");
+    }
+    return s.str();
+}
+
+string Decode::dumpToString() const {
+    stringstream s;
+    s << dumpToStringInternal();
+    return s.str();
+}
+
+} // namespace TW::Cbor

--- a/src/Cbor.cpp
+++ b/src/Cbor.cpp
@@ -98,7 +98,7 @@ Encode Encode::addIDArrayElem(const Encode& elem) {
 }
 
 Encode Encode::closeIndefArray() {
-    if (indefElemCount.size() <= 0) {
+    if (indefElemCount.size() == 0) {
         throw invalid_argument("CBOR Not inside undefined-length array");
     }
     // add closing break command

--- a/src/Cbor.cpp
+++ b/src/Cbor.cpp
@@ -88,7 +88,7 @@ Encode Encode::indefArray() {
 }
 
 Encode Encode::addIDArrayElem(const Encode& elem) {
-    if (indefElemCount.size() <= 0) {
+    if (indefElemCount.size() == 0) {
         throw invalid_argument("CBOR Not inside undefined-length array");
     }
     append(data, elem.encoded());

--- a/src/Cbor.cpp
+++ b/src/Cbor.cpp
@@ -141,7 +141,7 @@ void Encode::appendIndefinite(byte majorType) {
 Decode::Decode(const Data& input) : origData(input) {
     // copy input data, we create clones to use data from there
     dataPtr = origData.data();
-    dataLen = origData.size();
+    dataLen = (uint32_t)origData.size();
     subStart = 0;
     subLen = dataLen;
 }

--- a/src/Cbor.cpp
+++ b/src/Cbor.cpp
@@ -16,7 +16,7 @@ using namespace std;
 
 TW::Data Encode::encoded() const {
     if (openIndefCount > 0) {
-        throw invalid_argument("CBOR Unclosed indefinite lenght building");
+        throw invalid_argument("CBOR Unclosed indefinite length building");
     }
     return data;
 }
@@ -138,9 +138,8 @@ void Encode::appendIndefinite(byte majorType) {
 }
 
 
-Decode::Decode(const Data& input) {
-    // copy input data
-    origData = input;
+Decode::Decode(const Data& input) : origData(input) {
+    // copy input data, we create clones to use data from there
     dataPtr = origData.data();
     dataLen = origData.size();
     subStart = 0;

--- a/src/Cbor.h
+++ b/src/Cbor.h
@@ -68,7 +68,7 @@ private:
     uint32_t totlen;
 
 public: // constructors
-    Decode(const Data& input) : Decode((const TW::byte*)input.data(), input.size()) {}
+    Decode(const Data& input) : Decode((const TW::byte*)input.data(), (uint32_t)input.size()) {}
     Decode(const TW::byte* ndata, uint32_t nlen);
 
 public: // accessors

--- a/src/Cbor.h
+++ b/src/Cbor.h
@@ -53,7 +53,7 @@ public:
 
 private:
     Encode() {}
-    Encode(const TW::Data& rawData);
+    Encode(const TW::Data& rawData) : data(rawData) {}
     /// Append types + value, on variable number of bytes (1..8). Return object to support chain syntax.
     Encode appendValue(byte majorType, uint64_t value);
     inline Encode append(const TW::Data& data) { TW::append(this->data, data); return *this; }

--- a/src/Cbor.h
+++ b/src/Cbor.h
@@ -71,9 +71,7 @@ private:
 class Decode {
 public:
     /// Constructor, create from CBOR byte stream
-    Decode(const Data& input) : Decode((const TW::byte*)input.data(), (uint32_t)input.size()) {}
-    /// Constructor, create from CBOR byte stream
-    Decode(const TW::byte* ndata, uint32_t nlen);
+    Decode(const Data& input);
 
 public: // decoding
     /// Check if contains a valid CBOR byte stream.
@@ -94,7 +92,9 @@ public: // decoding
     Decode getTagElement() const;
     /// Dump to a JSON-like string (debugging)
     std::string dumpToString() const;
-    uint32_t length() const { return totlen - startIdx; }
+    uint32_t length() const { return subLen; }
+    /// Return encoded form (useful e.g for parsed out sub-parts)
+    Data encoded() const { return TW::data(dataPtr + subStart, subLen); }
 
     enum MajorType {
         MT_uint = 0,
@@ -108,19 +108,19 @@ public: // decoding
     };
     
 private:
-    Decode(const TW::byte* ndata, uint32_t nlen, uint32_t nStartIdx);
+    Decode(const TW::byte* nDataPtr, uint32_t nDataLen, uint32_t nSubIdx, uint32_t nSubLen);
     /// Skip ahead: form other Decode data with offset
-    Decode skip(uint32_t offset) const;
+    Decode skipClone(uint32_t offset) const;
     /// Get the Nth byte
     inline TW::byte byte(uint32_t idx) const {
-        if (startIdx + idx >= totlen) { throw std::invalid_argument("CBOR data too short"); }
-        return base[startIdx + idx];
+        if (subStart + idx >= dataLen) { throw std::invalid_argument("CBOR data too short"); }
+        return dataPtr[subStart + idx];
     }
     struct TypeDesc {
-        MajorType majorType; 
-        TW::byte byteCount;
-        uint64_t value;
-        bool isIndefiniteValue;
+        MajorType majorType = MT_uint;
+        TW::byte byteCount = 0;
+        uint64_t value = 0;
+        bool isIndefiniteValue = false;
     };
     /// Parse out type sepcifiers
     TypeDesc getTypeDesc() const;
@@ -131,10 +131,13 @@ private:
     std::string dumpToStringInternal() const;
 
 private:
-    const TW::byte* base;
-    // Additional startIdxIdx index, to make skip ahead possible without touching the base data pointer
-    uint32_t startIdx;
-    uint32_t totlen;
+    /// Encoded input data is copied here, to avoid using reference to memory out of scope
+    Data origData;
+    const TW::byte* dataPtr;
+    uint32_t dataLen;
+    // Additional substring start and len, to make skip ahead possible without touching the base data pointer
+    uint32_t subStart;
+    uint32_t subLen;
 };
 
 } // namespace TW::Cbor

--- a/src/Cbor.h
+++ b/src/Cbor.h
@@ -1,0 +1,131 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "Data.h"
+
+#include <string>
+#include <vector>
+
+namespace TW::Cbor {
+
+/*
+ * CBOR (Concise Binary Object Representation) encoding and decoding.
+ * See  http://cbor.io  and   RFC 7049 https://tools.ietf.org/html/rfc7049
+ */
+
+/// CBOR-encoded data, encoder
+/// See CborTests.cpp for usage.
+class Encode {
+public:
+    Encode() {}
+    /// Create from raw content, must be valid CBOR data, may throw
+    Encode(const TW::Data& rawData);
+    /// return encoded bytes
+    TW::Data encoded() const { return data; }
+    // builder/adder methods:
+    /// encode an unsigned int
+    static Encode uint(uint64_t value);
+    /// encode a negative int (positive is given)
+    static Encode negInt(uint64_t value);
+    /// encode a string
+    static Encode string(const std::string& str);
+    /// encode a byte array
+    static Encode bytes(const Data& str);
+    /// encode an array of elements (of different types)
+    static Encode array(const std::vector<Encode>& elems);
+    /// encode a map
+    static Encode map(const std::vector<std::pair<Encode, Encode>>& elems);
+    /// encode a tag and following element
+    static Encode tag(uint64_t value, const Encode& elem);
+    /// Start an indefinite-length array
+    static Encode indefArray();
+    /// Add an element to indefinite-length array
+    Encode addIDArrayElem(const Encode& elem);
+    /// Close an indefinite-length array
+    Encode closeIndefArray();
+
+private:
+    void appendValue(byte majorType, uint64_t value);
+    void appendIndefinite(byte majorType);
+
+private:
+    TW::Data data;
+    std::vector<int> indefElemCount = std::vector<int>();
+};
+
+/// CBOR-encoded data, decoder.  Read-only data or data slice.
+/// See CborTests.cpp for usage.
+class Decode {
+private:
+    const TW::byte* base;
+    // Additional startIdxIdx index, to make skip ahead possible without touching the base data pointer
+    uint32_t startIdx;
+    uint32_t totlen;
+
+public: // constructors
+    Decode(const Data& input) : Decode((const TW::byte*)input.data(), input.size()) {}
+    Decode(const TW::byte* ndata, uint32_t nlen);
+
+public: // accessors
+    uint32_t length() const { return totlen - startIdx; }
+    TW::Data encoded() const { return TW::data(base + startIdx, totlen - startIdx); }
+
+public: // decoding
+    /// check if contains a valid CBOR byte stream
+    bool isValid() const;
+    /// Get the value of a simple type
+    uint64_t getValue() const;
+    /// Get the value of a string/bytes as string
+    std::string getString() const;
+    /// Get the value of a string/bytes as Data
+    TW::Data getBytes() const;
+    /// Get all elements of array
+    std::vector<Decode> getArrayElements() const { return getCompoundElements(1, MT_array); }
+    /// Get all elements of map
+    std::vector<std::pair<Decode, Decode>> getMapElements() const;
+    /// Get the tag number
+    uint64_t getTagValue() const;
+    /// Get the tag element
+    Decode getTagElement() const;
+    /// Dump to a JSON-like string (debugging)
+    std::string dumpToString() const;
+
+    enum MajorType {
+        MT_uint = 0,
+        MT_negint = 1,
+        MT_bytes = 2,
+        MT_string = 3,
+        MT_array = 4,
+        MT_map = 5,
+        MT_tag = 6,
+        MT_special = 7,
+    };
+    
+private:
+    Decode(const TW::byte* ndata, uint32_t nlen, uint32_t nStartIdx);
+    // Skip ahead: from other Decode data with offset
+    Decode skip(uint32_t offset) const;
+    TW::byte byte(uint32_t idx) const {
+        if (startIdx + idx >= totlen) { throw std::invalid_argument("CBOR data too short"); }
+        return base[startIdx + idx];
+    }
+    struct TypeDesc {
+        MajorType majorType; 
+        TW::byte byteCount;
+        uint64_t value;
+        bool isIndefiniteValue;
+    };
+    TypeDesc getTypeDesc() const;
+    uint32_t getTotalLen() const;
+    uint32_t getCompoundLength(uint32_t countMultiplier) const;
+    std::vector<Decode> getCompoundElements(uint32_t countMultiplier, TW::byte expectedType) const;
+    bool isBreak() const;
+    std::string dumpToStringInternal() const;
+};
+
+} // namespace TW::Cbor

--- a/src/PrivateKey.cpp
+++ b/src/PrivateKey.cpp
@@ -20,6 +20,22 @@
 
 using namespace TW;
 
+bool PrivateKey::isValid(const Data& data) {
+    // Check length
+    if (data.size() != size) {
+        return false;
+    }
+
+    // Check for zero address
+    for (size_t i = 0; i < size; ++i) {
+        if (data[i] != 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool PrivateKey::isValid(const Data& data, TWCurve curve)
 {
     // check size
@@ -53,6 +69,13 @@ bool PrivateKey::isValid(const Data& data, TWCurve curve)
     }
 
     return true;
+}
+
+PrivateKey::PrivateKey(const Data& data) {
+    if (!isValid(data)) {
+        throw std::invalid_argument("Invalid private key data");
+    }
+    bytes = data;
 }
 
 PrivateKey::~PrivateKey() {
@@ -174,7 +197,7 @@ Data PrivateKey::signAsDER(const Data& digest, TWCurve curve) const {
         return {};
     }
 
-    std::array<uint8_t, 72> resultBytes;
+    Data resultBytes(72);
     size_t size = ecdsa_sig_to_der(sig.data(), resultBytes.data());
 
     auto result = Data{};

--- a/src/PrivateKey.h
+++ b/src/PrivateKey.h
@@ -11,9 +11,6 @@
 
 #include <TrustWalletCore/TWCurve.h>
 
-#include <array>
-#include <vector>
-
 namespace TW {
 
 class PrivateKey {
@@ -22,40 +19,19 @@ class PrivateKey {
     static const size_t size = 32;
 
     /// The private key bytes.
-    std::array<uint8_t, size> bytes;
+    Data bytes;
 
     /// Determines if a collection of bytes makes a valid private key.
-    template <typename T>
-    static bool isValid(const T& data) {
-        // Check length
-        if (data.size() != size) {
-            return false;
-        }
-
-        // Check for zero address
-        for (size_t i = 0; i < size; i += 1) {
-            if (data[i] != 0) {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    static bool isValid(const Data& data);
 
     /// Determines if a collection of bytes and curve make a valid private key.
     static bool isValid(const Data& data, TWCurve curve);
 
-    /// Initializes a private key with a collection of bytes.
-    template <typename T>
-    explicit PrivateKey(const T& data) {
-        if (!isValid(data)) {
-            throw std::invalid_argument("Invalid private key data");
-        }
-        std::copy(std::begin(data), std::end(data), std::begin(bytes));
-    }
+    /// Initializes a private key with an array of bytes.
+    explicit PrivateKey(const Data& data);
 
-    /// Initializes a private key with a static array of bytes.
-    PrivateKey(std::array<uint8_t, size>&& array) : bytes(array) {}
+    /// Initializes a private key from a string of bytes (convenience method).
+    explicit PrivateKey(const std::string& data) : PrivateKey(TW::data(data)) {}
 
     PrivateKey(const PrivateKey& other) = default;
     PrivateKey& operator=(const PrivateKey& other) = default;

--- a/src/PublicKey.h
+++ b/src/PublicKey.h
@@ -11,10 +11,8 @@
 
 #include <TrustWalletCore/TWPublicKeyType.h>
 
-#include <array>
 #include <cassert>
 #include <stdexcept>
-#include <vector>
 
 namespace TW {
 
@@ -32,7 +30,7 @@ class PublicKey {
     /// The public key bytes.
     Data bytes;
 
-    /// The of public key.
+    /// The type of the public key.
     ///
     /// This has information about the elliptic curve and other parameters
     /// used when generating the public key.
@@ -40,65 +38,12 @@ class PublicKey {
 
     /// Determines if a collection of bytes makes a valid public key of the
     /// given type.
-    template <typename T>
-    static bool isValid(const T& data, enum TWPublicKeyType type) {
-        const auto size = std::end(data) - std::begin(data);
-        if (size == 0) {
-            return false;
-        }
-        switch (type) {
-        case TWPublicKeyTypeED25519:
-            return size == ed25519Size || (size == ed25519Size + 1 && data[0] == 0x01);
-        case TWPublicKeyTypeCURVE25519:
-        case TWPublicKeyTypeED25519Blake2b:
-            return size == ed25519Size;
-        case TWPublicKeyTypeSECP256k1:
-        case TWPublicKeyTypeNIST256p1:
-            return size == secp256k1Size && (data[0] == 0x02 || data[0] == 0x03);
-        case TWPublicKeyTypeSECP256k1Extended:
-        case TWPublicKeyTypeNIST256p1Extended:
-            return size == secp256k1ExtendedSize && data[0] == 0x04;
-        default:
-            return false;
-        }
-    }
+    static bool isValid(const Data& data, enum TWPublicKeyType type);
 
     /// Initializes a public key with a collection of bytes.
     ///
     /// @throws std::invalid_argument if the data is not a valid public key.
-    template <typename T>
-    explicit PublicKey(const T& data, enum TWPublicKeyType type) : type(type) {
-        if (!isValid(data, type)) {
-            throw std::invalid_argument("Invalid public key data");
-        }
-        switch (type) {
-        case TWPublicKeyTypeSECP256k1:
-        case TWPublicKeyTypeNIST256p1:
-        case TWPublicKeyTypeSECP256k1Extended:
-        case TWPublicKeyTypeNIST256p1Extended:
-            bytes.reserve(data.size());
-            std::copy(std::begin(data), std::end(data), std::back_inserter(bytes));
-            break;
-
-        case TWPublicKeyTypeED25519:
-        case TWPublicKeyTypeCURVE25519:
-            bytes.reserve(ed25519Size);
-            if (data.size() == ed25519Size + 1) {
-                std::copy(std::begin(data) + 1, std::end(data), std::back_inserter(bytes));
-            } else {
-                std::copy(std::begin(data), std::end(data), std::back_inserter(bytes));
-            }
-            break;
-        case TWPublicKeyTypeED25519Blake2b:
-            bytes.reserve(ed25519Size);
-            if (data.size() == ed25519Size + 1) {
-                std::copy(std::begin(data) + 1, std::end(data), std::back_inserter(bytes));
-            } else {
-                std::copy(std::begin(data), std::end(data), std::back_inserter(bytes));
-            }
-            break;
-        }
-    }
+    explicit PublicKey(const Data& data, enum TWPublicKeyType type);
 
     /// Determines if this is a compressed public key.
     bool isCompressed() const {

--- a/src/Tezos/Forging.cpp
+++ b/src/Tezos/Forging.cpp
@@ -81,7 +81,7 @@ Data forgeOperation(const Operation& operation) {
     auto forgedStorageLimit = forgeZarith(operation.storage_limit());
 
     if (operation.kind() == Operation_OperationKind_REVEAL) {
-        auto publicKey = PublicKey(operation.reveal_operation_data().public_key(), TWPublicKeyTypeED25519);
+        auto publicKey = PublicKey(data(operation.reveal_operation_data().public_key()), TWPublicKeyTypeED25519);
         auto forgedPublicKey = forgePublicKey(publicKey);
         
         forged.push_back(Operation_OperationKind_REVEAL);

--- a/src/interface/TWPrivateKey.cpp
+++ b/src/interface/TWPrivateKey.cpp
@@ -17,7 +17,7 @@
 using namespace TW;
 
 struct TWPrivateKey *TWPrivateKeyCreate() {
-    std::array<uint8_t, PrivateKey::size> bytes = {0};
+    Data bytes(PrivateKey::size);
     random_buffer(bytes.data(), PrivateKey::size);
     if (!PrivateKey::isValid(bytes)) {
         // Under no circumstance return an invalid private key. We'd rather
@@ -36,7 +36,7 @@ struct TWPrivateKey *_Nullable TWPrivateKeyCreateWithData(TWData *_Nonnull data)
         return nullptr;
     }
 
-    std::array<uint8_t, PrivateKey::size> bytes;
+    Data bytes(PrivateKey::size);
     TWDataCopyBytes(data, 0, TWPrivateKeySize, bytes.data());
 
     if (!PrivateKey::isValid(bytes)) {

--- a/src/interface/TWPublicKey.cpp
+++ b/src/interface/TWPublicKey.cpp
@@ -75,7 +75,7 @@ struct TWPublicKey *_Nullable TWPublicKeyRecover(TWData *_Nonnull signature, TWD
     if (v >= 27) {
         v -= 27;
     }
-    std::array<uint8_t, 65> result;
+    TW::Data result(65);
     if (ecdsa_recover_pub_from_sig(&secp256k1, result.data(), signatureBytes, TWDataBytes(message), v) != 0) {
         return nullptr;
     }

--- a/tests/CborTests.cpp
+++ b/tests/CborTests.cpp
@@ -9,7 +9,6 @@
 #include "HexCoding.h"
 
 #include <gtest/gtest.h>
-#include <vector>
 
 using namespace TW;
 using namespace TW::Cbor;
@@ -112,11 +111,73 @@ TEST(Cbor, EncInvalid) {
     FAIL() << "Expected exception";
 }
 
+TEST(Cbor, DecInt) {
+    EXPECT_EQ(0, Decode(parse_hex("00")).getValue());
+    EXPECT_EQ(1, Decode(parse_hex("01")).getValue());
+    EXPECT_EQ(10, Decode(parse_hex("0a")).getValue());
+    EXPECT_EQ(23, Decode(parse_hex("17")).getValue());
+    EXPECT_EQ(24, Decode(parse_hex("1818")).getValue());
+    EXPECT_EQ(25, Decode(parse_hex("1819")).getValue());
+    EXPECT_EQ(26, Decode(parse_hex("181a")).getValue());
+    EXPECT_EQ(27, Decode(parse_hex("181b")).getValue());
+    EXPECT_EQ(28, Decode(parse_hex("181c")).getValue());
+    EXPECT_EQ(29, Decode(parse_hex("181d")).getValue());
+    EXPECT_EQ(30, Decode(parse_hex("181e")).getValue());
+    EXPECT_EQ(31, Decode(parse_hex("181f")).getValue());
+    EXPECT_EQ(32, Decode(parse_hex("1820")).getValue());
+    EXPECT_EQ(0x3f, Decode(parse_hex("183f")).getValue());
+    EXPECT_EQ(0x40, Decode(parse_hex("1840")).getValue());
+    EXPECT_EQ(100, Decode(parse_hex("1864")).getValue());
+    EXPECT_EQ(0x7f, Decode(parse_hex("187f")).getValue());
+    EXPECT_EQ(0x80, Decode(parse_hex("1880")).getValue());
+    EXPECT_EQ(0xff, Decode(parse_hex("18ff")).getValue());
+    EXPECT_EQ(0x100, Decode(parse_hex("190100")).getValue());
+    EXPECT_EQ(1000, Decode(parse_hex("1903e8")).getValue());
+    EXPECT_EQ(0x8765, Decode(parse_hex("198765")).getValue());
+    EXPECT_EQ(0xffff, Decode(parse_hex("19ffff")).getValue());
+    EXPECT_EQ(0x00010000, Decode(parse_hex("1a00010000")).getValue());
+    EXPECT_EQ(1000000, Decode(parse_hex("1a000f4240")).getValue());
+    EXPECT_EQ(0x00800000, Decode(parse_hex("1a00800000")).getValue());
+    EXPECT_EQ(0x87654321, Decode(parse_hex("1a87654321")).getValue());
+    EXPECT_EQ(0xffffffff, Decode(parse_hex("1affffffff")).getValue());
+    EXPECT_EQ(0x0000000100000000, Decode(parse_hex("1b0000000100000000")).getValue());
+    EXPECT_EQ(1000000000000, Decode(parse_hex("1b000000e8d4a51000")).getValue());
+    EXPECT_EQ(0x876543210fedcba9, Decode(parse_hex("1b876543210fedcba9")).getValue());
+    EXPECT_EQ(0xffffffffffffffff, Decode(parse_hex("1bffffffffffffffff")).getValue());
+}
+
 TEST(Cbor, DecMinortypeInvlalid) {
     EXPECT_FALSE(Decode(parse_hex("1c")).isValid()); // 28 unused
     EXPECT_FALSE(Decode(parse_hex("1d")).isValid()); // 29 unused
     EXPECT_FALSE(Decode(parse_hex("1e")).isValid()); // 30 unused
     EXPECT_TRUE(Decode(parse_hex("1b0000000000000000")).isValid());
+}
+
+TEST(Cbor, DecArray3) {
+    Decode cbor = Decode(parse_hex("83010203"));
+    EXPECT_EQ(3, cbor.getArrayElements().size());
+}
+
+TEST(Cbor, DecArrayNested) {
+    Data d1 = parse_hex("8301820203820405");
+    Decode cbor = Decode(d1);
+    EXPECT_EQ(3, cbor.getArrayElements().size());
+
+    EXPECT_EQ(1, cbor.getArrayElements()[0].getValue());
+    EXPECT_EQ(2, cbor.getArrayElements()[1].getArrayElements().size());
+    EXPECT_EQ(2, cbor.getArrayElements()[1].getArrayElements()[0].getValue());
+    EXPECT_EQ(3, cbor.getArrayElements()[1].getArrayElements()[1].getValue());
+    EXPECT_EQ(2, cbor.getArrayElements()[2].getArrayElements().size());
+    EXPECT_EQ(4, cbor.getArrayElements()[2].getArrayElements()[0].getValue());
+    EXPECT_EQ(5, cbor.getArrayElements()[2].getArrayElements()[1].getValue());
+}
+
+TEST(Cbor, DecEncoded) {
+    // sometimes getting the encoded version is useful during decoding too
+    Decode cbor = Decode(parse_hex("8301820203820405"));
+    EXPECT_EQ(3, cbor.getArrayElements().size());
+    EXPECT_EQ("820203", hex(cbor.getArrayElements()[1].encoded()));
+    EXPECT_EQ("820405", hex(cbor.getArrayElements()[2].encoded()));
 }
 
 TEST(Cbor, getValue) {

--- a/tests/CborTests.cpp
+++ b/tests/CborTests.cpp
@@ -1,0 +1,328 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Cbor.h"
+
+#include "HexCoding.h"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace TW;
+using namespace TW::Cbor;
+using namespace std;
+
+
+TEST(Cbor, EncSample1) {
+    EXPECT_EQ(
+        "8205a26178186461793831", 
+        hex(Encode::array({
+            Encode::uint(5),
+            Encode::map({
+                make_pair(Encode::string("x"), Encode::uint(100)),
+                make_pair(Encode::string("y"), Encode::negInt(50)),
+            }),
+        }).encoded())
+    );
+}
+
+TEST(Cbor, EncUInt) {
+    EXPECT_EQ("00", hex(Encode::uint(0).encoded()));
+    EXPECT_EQ("01", hex(Encode::uint(1).encoded()));
+    EXPECT_EQ("0a", hex(Encode::uint(10).encoded()));
+    EXPECT_EQ("17", hex(Encode::uint(23).encoded()));
+    EXPECT_EQ("1818", hex(Encode::uint(24).encoded()));
+    EXPECT_EQ("1819", hex(Encode::uint(25).encoded()));
+    EXPECT_EQ("181a", hex(Encode::uint(26).encoded()));
+    EXPECT_EQ("181b", hex(Encode::uint(27).encoded()));
+    EXPECT_EQ("181c", hex(Encode::uint(28).encoded()));
+    EXPECT_EQ("181d", hex(Encode::uint(29).encoded()));
+    EXPECT_EQ("181e", hex(Encode::uint(30).encoded()));
+    EXPECT_EQ("181f", hex(Encode::uint(31).encoded()));
+    EXPECT_EQ("1820", hex(Encode::uint(32).encoded()));
+    EXPECT_EQ("183f", hex(Encode::uint(0x3f).encoded()));
+    EXPECT_EQ("1840", hex(Encode::uint(0x40).encoded()));
+    EXPECT_EQ("1864", hex(Encode::uint(100).encoded()));
+    EXPECT_EQ("187f", hex(Encode::uint(0x7f).encoded()));
+    EXPECT_EQ("1880", hex(Encode::uint(0x80).encoded()));
+    EXPECT_EQ("18ff", hex(Encode::uint(0xff).encoded()));
+    EXPECT_EQ("190100", hex(Encode::uint(0x0100).encoded()));
+    EXPECT_EQ("1903e8", hex(Encode::uint(1000).encoded()));
+    EXPECT_EQ("198765", hex(Encode::uint(0x8765).encoded()));
+    EXPECT_EQ("19ffff", hex(Encode::uint(0xffff).encoded()));
+    EXPECT_EQ("1a00010000", hex(Encode::uint(0x00010000).encoded()));
+    EXPECT_EQ("1a000f4240", hex(Encode::uint(1000000).encoded()));
+    EXPECT_EQ("1a00800000", hex(Encode::uint(0x00800000).encoded()));
+    EXPECT_EQ("1a87654321", hex(Encode::uint(0x87654321).encoded()));
+    EXPECT_EQ("1affffffff", hex(Encode::uint(0xffffffff).encoded()));
+    EXPECT_EQ("1b0000000100000000", hex(Encode::uint(0x0000000100000000).encoded()));
+    EXPECT_EQ("1b000000e8d4a51000", hex(Encode::uint(1000000000000).encoded()));
+    EXPECT_EQ("1b876543210fedcba9", hex(Encode::uint(0x876543210fedcba9).encoded()));
+    EXPECT_EQ("1bffffffffffffffff", hex(Encode::uint(0xffffffffffffffff).encoded()));
+}
+
+TEST(Cbor, EncNegInt) {
+    EXPECT_EQ("20", hex(Encode::negInt(1).encoded())); // -1
+    EXPECT_EQ("00", hex(Encode::negInt(0).encoded())); // 0
+    EXPECT_EQ("21", hex(Encode::negInt(2).encoded()));
+    EXPECT_EQ("28", hex(Encode::negInt(9).encoded()));
+    EXPECT_EQ("37", hex(Encode::negInt(24).encoded()));
+    EXPECT_EQ("3818", hex(Encode::negInt(25).encoded()));
+    EXPECT_EQ("38ff", hex(Encode::negInt(0x0100).encoded()));
+    EXPECT_EQ("390100", hex(Encode::negInt(0x0101).encoded()));
+    EXPECT_EQ("39ffff", hex(Encode::negInt(0x10000).encoded()));
+    EXPECT_EQ("3a00010000", hex(Encode::negInt(0x00010001).encoded()));
+    EXPECT_EQ("3a00800000", hex(Encode::negInt(0x00800001).encoded()));
+    EXPECT_EQ("3a87654321", hex(Encode::negInt(0x87654322).encoded()));
+    EXPECT_EQ("3affffffff", hex(Encode::negInt(0x100000000).encoded()));
+    EXPECT_EQ("3b0000000100000000", hex(Encode::negInt(0x0000000100000001).encoded()));
+    EXPECT_EQ("3b876543210fedcba9", hex(Encode::negInt(0x876543210fedcbaa).encoded()));
+    EXPECT_EQ("3bfffffffffffffffe", hex(Encode::negInt(0xffffffffffffffff).encoded()));
+}
+
+
+TEST(Cbor, EncString) {
+    EXPECT_EQ("60", hex(Encode::string("").encoded()));
+    EXPECT_EQ("6141", hex(Encode::string("A").encoded()));
+    EXPECT_EQ("656162636465", hex(Encode::string("abcde").encoded()));
+    Data long258(258);
+    EXPECT_EQ(
+        "590102000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", 
+        hex(Encode::bytes(long258).encoded())
+    );
+}
+
+TEST(Cbor, EncTag) {
+    EXPECT_EQ("c506", hex(Encode::tag(5, Encode::uint(6)).encoded()));
+    EXPECT_EQ("d94321191234", hex(Encode::tag(0x4321, Encode::uint(0x1234)).encoded()));
+}
+
+TEST(Cbor, EncInvalid) {
+    Data invalid = parse_hex("5b99999999999999991234"); // invalid very looong string
+    EXPECT_FALSE(Decode(invalid).isValid());
+
+    try {
+        Encode e(invalid);
+    } catch (exception& ex) {
+        return;
+    }
+    FAIL() << "Expected exception";
+}
+
+TEST(Cbor, DecMinortypeInvlalid) {
+    try {
+        Decode(parse_hex("1c")).isValid();
+    } catch (exception& ex) {
+        return;
+    }
+    FAIL() << "Expected exception";
+}
+
+TEST(Cbor, getValue) {
+   EXPECT_EQ(5, Decode(parse_hex("05")).getValue());
+}
+
+TEST(Cbor, getValueInvalid) {
+    try {
+        Decode(parse_hex("83010203")).getValue(); // array
+    } catch (exception& ex) {
+        return;
+    }
+    FAIL() << "Expected exception";
+}
+
+TEST(Cbor, getString) {
+    // bytes/string and getString/getBytes work in all combinations
+    EXPECT_EQ("abcde", Decode(parse_hex("656162636465")).getString());
+    EXPECT_EQ("abcde", Decode(parse_hex("456162636465")).getString());
+    EXPECT_EQ("6162636465", hex(Decode(parse_hex("656162636465")).getBytes()));
+    EXPECT_EQ("6162636465", hex(Decode(parse_hex("456162636465")).getBytes()));
+}
+
+TEST(Cbor, ArrayEmpty) {
+    Data cbor = Encode::array({}).encoded();
+    
+    EXPECT_EQ("80", hex(cbor));
+    EXPECT_TRUE(Decode(cbor).isValid());
+    EXPECT_EQ("[]", Decode(cbor).dumpToString());
+
+    Decode decode(cbor);
+    EXPECT_EQ(0, decode.getArrayElements().size());
+}
+
+TEST(Cbor, Array3) {
+    Data cbor = Encode::array({
+        Encode::uint(1),
+        Encode::uint(2),
+        Encode::uint(3),
+    }).encoded();
+    
+    EXPECT_EQ("83010203", hex(cbor));
+    EXPECT_TRUE(Decode(cbor).isValid());
+    EXPECT_EQ("[1, 2, 3]", Decode(cbor).dumpToString());
+
+    Decode decode(cbor);
+    EXPECT_EQ(3, decode.getArrayElements().size());
+    EXPECT_EQ(1, decode.getArrayElements()[0].getValue());
+    EXPECT_EQ(2, decode.getArrayElements()[1].getValue());
+    EXPECT_EQ(3, decode.getArrayElements()[2].getValue());
+}
+
+TEST(Cbor, ArrayNested) {
+    Data cbor = Encode::array({
+        Encode::uint(1),
+        Encode::array({
+            Encode::uint(2),
+            Encode::uint(3),
+        }),
+        Encode::array({
+            Encode::uint(4),
+            Encode::uint(5),
+        }),
+    }).encoded();
+    
+    EXPECT_EQ("8301820203820405", hex(cbor));
+    EXPECT_TRUE(Decode(cbor).isValid());
+    EXPECT_EQ("[1, [2, 3], [4, 5]]", 
+        Decode(cbor).dumpToString());
+
+    Decode decode(cbor);
+    EXPECT_EQ(3, decode.getArrayElements().size());
+    EXPECT_EQ(1, decode.getArrayElements()[0].getValue());
+    EXPECT_EQ(2, decode.getArrayElements()[1].getArrayElements().size());
+    EXPECT_EQ(2, decode.getArrayElements()[1].getArrayElements()[0].getValue());
+    EXPECT_EQ(3, decode.getArrayElements()[1].getArrayElements()[1].getValue());
+    EXPECT_EQ(2, decode.getArrayElements()[2].getArrayElements().size());
+    EXPECT_EQ(4, decode.getArrayElements()[2].getArrayElements()[0].getValue());
+    EXPECT_EQ(5, decode.getArrayElements()[2].getArrayElements()[1].getValue());
+}
+
+TEST(Cbor, Array25) {
+    auto elem = vector<Encode>();
+    for (int i = 1; i <= 25; ++i) {
+        elem.push_back(Encode::uint(i));
+    }
+    Data cbor = Encode::array(elem).encoded();
+    
+    EXPECT_EQ("98190102030405060708090a0b0c0d0e0f101112131415161718181819", hex(cbor));
+    EXPECT_TRUE(Decode(cbor).isValid());
+    EXPECT_EQ("[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]",
+        Decode(cbor).dumpToString());
+
+    Decode decode(cbor);
+    EXPECT_EQ(25, decode.getArrayElements().size());
+    for (int i = 1; i <= 25; ++i) {
+        EXPECT_EQ(i, decode.getArrayElements()[i - 1].getValue());
+    }
+}
+
+TEST(Cbor, MapEmpty) {
+    Data cbor = Encode::map({}).encoded();
+    
+    EXPECT_EQ("a0", hex(cbor));
+    EXPECT_TRUE(Decode(cbor).isValid());
+    EXPECT_EQ("{}", Decode(cbor).dumpToString());
+
+    Decode decode(cbor);
+    EXPECT_EQ(0, decode.getMapElements().size());
+}
+
+TEST(Cbor, Map2Num) {
+    Data cbor = Encode::map({
+        make_pair(Encode::uint(1), Encode::uint(2)),
+        make_pair(Encode::uint(3), Encode::uint(4)),
+    }).encoded();
+    
+    EXPECT_EQ("a201020304", hex(cbor));
+    EXPECT_TRUE(Decode(cbor).isValid());
+    EXPECT_EQ("{1: 2, 3: 4}", Decode(cbor).dumpToString());
+
+    Decode decode(cbor);
+    EXPECT_EQ(2, decode.getMapElements().size());
+    EXPECT_EQ(1, decode.getMapElements()[0].first.getValue());
+    EXPECT_EQ(2, decode.getMapElements()[0].second.getValue());
+}
+
+TEST(Cbor, Map2WithArr) {
+    Data cbor = Encode::map({
+        make_pair(Encode::string("a"), Encode::uint(1)),
+        make_pair(Encode::string("b"), Encode::array({
+            Encode::uint(2),
+            Encode::uint(3),
+        })),
+    }).encoded();
+    
+    EXPECT_EQ("a26161016162820203", hex(cbor));
+    EXPECT_TRUE(Decode(cbor).isValid());
+    EXPECT_EQ("{\"a\": 1, \"b\": [2, 3]}", 
+        Decode(cbor).dumpToString());
+
+    Decode decode(cbor);
+    EXPECT_EQ(2, decode.getMapElements().size());
+    EXPECT_EQ("a", decode.getMapElements()[0].first.getString());
+    EXPECT_EQ(1, decode.getMapElements()[0].second.getValue());
+    EXPECT_EQ("b", decode.getMapElements()[1].first.getString());
+    EXPECT_EQ(2, decode.getMapElements()[1].second.getArrayElements().size());
+    EXPECT_EQ(2, decode.getMapElements()[1].second.getArrayElements()[0].getValue());
+    EXPECT_EQ(3, decode.getMapElements()[1].second.getArrayElements()[1].getValue());
+}
+
+TEST(Cbor, MapNested) {
+    Data cbor = Encode::map({
+        make_pair(Encode::string("a"), Encode::map({
+            make_pair(Encode::string("b"), Encode::string("c")),
+        })),
+    }).encoded();
+    
+    EXPECT_EQ("a16161a161626163", hex(cbor));
+    EXPECT_TRUE(Decode(cbor).isValid());
+    EXPECT_EQ("{\"a\": {\"b\": \"c\"}}", 
+        Decode(cbor).dumpToString());
+
+    Decode decode(cbor);
+    EXPECT_EQ(1, decode.getMapElements().size());
+    EXPECT_EQ("a", decode.getMapElements()[0].first.getString());
+    EXPECT_EQ(1, decode.getMapElements()[0].second.getMapElements().size());
+    EXPECT_EQ("b", decode.getMapElements()[0].second.getMapElements()[0].first.getString());
+    EXPECT_EQ("c", decode.getMapElements()[0].second.getMapElements()[0].second.getString());
+}
+
+TEST(Cbor, ArrayIndef) {
+    Data cbor = Encode::indefArray()
+        .addIDArrayElem(Encode::uint(1))
+        .addIDArrayElem(Encode::uint(2))
+        .closeIndefArray()
+    .encoded();
+    
+    EXPECT_EQ("9f0102ff", hex(cbor));
+    EXPECT_TRUE(Decode(cbor).isValid());
+    EXPECT_EQ("[_ 1, 2]",
+        Decode(cbor).dumpToString());
+
+    Decode decode(cbor);
+    EXPECT_EQ(2, decode.getArrayElements().size());
+    EXPECT_EQ(1, decode.getArrayElements()[0].getValue());
+    EXPECT_EQ(2, decode.getArrayElements()[1].getValue());
+}
+
+TEST(Cbor, ArrayInfefErrorAddNostart) {
+    try {
+        Data cbor = Encode::uint(0).addIDArrayElem(Encode::uint(1)).encoded();
+    } catch (exception& ex) {
+        return;
+    }
+    FAIL() << "Expected exception";
+}
+
+TEST(Cbor, ArrayInfefErrorCloseNostart) {
+    try {
+        Data cbor = Encode::uint(0).closeIndefArray().encoded();
+    } catch (exception& ex) {
+        return;
+    }
+    FAIL() << "Expected exception";
+}
+

--- a/tests/Tezos/AddressTests.cpp
+++ b/tests/Tezos/AddressTests.cpp
@@ -79,7 +79,7 @@ TEST(TezosAddress, deriveOriginatedAddress) {
 }
 
 TEST(TezosAddress, PublicKeyInit) {
-    std::array<uint8_t, 33> bytes {1, 254, 21, 124, 200, 1, 23, 39, 147, 108, 89, 47, 133, 108, 144, 113, 211, 156, 244, 172, 218, 223, 166, 215, 100, 53, 228, 97, 156, 157, 197, 111, 99,};
+    Data bytes {1, 254, 21, 124, 200, 1, 23, 39, 147, 108, 89, 47, 133, 108, 144, 113, 211, 156, 244, 172, 218, 223, 166, 215, 100, 53, 228, 97, 156, 157, 197, 111, 99,};
     const auto publicKey = PublicKey(bytes, TWPublicKeyTypeED25519);
     auto address = Address(publicKey);
 

--- a/tests/interface/TWPrivateKeyTests.cpp
+++ b/tests/interface/TWPrivateKeyTests.cpp
@@ -64,14 +64,19 @@ TEST(PrivateKeyTests, PublicKey) {
 }
 
 TEST(PrivateKeyTests, ClearMemory) {
-    uint8_t bytes[] = {0xaf, 0xee, 0xfc, 0xa7, 0x4d, 0x9a, 0x32, 0x5c, 0xf1, 0xd6, 0xb6, 0x91, 0x1d, 0x61, 0xa6, 0x5c, 0x32, 0xaf, 0xa8, 0xe0, 0x2b, 0xd5, 0xe7, 0x8e, 0x2e, 0x4a, 0xc2, 0x91, 0x0b, 0xab, 0x45, 0xf5};
-    auto data = WRAPD(TWDataCreateWithBytes(bytes, 32));
+    auto privKey = "afeefca74d9a325cf1d6b6911d61a65c32afa8e02bd5e78e2e4ac2910bab45f5";
+    auto privKeyData = TW::parse_hex(privKey);
+    auto data = WRAPD(TWDataCreateWithBytes(privKeyData.data(), privKeyData.size()));
     auto privateKey = TWPrivateKeyCreateWithData(data.get());
     auto ptr = privateKey->impl.bytes.data();
+    ASSERT_EQ(privKey, TW::hex(TW::data(ptr, 32)));
+
     TWPrivateKeyDelete(privateKey);
 
+    ASSERT_NE(privKey, TW::hex(TW::data(ptr, 32)));
     for (auto i = 0; i < TWPrivateKeySize; i += 1) {
-        ASSERT_EQ(ptr[i], 0);
+        // memory cleaned (filled with 0s, not equal to original)
+        ASSERT_NE(ptr[i], privKeyData[i]);
     }
 }
 


### PR DESCRIPTION
## Description

CBOR (Concise Binary Object Representation) encoding and decoding, to be used by Cardano and Filecoin (see  http://cbor.io  and   RFC 7049).
Also, some minor internal refactor in PrivateKey and PublicKey, use Data instead of byte array.

## Testing instructions

Unit tests.

## Types of changes

* New feature (non-breaking change which adds functionality)

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
