### PR TITLE
[harmony] updated data structures and tests for harmony staking support

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/harmony/TestHarmonyStakingDelegateSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/harmony/TestHarmonyStakingDelegateSigner.kt
@@ -16,7 +16,7 @@ class TestHarmonyStakingDelegateSigner {
     val oneAddress = "one1a0x3d6xpmr6f8wsyaxd9v36pytvp48zckswvv9"
     val privateKeyData = ByteString.copyFrom(PrivateKey("4edef2c24995d15b0e25cbd152fb0e2c05d3b79b9c2afd134e6f59f91bf99e48".toHexByteArray()).data())
     val pubKeyData = ByteString.copyFrom("b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611".toHexByteArray())
-    val blsSigData = ByteString.copyFrom("b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611".toHexByteArray())
+    val blsSigData = ByteString.copyFrom("4252b0f1210efb0d5061e8a706a7ea9d62292a7947a975472fb77e1af7278a1c3c2e6eeba73c0581ece398613829940df129f3071c9a24b4b448bb1e880dc5872a58cb07eed94294c4e01a5c864771cafef7b96be541cb3c521a98f01838dd94".toHexByteArray())
 
     init {
         System.loadLibrary("TrustWalletCore")
@@ -62,7 +62,7 @@ class TestHarmonyStakingDelegateSigner {
             minSelfDelegation = ByteString.copyFrom("0xa".toHexByteArray())
             maxTotalDelegation = ByteString.copyFrom("0x0bb8".toHexByteArray())
             addAllSlotPubKeys(listOf(pubKey))
-            slotKeySigs(listOf(blsSig))
+            addAllSlotKeySigs(listOf(blsSig))
             amount = ByteString.copyFrom("0x64".toHexByteArray())
         }
         return createValidator
@@ -86,12 +86,12 @@ class TestHarmonyStakingDelegateSigner {
         }
         val sign = AnySigner.sign(signingInput.build(), HARMONY, SigningOutput.parser())
 
-        val expected = "0xf8ed80f8a494ebcd16e8c1d8f493ba04e99a56474122d81a9c58f83885416c69636585616c69636591616c6963652e6861726d6f6e792e6f6e6583426f6295446f6e2774206d6573732077697468206d65212121ddc988016345785d8a0000c9880c7d713b49da0000c887b1a2bc2ec500000a820bb8f1b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b622476086116402806428a0476e8a0fe478e0d03ff10222d4d590bca8cee3ec51b830f4fc4a8bee5d0e9d28a03b2be18e73b2f99d7e2691485a0e166f28e62815079c126e68f876dc97339f8f"
+        val expected = "0xf9015280f9010894ebcd16e8c1d8f493ba04e99a56474122d81a9c58f83885416c69636585616c69636591616c6963652e6861726d6f6e792e6f6e6583426f6295446f6e2774206d6573732077697468206d65212121ddc988016345785d8a0000c9880c7d713b49da0000c887b1a2bc2ec500000a820bb8f1b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611f862b8604252b0f1210efb0d5061e8a706a7ea9d62292a7947a975472fb77e1af7278a1c3c2e6eeba73c0581ece398613829940df129f3071c9a24b4b448bb1e880dc5872a58cb07eed94294c4e01a5c864771cafef7b96be541cb3c521a98f01838dd946402806428a00d8437f81be3481b01542e9baef0445f3758cf084c5e1fba93d087ccce084cb1a0404c1a42442c2d39f84582353a1c67012451ff83ef6d3622f684041df9bf0072"
 
         assertEquals(Numeric.toHexString(sign.encoded.toByteArray()), expected)
         assertEquals(Numeric.toHexString(sign.v.toByteArray()), "0x28")
-        assertEquals(Numeric.toHexString(sign.r.toByteArray()), "0x476e8a0fe478e0d03ff10222d4d590bca8cee3ec51b830f4fc4a8bee5d0e9d28")
-        assertEquals(Numeric.toHexString(sign.s.toByteArray()), "0x3b2be18e73b2f99d7e2691485a0e166f28e62815079c126e68f876dc97339f8f")
+        assertEquals(Numeric.toHexString(sign.r.toByteArray()), "0x0d8437f81be3481b01542e9baef0445f3758cf084c5e1fba93d087ccce084cb1")
+        assertEquals(Numeric.toHexString(sign.s.toByteArray()), "0x404c1a42442c2d39f84582353a1c67012451ff83ef6d3622f684041df9bf0072")
     }
 
     @Test
@@ -118,7 +118,8 @@ class TestHarmonyStakingDelegateSigner {
             maxTotalDelegation = ByteString.copyFrom("0x0bb8".toHexByteArray())
             slotKeyToRemove = pubKeyData
             slotKeyToAdd = pubKeyData
-            active = true
+            slotKeyToAddSig = blsSigData
+            active = ByteString.copyFrom("0x1".toHexByteArray())
         }
         val staking = Harmony.StakingMessage.newBuilder()
         staking.apply {
@@ -135,12 +136,112 @@ class TestHarmonyStakingDelegateSigner {
         }
 
         val sign = AnySigner.sign(signingInput.build(), HARMONY, SigningOutput.parser())
-        val expected = "0xf9010801f8bf94ebcd16e8c1d8f493ba04e99a56474122d81a9c58f83885416c69636585616c69636591616c6963652e6861726d6f6e792e6f6e6583426f6295446f6e2774206d6573732077697468206d65212121c988016345785d8a00000a820bb8b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b6224760861102806427a05e54b55272f6bf5ffeca10d85976749d6b844cc9f30ba3285b9ab8a82d53e3e3a03ce04d9a9f834e20b22aa918ead346c84a04b1504fe3ff9e38f21c5e5712f013"
+        val expected = "0xf9016c01f9012294ebcd16e8c1d8f493ba04e99a56474122d81a9c58f83885416c69636585616c69636591616c6963652e6861726d6f6e792e6f6e6583426f6295446f6e2774206d6573732077697468206d65212121c988016345785d8a00000a820bb8b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611b8604252b0f1210efb0d5061e8a706a7ea9d62292a7947a975472fb77e1af7278a1c3c2e6eeba73c0581ece398613829940df129f3071c9a24b4b448bb1e880dc5872a58cb07eed94294c4e01a5c864771cafef7b96be541cb3c521a98f01838dd940102806427a089d6f87855619c31e933d5f00638ca58737dfffdfdf8b66a048a2e45f103e05da04aafc5c51a95412760c089371b411a5ab8f235b456291a9754d544b162df4eef"
 
         assertEquals(Numeric.toHexString(sign.encoded.toByteArray()), expected)
         assertEquals(Numeric.toHexString(sign.v.toByteArray()), "0x27")
-        assertEquals(Numeric.toHexString(sign.r.toByteArray()), "0x5e54b55272f6bf5ffeca10d85976749d6b844cc9f30ba3285b9ab8a82d53e3e3")
-        assertEquals(Numeric.toHexString(sign.s.toByteArray()), "0x3ce04d9a9f834e20b22aa918ead346c84a04b1504fe3ff9e38f21c5e5712f013")
+        assertEquals(Numeric.toHexString(sign.r.toByteArray()), "0x89d6f87855619c31e933d5f00638ca58737dfffdfdf8b66a048a2e45f103e05d")
+        assertEquals(Numeric.toHexString(sign.s.toByteArray()), "0x4aafc5c51a95412760c089371b411a5ab8f235b456291a9754d544b162df4eef")
+    }
+
+    @Test
+    fun testHarmonyStakingTransactionEditValidatorSigning2() {
+        val desc = Harmony.Description.newBuilder()
+        desc.apply {
+            name = "Alice"
+            identity = "alice"
+            website = "alice.harmony.one"
+            securityContact = "Bob"
+            details = "Don't mess with me!!!"
+        }
+        val rate = Harmony.Decimal.newBuilder()
+        rate.apply {
+            value = ByteString.copyFrom("0x1".toHexByteArray())
+            precision = ByteString.copyFrom("0x1".toHexByteArray())
+        }
+        val editValidator = Harmony.DirectiveEditValidator.newBuilder()
+        editValidator.apply {
+            validatorAddress = oneAddress
+            description = desc.build()
+            commissionRate = rate.build()
+            minSelfDelegation = ByteString.copyFrom("0xa".toHexByteArray())
+            maxTotalDelegation = ByteString.copyFrom("0x0bb8".toHexByteArray())
+            slotKeyToRemove = pubKeyData
+            slotKeyToAdd = pubKeyData
+            slotKeyToAddSig = blsSigData
+            active = ByteString.copyFrom("0x2".toHexByteArray())
+        }
+        val staking = Harmony.StakingMessage.newBuilder()
+        staking.apply {
+            nonce = ByteString.copyFrom("0x2".toHexByteArray())
+            gasPrice = ByteString.copyFrom("0x0".toHexByteArray())
+            gasLimit = ByteString.copyFrom("0x64".toHexByteArray())
+            editValidatorMessage = editValidator.build()
+        }
+        val signingInput = Harmony.SigningInput.newBuilder()
+        signingInput.apply {
+            privateKey = privateKeyData
+            chainId = ByteString.copyFrom("0x02".toHexByteArray())
+            stakingMessage = staking.build()
+        }
+
+        val sign = AnySigner.sign(signingInput.build(), HARMONY, SigningOutput.parser())
+        val expected = "0xf9016c01f9012294ebcd16e8c1d8f493ba04e99a56474122d81a9c58f83885416c69636585616c69636591616c6963652e6861726d6f6e792e6f6e6583426f6295446f6e2774206d6573732077697468206d65212121c988016345785d8a00000a820bb8b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611b8604252b0f1210efb0d5061e8a706a7ea9d62292a7947a975472fb77e1af7278a1c3c2e6eeba73c0581ece398613829940df129f3071c9a24b4b448bb1e880dc5872a58cb07eed94294c4e01a5c864771cafef7b96be541cb3c521a98f01838dd940202806428a09d1212ab7f54b05a4f89506ea1fe3bebecf5126544bc990b53b27f1fccb69d52a01d13704dce7399f154c2352d61ad1fc208880c267695cb423c57cd52b9821a79"
+
+        assertEquals(Numeric.toHexString(sign.encoded.toByteArray()), expected)
+        assertEquals(Numeric.toHexString(sign.v.toByteArray()), "0x28")
+        assertEquals(Numeric.toHexString(sign.r.toByteArray()), "0x9d1212ab7f54b05a4f89506ea1fe3bebecf5126544bc990b53b27f1fccb69d52")
+        assertEquals(Numeric.toHexString(sign.s.toByteArray()), "0x1d13704dce7399f154c2352d61ad1fc208880c267695cb423c57cd52b9821a79")
+    }
+
+    @Test
+    fun testHarmonyStakingTransactionEditValidatorSigning3() {
+        val desc = Harmony.Description.newBuilder()
+        desc.apply {
+            name = "Alice"
+            identity = "alice"
+            website = "alice.harmony.one"
+            securityContact = "Bob"
+            details = "Don't mess with me!!!"
+        }
+        val rate = Harmony.Decimal.newBuilder()
+        rate.apply {
+            value = ByteString.copyFrom("0x1".toHexByteArray())
+            precision = ByteString.copyFrom("0x1".toHexByteArray())
+        }
+        val editValidator = Harmony.DirectiveEditValidator.newBuilder()
+        editValidator.apply {
+            validatorAddress = oneAddress
+            description = desc.build()
+            commissionRate = rate.build()
+            minSelfDelegation = ByteString.copyFrom("0xa".toHexByteArray())
+            maxTotalDelegation = ByteString.copyFrom("0x0bb8".toHexByteArray())
+            slotKeyToRemove = pubKeyData
+            slotKeyToAdd = pubKeyData
+            slotKeyToAddSig = blsSigData
+            active = ByteString.copyFrom("0x0".toHexByteArray())
+        }
+        val staking = Harmony.StakingMessage.newBuilder()
+        staking.apply {
+            nonce = ByteString.copyFrom("0x2".toHexByteArray())
+            gasPrice = ByteString.copyFrom("0x0".toHexByteArray())
+            gasLimit = ByteString.copyFrom("0x64".toHexByteArray())
+            editValidatorMessage = editValidator.build()
+        }
+        val signingInput = Harmony.SigningInput.newBuilder()
+        signingInput.apply {
+            privateKey = privateKeyData
+            chainId = ByteString.copyFrom("0x02".toHexByteArray())
+            stakingMessage = staking.build()
+        }
+
+        val sign = AnySigner.sign(signingInput.build(), HARMONY, SigningOutput.parser())
+        val expected = "0xf9016c01f9012294ebcd16e8c1d8f493ba04e99a56474122d81a9c58f83885416c69636585616c69636591616c6963652e6861726d6f6e792e6f6e6583426f6295446f6e2774206d6573732077697468206d65212121c988016345785d8a00000a820bb8b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611b8604252b0f1210efb0d5061e8a706a7ea9d62292a7947a975472fb77e1af7278a1c3c2e6eeba73c0581ece398613829940df129f3071c9a24b4b448bb1e880dc5872a58cb07eed94294c4e01a5c864771cafef7b96be541cb3c521a98f01838dd948002806427a02f160fbf125b614764f9d45dc20acc63da41b02f380e20135e72bc7e74ab3205a011a1d8824a871361e2817145e87148b072c378c38d037df482214a3e4e3f2205"
+
+        assertEquals(Numeric.toHexString(sign.encoded.toByteArray()), expected)
+        assertEquals(Numeric.toHexString(sign.v.toByteArray()), "0x27")
+        assertEquals(Numeric.toHexString(sign.r.toByteArray()), "0x2f160fbf125b614764f9d45dc20acc63da41b02f380e20135e72bc7e74ab3205")
+        assertEquals(Numeric.toHexString(sign.s.toByteArray()), "0x11a1d8824a871361e2817145e87148b072c378c38d037df482214a3e4e3f2205")
     }
 
     @Test

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/harmony/TestHarmonyStakingDelegateSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/harmony/TestHarmonyStakingDelegateSigner.kt
@@ -16,6 +16,7 @@ class TestHarmonyStakingDelegateSigner {
     val oneAddress = "one1a0x3d6xpmr6f8wsyaxd9v36pytvp48zckswvv9"
     val privateKeyData = ByteString.copyFrom(PrivateKey("4edef2c24995d15b0e25cbd152fb0e2c05d3b79b9c2afd134e6f59f91bf99e48".toHexByteArray()).data())
     val pubKeyData = ByteString.copyFrom("b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611".toHexByteArray())
+    val blsSigData = ByteString.copyFrom("b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611".toHexByteArray())
 
     init {
         System.loadLibrary("TrustWalletCore")
@@ -52,6 +53,7 @@ class TestHarmonyStakingDelegateSigner {
             maxChangeRate = mcr.build()
         }
         val pubKey = pubKeyData
+        val blsSig = blsSigData
         val createValidator = Harmony.DirectiveCreateValidator.newBuilder()
         createValidator.apply {
             validatorAddress = oneAddress
@@ -60,6 +62,7 @@ class TestHarmonyStakingDelegateSigner {
             minSelfDelegation = ByteString.copyFrom("0xa".toHexByteArray())
             maxTotalDelegation = ByteString.copyFrom("0x0bb8".toHexByteArray())
             addAllSlotPubKeys(listOf(pubKey))
+            slotKeySigs(listOf(blsSig))
             amount = ByteString.copyFrom("0x64".toHexByteArray())
         }
         return createValidator
@@ -115,6 +118,7 @@ class TestHarmonyStakingDelegateSigner {
             maxTotalDelegation = ByteString.copyFrom("0x0bb8".toHexByteArray())
             slotKeyToRemove = pubKeyData
             slotKeyToAdd = pubKeyData
+            active = true
         }
         val staking = Harmony.StakingMessage.newBuilder()
         staking.apply {

--- a/src/Harmony/Signer.cpp
+++ b/src/Harmony/Signer.cpp
@@ -8,6 +8,7 @@
 #include "../Ethereum/RLP.h"
 #include "../HexCoding.h"
 
+
 using namespace TW;
 using namespace TW::Harmony;
 
@@ -215,9 +216,14 @@ Proto::SigningOutput Signer::signEditValidator(const Proto::SigningInput &input)
         /* SlotKeyToRemove */
         Data(input.staking_message().edit_validator_message().slot_key_to_remove().begin(),
              input.staking_message().edit_validator_message().slot_key_to_remove().end()),
-        /* SlotKeyToRemove */
+        /* SlotKeyToAdd */
         Data(input.staking_message().edit_validator_message().slot_key_to_add().begin(),
-             input.staking_message().edit_validator_message().slot_key_to_add().end()));
+             input.staking_message().edit_validator_message().slot_key_to_add().end()),
+        /* SlotKeyToAddSig */
+        Data(input.staking_message().edit_validator_message().slot_key_to_add_sig().begin(),
+             input.staking_message().edit_validator_message().slot_key_to_add_sig().end()),
+        /* Active */
+        load(input.staking_message().edit_validator_message().active()));
 
     auto stakingTx = Staking<EditValidator>(
         DirectiveEditValidator, editValidator, load(input.staking_message().nonce()),

--- a/src/Harmony/Staking.h
+++ b/src/Harmony/Staking.h
@@ -106,18 +106,20 @@ class CreateValidator {
     uint256_t maxTotalDelegation;
     uint256_t amount;
     vector<vector<uint8_t>> slotPubKeys;
+    vector<vector<uint8_t>> slotKeySigs;
 
     CreateValidator(Address validatorAddress, Description description,
                     CommissionRate commissionRates, uint256_t minSelfDelegation,
                     uint256_t maxTotalDelegation, vector<vector<uint8_t>> slotPubKeys,
-                    uint256_t amount)
+                    vector<vector<uint8_t>> slotKeySigs,uint256_t amount)
         : validatorAddress(move(validatorAddress))
         , description(move(description))
         , commissionRates(move(commissionRates))
         , minSelfDelegation(move(minSelfDelegation))
         , maxTotalDelegation(move(maxTotalDelegation))
         , amount(move(amount))
-        , slotPubKeys(move(slotPubKeys)) {}
+        , slotPubKeys(move(slotPubKeys))
+        , slotKeySigs(move(slotKeySigs)) {}
 };
 
 class EditValidator {
@@ -129,17 +131,22 @@ class EditValidator {
     uint256_t maxTotalDelegation;
     vector<uint8_t> slotKeyToRemove;
     vector<uint8_t> slotKeyToAdd;
+    vector<uint8_t> slotKeyToAddSig;
+    bool            active;
 
     EditValidator(Address validatorAddress, Description description, Decimal *commissionRate,
                   uint256_t minSelfDelegation, uint256_t maxTotalDelegation,
-                  vector<uint8_t> slotKeyToRemove, vector<uint8_t> slotKeyToAdd)
+                  vector<uint8_t> slotKeyToRemove, vector<uint8_t> slotKeyToAdd,
+                  vector<uint8_t> slotKeyToAddSig, active)
         : validatorAddress(move(validatorAddress))
         , description(move(description))
         , commissionRate(move(commissionRate))
         , minSelfDelegation(move(minSelfDelegation))
         , maxTotalDelegation(move(maxTotalDelegation))
         , slotKeyToRemove(move(slotKeyToRemove))
-        , slotKeyToAdd(move(slotKeyToAdd)) {}
+        , slotKeyToAdd(move(slotKeyToAdd))
+        , slotKeyToAddSig(move(slotKeyToAddSig))
+        , active(active){}
 };
 
 class Delegate {

--- a/src/Harmony/Staking.h
+++ b/src/Harmony/Staking.h
@@ -132,12 +132,12 @@ class EditValidator {
     vector<uint8_t> slotKeyToRemove;
     vector<uint8_t> slotKeyToAdd;
     vector<uint8_t> slotKeyToAddSig;
-    bool            active;
+    uint256_t        active;
 
     EditValidator(Address validatorAddress, Description description, Decimal *commissionRate,
                   uint256_t minSelfDelegation, uint256_t maxTotalDelegation,
                   vector<uint8_t> slotKeyToRemove, vector<uint8_t> slotKeyToAdd,
-                  vector<uint8_t> slotKeyToAddSig, active)
+                  vector<uint8_t> slotKeyToAddSig, uint256_t  active)
         : validatorAddress(move(validatorAddress))
         , description(move(description))
         , commissionRate(move(commissionRate))
@@ -146,7 +146,7 @@ class EditValidator {
         , slotKeyToRemove(move(slotKeyToRemove))
         , slotKeyToAdd(move(slotKeyToAdd))
         , slotKeyToAddSig(move(slotKeyToAddSig))
-        , active(active){}
+        , active(move(active)){}
 };
 
 class Delegate {

--- a/src/proto/Harmony.proto
+++ b/src/proto/Harmony.proto
@@ -99,7 +99,8 @@ message DirectiveCreateValidator {
     bytes min_self_delegation = 4;
     bytes max_total_delegation = 5;
     repeated bytes slot_pub_keys = 6;
-    bytes amount = 7;
+    repeated bytes slot_key_sigs = 7;
+    bytes amount = 8;
 }
 
 message DirectiveEditValidator {
@@ -110,6 +111,8 @@ message DirectiveEditValidator {
     bytes max_total_delegation = 5;
     bytes slot_key_to_remove = 6;
     bytes slot_key_to_add = 7;
+    bytes slot_key_to_add_sig = 8;
+    bytes active = 9;
 }
 
 message DirectiveDelegate {

--- a/swift/Tests/Blockchains/HarmonyTests.swift
+++ b/swift/Tests/Blockchains/HarmonyTests.swift
@@ -38,6 +38,7 @@ class HarmonyTests: XCTestCase {
     let oneAddress = "one1a0x3d6xpmr6f8wsyaxd9v36pytvp48zckswvv9"
     let privateKeyData = Data(hexString: "4edef2c24995d15b0e25cbd152fb0e2c05d3b79b9c2afd134e6f59f91bf99e48")!
     let pubKeyData = Data(hexString: "b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611")!
+    let blsSigData = Data(hexString: "b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611")!
 
     func testStakingCreateValidator() {
         let description = HarmonyDescription.with {
@@ -65,6 +66,7 @@ class HarmonyTests: XCTestCase {
             $0.maxChangeRate = maxChangeRate
         }
         let pubKey = pubKeyData
+        let blsSig = blsSigData
         let createValidator = HarmonyDirectiveCreateValidator.with {
             $0.validatorAddress = oneAddress
             $0.description_p = description
@@ -72,6 +74,7 @@ class HarmonyTests: XCTestCase {
             $0.minSelfDelegation = Data(hexString: "0xa")!
             $0.maxTotalDelegation = Data(hexString: "0x0bb8")!
             $0.slotPubKeys = [pubKey]
+            $0.slotKeySigs = [blsSig]
             $0.amount = Data(hexString: "0x64")!
         }
         let staking = HarmonyStakingMessage.with {
@@ -120,6 +123,8 @@ class HarmonyTests: XCTestCase {
             $0.maxTotalDelegation = Data(hexString: "0x0bb8")!
             $0.slotKeyToRemove = pubKeyData
             $0.slotKeyToAdd = pubKeyData
+            $0.slotKeyToAddSig = blsSigData
+            $0.active = true
         }
         let staking = HarmonyStakingMessage.with {
             $0.editValidatorMessage = editValidator

--- a/swift/Tests/Blockchains/HarmonyTests.swift
+++ b/swift/Tests/Blockchains/HarmonyTests.swift
@@ -38,7 +38,7 @@ class HarmonyTests: XCTestCase {
     let oneAddress = "one1a0x3d6xpmr6f8wsyaxd9v36pytvp48zckswvv9"
     let privateKeyData = Data(hexString: "4edef2c24995d15b0e25cbd152fb0e2c05d3b79b9c2afd134e6f59f91bf99e48")!
     let pubKeyData = Data(hexString: "b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611")!
-    let blsSigData = Data(hexString: "b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611")!
+    let blsSigData = Data(hexString: "4252b0f1210efb0d5061e8a706a7ea9d62292a7947a975472fb77e1af7278a1c3c2e6eeba73c0581ece398613829940df129f3071c9a24b4b448bb1e880dc5872a58cb07eed94294c4e01a5c864771cafef7b96be541cb3c521a98f01838dd94")!
 
     func testStakingCreateValidator() {
         let description = HarmonyDescription.with {
@@ -80,7 +80,7 @@ class HarmonyTests: XCTestCase {
         let staking = HarmonyStakingMessage.with {
             $0.createValidatorMessage = createValidator
             $0.nonce = Data(hexString: "0x2")!
-            $0.gasPrice = Data(hexString: "0x")!
+            $0.gasPrice = Data(hexString: "0x0")!
             $0.gasLimit = Data(hexString: "0x64")!
         }
         let input = HarmonySigningInput.with {
@@ -90,17 +90,12 @@ class HarmonyTests: XCTestCase {
         }
         let output: HarmonySigningOutput = AnySigner.sign(input: input, coin: .harmony)
 
-        let expected = "f8ed80f8a494ebcd16e8c1d8f493ba04e99a56474122d81a9c58f83885416c69636585616c69636591616c6963"
-            + "652e6861726d6f6e792e6f6e6583426f6295446f6e2774206d6573732077697468206d65212121ddc988016345"
-            + "785d8a0000c9880c7d713b49da0000c887b1a2bc2ec500000a820bb8f1b0b9486167ab9087ab818dc4ce026edb"
-            + "5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b622476086116402806428a0476e8a0fe478"
-            + "e0d03ff10222d4d590bca8cee3ec51b830f4fc4a8bee5d0e9d28a03b2be18e73b2f99d7e2691485a0e166f28e6"
-            + "2815079c126e68f876dc97339f8f"
+        let expected = "f9015280f9010894ebcd16e8c1d8f493ba04e99a56474122d81a9c58f83885416c69636585616c69636591616c6963652e6861726d6f6e792e6f6e6583426f6295446f6e2774206d6573732077697468206d65212121ddc988016345785d8a0000c9880c7d713b49da0000c887b1a2bc2ec500000a820bb8f1b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611f862b8604252b0f1210efb0d5061e8a706a7ea9d62292a7947a975472fb77e1af7278a1c3c2e6eeba73c0581ece398613829940df129f3071c9a24b4b448bb1e880dc5872a58cb07eed94294c4e01a5c864771cafef7b96be541cb3c521a98f01838dd946402806428a00d8437f81be3481b01542e9baef0445f3758cf084c5e1fba93d087ccce084cb1a0404c1a42442c2d39f84582353a1c67012451ff83ef6d3622f684041df9bf0072"
 
         XCTAssertEqual(output.encoded.hexString, expected)
         XCTAssertEqual(output.v.hexString, "28")
-        XCTAssertEqual(output.r.hexString, "476e8a0fe478e0d03ff10222d4d590bca8cee3ec51b830f4fc4a8bee5d0e9d28")
-        XCTAssertEqual(output.s.hexString, "3b2be18e73b2f99d7e2691485a0e166f28e62815079c126e68f876dc97339f8f")
+        XCTAssertEqual(output.r.hexString, "0d8437f81be3481b01542e9baef0445f3758cf084c5e1fba93d087ccce084cb1")
+        XCTAssertEqual(output.s.hexString, "404c1a42442c2d39f84582353a1c67012451ff83ef6d3622f684041df9bf0072")
     }
 
     func testStakingEditValidator() {
@@ -124,7 +119,7 @@ class HarmonyTests: XCTestCase {
             $0.slotKeyToRemove = pubKeyData
             $0.slotKeyToAdd = pubKeyData
             $0.slotKeyToAddSig = blsSigData
-            $0.active = true
+            $0.active = Data(hexString: "0x1")!
         }
         let staking = HarmonyStakingMessage.with {
             $0.editValidatorMessage = editValidator
@@ -139,18 +134,100 @@ class HarmonyTests: XCTestCase {
         }
         let output: HarmonySigningOutput = AnySigner.sign(input: input, coin: .harmony)
 
-        let expected = "f9010801f8bf94ebcd16e8c1d8f493ba04e99a56474122d81a9c58f83885416c69636585616c69636591616c"
-            + "6963652e6861726d6f6e792e6f6e6583426f6295446f6e2774206d6573732077697468206d65212121c9880163"
-            + "45785d8a00000a820bb8b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7"
-            + "d12f0e6dd5307a73b62247608611b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced"
-            + "1ad181e7d12f0e6dd5307a73b6224760861102806427a05e54b55272f6bf5ffeca10d85976749d6b844cc9f30b"
-            + "a3285b9ab8a82d53e3e3a03ce04d9a9f834e20b22aa918ead346c84a04b1504fe3ff9e38f21c5e5712f013"
+        let expected = "f9016c01f9012294ebcd16e8c1d8f493ba04e99a56474122d81a9c58f83885416c69636585616c69636591616c6963652e6861726d6f6e792e6f6e6583426f6295446f6e2774206d6573732077697468206d65212121c988016345785d8a00000a820bb8b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611b8604252b0f1210efb0d5061e8a706a7ea9d62292a7947a975472fb77e1af7278a1c3c2e6eeba73c0581ece398613829940df129f3071c9a24b4b448bb1e880dc5872a58cb07eed94294c4e01a5c864771cafef7b96be541cb3c521a98f01838dd940102806427a089d6f87855619c31e933d5f00638ca58737dfffdfdf8b66a048a2e45f103e05da04aafc5c51a95412760c089371b411a5ab8f235b456291a9754d544b162df4eef"
 
         XCTAssertEqual(output.encoded.hexString, expected)
         XCTAssertEqual(output.v.hexString, "27")
-        XCTAssertEqual(output.r.hexString, "5e54b55272f6bf5ffeca10d85976749d6b844cc9f30ba3285b9ab8a82d53e3e3")
-        XCTAssertEqual(output.s.hexString, "3ce04d9a9f834e20b22aa918ead346c84a04b1504fe3ff9e38f21c5e5712f013")
+        XCTAssertEqual(output.r.hexString, "89d6f87855619c31e933d5f00638ca58737dfffdfdf8b66a048a2e45f103e05d")
+        XCTAssertEqual(output.s.hexString, "4aafc5c51a95412760c089371b411a5ab8f235b456291a9754d544b162df4eef")
     }
+
+    func testStakingEditValidator2() {
+        let desc = HarmonyDescription.with {
+            $0.name = "Alice"
+            $0.identity = "alice"
+            $0.website = "alice.harmony.one"
+            $0.securityContact = "Bob"
+            $0.details = "Don't mess with me!!!"
+        }
+        let commissionRate = HarmonyDecimal.with {
+            $0.value = Data(hexString: "0x1")!
+            $0.precision = Data(hexString: "0x1")!
+        }
+        let editValidator = HarmonyDirectiveEditValidator.with {
+            $0.validatorAddress = oneAddress
+            $0.description_p = desc
+            $0.commissionRate = commissionRate
+            $0.minSelfDelegation = Data(hexString: "0xa")!
+            $0.maxTotalDelegation = Data(hexString: "0x0bb8")!
+            $0.slotKeyToRemove = pubKeyData
+            $0.slotKeyToAdd = pubKeyData
+            $0.slotKeyToAddSig = blsSigData
+            $0.active = Data(hexString: "0x2")!
+        }
+        let staking = HarmonyStakingMessage.with {
+            $0.editValidatorMessage = editValidator
+            $0.nonce = Data(hexString: "0x2")!
+            $0.gasPrice = Data(hexString: "0x")!
+            $0.gasLimit = Data(hexString: "0x64")!
+        }
+        let input = HarmonySigningInput.with {
+            $0.chainID = Data(hexString: localNet)!
+            $0.privateKey = privateKeyData
+            $0.stakingMessage = staking
+        }
+        let output: HarmonySigningOutput = AnySigner.sign(input: input, coin: .harmony)
+
+        let expected = "f9016c01f9012294ebcd16e8c1d8f493ba04e99a56474122d81a9c58f83885416c69636585616c69636591616c6963652e6861726d6f6e792e6f6e6583426f6295446f6e2774206d6573732077697468206d65212121c988016345785d8a00000a820bb8b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611b8604252b0f1210efb0d5061e8a706a7ea9d62292a7947a975472fb77e1af7278a1c3c2e6eeba73c0581ece398613829940df129f3071c9a24b4b448bb1e880dc5872a58cb07eed94294c4e01a5c864771cafef7b96be541cb3c521a98f01838dd940202806428a09d1212ab7f54b05a4f89506ea1fe3bebecf5126544bc990b53b27f1fccb69d52a01d13704dce7399f154c2352d61ad1fc208880c267695cb423c57cd52b9821a79"
+        XCTAssertEqual(output.encoded.hexString, expected)
+        XCTAssertEqual(output.v.hexString, "28")
+        XCTAssertEqual(output.r.hexString, "9d1212ab7f54b05a4f89506ea1fe3bebecf5126544bc990b53b27f1fccb69d52")
+        XCTAssertEqual(output.s.hexString, "1d13704dce7399f154c2352d61ad1fc208880c267695cb423c57cd52b9821a79")
+    }
+
+    func testStakingEditValidator3() {
+        let desc = HarmonyDescription.with {
+            $0.name = "Alice"
+            $0.identity = "alice"
+            $0.website = "alice.harmony.one"
+            $0.securityContact = "Bob"
+            $0.details = "Don't mess with me!!!"
+        }
+        let commissionRate = HarmonyDecimal.with {
+            $0.value = Data(hexString: "0x1")!
+            $0.precision = Data(hexString: "0x1")!
+        }
+        let editValidator = HarmonyDirectiveEditValidator.with {
+            $0.validatorAddress = oneAddress
+            $0.description_p = desc
+            $0.commissionRate = commissionRate
+            $0.minSelfDelegation = Data(hexString: "0xa")!
+            $0.maxTotalDelegation = Data(hexString: "0x0bb8")!
+            $0.slotKeyToRemove = pubKeyData
+            $0.slotKeyToAdd = pubKeyData
+            $0.slotKeyToAddSig = blsSigData
+            $0.active = Data(hexString: "0x0")!
+        }
+        let staking = HarmonyStakingMessage.with {
+            $0.editValidatorMessage = editValidator
+            $0.nonce = Data(hexString: "0x2")!
+            $0.gasPrice = Data(hexString: "0x")!
+            $0.gasLimit = Data(hexString: "0x64")!
+        }
+        let input = HarmonySigningInput.with {
+            $0.chainID = Data(hexString: localNet)!
+            $0.privateKey = privateKeyData
+            $0.stakingMessage = staking
+        }
+        let output: HarmonySigningOutput = AnySigner.sign(input: input, coin: .harmony)
+
+        let expected = "f9016c01f9012294ebcd16e8c1d8f493ba04e99a56474122d81a9c58f83885416c69636585616c69636591616c6963652e6861726d6f6e792e6f6e6583426f6295446f6e2774206d6573732077697468206d65212121c988016345785d8a00000a820bb8b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611b8604252b0f1210efb0d5061e8a706a7ea9d62292a7947a975472fb77e1af7278a1c3c2e6eeba73c0581ece398613829940df129f3071c9a24b4b448bb1e880dc5872a58cb07eed94294c4e01a5c864771cafef7b96be541cb3c521a98f01838dd948002806427a02f160fbf125b614764f9d45dc20acc63da41b02f380e20135e72bc7e74ab3205a011a1d8824a871361e2817145e87148b072c378c38d037df482214a3e4e3f2205"
+        XCTAssertEqual(output.encoded.hexString, expected)
+        XCTAssertEqual(output.v.hexString, "27")
+        XCTAssertEqual(output.r.hexString, "2f160fbf125b614764f9d45dc20acc63da41b02f380e20135e72bc7e74ab3205")
+        XCTAssertEqual(output.s.hexString, "11a1d8824a871361e2817145e87148b072c378c38d037df482214a3e4e3f2205")
+    }
+
 
     func testStakingDelegate() {
         let delegate = HarmonyDirectiveDelegate.with {

--- a/tests/Harmony/StakingTests.cpp
+++ b/tests/Harmony/StakingTests.cpp
@@ -72,6 +72,12 @@ TEST(HarmonyStaking, SignCreateValidator) {
                       "2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611");
     createValidatorMsg->add_slot_pub_keys(value.data(), value.size());
 
+    value = parse_hex("4252b0f1210efb0d5061e8a706a7ea9d62292a7947a975472f"
+                      "b77e1af7278a1c3c2e6eeba73c0581ece398613829940df129"
+                      "f3071c9a24b4b448bb1e880dc5872a58cb07eed94294c4e01a"
+                      "5c864771cafef7b96be541cb3c521a98f01838dd94");
+    createValidatorMsg->add_slot_key_sigs(value.data(), value.size());
+
     value = store(uint256_t("100"));
     createValidatorMsg->set_amount(value.data(), value.size());
 
@@ -87,16 +93,18 @@ TEST(HarmonyStaking, SignCreateValidator) {
     auto proto_output = Signer::sign(input);
 
     auto expectEncoded =
-        "f8ed80f8a494ebcd16e8c1d8f493ba04e99a56474122d81a9c58f83885416c69636585616c69636591616c6963"
-        "652e6861726d6f6e792e6f6e6583426f6295446f6e2774206d6573732077697468206d65212121ddc988016345"
-        "785d8a0000c9880c7d713b49da0000c887b1a2bc2ec500000a820bb8f1b0b9486167ab9087ab818dc4ce026edb"
-        "5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b622476086116402806428a0476e8a0fe478"
-        "e0d03ff10222d4d590bca8cee3ec51b830f4fc4a8bee5d0e9d28a03b2be18e73b2f99d7e2691485a0e166f28e6"
-        "2815079c126e68f876dc97339f8f";
+            "f9015280f9010894ebcd16e8c1d8f493ba04e99a56474122d81a9c58f83885416c69636585616c696365916"
+            "16c6963652e6861726d6f6e792e6f6e6583426f6295446f6e2774206d6573732077697468206d65212121dd"
+            "c988016345785d8a0000c9880c7d713b49da0000c887b1a2bc2ec500000a820bb8f1b0b9486167ab9087ab8"
+            "18dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611f862b860"
+            "4252b0f1210efb0d5061e8a706a7ea9d62292a7947a975472fb77e1af7278a1c3c2e6eeba73c0581ece3986"
+            "13829940df129f3071c9a24b4b448bb1e880dc5872a58cb07eed94294c4e01a5c864771cafef7b96be541cb"
+            "3c521a98f01838dd946402806428a00d8437f81be3481b01542e9baef0445f3758cf084c5e1fba93d087ccc"
+            "e084cb1a0404c1a42442c2d39f84582353a1c67012451ff83ef6d3622f684041df9bf0072";
 
     auto v = "28";
-    auto r = "476e8a0fe478e0d03ff10222d4d590bca8cee3ec51b830f4fc4a8bee5d0e9d28";
-    auto s = "3b2be18e73b2f99d7e2691485a0e166f28e62815079c126e68f876dc97339f8f";
+    auto r = "0d8437f81be3481b01542e9baef0445f3758cf084c5e1fba93d087ccce084cb1";
+    auto s = "404c1a42442c2d39f84582353a1c67012451ff83ef6d3622f684041df9bf0072";
 
     ASSERT_EQ(hex(proto_output.encoded()), expectEncoded);
     ASSERT_EQ(hex(proto_output.v()), v);
@@ -142,6 +150,15 @@ TEST(HarmonyStaking, SignEditValidator) {
     editValidatorMsg->set_slot_key_to_remove(value.data(), value.size());
     editValidatorMsg->set_slot_key_to_add(value.data(), value.size());
 
+    value = parse_hex("4252b0f1210efb0d5061e8a706a7ea9d62292a7947a975472f"
+                      "b77e1af7278a1c3c2e6eeba73c0581ece398613829940df129"
+                      "f3071c9a24b4b448bb1e880dc5872a58cb07eed94294c4e01a"
+                      "5c864771cafef7b96be541cb3c521a98f01838dd94");
+    editValidatorMsg->set_slot_key_to_add_sig(value.data(), value.size());
+
+    value = store(uint256_t("1"));
+    editValidatorMsg->set_active(value.data(), value.size());
+
     value = store(uint256_t("0x02"));
     stakingMessage->set_nonce(value.data(), value.size());
 
@@ -154,16 +171,11 @@ TEST(HarmonyStaking, SignEditValidator) {
     auto proto_output = Signer::sign(input);
 
     auto expectEncoded =
-        "f9010801f8bf94ebcd16e8c1d8f493ba04e99a56474122d81a9c58f83885416c69636585616c69636591616c"
-        "6963652e6861726d6f6e792e6f6e6583426f6295446f6e2774206d6573732077697468206d65212121c9880163"
-        "45785d8a00000a820bb8b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7"
-        "d12f0e6dd5307a73b62247608611b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced"
-        "1ad181e7d12f0e6dd5307a73b6224760861102806427a05e54b55272f6bf5ffeca10d85976749d6b844cc9f30b"
-        "a3285b9ab8a82d53e3e3a03ce04d9a9f834e20b22aa918ead346c84a04b1504fe3ff9e38f21c5e5712f013";
+        "f9016c01f9012294ebcd16e8c1d8f493ba04e99a56474122d81a9c58f83885416c69636585616c69636591616c6963652e6861726d6f6e792e6f6e6583426f6295446f6e2774206d6573732077697468206d65212121c988016345785d8a00000a820bb8b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611b0b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611b8604252b0f1210efb0d5061e8a706a7ea9d62292a7947a975472fb77e1af7278a1c3c2e6eeba73c0581ece398613829940df129f3071c9a24b4b448bb1e880dc5872a58cb07eed94294c4e01a5c864771cafef7b96be541cb3c521a98f01838dd940102806427a089d6f87855619c31e933d5f00638ca58737dfffdfdf8b66a048a2e45f103e05da04aafc5c51a95412760c089371b411a5ab8f235b456291a9754d544b162df4eef";
 
     auto v = "27";
-    auto r = "5e54b55272f6bf5ffeca10d85976749d6b844cc9f30ba3285b9ab8a82d53e3e3";
-    auto s = "3ce04d9a9f834e20b22aa918ead346c84a04b1504fe3ff9e38f21c5e5712f013";
+    auto r = "89d6f87855619c31e933d5f00638ca58737dfffdfdf8b66a048a2e45f103e05d";
+    auto s = "4aafc5c51a95412760c089371b411a5ab8f235b456291a9754d544b162df4eef";
 
     ASSERT_EQ(hex(proto_output.encoded()), expectEncoded);
     ASSERT_EQ(hex(proto_output.v()), v);

--- a/tests/Harmony/TWHarmonyStakingTests.cpp
+++ b/tests/Harmony/TWHarmonyStakingTests.cpp
@@ -73,6 +73,12 @@ TEST(TWHarmonyStakingSigner, CreateValidator) {
                       "2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611");
     createValidatorMsg->add_slot_pub_keys(value.data(), value.size());
 
+    value = parse_hex("4252b0f1210efb0d5061e8a706a7ea9d62292a7947a975472f"
+                      "b77e1af7278a1c3c2e6eeba73c0581ece398613829940df129"
+                      "f3071c9a24b4b448bb1e880dc5872a58cb07eed94294c4e01a"
+                      "5c864771cafef7b96be541cb3c521a98f01838dd94");
+    createValidatorMsg->add_slot_key_sigs(value.data(), value.size());
+
     value = store(uint256_t("100"));
     createValidatorMsg->set_amount(value.data(), value.size());
 
@@ -90,13 +96,14 @@ TEST(TWHarmonyStakingSigner, CreateValidator) {
     ANY_SIGN(input, TWCoinTypeHarmony);
 
     auto shouldBeV = "28";
-    auto shouldBeR = "476e8a0fe478e0d03ff10222d4d590bca8cee3ec51b830f4fc4a8bee5d0e9d28";
-    auto shouldBeS = "3b2be18e73b2f99d7e2691485a0e166f28e62815079c126e68f876dc97339f8f";
+    auto shouldBeR = "0d8437f81be3481b01542e9baef0445f3758cf084c5e1fba93d087ccce084cb1";
+    auto shouldBeS = "404c1a42442c2d39f84582353a1c67012451ff83ef6d3622f684041df9bf0072";
 
     ASSERT_EQ(hex(output.v()), shouldBeV);
     ASSERT_EQ(hex(output.r()), shouldBeR);
     ASSERT_EQ(hex(output.s()), shouldBeS);
 }
+
 
 TEST(TWHarmonyStakingSigner, EditValidator) {
     auto input = Proto::SigningInput();
@@ -136,6 +143,16 @@ TEST(TWHarmonyStakingSigner, EditValidator) {
     editValidatorMsg->set_slot_key_to_remove(value.data(), value.size());
     editValidatorMsg->set_slot_key_to_add(value.data(), value.size());
 
+    value = parse_hex("4252b0f1210efb0d5061e8a706a7ea9d62292a7947a975472f"
+                      "b77e1af7278a1c3c2e6eeba73c0581ece398613829940df129"
+                      "f3071c9a24b4b448bb1e880dc5872a58cb07eed94294c4e01a"
+                      "5c864771cafef7b96be541cb3c521a98f01838dd94");
+    editValidatorMsg->set_slot_key_to_add_sig(value.data(), value.size());
+
+    //test active
+    value = store(uint256_t("1"));
+    editValidatorMsg->set_active(value.data(), value.size());
+
     value = store(uint256_t("0x02"));
     stakingMessage->set_nonce(value.data(), value.size());
 
@@ -149,13 +166,154 @@ TEST(TWHarmonyStakingSigner, EditValidator) {
     ANY_SIGN(input, TWCoinTypeHarmony);
 
     auto shouldBeV = "27";
-    auto shouldBeR = "5e54b55272f6bf5ffeca10d85976749d6b844cc9f30ba3285b9ab8a82d53e3e3";
-    auto shouldBeS = "3ce04d9a9f834e20b22aa918ead346c84a04b1504fe3ff9e38f21c5e5712f013";
+    auto shouldBeR = "89d6f87855619c31e933d5f00638ca58737dfffdfdf8b66a048a2e45f103e05d";
+    auto shouldBeS = "4aafc5c51a95412760c089371b411a5ab8f235b456291a9754d544b162df4eef";
 
     ASSERT_EQ(hex(output.v()), shouldBeV);
     ASSERT_EQ(hex(output.r()), shouldBeR);
     ASSERT_EQ(hex(output.s()), shouldBeS);
 }
+
+TEST(TWHarmonyStakingSigner, EditValidator2) {
+
+    auto input = Proto::SigningInput();
+    input.set_private_key(PRIVATE_KEY.bytes.data(), PRIVATE_KEY.bytes.size());
+
+    auto value = store(uint256_t("0x2"));
+    input.set_chain_id(value.data(), value.size());
+
+    auto stakingMessage = input.mutable_staking_message();
+    auto editValidatorMsg = stakingMessage->mutable_edit_validator_message();
+
+    editValidatorMsg->set_validator_address(TEST_ACCOUNT);
+
+    auto description = editValidatorMsg->mutable_description();
+    description->set_name("Alice");
+    description->set_identity("alice");
+    description->set_website("alice.harmony.one");
+    description->set_security_contact("Bob");
+    description->set_details("Don't mess with me!!!");
+
+    auto commissionRate = editValidatorMsg->mutable_commission_rate();
+
+    // (value, precision): (1, 1) represents 0.1
+    value = store(uint256_t("1"));
+    commissionRate->set_value(value.data(), value.size());
+    value = store(uint256_t("1"));
+    commissionRate->set_precision(value.data(), value.size());
+
+    value = store(uint256_t("10"));
+    editValidatorMsg->set_min_self_delegation(value.data(), value.size());
+
+    value = store(uint256_t("3000"));
+    editValidatorMsg->set_max_total_delegation(value.data(), value.size());
+
+    value = parse_hex("b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df"
+                      "2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611");
+    editValidatorMsg->set_slot_key_to_remove(value.data(), value.size());
+    editValidatorMsg->set_slot_key_to_add(value.data(), value.size());
+
+    value = parse_hex("4252b0f1210efb0d5061e8a706a7ea9d62292a7947a975472f"
+                      "b77e1af7278a1c3c2e6eeba73c0581ece398613829940df129"
+                      "f3071c9a24b4b448bb1e880dc5872a58cb07eed94294c4e01a"
+                      "5c864771cafef7b96be541cb3c521a98f01838dd94");
+    editValidatorMsg->set_slot_key_to_add_sig(value.data(), value.size());
+
+    //test null
+    value = store(uint256_t("0"));
+    editValidatorMsg->set_active(value.data(), value.size());
+
+    value = store(uint256_t("0x02"));
+    stakingMessage->set_nonce(value.data(), value.size());
+
+    value = store(uint256_t("0x0"));
+    stakingMessage->set_gas_price(value.data(), value.size());
+
+    value = store(uint256_t("0x64"));
+    stakingMessage->set_gas_limit(value.data(), value.size());
+
+    Proto::SigningOutput output;
+    ANY_SIGN(input, TWCoinTypeHarmony);
+
+    auto shouldBeV = "27";
+    auto shouldBeR = "2f160fbf125b614764f9d45dc20acc63da41b02f380e20135e72bc7e74ab3205";
+    auto shouldBeS = "11a1d8824a871361e2817145e87148b072c378c38d037df482214a3e4e3f2205";
+
+    ASSERT_EQ(hex(output.v()), shouldBeV);
+    ASSERT_EQ(hex(output.r()), shouldBeR);
+    ASSERT_EQ(hex(output.s()), shouldBeS);
+}
+
+TEST(TWHarmonyStakingSigner, EditValidator3) {
+
+    auto input = Proto::SigningInput();
+    input.set_private_key(PRIVATE_KEY.bytes.data(), PRIVATE_KEY.bytes.size());
+
+    auto value = store(uint256_t("0x2"));
+    input.set_chain_id(value.data(), value.size());
+
+    auto stakingMessage = input.mutable_staking_message();
+    auto editValidatorMsg = stakingMessage->mutable_edit_validator_message();
+
+    editValidatorMsg->set_validator_address(TEST_ACCOUNT);
+
+    auto description = editValidatorMsg->mutable_description();
+    description->set_name("Alice");
+    description->set_identity("alice");
+    description->set_website("alice.harmony.one");
+    description->set_security_contact("Bob");
+    description->set_details("Don't mess with me!!!");
+
+    auto commissionRate = editValidatorMsg->mutable_commission_rate();
+
+    // (value, precision): (1, 1) represents 0.1
+    value = store(uint256_t("1"));
+    commissionRate->set_value(value.data(), value.size());
+    value = store(uint256_t("1"));
+    commissionRate->set_precision(value.data(), value.size());
+
+    value = store(uint256_t("10"));
+    editValidatorMsg->set_min_self_delegation(value.data(), value.size());
+
+    value = store(uint256_t("3000"));
+    editValidatorMsg->set_max_total_delegation(value.data(), value.size());
+
+    value = parse_hex("b9486167ab9087ab818dc4ce026edb5bf216863364c32e42df"
+                      "2af03c5ced1ad181e7d12f0e6dd5307a73b62247608611");
+    editValidatorMsg->set_slot_key_to_remove(value.data(), value.size());
+    editValidatorMsg->set_slot_key_to_add(value.data(), value.size());
+
+    value = parse_hex("4252b0f1210efb0d5061e8a706a7ea9d62292a7947a975472f"
+                      "b77e1af7278a1c3c2e6eeba73c0581ece398613829940df129"
+                      "f3071c9a24b4b448bb1e880dc5872a58cb07eed94294c4e01a"
+                      "5c864771cafef7b96be541cb3c521a98f01838dd94");
+    editValidatorMsg->set_slot_key_to_add_sig(value.data(), value.size());
+
+    //test inactive
+    value = store(uint256_t("2"));
+    editValidatorMsg->set_active(value.data(), value.size());
+
+    value = store(uint256_t("0x02"));
+    stakingMessage->set_nonce(value.data(), value.size());
+
+    value = store(uint256_t("0x0"));
+    stakingMessage->set_gas_price(value.data(), value.size());
+
+    value = store(uint256_t("0x64"));
+    stakingMessage->set_gas_limit(value.data(), value.size());
+
+    Proto::SigningOutput output;
+    ANY_SIGN(input, TWCoinTypeHarmony);
+
+    auto shouldBeV = "28";
+    auto shouldBeR = "9d1212ab7f54b05a4f89506ea1fe3bebecf5126544bc990b53b27f1fccb69d52";
+    auto shouldBeS = "1d13704dce7399f154c2352d61ad1fc208880c267695cb423c57cd52b9821a79";
+
+    ASSERT_EQ(hex(output.v()), shouldBeV);
+    ASSERT_EQ(hex(output.r()), shouldBeR);
+    ASSERT_EQ(hex(output.s()), shouldBeS);
+}
+
 
 TEST(TWHarmonyStakingSigner, Delegate) {
     auto input = Proto::SigningInput();
@@ -192,6 +350,8 @@ TEST(TWHarmonyStakingSigner, Delegate) {
     ASSERT_EQ(hex(output.r()), shouldBeR);
     ASSERT_EQ(hex(output.s()), shouldBeS);
 }
+
+
 
 TEST(TWHarmonyStakingSigner, Undelegate) {
     auto input = Proto::SigningInput();


### PR DESCRIPTION
## [harmony] updated data structures and tests for harmony staking support

  Updated the staking transaction fields based on the latest harmony staking packet
  Updated test cases for the new data structure fields:
 
  Note: the field "active" in DirectiveEditValidator has three values 0: nil (no change),  1: change to active, 2: change to inactive. Please update UI in ios/android app for these three values.

message DirectiveEditValidator {
    string validator_address = 1;
    Description description = 2;
    Decimal commission_rate = 3;
    bytes min_self_delegation = 4;
    bytes max_total_delegation = 5;
    bytes slot_key_to_remove = 6;
    bytes slot_key_to_add = 7;
    bytes slot_key_to_add_sig = 8;
    bytes active = 9;   <== 0: nil,  1: active, 2:inactive
}

## Testing results

   Passed the following tests
  1) ./bootstrap.sh
  2) ./tools/ios-test
  3) ./tools/android-test