### PR TITLE
Fix crash in EthereumAbi encoder with wrong parameter type.

### DIFF
--- a/src/interface/TWEthereumAbiFunction.cpp
+++ b/src/interface/TWEthereumAbiFunction.cpp
@@ -221,7 +221,11 @@ uint8_t TWEthereumAbiFunctionGetParamUInt8(struct TWEthereumAbiFunction *_Nonnul
     if (!function.getParam(idx, param, isOutput)) {
         return 0;
     }
-    return (std::dynamic_pointer_cast<ParamUInt8>(param))->getVal();
+    auto param2 = std::dynamic_pointer_cast<ParamUInt8>(param);
+    if (param2 == nullptr) {
+        return 0;
+    }
+    return param2->getVal();
 }
 
 uint64_t TWEthereumAbiFunctionGetParamUInt64(struct TWEthereumAbiFunction *_Nonnull func_in, int idx, bool isOutput) {
@@ -232,21 +236,31 @@ uint64_t TWEthereumAbiFunctionGetParamUInt64(struct TWEthereumAbiFunction *_Nonn
     if (!function.getParam(idx, param, isOutput)) {
         return 0;
     }
-    return (std::dynamic_pointer_cast<ParamUInt64>(param))->getVal();
+    auto param2 = std::dynamic_pointer_cast<ParamUInt64>(param);
+    if (param2 == nullptr) {
+        return 0;
+    }
+    return param2->getVal();
 }
 
 TWData *_Nonnull TWEthereumAbiFunctionGetParamUInt256(struct TWEthereumAbiFunction *_Nonnull func_in, int idx, bool isOutput) {
     assert(func_in != nullptr);
     Function& function = func_in->impl;
 
-    TW::Data valDat;
+    uint256_t val256 = 0;
     std::shared_ptr<ParamBase> param;
     if (!function.getParam(idx, param, isOutput)) {
-        return TWDataCreateWithData(&valDat);
+        TW::Data valData = TW::store(val256);
+        return TWDataCreateWithData(&valData);
     }
-    uint256_t val256 = (std::dynamic_pointer_cast<ParamUInt256>(param))->getVal();
-    valDat = TW::store(val256);
-    return TWDataCreateWithData(&valDat);
+    auto param2 = std::dynamic_pointer_cast<ParamUInt256>(param);
+    if (param2 == nullptr) {
+        TW::Data valData = TW::store(val256);
+        return TWDataCreateWithData(&valData);
+    }
+    val256 = param2->getVal();
+    TW::Data valData = TW::store(val256);
+    return TWDataCreateWithData(&valData);
 }
 
 bool TWEthereumAbiFunctionGetParamBool(struct TWEthereumAbiFunction *_Nonnull func_in, int idx, bool isOutput) {
@@ -257,7 +271,11 @@ bool TWEthereumAbiFunctionGetParamBool(struct TWEthereumAbiFunction *_Nonnull fu
     if (!function.getParam(idx, param, isOutput)) {
         return false;
     }
-    return (std::dynamic_pointer_cast<ParamBool>(param))->getVal();
+    auto param2 = std::dynamic_pointer_cast<ParamBool>(param);
+    if (param2 == nullptr) {
+        return false;
+    }
+    return param2->getVal();
 }
 
 TWString *_Nonnull TWEthereumAbiFunctionGetParamString(struct TWEthereumAbiFunction *_Nonnull func_in, int idx, bool isOutput) {
@@ -269,7 +287,11 @@ TWString *_Nonnull TWEthereumAbiFunctionGetParamString(struct TWEthereumAbiFunct
     if (!function.getParam(idx, param, isOutput)) {
         return TWStringCreateWithUTF8Bytes(valStr.c_str());
     }
-    valStr = (std::dynamic_pointer_cast<ParamString>(param))->getVal();
+    auto param2 = std::dynamic_pointer_cast<ParamString>(param);
+    if (param2 == nullptr) {
+        return TWStringCreateWithUTF8Bytes(valStr.c_str());
+    }
+    valStr = param2->getVal();
     return TWStringCreateWithUTF8Bytes(valStr.c_str());
 }
 
@@ -280,10 +302,14 @@ TWData *_Nonnull TWEthereumAbiFunctionGetParamAddress(struct TWEthereumAbiFuncti
     Data valData;
     std::shared_ptr<ParamBase> param;
     if (!function.getParam(idx, param, isOutput)) {
-        return TWDataCreateWithBytes(valData.data(), valData.size());
+        return TWDataCreateWithData(&valData);
     }
-    valData = (std::dynamic_pointer_cast<ParamAddress>(param))->getData();
-    return TWDataCreateWithBytes(valData.data(), valData.size());
+    auto param2 = std::dynamic_pointer_cast<ParamAddress>(param);
+    if (param2 == nullptr) {
+        return TWDataCreateWithData(&valData);
+    }
+    valData = param2->getData();
+    return TWDataCreateWithData(&valData);
 }
 
 ///// AddInArrayParam
@@ -294,6 +320,9 @@ int addInArrayParam(Function& function, int arrayIdx, const std::shared_ptr<Para
         return -1;
     }
     std::shared_ptr<ParamArray> paramArr = std::dynamic_pointer_cast<ParamArray>(param);
+    if (paramArr == nullptr) {
+        return -1; // not an array
+    }
     return paramArr->addParam(childParam);
 }
 

--- a/tests/Ethereum/TWEthereumAbiEncoderTests.cpp
+++ b/tests/Ethereum/TWEthereumAbiEncoderTests.cpp
@@ -240,6 +240,7 @@ TEST(TWEthereumAbi, GetParamWrongType) {
     // GetParameter with correct types
     EXPECT_EQ(1, TWEthereumAbiFunctionGetParamUInt8(func, 0, true));
     EXPECT_EQ(2, TWEthereumAbiFunctionGetParamUInt64(func, 1, true));
+
     // GetParameter with wrong type, default value (0) is returned
     EXPECT_EQ(0, TWEthereumAbiFunctionGetParamUInt8(func, 1, true));
     EXPECT_EQ(0, TWEthereumAbiFunctionGetParamUInt64(func, 0, true));
@@ -247,6 +248,14 @@ TEST(TWEthereumAbi, GetParamWrongType) {
     EXPECT_EQ(false, TWEthereumAbiFunctionGetParamBool(func, 0, true));
     EXPECT_EQ("", std::string(TWStringUTF8Bytes(TWEthereumAbiFunctionGetParamString(func, 0, true))));
     EXPECT_EQ("", hex(*(static_cast<const Data*>(TWEthereumAbiFunctionGetParamAddress(func, 0, true)))));
+
+    // GetParameter with wrong index, default value (0) is returned
+    EXPECT_EQ(0, TWEthereumAbiFunctionGetParamUInt8(func, 99, true));
+    EXPECT_EQ(0, TWEthereumAbiFunctionGetParamUInt64(func, 99, true));
+    EXPECT_EQ("00", hex(*(static_cast<const Data*>(TWEthereumAbiFunctionGetParamUInt256(func, 99, true)))));
+    EXPECT_EQ(false, TWEthereumAbiFunctionGetParamBool(func, 99, true));
+    EXPECT_EQ("", std::string(TWStringUTF8Bytes(TWEthereumAbiFunctionGetParamString(func, 99, true))));
+    EXPECT_EQ("", hex(*(static_cast<const Data*>(TWEthereumAbiFunctionGetParamAddress(func, 99, true)))));
 
     // delete
     TWEthereumAbiEncoderDeleteFunction(func);

--- a/tests/Ethereum/TWEthereumAbiEncoderTests.cpp
+++ b/tests/Ethereum/TWEthereumAbiEncoderTests.cpp
@@ -230,4 +230,26 @@ TEST(TWEthereumAbi, DecodeOutputFuncCase1) {
     TWEthereumAbiEncoderDeleteFunction(func);
 }
 
+TEST(TWEthereumAbi, GetParamWrongType) {
+    TWEthereumAbiFunction* func = TWEthereumAbiEncoderBuildFunction(TWStringCreateWithUTF8Bytes("func"));
+    ASSERT_TRUE(func != nullptr);
+    // add parameters
+    EXPECT_EQ(0, TWEthereumAbiFunctionAddParamUInt8(func, 1, true));
+    EXPECT_EQ(1, TWEthereumAbiFunctionAddParamUInt64(func, 2, true));
+
+    // GetParameter with correct types
+    EXPECT_EQ(1, TWEthereumAbiFunctionGetParamUInt8(func, 0, true));
+    EXPECT_EQ(2, TWEthereumAbiFunctionGetParamUInt64(func, 1, true));
+    // GetParameter with wrong type, default value (0) is returned
+    EXPECT_EQ(0, TWEthereumAbiFunctionGetParamUInt8(func, 1, true));
+    EXPECT_EQ(0, TWEthereumAbiFunctionGetParamUInt64(func, 0, true));
+    EXPECT_EQ("00", hex(*(static_cast<const Data*>(TWEthereumAbiFunctionGetParamUInt256(func, 0, true)))));
+    EXPECT_EQ(false, TWEthereumAbiFunctionGetParamBool(func, 0, true));
+    EXPECT_EQ("", std::string(TWStringUTF8Bytes(TWEthereumAbiFunctionGetParamString(func, 0, true))));
+    EXPECT_EQ("", hex(*(static_cast<const Data*>(TWEthereumAbiFunctionGetParamAddress(func, 0, true)))));
+
+    // delete
+    TWEthereumAbiEncoderDeleteFunction(func);
+}
+
 } // namespace TW::Ethereum

--- a/tests/Ethereum/TWEthereumAbiValueEncodeTests.cpp
+++ b/tests/Ethereum/TWEthereumAbiValueEncodeTests.cpp
@@ -9,7 +9,7 @@
 #include "Data.h"
 #include "HexCoding.h"
 #include "uint256.h"
-#include "TWTestUtilities.h"
+#include "../interface/TWTestUtilities.h"
 #include <gtest/gtest.h>
 
 using namespace TW;


### PR DESCRIPTION
## Description

Fix crash in EthereumAbi encoder with wrong parameter type.  Fixes #895 .

## Testing instructions

Unit tests, incl. new test.

## Types of changes

<!-- * Bug fix (non-breaking change which fixes an issue) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description (e.g. 'Fixes #444 ).
