### PR TITLE
Improve newcoin scaffold

### DIFF
--- a/codegen/bin/newcoin
+++ b/codegen/bin/newcoin
@@ -31,8 +31,13 @@ def self.format_name_lowercase(coin)
   format_name(coin).downcase
 end
 
+def self.format_name_uppercase(coin)
+  format_name(coin).upcase
+end
+
 def self.generate_file(templateFile, folder, fileName, coin)
     @coin = coin
+    name = format_name(coin)
     path = File.expand_path(templateFile, File.join(File.dirname(__FILE__), '..', 'lib', 'templates'))
     template = ERB.new(File.read(path), nil, '-')
     result = template.result(binding)
@@ -41,6 +46,37 @@ def self.generate_file(templateFile, folder, fileName, coin)
     path = File.join(folder, fileName)
     File.write(path, result)
     puts "Generated file " + path
+end
+
+def self.insert_coint_type(coin)
+    target_file = "include/TrustWalletCore/TWCoinType.h"
+    target_line = "    TWCoinType#{coin['name']} = #{coin_type(coin['derivationPath'])},\n"
+    if insert_target_line(target_file, target_line, "};\n")
+        insert_blockchain_type(coin)
+    end
+end
+
+def insert_blockchain_type(coin)
+    target_file = "include/TrustWalletCore/TWBlockchain.h"
+    line_number = File.readlines(target_file).count
+    target_line = "    TWBlockchain#{coin['blockchain']} = #{line_number - 17},\n"
+    puts target_line
+    insert_target_line(target_file, target_line, "};\n")
+end
+
+def self.insert_target_line(target_file, target_line, original_line)
+    lines = File.readlines(target_file)
+    index = lines.index(target_line)
+    if index.nil?
+        index = lines.index(original_line)
+        lines.insert(index, target_line)
+        puts "Update #{target_file}"
+        File.open(target_file, "w+") do |f|
+            f.puts(lines)
+        end
+        return true
+    end
+    return false
 end
 
 command_line_args = ARGV
@@ -71,17 +107,23 @@ if coinSelect.length() == 0
     return
 end
 coin = coinSelect.first
+name = format_name(coin)
 
-generate_file("newcoin/Address.h.erb", "src/#{format_name(coin)}", "Address.h", coin)
-generate_file("newcoin/Address.cpp.erb", "src/#{format_name(coin)}", "Address.cpp", coin)
-generate_file("newcoin/Signer.h.erb", "src/#{format_name(coin)}", "Signer.h", coin)
-generate_file("newcoin/Signer.cpp.erb", "src/#{format_name(coin)}", "Signer.cpp", coin)
-generate_file("newcoin/TWSigner.h.erb", "include/TrustWalletCore", "TW#{format_name(coin)}Signer.h", coin)
-generate_file("newcoin/TWSigner.cpp.erb", "src/interface", "TW#{format_name(coin)}Signer.cpp", coin)
-generate_file("newcoin/AddressTests.cpp.erb", "tests/#{format_name(coin)}", "AddressTests.cpp", coin)
-generate_file("newcoin/SignerTests.cpp.erb", "tests/#{format_name(coin)}", "SignerTests.cpp", coin)
-generate_file("newcoin/TWTests.cpp.erb", "tests/interface", "TW#{format_name(coin)}Tests.cpp", coin)
-coin_test_gen.generate_coin_test_file(coin)
-generate_file("newcoin/AddressTests.kt.erb", "android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/#{format_name_lowercase(coin)}", "AddressTests#{format_name(coin)}.kt", coin)
-generate_file("newcoin/SignerTests.kt.erb", "android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/#{format_name_lowercase(coin)}", "SignerTests#{format_name(coin)}.kt", coin)
-generate_file("newcoin/Tests.swift.erb", "swift/Tests/Blockchains", "#{format_name(coin)}Tests.swift", coin)
+
+insert_coint_type(coin)
+
+generate_file("newcoin/Address.h.erb", "src/#{name}", "Address.h", coin)
+generate_file("newcoin/Address.cpp.erb", "src/#{name}", "Address.cpp", coin)
+generate_file("newcoin/Proto.erb", "src/proto", "#{name}.proto", coin)
+generate_file("newcoin/Signer.h.erb", "src/#{name}", "Signer.h", coin)
+generate_file("newcoin/Signer.cpp.erb", "src/#{name}", "Signer.cpp", coin)
+generate_file("newcoin/TWSigner.h.erb", "include/TrustWalletCore", "TW#{name}Signer.h", coin)
+generate_file("newcoin/TWSigner.cpp.erb", "src/interface", "TW#{name}Signer.cpp", coin)
+generate_file("newcoin/AddressTests.cpp.erb", "tests/#{name}", "AddressTests.cpp", coin)
+generate_file("newcoin/SignerTests.cpp.erb", "tests/#{name}", "SignerTests.cpp", coin)
+generate_file("newcoin/TWTests.cpp.erb", "tests/interface", "TW#{name}Tests.cpp", coin)
+generate_file("newcoin/AddressTests.kt.erb", "android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/#{format_name_lowercase(coin)}", "Test#{name}Address.kt", coin)
+generate_file("newcoin/SignerTests.kt.erb", "android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/#{format_name_lowercase(coin)}", "Test#{name}Signer.kt", coin)
+generate_file("newcoin/Tests.swift.erb", "swift/Tests/Blockchains", "#{name}Tests.swift", coin)
+
+puts "please tools/generate-files to generate Swift/Java/Protobuf files"

--- a/codegen/lib/templates/newcoin/AddressTests.kt.erb
+++ b/codegen/lib/templates/newcoin/AddressTests.kt.erb
@@ -10,12 +10,9 @@ import com.trustwallet.core.app.utils.toHex
 import com.trustwallet.core.app.utils.toHexByteArray
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import wallet.core.jni.<%= format_name(coin) %>Address
-import wallet.core.jni.PrivateKey
-import wallet.core.jni.PublicKey
-import wallet.core.jni.PublicKeyType
+import wallet.core.jni.*
 
-class Test<%= format_name(coin) %>Address {
+class Test<%= name %>Address {
 
     init {
         System.loadLibrary("TrustWalletCore")
@@ -27,8 +24,8 @@ class Test<%= format_name(coin) %>Address {
 
         val key = PrivateKey("__PRIVATE_KEY_DATA__".toHexByteArray())
         val pubkey = key.publicKeyEd25519
-        val address = <%= format_name(coin) %>Address(pubkey)
-        val expected = <%= format_name(coin) %>Address("__EXPECTED_RESULT_ADDRESS__")
+        val address = AnyAddress(pubkey, CoinType.<%= format_name_uppercase(coin) %>)
+        val expected = AnyAddress("__EXPECTED_RESULT_ADDRESS__", CoinType.<%= format_name_uppercase(coin) %>)
 
         assertEquals(pubkey.data().toHex(), "0x__EXPECTED_PUBKEY_DATA__")
         assertEquals(address.description(), expected.description())

--- a/codegen/lib/templates/newcoin/Proto.erb
+++ b/codegen/lib/templates/newcoin/Proto.erb
@@ -1,0 +1,32 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+syntax = "proto3";
+
+package TW.<%= name %>.Proto;
+option java_package = "wallet.core.jni.proto";
+
+// TODO: typical balance transfer, add more fields needed to sign
+message TransferMessage {
+    int64 amount = 1;
+    int64 fee = 2;
+    string to = 3;
+}
+
+// TODO: Input data necessary to create a signed transaction.
+message SigningInput {
+    bytes private_key = 1;
+
+    oneof message_oneof {
+        TransferMessage transfer = 2;
+    }
+}
+
+// Transaction signing output.
+message SigningOutput {
+    // Signed and encoded transaction bytes.
+    bytes encoded = 1;
+}

--- a/codegen/lib/templates/newcoin/Signer.cpp.erb
+++ b/codegen/lib/templates/newcoin/Signer.cpp.erb
@@ -9,25 +9,18 @@
 #include "../PublicKey.h"
 
 using namespace TW;
-using namespace TW::<%= format_name(coin) %>;
+using namespace TW::<%= name %>;
 
-/*
+
 Proto::SigningOutput Signer::sign(const Proto::SigningInput &input) noexcept {
     // TODO: Check and finalize implementation
 
     auto protoOutput = Proto::SigningOutput();
-    auto key = PrivateKey(Data(input.private_key().begin(), input.private_key().end()));
-    auto pubkey = key.getPublicKey(TWPublicKeyTypeED25519);
-    auto from = Address(pubkey);
+    Data encoded;
+    // auto privateKey = PrivateKey(Data(input.private_key().begin(), input.private_key().end()));
+    // auto signature = privateKey.sign(payload, TWCurveED25519);
+    // encoded = encodeSignature(signature);
 
-    // ...
-    
+    protoOutput.set_encoded(encoded.data(), encoded.size());
     return protoOutput;
 }
-
-Data Signer::sign(const PrivateKey &privateKey, Transaction &transaction) noexcept {
-    // TODO: Finalize implementation
-
-    return Data();
-}
-*/

--- a/codegen/lib/templates/newcoin/Signer.h.erb
+++ b/codegen/lib/templates/newcoin/Signer.h.erb
@@ -8,27 +8,23 @@
 
 #include "../Data.h"
 #include "../PrivateKey.h"
+#include "../proto/<%= name %>.pb.h"
 
-namespace TW::<%= format_name(coin) %> {
+namespace TW::<%= name %> {
 
-/// Helper class that performs <%= format_name(coin) %> transaction signing.
+/// Helper class that performs <%= name %> transaction signing.
 class Signer {
 public:
-    // TODO: Finalize class definition
-
     /// Hide default constructor
     Signer() = delete;
 
     /// Signs a Proto::SigningInput transaction
-    //static Proto::SigningOutput sign(const Proto::SigningInput& input) noexcept;
-
-    /// Signs the given transaction.
-    //static Data sign(const PrivateKey& privateKey, Transaction& transaction) noexcept;
+    static Proto::SigningOutput sign(const Proto::SigningInput& input) noexcept;
 };
 
-} // namespace TW::<%= format_name(coin) %>
+} // namespace TW::<%= name %>
 
 /// Wrapper for C interface.
-struct TW<%= format_name(coin) %>Signer {
-    TW::<%= format_name(coin) %>::Signer impl;
+struct TW<%= name %>Signer {
+    TW::<%= name %>::Signer impl;
 };

--- a/codegen/lib/templates/newcoin/SignerTests.kt.erb
+++ b/codegen/lib/templates/newcoin/SignerTests.kt.erb
@@ -26,8 +26,8 @@ class Test<%= format_name(coin) %>Signer {
     fun <%= format_name(coin) %>TransactionSigning() {
         // TODO: Finalize implementation
 
-        //val transaction = <%= format_name(coin) %>.TransactionPay.newBuilder()
-        //    .setToAddress("...")
+        //val transfer = <%= format_name(coin) %>.TransferMessage.newBuilder()
+        //    .setTo("...")
         //    .setAmount(...)
         //    ...
         //    .build()

--- a/codegen/lib/templates/newcoin/TWSigner.cpp.erb
+++ b/codegen/lib/templates/newcoin/TWSigner.cpp.erb
@@ -4,23 +4,20 @@
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
 
-#include <TrustWalletCore/TW<%= format_name(coin) %>Signer.h>
+#include <TrustWalletCore/TW<%= name %>Signer.h>
 
-#include "../<%= format_name(coin) %>/Signer.h"
+#include "../<%= name %>/Signer.h"
+#include "../proto/<%= name %>.pb.h"
 
 using namespace TW;
-using namespace TW::<%= format_name(coin) %>;
+using namespace TW::<%= name %>;
 
-/*
-TW_<%= format_name(coin) %>_Proto_SigningOutput TW<%= format_name(coin) %>SignerSign(TW_<%= format_name(coin) %>_Proto_SigningInput data) {
-    // TODO: Finalize implementation
+TW_<%= name %>_Proto_SigningOutput TW<%= name %>SignerSign(TW_<%= name %>_Proto_SigningInput data) {
+    Proto::SigningInput input;
+    input.ParseFromArray(TWDataBytes(data), static_cast<int>(TWDataSize(data)));
 
-    //Proto::SigningInput input;
-    //input.ParseFromArray(TWDataBytes(data), static_cast<int>(TWDataSize(data)));
-    //
-    //auto protoOutput = Signer::sign(input);
-    //
-    //auto serialized = protoOutput.SerializeAsString();
-    //return TWDataCreateWithBytes(reinterpret_cast<const uint8_t *>(serialized.data()), serialized.size());
+    auto protoOutput = Signer::sign(input);
+    auto serialized = protoOutput.SerializeAsString();
+
+    return TWDataCreateWithBytes(reinterpret_cast<const uint8_t *>(serialized.data()), serialized.size());
 }
-*/

--- a/codegen/lib/templates/newcoin/TWSigner.h.erb
+++ b/codegen/lib/templates/newcoin/TWSigner.h.erb
@@ -6,16 +6,16 @@
 #pragma once
 
 #include "TWBase.h"
-//#include "TW<%= format_name(coin) %>Proto.h"
+#include "TW<%= name %>Proto.h"
 
 TW_EXTERN_C_BEGIN
 
-/// Helper class to sign <%= format_name(coin) %> transactions.
+/// Helper class to sign <%= name %> transactions.
 TW_EXPORT_CLASS
-struct TW<%= format_name(coin) %>Signer;
+struct TW<%= name %>Signer;
 
 /// Signs a transaction.
-//TW_EXPORT_STATIC_METHOD
-//TW_<%= format_name(coin) %>_Proto_SigningOutput TW<%= format_name(coin) %>SignerSign(TW_<%= format_name(coin) %>_Proto_SigningInput input);
+TW_EXPORT_STATIC_METHOD
+TW_<%= name %>_Proto_SigningOutput TW<%= name %>SignerSign(TW_<%= name %>_Proto_SigningInput input);
 
 TW_EXTERN_C_END

--- a/codegen/lib/templates/newcoin/TWTests.cpp.erb
+++ b/codegen/lib/templates/newcoin/TWTests.cpp.erb
@@ -4,8 +4,7 @@
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
 
-#include <TrustWalletCore/TW<%= format_name(coin) %>Address.h>
-#include <TrustWalletCore/TW<%= format_name(coin) %>Signer.h>
+#include <TrustWalletCore/TW<%= name %>Signer.h>
 #include "HexCoding.h"
 
 #include "TWTestUtilities.h"
@@ -15,10 +14,10 @@ using namespace TW;
 
 // TODO: Finalize tests
 
-TEST(TW<%= format_name(coin) %>, Address) {
+TEST(TW<%= name %>, Address) {
     // TODO: Finalize test implementation
 }
 
-TEST(TW<%= format_name(coin) %>, Sign) {
+TEST(TW<%= name %>, Sign) {
     // TODO: Finalize test implementation
 }

--- a/codegen/lib/templates/newcoin/Tests.swift.erb
+++ b/codegen/lib/templates/newcoin/Tests.swift.erb
@@ -7,7 +7,7 @@
 import TrustWalletCore
 import XCTest
 
-class <%= format_name(coin) %>Tests: XCTestCase {
+class <%= name %>Tests: XCTestCase {
     // TODO: Check and finalize implementation
 
     func testAddress() {
@@ -15,8 +15,8 @@ class <%= format_name(coin) %>Tests: XCTestCase {
 
         let key = PrivateKey(data: Data(hexString: "__PRIVATE_KEY_DATA__")!)!
         let pubkey = key.getPublicKeyEd25519()
-        let address = <%= format_name(coin) %>Address(publicKey: pubkey)
-        let addressFromString = <%= format_name(coin) %>Address(string: "__ADDRESS_DATA__")!
+        let address = AnyAddress(publicKey: pubkey, coin: .<%= format_name_lowercase(coin) %>)
+        let addressFromString = AnyAddress(string: "__ADDRESS_DATA__", coin: .<%= format_name_lowercase(coin) %>)!
 
         XCTAssertEqual(pubkey.data.hexString, "__EXPECTED_PUBKEY_DATA__")
         XCTAssertEqual(address.description, addressFromString.description)

--- a/coins.json
+++ b/coins.json
@@ -1285,25 +1285,25 @@
         }
     },
     {
-        "id": "cardano", 
-        "name": "Cardano", 
-        "symbol": "ADA", 
-        "decimals": 6, 
-        "blockchain": "Cardano", 
-        "derivationPath": "m/44'/1815'/0'/0/0", 
-        "curve": "ed25519Extended", 
-        "publicKeyType": "ed25519Extended", 
+        "id": "cardano",
+        "name": "Cardano",
+        "symbol": "ADA",
+        "decimals": 6,
+        "blockchain": "Cardano",
+        "derivationPath": "m/44'/1815'/0'/0/0",
+        "curve": "ed25519Extended",
+        "publicKeyType": "ed25519Extended",
         "explorer": {
-            "url": "https://cardanoexplorer.com", 
+            "url": "https://cardanoexplorer.com",
             "txPath": "/tx/",
             "accountPath": "/address/",
             "sampleTx": "b7a6c5cadab0f64bdc89c77ee4a351463aba5c33f2cef6bbd6542a74a90a3af3",
             "sampleAccount": "DdzFFzCqrhstpwKc8WMvPwwBb5oabcTW9zc5ykA37wJR4tYQucvsR9dXb2kEGNXkFJz2PtrpzfRiZkx8R1iNo8NYqdsukVmv7EAybFwC"
         },
         "info": {
-            "url": "https://www.cardano.org", 
-            "client": "https://github.com/input-output-hk/cardano-sl", 
-            "clientPublic": "", 
+            "url": "https://www.cardano.org",
+            "client": "https://github.com/input-output-hk/cardano-sl",
+            "clientPublic": "",
             "clientDocs": "https://cardanodocs.com/introduction/"
         }
     }


### PR DESCRIPTION
Based on #817, part of #816 
1. Developers can focus on c++ implementation, don't have to worry about C interfaces for address / signer.
2. A default `proto` file is also added

How to test: 

1. Add below to `coins.json`
```json
{
        "id": "nervos",
        "name": "Nervos",
        "symbol": "CKB",
        "decimals": 8,
        "blockchain": "Nervos",
        "derivationPath": "m/44'/309'/0'/0/0",
        "curve": "secp256k1",
        "publicKeyType": "secp256k1",
        "explorer": {
            "url": "https://explorer.nervos.org",
            "txPath": "/transaction/",
            "accountPath": "/address/"
        },
        "info": {
            "url": "https://www.nervos.org",
            "client": "https://github.com/nervosnetwork/ckb",
            "clientPublic": "",
            "clientDocs": "https://docs.nervos.org/introduction/welcome.html"
        }
    }
```
2. run `codegen/bin/newcoin nervos`
2. handle `TWCoinTypeNervos` in `Coin.cpp`
3. build and run