### PR TITLE
Fix codegen flag mapping

### DIFF
--- a/codegen/bin/codegen
+++ b/codegen/bin/codegen
@@ -25,10 +25,10 @@ OptionParser.new do |opts|
   opts.banner = 'Usage: codegen [options]'
 
   opts.on('-i', '--input FOLDER', "Input folder with C headers. Default: #{options.input}") do |v|
-    options.swift = v
+    options.input = v
   end
   opts.on('-o', '--output FOLDER', "Output folder. Default: #{options.output}") do |v|
-    options.swift = v
+    options.output = v
   end
   opts.on('-s', '--swift', "Generate Swift code. Default: #{options.swift}") do |v|
     options.swift = v


### PR DESCRIPTION
## Description

`codegen -i <value>` and `codegen -o <value>` flags are incorrectly mapped to `options.swift`

Guess the changes are so trivial they don't require any tests or documentation.

## Testing instructions

Run `./codegen/bin/codegen -i <value>` with a different input directory

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.