### PR TITLE
Update ETC explorer to etcblockexplorer.com.

### DIFF
--- a/coins.json
+++ b/coins.json
@@ -241,9 +241,9 @@
         "curve": "secp256k1",
         "publicKeyType": "secp256k1Extended",
         "explorer": {
-            "url": "https://blockscout.com/etc/mainnet",
+            "url": "https://etcblockexplorer.com",
             "txPath": "/tx/",
-            "accountPath": "/address/"
+            "accountPath": "/addr/"
         },
         "info": {
             "url": "https://ethereumclassic.org",

--- a/tests/EthereumClassic/TWCoinTypeTests.cpp
+++ b/tests/EthereumClassic/TWCoinTypeTests.cpp
@@ -27,8 +27,8 @@ TEST(TWEthereumClassicCoinType, TWCoinType) {
     ASSERT_EQ(0x0, TWCoinTypeP2shPrefix(TWCoinTypeEthereumClassic));
     ASSERT_EQ(0x0, TWCoinTypeStaticPrefix(TWCoinTypeEthereumClassic));
     assertStringsEqual(symbol, "ETC");
-    assertStringsEqual(txUrl, "https://blockscout.com/etc/mainnet/tx/0x66004165d3901819dc22e568931591d2e4287bda54995f4ce2701a12016f5997");
-    assertStringsEqual(accUrl, "https://blockscout.com/etc/mainnet/address/0x9eab4b0fc468a7f5d46228bf5a76cb52370d068d");
+    assertStringsEqual(txUrl, "https://etcblockexplorer.com/tx/0x66004165d3901819dc22e568931591d2e4287bda54995f4ce2701a12016f5997");
+    assertStringsEqual(accUrl, "https://etcblockexplorer.com/addr/0x9eab4b0fc468a7f5d46228bf5a76cb52370d068d");
     assertStringsEqual(id, "classic");
     assertStringsEqual(name, "Ethereum Classic");
 }


### PR DESCRIPTION
## Description

Change ETC explorer to etcblockexplorer.com, as blockscout.com is ceasing support.  Fixes issue #822 .

## Testing instructions

Check explorer URLs from tests/EthereumClassic/TWCoinTypeTests.cpp .

## Types of changes

* Minor

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
