### PR TITLE
Filecoin support

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
@@ -83,5 +83,6 @@ class CoinAddressDerivationTests {
         KAVA -> assertEquals("kava1drpa0x9ptz0fql3frv562rcrhj2nstuz3pas87", address)
         CARDANO -> assertEquals("addr1snpa4z7ntyfszv7ckquprdw75w4qjqh0qmya9jtkpxxlzxghlqyvv7l0yjamh8fxraw06p3ua8sj2g2gv98v4849s43t9g2999kquuu5egnprk", address)
         NEO -> assertEquals("AT6w7PJvwPcSqHvtbNBY2aHPDv12eW5Uuf", address)
+        FILECOIN -> assertEquals("f1zzykebxldfcakj5wdb5n3n7priul522fnmjzori", address)
     }
 }

--- a/coins.json
+++ b/coins.json
@@ -1330,5 +1330,28 @@
             "clientPublic": "http://seed1.ngd.network:10332",
             "clientDocs": "https://neo.org/eco"
         }
+    },
+    {
+        "id": "filecoin",
+        "name": "Filecoin",
+        "symbol": "FIL",
+        "decimals": 18,
+        "blockchain": "Filecoin",
+        "derivationPath": "m/44'/461'/0'/0/0",
+        "curve": "secp256k1",
+        "publicKeyType": "secp256k1Extended",
+        "explorer": {
+            "url": "https://filscan.io",
+            "txPath": "/#/message/detail?cid=",
+            "accountPath": "/#/address/detail?address=",
+            "sampleTx": "bafy2bzacecbm3ofxjjzcl2rg32ninphza34mm3ijr55zjsamwfqmz4ib63mqe",
+            "sampleAccount": "t1nbb73vhk5dtmnsgeaetbo76daepqjtrfoccn74i"
+        },
+        "info": {
+            "url": "https://filecoin.io/",
+            "client": "https://github.com/filecoin-project/lotus",
+            "clientPublic": "",
+            "clientDocs": "https://docs.lotu.sh"
+        }
     }
 ]

--- a/docs/coins.md
+++ b/docs/coins.md
@@ -41,6 +41,7 @@ This list is generated from [./coins.json](../coins.json)
 | 434     | Kusama           | KSM    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/kusama/info/logo.png" width="32" />       | <https://kusama.network>      |
 | 457     | Aeternity        | AE     | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/aeternity/info/logo.png" width="32" />    | <https://aeternity.com>       |
 | 459     | Kava             | KAVA   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/kava/info/logo.png" width="32" />         | <https://kava.io>             |
+| 461     | Filecoin         | FIL    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/filecoin/info/logo.png" width="32" />     | <https://filecoin.io/>        |
 | 500     | Theta            | THETA  | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/theta/info/logo.png" width="32" />        | <https://www.thetatoken.org>  |
 | 501     | Solana           | SOL    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/solana/info/logo.png" width="32" />       | <https://solana.com>          |
 | 714     | Binance          | BNB    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/info/logo.png" width="32" />      | <https://binance.org>         |

--- a/include/TrustWalletCore/TWBlockchain.h
+++ b/include/TrustWalletCore/TWBlockchain.h
@@ -44,6 +44,7 @@ enum TWBlockchain {
     TWBlockchainPolkadot = 29,
     TWBlockchainCardano = 30,
     TWBlockchainNEO = 31,
+    TWBlockchainFilecoin = 32,
 };
 
 TW_EXTERN_C_END

--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -79,6 +79,7 @@ enum TWCoinType {
     TWCoinTypeAlgorand = 283,
     TWCoinTypeKusama = 434,
     TWCoinTypePolkadot = 354,
+    TWCoinTypeFilecoin = 461,
 };
 
 /// Returns the blockchain for a coin type.

--- a/include/TrustWalletCore/TWFilecoinSigner.h
+++ b/include/TrustWalletCore/TWFilecoinSigner.h
@@ -1,0 +1,23 @@
+// Copyright © 2017-2020 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "TWBase.h"
+#include "TWData.h"
+#include "TWFilecoinProto.h"
+
+TW_EXTERN_C_BEGIN
+
+/// Helper class to sign Filecoin transactions.
+TW_EXPORT_CLASS
+struct TWFilecoinSigner;
+
+/// Signs a transaction.
+TW_EXPORT_STATIC_METHOD
+TW_Filecoin_Proto_SigningOutput TWFilecoinSignerSign(TW_Filecoin_Proto_SigningInput input);
+
+TW_EXTERN_C_END

--- a/src/Coin.cpp
+++ b/src/Coin.cpp
@@ -20,6 +20,7 @@
 #include "EOS/Address.h"
 #include "Ethereum/Address.h"
 #include "FIO/Address.h"
+#include "Filecoin/Address.h"
 #include "Groestlcoin/Address.h"
 #include "Harmony/Address.h"
 #include "Icon/Address.h"
@@ -190,6 +191,9 @@ bool TW::validateAddress(TWCoinType coin, const std::string& string) {
 
     case TWCoinTypeNEO:
         return NEO::Address::isValid(string);
+
+    case TWCoinTypeFilecoin:
+        return Filecoin::Address::isValid(string);
     }
 }
 
@@ -361,6 +365,9 @@ std::string TW::deriveAddress(TWCoinType coin, const PublicKey& publicKey) {
 
     case TWCoinTypeNEO:
         return NEO::Address(publicKey).string();
+
+    case TWCoinTypeFilecoin:
+        return Filecoin::Address(publicKey).string();
     }
 }
 

--- a/src/Filecoin/Address.cpp
+++ b/src/Filecoin/Address.cpp
@@ -1,0 +1,178 @@
+// Copyright © 2017-2020 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Address.h"
+
+#include "../Base32.h"
+#include "../Data.h"
+
+using namespace TW;
+using namespace TW::Filecoin;
+
+static const char BASE32_ALPHABET_FILECOIN[] = "abcdefghijklmnopqrstuvwxyz234567";
+static constexpr size_t checksumSize = 4;
+
+bool Address::isValid(const Data& data) {
+    if (data.size() < 2) {
+        return false;
+    }
+    Type type = getType(data[0]);
+    if (type == Type::Invalid) {
+        return false;
+    } else if (type == Type::ID) {
+        // Verify varuint encoding
+        if (data.size() > 11) {
+            return false;
+        }
+        if (data.size() == 11 && data[10] > 0x01) {
+            return false;
+        }
+        int i;
+        for (i = 1; i < data.size(); i++) {
+            if ((data[i] & 0x80) == 0) {
+                break;
+            }
+        }
+        return i == data.size() - 1;
+    } else {
+        return data.size() == (1 + Address::payloadSize(type));
+    }
+}
+
+static bool isValidID(const std::string& string) {
+    if (string.length() > 22)
+        return false;
+    for (int i = 2; i < string.length(); i++) {
+        if (string[i] < '0' || string[i] > '9') {
+            return false;
+        }
+    }
+    try {
+        size_t chars;
+        [[maybe_unused]] uint64_t id = std::stoull(string.substr(2), &chars);
+        return chars > 0;
+    } catch (...) {
+        return false;
+    }
+}
+
+static bool isValidBase32(const std::string& string, Address::Type type) {
+    // Check if valid Base32.
+    uint8_t size = Address::payloadSize(type);
+    Data decoded;
+    if (!Base32::decode(string.substr(2), decoded, BASE32_ALPHABET_FILECOIN)) {
+        return false;
+    }
+
+    // Check size
+    if (decoded.size() != size + checksumSize) {
+        return false;
+    }
+
+    // Extract raw address.
+    Data address;
+    address.push_back(static_cast<uint8_t>(type));
+    address.insert(address.end(), decoded.data(), decoded.data() + size);
+
+    // Verify checksum.
+    Data should_sum = Hash::blake2b(address, checksumSize);
+    return std::memcmp(should_sum.data(), decoded.data() + size, checksumSize) == 0;
+}
+
+bool Address::isValid(const std::string& string) {
+    if (string.length() < 3) {
+        return false;
+    }
+    // Only main net addresses supported.
+    if (string[0] != PREFIX) {
+        return false;
+    }
+    // Get address type.
+    auto type = parseType(string[1]);
+    if (type == Type::Invalid) {
+        return false;
+    }
+
+    // ID addresses are special, they are just numbers.
+    return type == Type::ID ? isValidID(string) : isValidBase32(string, type);
+}
+
+Address::Address(const std::string& string) {
+    if (!isValid(string))
+        throw std::invalid_argument("Invalid address data");
+
+    Type type = parseType(string[1]);
+    // First byte is type
+    bytes.push_back(static_cast<uint8_t>(type));
+    if (type == Type::ID) {
+        uint64_t id = std::stoull(string.substr(2));
+        while (id >= 0x80) {
+            bytes.push_back(((uint8_t)id) | 0x80);
+            id >>= 7;
+        }
+        bytes.push_back((uint8_t)id);
+        return;
+    }
+
+    Data decoded;
+    if (!Base32::decode(string.substr(2), decoded, BASE32_ALPHABET_FILECOIN))
+        throw std::invalid_argument("Invalid address data");
+    uint8_t payloadSize = Address::payloadSize(type);
+
+    bytes.insert(bytes.end(), decoded.data(), decoded.data() + payloadSize);
+}
+
+Address::Address(const Data& data) {
+    if (!isValid(data)) {
+        throw std::invalid_argument("Invalid address data");
+    }
+    bytes = data;
+}
+
+Address::Address(const PublicKey& publicKey) {
+    bytes.push_back(static_cast<uint8_t>(Type::SECP256K1));
+    Data hash = Hash::blake2b(publicKey.bytes, payloadSize(Type::SECP256K1));
+    bytes.insert(bytes.end(), hash.begin(), hash.end());
+}
+
+std::string Address::string() const {
+    std::string s;
+    // Main net address prefix
+    s.push_back(PREFIX);
+    // Address type prefix
+    s.push_back(typeAscii(type()));
+
+    if (type() == Type::ID) {
+        uint64_t id = 0;
+        unsigned shift = 0;
+        for (int i = 1; i < bytes.size(); i++) {
+            if (bytes[i] < 0x80) {
+                id |= bytes[i] << shift;
+                break;
+            } else {
+                id |= ((uint64_t)(bytes[i] & 0x7F)) << shift;
+                shift += 7;
+            }
+        }
+        s.append(std::to_string(id));
+        return s;
+    }
+
+    uint8_t payloadSize = Address::payloadSize(type());
+    // Base32 encoded body
+    Data toEncode(payloadSize + checksumSize);
+    // Copy address payload without prefix
+    std::copy(bytes.data() + 1, bytes.data() + payloadSize + 1, toEncode.data());
+    // Append Blake2b checksum
+    Data bytesVec;
+    bytesVec.assign(std::begin(bytes), std::end(bytes));
+    Data sum = Hash::blake2b(bytesVec, checksumSize);
+    assert(sum.size() == checksumSize);
+    std::copy(sum.begin(), sum.end(), toEncode.data() + payloadSize);
+    s.append(Base32::encode(toEncode, BASE32_ALPHABET_FILECOIN));
+
+    return s;
+}

--- a/src/Filecoin/Address.h
+++ b/src/Filecoin/Address.h
@@ -1,0 +1,104 @@
+// Copyright © 2017-2020 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "../PublicKey.h"
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace TW::Filecoin {
+
+class Address {
+  public:
+    enum class Type : uint8_t {
+        ID = 0,
+        SECP256K1 = 1,
+        ACTOR = 2,
+        BLS = 3,
+        Invalid,
+    };
+
+    /// Address data with address type prefix.
+    Data bytes;
+
+    /// Determines whether a collection of bytes makes a valid address.
+    static bool isValid(const Data& data);
+
+    /// Determines whether a string makes a valid encoded address.
+    static bool isValid(const std::string& string);
+
+    /// Initializes an address with a string representation.
+    explicit Address(const std::string& string);
+
+    /// Initializes an address with a collection of bytes.
+    explicit Address(const Data& data);
+
+    /// Initializes an address with a secp256k1 public key.
+    explicit Address(const PublicKey& publicKey);
+
+    /// Returns a string representation of the address.
+    [[nodiscard]] std::string string() const;
+
+    /// Returns the type of an address.
+    Type type() const { return getType(bytes[0]); }
+
+    /// Address prefix
+    static constexpr char PREFIX = 'f';
+
+  public:
+    /// Attempts to get the type by number.
+    static Type getType(uint8_t raw) {
+        switch (raw) {
+        case 0:
+            return Type::ID;
+        case 1:
+            return Type::SECP256K1;
+        case 2:
+            return Type::ACTOR;
+        case 3:
+            return Type::BLS;
+        default:
+            return Type::Invalid;
+        }
+    }
+
+    /// Attempts to get the type by ASCII.
+    static Type parseType(char c) {
+        if (c >= '0' && c <= '3') {
+            return static_cast<Type>(c - '0');
+        } else {
+            return Type::Invalid;
+        }
+    }
+
+    /// Returns ASCII character of type
+    static char typeAscii(Type t) { return '0' + static_cast<char>(t); }
+
+    // Returns the payload size (excluding any prefixes) of an address type.
+    // If the payload size is undefined/variable (e.g. ID)
+    // or the type is unknown, it returns zero.
+    static uint8_t payloadSize(Type t) {
+        switch (t) {
+        case Type::SECP256K1:
+        case Type::ACTOR:
+            return 20;
+        case Type::BLS:
+            return 48;
+        default:
+            return 0;
+        }
+    }
+};
+
+inline bool operator==(const Address& lhs, const Address& rhs) {
+    return lhs.bytes == rhs.bytes;
+}
+
+} // namespace TW::Filecoin

--- a/src/Filecoin/Signer.cpp
+++ b/src/Filecoin/Signer.cpp
@@ -1,0 +1,40 @@
+// Copyright © 2017-2020 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Signer.h"
+
+using namespace TW;
+using namespace TW::Filecoin;
+
+Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) noexcept {
+    // Load private key and transaction from Protobuf input.
+    auto key = PrivateKey(Data(input.private_key().begin(), input.private_key().end()));
+    auto pubkey = key.getPublicKey(TWPublicKeyTypeSECP256k1Extended);
+    Address from_address(pubkey);
+    Address to_address(input.to_address());
+    Transaction transaction(
+        /* to */ to_address,
+        /* from */ from_address,
+        /* nonce */ input.nonce(),
+        /* value */ load(input.value()),
+        /* gasPrice */ load(input.gas_price()),
+        /* gasLimit */ input.gas_limit());
+
+    // Sign transaction.
+    auto signature = sign(key, transaction);
+    auto encoded = transaction.serialize(signature);
+
+    // Return Protobuf output.
+    Proto::SigningOutput protoOutput;
+    protoOutput.set_encoded(encoded.data(), encoded.size());
+    return protoOutput;
+}
+
+Data Signer::sign(const PrivateKey& privateKey, Transaction& transaction) noexcept {
+    Data toSign = Hash::blake2b(transaction.cid(), 32);
+    auto signature = privateKey.sign(toSign, TWCurveSECP256k1);
+    return Data(signature.begin(), signature.end());
+}

--- a/src/Filecoin/Signer.h
+++ b/src/Filecoin/Signer.h
@@ -1,0 +1,35 @@
+// Copyright © 2017-2020 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "Transaction.h"
+
+#include "../Data.h"
+#include "../Hash.h"
+#include "../PrivateKey.h"
+#include "../proto/Filecoin.pb.h"
+
+namespace TW::Filecoin {
+
+/// Helper class that performs Filecoin transaction signing.
+class Signer {
+  public:
+    Signer() = delete;
+
+    /// Signs a Proto::SigningInput transaction.
+    static Proto::SigningOutput sign(const Proto::SigningInput& input) noexcept;
+
+    /// Signs the given transaction.
+    static Data sign(const PrivateKey& privateKey, Transaction& transaction) noexcept;
+};
+
+} // namespace TW::Filecoin
+
+/// Wrapper for C interface.
+struct TWFilecoinSigner {
+    TW::Filecoin::Signer impl;
+};

--- a/src/Filecoin/Transaction.cpp
+++ b/src/Filecoin/Transaction.cpp
@@ -1,0 +1,64 @@
+// Copyright © 2017-2020 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Transaction.h"
+
+using namespace TW;
+using namespace TW::Filecoin;
+
+// encodeVaruint encodes a 256-bit number into a big endian encoding, omitting leading zeros.
+static Data encodeVaruint(const uint256_t& value) {
+    Data data;
+    encode256BE(data, value, 256);
+    size_t i = 0;
+    for (i = 0; i < data.size(); ++i) {
+        if (data[i] != 0) {
+            break;
+        }
+    }
+    Data small;
+    small.assign(data.begin() + i - 1, data.end());
+    return small;
+}
+
+// cidPrefix is the CID + Multihash prefix of transaction CIDs.
+const Data cidPrefix = {
+    // CIDv1 with CBOR codec
+    0x01,
+    0x71,
+    // Blake2b-256 with 32 byte output
+    0xa0,
+    0xe4,
+    0x02,
+    0x20,
+};
+
+Cbor::Encode Transaction::message() const {
+    return Cbor::Encode::array(
+        {Cbor::Encode::bytes(to.bytes), Cbor::Encode::bytes(from.bytes), Cbor::Encode::uint(nonce),
+         Cbor::Encode::bytes(encodeVaruint(value)), Cbor::Encode::bytes(encodeVaruint(gasPrice)),
+         Cbor::Encode::bytes(encodeVaruint(gasLimit)), Cbor::Encode::uint(0),
+         Cbor::Encode::bytes(Data())});
+}
+
+Data Transaction::cid() const {
+    Data cid;
+    cid.reserve(cidPrefix.size() + 32);
+    cid.insert(cid.end(), cidPrefix.begin(), cidPrefix.end());
+    Data hash = Hash::blake2b(message().encoded(), 32);
+    cid.insert(cid.end(), hash.begin(), hash.end());
+    return cid;
+}
+
+Data Transaction::serialize(Data& signature) const {
+    // Wrap signature in object.
+    Data sigObject;
+    TW::append(sigObject, 0x01); // Prepend IKTSecp256k1 type
+    TW::append(sigObject, signature);
+    // Create Filecoin SignedMessage
+    auto signedMessage = Cbor::Encode::array({message(), Cbor::Encode::bytes(sigObject)});
+    return signedMessage.encoded();
+}

--- a/src/Filecoin/Transaction.h
+++ b/src/Filecoin/Transaction.h
@@ -1,0 +1,56 @@
+// Copyright © 2017-2020 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include <utility>
+
+#include "Address.h"
+#include "../Cbor.h"
+#include "../uint256.h"
+
+namespace TW::Filecoin {
+
+class Transaction {
+  public:
+    // Recipient address
+    Address to;
+    // Sender address
+    Address from;
+    // Transaction nonce
+    uint64_t nonce;
+    // Transaction value
+    uint256_t value;
+    // Miner fee
+    uint256_t gasPrice;
+    uint256_t gasLimit;
+    // Transaction type; 0 for simple transfers
+    uint64_t method;
+    // Transaction data; empty for simple transfers
+    Data params;
+
+    Transaction(Address to, Address from, uint64_t nonce, uint256_t value, uint256_t gprice,
+                uint256_t glimit)
+        : to(std::move(to))
+        , from(std::move(from))
+        , nonce(nonce)
+        , value(std::move(value))
+        , gasPrice(std::move(gprice))
+        , gasLimit(std::move(glimit))
+        , method(0) {}
+
+  public:
+    // message returns the CBOR encoding of the Filecoin Message to be signed.
+    Cbor::Encode message() const;
+
+    // cid returns the raw Filecoin message CID (excluding the signature).
+    Data cid() const;
+
+    // serialize returns the CBOR encoding of the Filecoin SignedMessage.
+    Data serialize(Data& signature) const;
+};
+
+} // namespace TW::Filecoin

--- a/src/interface/TWFilecoinSigner.cpp
+++ b/src/interface/TWFilecoinSigner.cpp
@@ -1,0 +1,25 @@
+// Copyright © 2017-2019 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include <TrustWalletCore/TWFilecoinSigner.h>
+
+#include "../Filecoin/Signer.h"
+#include "../Filecoin/Transaction.h"
+#include "../PrivateKey.h"
+
+using namespace TW;
+using namespace TW::Filecoin;
+
+TW_Filecoin_Proto_SigningOutput TWFilecoinSignerSign(TW_Filecoin_Proto_SigningInput data) {
+    Proto::SigningInput input;
+    input.ParseFromArray(TWDataBytes(data), static_cast<int>(TWDataSize(data)));
+
+    auto protoOutput = Signer::sign(input);
+
+    auto serialized = protoOutput.SerializeAsString();
+    return TWDataCreateWithBytes(reinterpret_cast<const uint8_t*>(serialized.data()),
+                                 serialized.size());
+}

--- a/src/proto/Filecoin.proto
+++ b/src/proto/Filecoin.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package TW.Filecoin.Proto;
+option java_package = "wallet.core.jni.proto";
+
+// Input data necessary to create a signed transaction.
+message SigningInput {
+    // Private key of sender account.
+    bytes private_key = 1;
+
+    // Recipient's address.
+    string to_address = 2;
+
+    // Transaction nonce.
+    uint64 nonce = 3;
+
+    // Transfer value.
+    bytes value = 4;
+
+    // Gas price.
+    bytes gas_price = 5;
+
+    // Gas limit.
+    uint64 gas_limit = 6;
+}
+
+// Transaction signing output.
+message SigningOutput {
+    bytes encoded = 1;
+}

--- a/swift/Tests/Blockchains/FilecoinTests.swift
+++ b/swift/Tests/Blockchains/FilecoinTests.swift
@@ -1,0 +1,35 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+import XCTest
+import TrustWalletCore
+
+class FilecoinTests: XCTestCase {
+
+    func testAddress() {
+        let privateKey = PrivateKey(data: Data(hexString: "1d969865e189957b9824bd34f26d5cbf357fda1a6d844cbf0c9ab1ed93fa7dbe")!)!
+        let publicKey = privateKey.getPublicKeySecp256k1(compressed: false)
+        let address = AnyAddress(publicKey: publicKey, coin: .filecoin)
+        XCTAssertEqual(address.description, "f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq")
+    }
+
+    func testSigner() {
+        let input = FilecoinSigningInput.with {
+            $0.privateKey = Data(hexString: "1d969865e189957b9824bd34f26d5cbf357fda1a6d844cbf0c9ab1ed93fa7dbe")!
+            $0.toAddress = "f3um6uo3qt5of54xjbx3hsxbw5mbsc6auxzrvfxekn5bv3duewqyn2tg5rhrlx73qahzzpkhuj7a34iq7oifsq"
+            $0.nonce = 2
+            // 600 FIL
+            $0.value = Data(hexString: "2086ac351052600000")!
+            $0.gasPrice = Data(hexString: "02")!
+            $0.gasLimit = 1000
+        }
+
+        let output = FilecoinSigner.sign(input: input)
+
+        XCTAssertEqual(output.encoded.hexString, "8288583103a33d476e13eb8bde5d21becf2b86dd60642f0297cc6a5b914de86bb1d096861ba99bb13c577fee003e72f51e89f837c45501cf01bf485f61435e6770b52615bf455e043a2361024a002086ac351052600000420002430003e800405842014e896d4fa72a1f39c37a4415629dfbb7ea301b7f001fff60befa485903f51d824659ba19c5bc969d7206de7afabfc4a0eec2dd34f15e58a064adf4ee9f72e64f01")
+    }
+
+}

--- a/swift/Tests/CoinAddressDerivationTests.swift
+++ b/swift/Tests/CoinAddressDerivationTests.swift
@@ -190,6 +190,9 @@ class CoinAddressDerivationTests: XCTestCase {
                 case .neo:
                     let expectedResult = "AT6w7PJvwPcSqHvtbNBY2aHPDv12eW5Uuf"
                     AssetCoinDerivation(coin, expectedResult, derivedAddress, address)
+                case .filecoin:
+                    let expectedResult = "f1zzykebxldfcakj5wdb5n3n7priul522fnmjzori"
+                    AssetCoinDerivation(coin, expectedResult, derivedAddress, address)
                 }
             }
         }

--- a/tests/Filecoin/AddressTests.cpp
+++ b/tests/Filecoin/AddressTests.cpp
@@ -1,0 +1,97 @@
+// Copyright © 2017-2020 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Filecoin/Address.h"
+#include "HexCoding.h"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace TW;
+using namespace TW::Filecoin;
+
+struct address_test {
+    std::string encoded;
+    const char* hex;
+};
+
+static const address_test validAddresses[] = {
+    // ID addresses
+    {"f00",                    "0000"},
+    {"f01",                    "0001"},
+    {"f010",                   "000a"},
+    {"f0150",                  "009601"},
+    {"f0499",                  "00f303"},
+    {"f01024",                 "008008"},
+    {"f01729",                 "00c10d"},
+    {"f0999999",               "00bf843d"},
+    {"f018446744073709551615", "00ffffffffffffffffff01"},
+    // secp256k1 addresses
+    {"f15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq", "01ea0f0ea039b291a0f08fd179e0556a8c3277c0d3"},
+    {"f12fiakbhe2gwd5cnmrenekasyn6v5tnaxaqizq6a", "01d1500504e4d1ac3e89ac891a4502586fabd9b417"},
+    {"f1wbxhu3ypkuo6eyp6hjx6davuelxaxrvwb2kuwva", "01b06e7a6f0f551de261fe3a6fe182b422ee0bc6b6"},
+    {"f1xtwapqc6nh4si2hcwpr3656iotzmlwumogqbuaa", "01bcec07c05e69f92468e2b3e3bf77c874f2c5da8c"},
+    {"f1xcbgdhkgkwht3hrrnui3jdopeejsoatkzmoltqy", "01b882619d46558f3d9e316d11b48dcf211327026a"},
+    {"f17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy", "01fd1d0f4dfcd7e99afcb99a8326b7dc459d32c628"},
+    // Actor addresses
+    {"f24vg6ut43yw2h2jqydgbg2xq7x6f4kub3bg6as6i", "02e54dea4f9bc5b47d261819826d5e1fbf8bc5503b"},
+    {"f25nml2cfbljvn4goqtclhifepvfnicv6g7mfmmvq", "02eb58bd08a15a6ade19d0989674148fa95a8157c6"},
+    {"f2nuqrg7vuysaue2pistjjnt3fadsdzvyuatqtfei", "026d21137eb4c4814269e894d296cf6500e43cd714"},
+    {"f24dd4ox4c2vpf5vk5wkadgyyn6qtuvgcpxxon64a", "02e0c7c75f82d55e5ed55db28033630df4274a984f"},
+    {"f2gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y", "02316b4c1ff5d4afb7826ceab5bb0f2c3e0f364053"},
+    // BLS addresses
+    {"f3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss4a","03ad58df696e2d4e91ea86c881e938ba4ea81b395e12797b84b9cf314b9546705e839c7a99d606b247ddb4f9ac7a3414dd"},
+    {"f3wmuu6crofhqmm3v4enos73okk2l366ck6yc4owxwbdtkmpk42ohkqxfitcpa57pjdcftql4tojda2poeruwa","03b3294f0a2e29e0c66ebc235d2fedca5697bf784af605c75af608e6a63d5cd38ea85ca8989e0efde9188b382f9372460d"},
+    {"f3s2q2hzhkpiknjgmf4zq3ejab2rh62qbndueslmsdzervrhapxr7dftie4kpnpdiv2n6tvkr743ndhrsw6d3a","0396a1a3e4ea7a14d49985e661b22401d44fed402d1d0925b243c923589c0fbc7e32cd04e29ed78d15d37d3aaa3fe6da33"},
+    {"f3q22fijmmlckhl56rn5nkyamkph3mcfu5ed6dheq53c244hfmnq2i7efdma3cj5voxenwiummf2ajlsbxc65a","0386b454258c589475f7d16f5aac018a79f6c1169d20fc33921dd8b5ce1cac6c348f90a3603624f6aeb91b64518c2e8095"},
+    {"f3u5zgwa4ael3vuocgc5mfgygo4yuqocrntuuhcklf4xzg5tcaqwbyfabxetwtj4tsam3pbhnwghyhijr5mixa","03a7726b038022f75a384617585360cee629070a2d9d28712965e5f26ecc40858382803724ed34f2720336f09db631f074"},
+};
+
+static const std::string invalidAddresses[] = {
+    "",
+    "f0-1",                   // Negative :)
+    "f018446744073709551616", // Greater than max uint64_t
+    "f15ihq5ibzwki2b4ep2f46avlkr\0zhpqgtga7pdrq", // Embedded NUL
+    "t15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq",  // Test net
+    "a15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq",  // Unknown net
+    "f95ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq",  // Unknown address type
+    // Invalid checksum cases
+    "f15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7rdrr",
+    "f24vg6ut43yw2h2jqydgbg2xq7x6f4kub3bg6as66",
+    "f3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss44",
+};
+
+TEST(FilecoinAddress, IsValid) {
+    for (const auto& test : validAddresses) {
+        ASSERT_TRUE(Address::isValid(test.encoded))
+            << "is_valid() != true: " << test.encoded << std::endl;
+        ASSERT_TRUE(Address::isValid(parse_hex(test.hex)))
+            << "is_valid() != true: " << test.hex << std::endl;
+    }
+    for (const auto& address : invalidAddresses)
+        ASSERT_FALSE(Address::isValid(address)) << "is_valid() != false: " << address << std::endl;
+
+    ASSERT_FALSE(Address::isValid(parse_hex("00"))) << "Empty varuint";
+    ASSERT_FALSE(Address::isValid(parse_hex("00ff"))) << "Short varuint";
+    ASSERT_FALSE(Address::isValid(parse_hex("00ff00ff"))) << "Varuint with hole";
+    ASSERT_FALSE(Address::isValid(parse_hex("000101"))) << "Long varuint";
+    ASSERT_FALSE(Address::isValid(parse_hex("000000"))) << "Long varuint";
+    ASSERT_FALSE(Address::isValid(parse_hex("00ffffffffffffffffff02"))) << "Overflow";
+}
+
+TEST(FilecoinAddress, String) {
+    for (const auto& test : validAddresses) {
+        Address a(parse_hex(test.hex));
+        ASSERT_EQ(a.string(), test.encoded) << "Address(" << test.hex << ")";
+    }
+}
+
+TEST(FilecoinAddress, FromString) {
+    for (const auto& test : validAddresses) {
+        Address a(test.encoded);
+        ASSERT_EQ(hex(a.bytes), test.hex) << "Address(" << test.encoded << ")";
+    }
+}

--- a/tests/Filecoin/SignerTests.cpp
+++ b/tests/Filecoin/SignerTests.cpp
@@ -1,0 +1,46 @@
+// Copyright © 2017-2019 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Filecoin/Address.h"
+#include "Filecoin/Signer.h"
+#include "HexCoding.h"
+#include "PrivateKey.h"
+
+#include <gtest/gtest.h>
+
+namespace TW::Filecoin {
+
+TEST(FilecoinSigner, DerivePublicKey) {
+    const PrivateKey privateKey(
+        parse_hex("1d969865e189957b9824bd34f26d5cbf357fda1a6d844cbf0c9ab1ed93fa7dbe"));
+    const PublicKey publicKey((privateKey.getPublicKey(TWPublicKeyTypeSECP256k1Extended)));
+    const Address address(publicKey);
+    ASSERT_EQ(address.string(), "f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq");
+}
+
+TEST(FilecoinSigner, Sign) {
+    const PrivateKey privateKey(
+        parse_hex("1d969865e189957b9824bd34f26d5cbf357fda1a6d844cbf0c9ab1ed93fa7dbe"));
+    const PublicKey publicKey((privateKey.getPublicKey(TWPublicKeyTypeSECP256k1Extended)));
+    const Address fromAddress(publicKey);
+    const Address toAddress("f1rletqqhinhagw6nxjcr4kbfws25thgt7owzuruy");
+
+    Transaction tx(toAddress, fromAddress,
+                   /*nonce*/ 1,
+                   /*value*/ 6000,
+                   /*gasPrice*/ 2,
+                   /*gasLimit*/ 200);
+
+    Data signature = Signer::sign(privateKey, tx);
+
+    ASSERT_EQ(
+        hex(tx.serialize(signature)),
+        "828855018ac93840e869c06b79b748a3c504b696bb339a7f5501cf01bf485f61435e6770b52615bf455e043a23"
+        "6101430017704200024200c80040584201477bcf9a71c9e19af77fbd92677230a9612d927877e439eb4aa30643"
+        "0a4ffae42251194820df211d00075e88e68c9704a880448532ec0092045a1e00e8f1cbb900");
+}
+
+} // namespace TW::Filecoin

--- a/tests/Filecoin/TWCoinTypeTests.cpp
+++ b/tests/Filecoin/TWCoinTypeTests.cpp
@@ -1,0 +1,34 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here MAY BE LOST.
+// Generated one-time (codegen/bin/cointests)
+//
+
+#include "../interface/TWTestUtilities.h"
+#include <TrustWalletCore/TWCoinTypeConfiguration.h>
+#include <gtest/gtest.h>
+
+TEST(TWFilecoinCoinType, TWCoinType) {
+    auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeFilecoin));
+    auto txId = TWStringCreateWithUTF8Bytes(
+        "bafy2bzacecbm3ofxjjzcl2rg32ninphza34mm3ijr55zjsamwfqmz4ib63mqe");
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeFilecoin, txId));
+    auto accId = TWStringCreateWithUTF8Bytes("t1nbb73vhk5dtmnsgeaetbo76daepqjtrfoccn74i");
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeFilecoin, accId));
+    auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeFilecoin));
+    auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeFilecoin));
+
+    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeFilecoin), 18);
+    ASSERT_EQ(TWBlockchainFilecoin, TWCoinTypeBlockchain(TWCoinTypeFilecoin));
+    ASSERT_EQ(0x0, TWCoinTypeP2shPrefix(TWCoinTypeFilecoin));
+    ASSERT_EQ(0x0, TWCoinTypeStaticPrefix(TWCoinTypeFilecoin));
+    assertStringsEqual(symbol, "FIL");
+    assertStringsEqual(txUrl, "https://filscan.io/#/message/detail?cid=bafy2bzacecbm3ofxjjzcl2rg32ninphza34mm3ijr55zjsamwfqmz4ib63mqe");
+    assertStringsEqual(accUrl, "https://filscan.io/#/address/detail?address=t1nbb73vhk5dtmnsgeaetbo76daepqjtrfoccn74i");
+    assertStringsEqual(id, "filecoin");
+    assertStringsEqual(name, "Filecoin");
+}

--- a/tests/Filecoin/TransactionTests.cpp
+++ b/tests/Filecoin/TransactionTests.cpp
@@ -1,0 +1,36 @@
+// Copyright © 2017-2020 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Filecoin/Address.h"
+#include "Filecoin/Transaction.h"
+#include "HexCoding.h"
+#include "PrivateKey.h"
+
+#include <gtest/gtest.h>
+
+namespace TW::Filecoin {
+
+TEST(FilecoinTransaction, Serialize) {
+    const PrivateKey privateKey(
+        parse_hex("2f0f1d2c8de955c7c3fb4d9cae02539fadcb13fa998ccd9a1e871bed95f1941e"));
+    const auto publicKey = privateKey.getPublicKey(TWPublicKeyTypeSECP256k1Extended);
+    const Address fromAddress(publicKey);
+    const Address toAddress("f1hvadvq4rd2pyayrigjx2nbqz2nvemqouslw4wxi");
+
+    Transaction tx(toAddress, fromAddress,
+                   /*nonce*/ 0x1234567890,
+                   /*value*/ 1000,
+                   /*gasPrice*/ 1,
+                   /*gasLimit*/ 50);
+
+    ASSERT_EQ(hex(tx.message().encoded()),
+              "8855013d403ac3911e9f806228326fa68619d36a4641d455013d413d4c3fe3d89f99495a48c6046224a7"
+              "1f0cd71b0000001234567890430003e84200014200320040");
+    ASSERT_EQ(hex(tx.cid()),
+              "0171a0e4022020421f7d6207c9575803d5d96387c399acbf4bdac3026196cb4d423bc8966bb1");
+}
+
+} // namespace TW::Filecoin

--- a/tests/interface/TWFilecoinSignerTests.cpp
+++ b/tests/interface/TWFilecoinSignerTests.cpp
@@ -1,0 +1,60 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "TWTestUtilities.h"
+#include <TrustWalletCore/TWFilecoinSigner.h>
+
+#include "Data.h"
+#include "HexCoding.h"
+#include "proto/Filecoin.pb.h"
+#include "uint256.h"
+
+#include <gtest/gtest.h>
+
+using namespace TW;
+using namespace Filecoin;
+
+TEST(TWFilecoinSigner, Sign) {
+    Proto::SigningInput input;
+    auto privateKey = parse_hex("1d969865e189957b9824bd34f26d5cbf357fda1a6d844cbf0c9ab1ed93fa7dbe");
+    auto toAddress =
+        "f3um6uo3qt5of54xjbx3hsxbw5mbsc6auxzrvfxekn5bv3duewqyn2tg5rhrlx73qahzzpkhuj7a34iq7oifsq";
+    uint64_t nonce = 2;
+    // 600 FIL
+    // auto value = parse_hex("2086ac351052600000");
+    auto value = store(uint256_t(600) * uint256_t(1'000'000'000) * uint256_t(1'000'000'000));
+    auto gasPrice = store(uint256_t(2));
+    uint64_t gasLimit = 1000;
+
+    input.set_private_key(privateKey.data(), privateKey.size());
+    input.set_to_address(toAddress);
+    input.set_nonce(nonce);
+    input.set_value(value.data(), value.size());
+    input.set_gas_price(gasPrice.data(), gasPrice.size());
+    input.set_gas_limit(gasLimit);
+
+    auto inputString = input.SerializeAsString();
+    auto inputData = TWDataCreateWithBytes((const byte*)inputString.data(), inputString.size());
+
+    auto outputData = TWFilecoinSignerSign(inputData);
+
+    ASSERT_EQ(hex(TWDataBytes(outputData), TWDataBytes(outputData) + TWDataSize(outputData)),
+              "0aa4018288583103a33d476e13eb8bde5d21becf2b86dd60642f0297cc6a5b914de86bb1d096861ba99b"
+              "b13c577fee003e72f51e89f837c45501cf01bf485f61435e6770b52615bf455e043a2361024a002086ac"
+              "351052600000420002430003e800405842014e896d4fa72a1f39c37a4415629dfbb7ea301b7f001fff60"
+              "befa485903f51d824659ba19c5bc969d7206de7afabfc4a0eec2dd34f15e58a064adf4ee9f72e64f01");
+
+    Proto::SigningOutput output;
+    output.ParseFromArray(TWDataBytes(outputData), TWDataSize(outputData));
+
+    ASSERT_EQ(hex(output.encoded()),
+              "8288583103a33d476e13eb8bde5d21becf2b86dd60642f0297cc6a5b914de86bb1d096861ba99bb13c57"
+              "7fee003e72f51e89f837c45501cf01bf485f61435e6770b52615bf455e043a2361024a002086ac351052"
+              "600000420002430003e800405842014e896d4fa72a1f39c37a4415629dfbb7ea301b7f001fff60befa48"
+              "5903f51d824659ba19c5bc969d7206de7afabfc4a0eec2dd34f15e58a064adf4ee9f72e64f01");
+
+    TWDataDelete(inputData);
+}


### PR DESCRIPTION
## Description

Adds support for Filecoin, implementing a secp256k1-based wallet.
(Old PR https://github.com/trustwallet/wallet-core/pull/784)

## Changes

 - Filecoin support (with secp256k1 wallet)

## Checklist

- [x] Support ID, SECP256K1, Actor and BLS Adresses.
- [x] Pass test vectors from Lotus
- [x] Add Signer & Transaction tests
- [x] Send generated transaction to network
- [x] Add token image (https://github.com/trustwallet/assets/pull/965)
- [x] Wait for steps in #780 to be resolved
- [x] Update derivation path
- [x] Add iOS/Android tests

Closes #780.