### PR TITLE
Fix zilliqa address data tests unstable

### DIFF
--- a/include/TrustWalletCore/TWString.h
+++ b/include/TrustWalletCore/TWString.h
@@ -22,6 +22,9 @@ typedef const void TWString;
 /// Creates a string from a null-terminated UTF8 byte array. It must be deleted at the end.
 TWString *_Nonnull TWStringCreateWithUTF8Bytes(const char *_Nonnull bytes);
 
+/// Creates a string from a raw byte array and size.
+TWString *_Nonnull TWStringCreateWithRawBytes(const uint8_t *_Nonnull bytes, size_t size);
+
 /// Creates a hexadecimal string from a block of data. It must be deleted at the end.
 TWString *_Nonnull TWStringCreateWithHexData(TWData *_Nonnull data);
 

--- a/src/interface/TWAnyAddress.cpp
+++ b/src/interface/TWAnyAddress.cpp
@@ -153,6 +153,7 @@ TWData* _Nonnull TWAnyAddressData(struct TWAnyAddress* _Nonnull address) {
         if (!Zilliqa::Address::decode(string, addr)) {
             break;
         }
+        // data in Zilliqa is a checksummed string with 0x prefix
         auto str = Zilliqa::checkSum(addr.getKeyHash());
         data = Data(str.begin(), str.end());
         break;

--- a/src/interface/TWString.cpp
+++ b/src/interface/TWString.cpp
@@ -13,6 +13,13 @@ TWString *_Nonnull TWStringCreateWithUTF8Bytes(const char *_Nonnull bytes) {
     return s;
 }
 
+TWString *_Nonnull TWStringCreateWithRawBytes(const uint8_t *_Nonnull bytes, size_t size) {
+    auto s = new std::string(bytes, bytes + size);
+    // append null terminator
+    s->append(size, '\0');
+    return s;
+}
+
 size_t TWStringSize(TWString *_Nonnull string) {
     auto s = reinterpret_cast<const std::string*>(string);
     return s->size();

--- a/tests/interface/TWAnyAddressTests.cpp
+++ b/tests/interface/TWAnyAddressTests.cpp
@@ -88,7 +88,7 @@ TEST(AnyAddress, Data) {
 
         auto expectedKeyHash = "0xF9dad33332CF77E783B3452aE982c85effCa6DDf";
         auto keyHash = WRAPD(TWAnyAddressData(addr.get()));
-        auto checksumed = WRAPS(TWStringCreateWithRawBytes(TWDataBytes(keyHash.get()), strlen(expectedKeyHash)));
+        auto checksumed = WRAPS(TWStringCreateWithRawBytes(TWDataBytes(keyHash.get()), strnlen(expectedKeyHash, 42)));
         assertStringsEqual(checksumed, expectedKeyHash);
     }
     // kusama

--- a/tests/interface/TWAnyAddressTests.cpp
+++ b/tests/interface/TWAnyAddressTests.cpp
@@ -85,9 +85,11 @@ TEST(AnyAddress, Data) {
     {
         auto string = STRING("zil1l8ddxvejeam70qang54wnqkgtmlu5mwlgzy64z");
         auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithString(string.get(), TWCoinTypeZilliqa));
-        auto data = WRAPD(TWAnyAddressData(addr.get()));
-        auto checksumed = WRAPS(TWStringCreateWithUTF8Bytes((const char *)TWDataBytes(data.get())));
-        assertStringsEqual(checksumed, "0xF9dad33332CF77E783B3452aE982c85effCa6DDf");
+
+        auto expectedKeyHash = "0xF9dad33332CF77E783B3452aE982c85effCa6DDf";
+        auto keyHash = WRAPD(TWAnyAddressData(addr.get()));
+        auto checksumed = WRAPS(TWStringCreateWithRawBytes(TWDataBytes(keyHash.get()), strlen(expectedKeyHash)));
+        assertStringsEqual(checksumed, expectedKeyHash);
     }
     // kusama
     {

--- a/tests/interface/TWZilliqaTests.cpp
+++ b/tests/interface/TWZilliqaTests.cpp
@@ -32,11 +32,13 @@ TEST(Zilliqa, Address) {
 
     auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithString(string.get(), TWCoinTypeZilliqa));
     auto desc = WRAPS(TWAnyAddressDescription(address.get()));
+
+    auto expectedKeyHash = "0xDdb41006F7B6FA8e5FBF06A71c01F789FeBC66e8";
     auto keyHash = WRAPD(TWAnyAddressData(address.get()));
-    auto keyHashString = WRAPS(TWStringCreateWithUTF8Bytes((const char *)TWDataBytes(keyHash.get())));
+    auto keyHashString = WRAPS(TWStringCreateWithRawBytes(TWDataBytes(keyHash.get()), strlen(expectedKeyHash)));
 
     assertStringsEqual(desc, "zil1mk6pqphhkmaguhalq6n3cq0h38ltcehg0rfmv6");
-    assertStringsEqual(keyHashString, "0xDdb41006F7B6FA8e5FBF06A71c01F789FeBC66e8");
+    assertStringsEqual(keyHashString, expectedKeyHash);
 }
 
 TEST(Zilliqa, Signing) {

--- a/tests/interface/TWZilliqaTests.cpp
+++ b/tests/interface/TWZilliqaTests.cpp
@@ -35,7 +35,7 @@ TEST(Zilliqa, Address) {
 
     auto expectedKeyHash = "0xDdb41006F7B6FA8e5FBF06A71c01F789FeBC66e8";
     auto keyHash = WRAPD(TWAnyAddressData(address.get()));
-    auto keyHashString = WRAPS(TWStringCreateWithRawBytes(TWDataBytes(keyHash.get()), strlen(expectedKeyHash)));
+    auto keyHashString = WRAPS(TWStringCreateWithRawBytes(TWDataBytes(keyHash.get()), strnlen(expectedKeyHash, 42)));
 
     assertStringsEqual(desc, "zil1mk6pqphhkmaguhalq6n3cq0h38ltcehg0rfmv6");
     assertStringsEqual(keyHashString, expectedKeyHash);


### PR DESCRIPTION
`TWStringCreateWithUTF8Bytes` expects null terminated string, We should call `TWStringCreateWithRawBytes` in tests