### PR TITLE
[Housekeeping] Update notice in generated protobuf headers, take out internal protobuf generation

### DIFF
--- a/include/TrustWalletCore/TWAeternityProto.h
+++ b/include/TrustWalletCore/TWAeternityProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWAionProto.h
+++ b/include/TrustWalletCore/TWAionProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWAlgorandProto.h
+++ b/include/TrustWalletCore/TWAlgorandProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWAnyProto.h
+++ b/include/TrustWalletCore/TWAnyProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWBinanceProto.h
+++ b/include/TrustWalletCore/TWBinanceProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWBitcoinProto.h
+++ b/include/TrustWalletCore/TWBitcoinProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWBravoProto.h
+++ b/include/TrustWalletCore/TWBravoProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWCardanoProto.h
+++ b/include/TrustWalletCore/TWCardanoProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWCommonProto.h
+++ b/include/TrustWalletCore/TWCommonProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWCosmosProto.h
+++ b/include/TrustWalletCore/TWCosmosProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWDecredProto.h
+++ b/include/TrustWalletCore/TWDecredProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWEOSProto.h
+++ b/include/TrustWalletCore/TWEOSProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWEthereumProto.h
+++ b/include/TrustWalletCore/TWEthereumProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWHarmonyProto.h
+++ b/include/TrustWalletCore/TWHarmonyProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWIconProto.h
+++ b/include/TrustWalletCore/TWIconProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWIoTeXProto.h
+++ b/include/TrustWalletCore/TWIoTeXProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWNEARProto.h
+++ b/include/TrustWalletCore/TWNEARProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWNULSProto.h
+++ b/include/TrustWalletCore/TWNULSProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWNanoProto.h
+++ b/include/TrustWalletCore/TWNanoProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWNebulasProto.h
+++ b/include/TrustWalletCore/TWNebulasProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWNimiqProto.h
+++ b/include/TrustWalletCore/TWNimiqProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWOntologyProto.h
+++ b/include/TrustWalletCore/TWOntologyProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWPolkadotProto.h
+++ b/include/TrustWalletCore/TWPolkadotProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWRippleProto.h
+++ b/include/TrustWalletCore/TWRippleProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWSolanaProto.h
+++ b/include/TrustWalletCore/TWSolanaProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWStellarProto.h
+++ b/include/TrustWalletCore/TWStellarProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWTezosProto.h
+++ b/include/TrustWalletCore/TWTezosProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWThetaProto.h
+++ b/include/TrustWalletCore/TWThetaProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWTronProto.h
+++ b/include/TrustWalletCore/TWTronProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWVeChainProto.h
+++ b/include/TrustWalletCore/TWVeChainProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWWavesProto.h
+++ b/include/TrustWalletCore/TWWavesProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/include/TrustWalletCore/TWZilliqaProto.h
+++ b/include/TrustWalletCore/TWZilliqaProto.h
@@ -3,6 +3,8 @@
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here WILL BE LOST.
 
 #pragma once
 

--- a/tools/generate-files
+++ b/tools/generate-files
@@ -56,9 +56,9 @@ else
     "$PROTOC" -I=$PREFIX/include -I=src/proto --cpp_out=src/proto --java_out=jni/java src/proto/*.proto
 fi
 
-# Generate internal Protobuf files
-"$PROTOC" -I=$PREFIX/include -I=src/Tron/Protobuf --cpp_out=src/Tron/Protobuf src/Tron/Protobuf/*.proto
-"$PROTOC" -I=$PREFIX/include -I=src/Zilliqa/Protobuf --cpp_out=src/Zilliqa/Protobuf src/Zilliqa/Protobuf/*.proto
+# Generate internal message protocol Protobuf files -- not every time
+#"$PROTOC" -I=$PREFIX/include -I=src/Tron/Protobuf --cpp_out=src/Tron/Protobuf src/Tron/Protobuf/*.proto
+#"$PROTOC" -I=$PREFIX/include -I=src/Zilliqa/Protobuf --cpp_out=src/Zilliqa/Protobuf src/Zilliqa/Protobuf/*.proto
 
 # Generate Proto interface file
 "$PROTOC" -I=$PREFIX/include -I=src/proto --plugin=$PREFIX/bin/protoc-gen-c-typedef --c-typedef_out include/TrustWalletCore src/proto/*.proto


### PR DESCRIPTION
## Description

Two minor changes:
- Notice in generated protobuf .h files has been updated; has a note that it is a generated file.  The protobuf-plugin generator was updated (not intentionally with Cardano PR), now the generated files are updated too.
- Two coins have 'internal' protobuf files -- these are not used for TrustWallet cpp/ios (or kotlin) serialization, but blockchain RPC message formats.  These have been generated once and not expected to change often, so they are taken out from generation.
- For consideration: remove generated files from git!

## Testing instructions

./bootdstrap.sh, nothing special.

## Types of changes

* Minor refactoring

## Checklist

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
