### PR TITLE
Add Bitcoin Gold implementation

### DIFF
--- a/coins.json
+++ b/coins.json
@@ -101,6 +101,34 @@
         }
     },
     {
+        "id": "bitcoingold",
+        "name": "Bitcoin Gold",
+        "symbol": "BTG",
+        "decimals": 8,
+        "blockchain": "Bitcoin",
+        "derivationPath": "m/84'/156'/0'/0/0",
+        "curve": "secp256k1",
+        "publicKeyType": "secp256k1",
+        "p2pkhPrefix": 38,
+        "p2shPrefix": 23,
+        "hrp": "btg",
+        "publicKeyHasher": "sha256ripemd",
+        "base58Hasher": "sha256d",
+        "xpub": "zpub",
+        "xprv": "zprv",
+        "explorer": {
+            "url": "https://explorer.bitcoingold.org/insight",
+            "txPath": "/tx/",
+            "accountPath": "/address/"
+        },
+        "info": {
+            "url": "https://bitcoingold.org",
+            "client": "https://github.com/trezor/blockbook",
+            "clientPublic": "",
+            "clientDocs": "https://github.com/trezor/blockbook/blob/master/docs/api.md"
+        }
+    },
+    {
         "id": "callisto",
         "name": "Callisto",
         "symbol": "CLO",

--- a/docs/coins.md
+++ b/docs/coins.md
@@ -22,6 +22,7 @@ This list is generated from [./coins.json](../coins.json)
 | 144     | XRP              | XRP    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ripple/info/logo.png" width="32" />       | <https://ripple.com/xrp>      |
 | 145     | Bitcoin Cash     | BCH    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/bitcoincash/info/logo.png" width="32" />  | <https://bitcoincash.org>     |
 | 148     | Stellar          | XLM    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/stellar/info/logo.png" width="32" />      | <https://stellar.org>         |
+| 156     | Bitcoin Gold     | BTG    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/bitcoingold/info/logo.png" width="32" />  | <https://bitcoingold.org>     |
 | 165     | Nano             | NANO   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/nano/info/logo.png" width="32" />         | <https://nano.org>            |
 | 175     | Ravencoin        | RVN    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ravencoin/info/logo.png" width="32" />    | <https://ravencoin.org>       |
 | 178     | POA Network      | POA    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/poa/info/logo.png" width="32" />          | <https://poa.network>         |

--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -27,6 +27,7 @@ enum TWCoinType {
     TWCoinTypeBinance = 714,
     TWCoinTypeBitcoin = 0,
     TWCoinTypeBitcoinCash = 145,
+    TWCoinTypeBitcoinGold = 156,
     TWCoinTypeCallisto = 820,
     TWCoinTypeCardano = 1815, // Note: Cardano Shelley testnet uses purpose 1852 (not 44) 1852/1815
     TWCoinTypeCosmos = 118,

--- a/src/Bitcoin/Entry.cpp
+++ b/src/Bitcoin/Entry.cpp
@@ -22,6 +22,7 @@ bool Entry::validateAddress(TWCoinType coin, const string& address, TW::byte p2p
         case TWCoinTypeMonacoin:
         case TWCoinTypeQtum:
         case TWCoinTypeViacoin:
+        case TWCoinTypeBitcoinGold:
             return SegwitAddress::isValid(address, hrp)
                 || Address::isValid(address, {{p2pkh}, {p2sh}});
 
@@ -60,6 +61,7 @@ string Entry::deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byt
         case TWCoinTypeDigiByte:
         case TWCoinTypeLitecoin:
         case TWCoinTypeViacoin:
+        case TWCoinTypeBitcoinGold:
             return SegwitAddress(publicKey, 0, hrp).string();
 
         case TWCoinTypeBitcoinCash:

--- a/src/Bitcoin/Entry.h
+++ b/src/Bitcoin/Entry.h
@@ -18,6 +18,7 @@ public:
         return {
             TWCoinTypeBitcoin,
             TWCoinTypeBitcoinCash,
+            TWCoinTypeBitcoinGold,
             TWCoinTypeDash,
             TWCoinTypeDigiByte,
             TWCoinTypeDogecoin,

--- a/src/BitcoinGold/Address.cpp
+++ b/src/BitcoinGold/Address.cpp
@@ -1,0 +1,10 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Address.h"
+
+using namespace TW::BitcoinGold;
+

--- a/src/BitcoinGold/Address.h
+++ b/src/BitcoinGold/Address.h
@@ -1,0 +1,35 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "../Base58Address.h"
+#include "../Data.h"
+#include "../PublicKey.h"
+
+#include <string>
+
+namespace TW::BitcoinGold {
+
+/// BitcoinGold base58 address
+class Address : public TW::Base58Address<21> {
+  public:
+    /// Initializes a  address with a string representation.
+    explicit Address(const std::string& string) : TW::Base58Address<21>(string) {}
+
+    /// Initializes a  address with a collection of bytes.
+    explicit Address(const Data& data) : TW::Base58Address<21>(data) {}
+
+    /// Initializes a  address with a public key and a prefix.
+    Address(const PublicKey& publicKey, byte prefix) : TW::Base58Address<21>(publicKey, {prefix}) {}
+};
+
+} // namespace TW::BitcoinGold
+
+/// Wrapper for C interface.
+struct TWBitcoinGoldAddress {
+    TW::BitcoinGold::Address impl;
+};

--- a/src/BitcoinGold/SegwitAddress.cpp
+++ b/src/BitcoinGold/SegwitAddress.cpp
@@ -1,0 +1,10 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "SegwitAddress.h"
+
+using namespace TW::BitcoinGold;
+

--- a/src/BitcoinGold/SegwitAddress.h
+++ b/src/BitcoinGold/SegwitAddress.h
@@ -1,0 +1,45 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "../Bitcoin/SegwitAddress.h"
+
+#include <string>
+
+namespace TW::BitcoinGold {
+
+/// BitcoinGold segwit address
+class SegwitAddress : public TW::Bitcoin::SegwitAddress {
+
+  public:
+
+    /// Initializes a Bech32 address with a human-readable part, a witness
+    /// version, and a witness program.
+    SegwitAddress(std::string hrp, int witver, std::vector<uint8_t> witprog)
+        : TW::Bitcoin::SegwitAddress(hrp, witver, witprog) {}
+
+    /// Initializes a Bech32 address with a public key and a HRP prefix.
+    SegwitAddress(const PublicKey& publicKey, int witver, std::string hrp)
+        : TW::Bitcoin::SegwitAddress(publicKey, witver, hrp) {}
+
+    bool operator==(const SegwitAddress& rhs) const {
+        return hrp == rhs.hrp && witnessVersion == rhs.witnessVersion &&
+               witnessProgram == rhs.witnessProgram;
+    }
+
+  private:
+    SegwitAddress() = default;
+};
+
+} // namespace TW::BitcoinGold
+
+/// Wrapper for C interface.
+struct TWBitcoinGoldSegwitAddress {
+    TW::BitcoinGold::SegwitAddress impl;
+};
+
+

--- a/src/BitcoinGold/Signer.cpp
+++ b/src/BitcoinGold/Signer.cpp
@@ -1,0 +1,12 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Signer.h"
+#include "Address.h"
+#include "../PublicKey.h"
+
+using namespace TW;
+using namespace TW::BitcoinGold;

--- a/src/BitcoinGold/Signer.h
+++ b/src/BitcoinGold/Signer.h
@@ -1,0 +1,32 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "../Data.h"
+#include "../PrivateKey.h"
+#include "../proto/BitcoinGold.pb.h"
+
+#include "../Bitcoin/Signer.h"
+
+namespace TW::BitcoinGold {
+
+/// Helper class that performs BitcoinGold transaction signing.
+class Signer : public TW::Bitcoin::Signer {
+public:
+    /// Hide default constructor
+    Signer() = delete;
+
+    /// BitcoinGold transaction use Bitcoin signer
+    // static Proto::SigningOutput sign(const Proto::SigningInput& input) noexcept;
+};
+
+} // namespace TW::BitcoinGold
+
+/// Wrapper for C interface.
+struct TWBitcoinGoldSigner {
+    TW::BitcoinGold::Signer impl;
+};

--- a/src/proto/BitcoinGold.proto
+++ b/src/proto/BitcoinGold.proto
@@ -1,0 +1,12 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+syntax = "proto3";
+
+package TW.BitcoinGold.Proto;
+option java_package = "wallet.core.jni.proto";
+
+import "Bitcoin.proto";

--- a/src/proto/BitcoinGold.proto
+++ b/src/proto/BitcoinGold.proto
@@ -9,4 +9,3 @@ syntax = "proto3";
 package TW.BitcoinGold.Proto;
 option java_package = "wallet.core.jni.proto";
 
-import "Bitcoin.proto";

--- a/tests/BitcoinGold/TWAddressTests.cpp
+++ b/tests/BitcoinGold/TWAddressTests.cpp
@@ -1,0 +1,34 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+//
+
+#include "../interface/TWTestUtilities.h"
+#include "BitcoinGold/Address.h"
+#include "PrivateKey.h"
+#include "PublicKey.h"
+#include "HexCoding.h"
+#include <gtest/gtest.h>
+#include <TrustWalletCore/TWAnyAddress.h>
+
+using namespace TW;
+
+const char *PRIVATE_KEY = "CA6D1402199530A5D610A01A53505B6A344CF61B0CCB2902D5AEFBEA63C274BB";
+const char *ADDRESS = "GSGUyooxtCUVBonYV8AANp7FvKy3WTvpMR";
+const char *FAKEADDRESS =  "GSGUyooxtCUVBonYV9AANp7FvKy3WTvpMR";
+
+TEST(TWBitcoinGoldAddress, Valid) {
+    ASSERT_TRUE(BitcoinGold::Address::isValid(std::string(ADDRESS)));
+    ASSERT_FALSE(BitcoinGold::Address::isValid(std::string(FAKEADDRESS)));
+}
+
+TEST(TWBitcoinGoldAddress, PubkeyToAddress) {
+    const auto privateKey = PrivateKey(parse_hex(PRIVATE_KEY));
+    const auto publicKey = privateKey.getPublicKey(TWPublicKeyTypeSECP256k1);
+
+    /// construct with public key
+    auto address = BitcoinGold::Address(PublicKey(publicKey), 38);
+    ASSERT_EQ(address.string(), ADDRESS);
+}

--- a/tests/BitcoinGold/TWCoinTypeTests.cpp
+++ b/tests/BitcoinGold/TWCoinTypeTests.cpp
@@ -1,0 +1,34 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here MAY BE LOST.
+// Generated one-time (codegen/bin/cointests)
+//
+
+#include "../interface/TWTestUtilities.h"
+#include <TrustWalletCore/TWCoinTypeConfiguration.h>
+#include <gtest/gtest.h>
+
+
+TEST(TWBitcoinGoldCoinType, TWCoinType) {
+    auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeBitcoinGold));
+    auto txId = TWStringCreateWithUTF8Bytes("2f807d7734de35d2236a1b3d8704eb12954f5f82ea66987949b10e94d9999b23");
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeBitcoinGold, txId));
+    auto accId = TWStringCreateWithUTF8Bytes("GJjz2Du9BoJQ3CPcoyVTHUJZSj62i1693U");
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeBitcoinGold, accId));
+    auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeBitcoinGold));
+    auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeBitcoinGold));
+
+    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeBitcoinGold), 8);
+    ASSERT_EQ(TWBlockchainBitcoin, TWCoinTypeBlockchain(TWCoinTypeBitcoinGold));
+    ASSERT_EQ(23, TWCoinTypeP2shPrefix(TWCoinTypeBitcoinGold));
+    ASSERT_EQ(0, TWCoinTypeStaticPrefix(TWCoinTypeBitcoinGold));
+    assertStringsEqual(symbol, "BTG");
+    assertStringsEqual(txUrl, "https://explorer.bitcoingold.org/insight/tx/2f807d7734de35d2236a1b3d8704eb12954f5f82ea66987949b10e94d9999b23");
+    assertStringsEqual(accUrl, "https://explorer.bitcoingold.org/insight/address/GJjz2Du9BoJQ3CPcoyVTHUJZSj62i1693U");
+    assertStringsEqual(id, "bitcoingold");
+    assertStringsEqual(name, "Bitcoin Gold");
+}

--- a/tests/BitcoinGold/TWSegwitAddressTests.cpp
+++ b/tests/BitcoinGold/TWSegwitAddressTests.cpp
@@ -15,30 +15,6 @@
 
 using namespace TW;
 
-
-// {
-//   "address": "btg1qtesn92ddy8m5yvypgsdtft3zj5qldj9g2u52sk",
-//   "scriptPubKey": "00145e6132a9ad21f7423081441ab4ae229501f6c8a8",
-//   "ismine": true,
-//   "iswatchonly": false,
-//   "isscript": false,
-//   "iswitness": true,
-//   "witness_version": 0,
-//   "witness_program": "5e6132a9ad21f7423081441ab4ae229501f6c8a8",
-//   "pubkey": "02f74712b5d765a73b52a14c1e113f2ef3f9502d09d5987ee40f53828cfe68b9a6",
-//   "label": "",
-//   "timestamp": 1520169519,
-//   "hdkeypath": "m/0'/0'/7'",
-//   "hdseedid": "78087f46f7ca96b35bd3a5ab2331f7c96780166d",
-//   "hdmasterkeyid": "78087f46f7ca96b35bd3a5ab2331f7c96780166d",
-//   "labels": [
-//     {
-//       "name": "",
-//       "purpose": "receive"
-//     }
-//   ]
-// }
-
 TEST(TWBitcoinGoldSegwitAddress, Valid) {
     ASSERT_TRUE(BitcoinGold::SegwitAddress::isValid("btg1qtesn92ddy8m5yvypgsdtft3zj5qldj9g2u52sk"));
     ASSERT_FALSE(BitcoinGold::SegwitAddress::isValid("btg1qtesn92ddy8m5yvypgsdtft3zj5qldj9g2u52sl"));

--- a/tests/BitcoinGold/TWSegwitAddressTests.cpp
+++ b/tests/BitcoinGold/TWSegwitAddressTests.cpp
@@ -1,0 +1,73 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+//
+
+#include "../interface/TWTestUtilities.h"
+#include "BitcoinGold/SegwitAddress.h"
+#include "PrivateKey.h"
+#include "PublicKey.h"
+#include "HexCoding.h"
+#include <gtest/gtest.h>
+#include <TrustWalletCore/TWAnyAddress.h>
+
+using namespace TW;
+
+
+// {
+//   "address": "btg1qtesn92ddy8m5yvypgsdtft3zj5qldj9g2u52sk",
+//   "scriptPubKey": "00145e6132a9ad21f7423081441ab4ae229501f6c8a8",
+//   "ismine": true,
+//   "iswatchonly": false,
+//   "isscript": false,
+//   "iswitness": true,
+//   "witness_version": 0,
+//   "witness_program": "5e6132a9ad21f7423081441ab4ae229501f6c8a8",
+//   "pubkey": "02f74712b5d765a73b52a14c1e113f2ef3f9502d09d5987ee40f53828cfe68b9a6",
+//   "label": "",
+//   "timestamp": 1520169519,
+//   "hdkeypath": "m/0'/0'/7'",
+//   "hdseedid": "78087f46f7ca96b35bd3a5ab2331f7c96780166d",
+//   "hdmasterkeyid": "78087f46f7ca96b35bd3a5ab2331f7c96780166d",
+//   "labels": [
+//     {
+//       "name": "",
+//       "purpose": "receive"
+//     }
+//   ]
+// }
+
+TEST(TWBitcoinGoldSegwitAddress, Valid) {
+    ASSERT_TRUE(BitcoinGold::SegwitAddress::isValid("btg1qtesn92ddy8m5yvypgsdtft3zj5qldj9g2u52sk"));
+    ASSERT_FALSE(BitcoinGold::SegwitAddress::isValid("btg1qtesn92ddy8m5yvypgsdtft3zj5qldj9g2u52sl"));
+}
+
+/// Initializes a Bech32 address with a human-readable part, a witness
+/// version, and a witness program.
+TEST(TWBitcoinGoldSegwitAddress, WitnessProgramToAddress) {
+    auto address = BitcoinGold::SegwitAddress("btg", 0, parse_hex("5e6132a9ad21f7423081441ab4ae229501f6c8a8"));
+
+    ASSERT_TRUE(BitcoinGold::SegwitAddress::isValid(address.string()));
+    ASSERT_EQ(address.string(), "btg1qtesn92ddy8m5yvypgsdtft3zj5qldj9g2u52sk");
+}
+
+/// Initializes a Bech32 address with a public key and a HRP prefix.
+TEST(TWBitcoinGoldSegwitAddress, PubkeyToAddress) {
+    const auto publicKey = PublicKey(parse_hex("02f74712b5d765a73b52a14c1e113f2ef3f9502d09d5987ee40f53828cfe68b9a6"), TWPublicKeyTypeSECP256k1);
+
+    /// construct with public key
+    auto address = BitcoinGold::SegwitAddress(publicKey, 0, "btg");
+
+    ASSERT_TRUE(BitcoinGold::SegwitAddress::isValid(address.string()));
+    ASSERT_EQ(address.string(), "btg1qtesn92ddy8m5yvypgsdtft3zj5qldj9g2u52sk");
+}
+
+/// Decodes a SegWit address.
+TEST(TWBitcoinGoldSegwitAddress, Decode) {
+    std::pair<Bitcoin::SegwitAddress, bool> result = BitcoinGold::SegwitAddress::decode("btg1qtesn92ddy8m5yvypgsdtft3zj5qldj9g2u52sk");
+
+    ASSERT_TRUE(result.second);
+    ASSERT_EQ(result.first.string(), "btg1qtesn92ddy8m5yvypgsdtft3zj5qldj9g2u52sk");
+}

--- a/tests/BitcoinGold/TWSignerTests.cpp
+++ b/tests/BitcoinGold/TWSignerTests.cpp
@@ -1,0 +1,84 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include <TrustWalletCore/TWAnyAddress.h>
+#include <TrustWalletCore/TWAnySigner.h>
+#include <TrustWalletCore/TWBitcoinSigHashType.h>
+#include <gtest/gtest.h>
+
+#include "BitcoinGold/SegwitAddress.h"
+#include "proto/Bitcoin.pb.h"
+#include "Bitcoin/OutPoint.h"
+#include "Bitcoin/Script.h"
+#include "Bitcoin/Transaction.h"
+#include "Bitcoin/TransactionBuilder.h"
+#include "Bitcoin/TransactionSigner.h"
+#include "HexCoding.h"
+#include "../interface/TWTestUtilities.h"
+
+using namespace TW;
+using namespace TW::Bitcoin;
+
+TEST(TWBitcoinGoldSigner, SignTransaction) {
+    const int64_t amount = 10000;
+
+    // Setup input
+    Proto::SigningInput input;
+    input.set_coin_type(TWCoinTypeBitcoinGold);
+    input.set_hash_type(TWBitcoinSigHashTypeFork | TWBitcoinSigHashTypeAll | (79 << 8));
+    input.set_amount(amount);
+    input.set_byte_fee(1);
+    input.set_to_address("btg1qmd6x5awe4t5fjhgntv0pngzdwajjg250wxdcs0");
+    input.set_change_address("btg1qawhpp9gv3g662phqufjmj2ps2ge7sq4thy5g07");
+
+    auto utxoKey0 = parse_hex("cbe13a79b82ec7f8871b336a64fd8d531f598e7c9022e29c67e824cfd54af57f");
+    input.add_private_key(utxoKey0.data(), utxoKey0.size());
+
+
+    auto scriptPub1 = Script(parse_hex("0014db746a75d9aae8995d135b1e19a04d7765242a8f"));
+    auto scriptHash = std::vector<uint8_t>();
+    scriptPub1.matchPayToWitnessPublicKeyHash(scriptHash);
+    auto scriptHashHex = hex(scriptHash.begin(), scriptHash.end());
+
+    auto redeemScript = Script::buildPayToPublicKeyHash(scriptHash);
+    auto scriptString = std::string(redeemScript.bytes.begin(), redeemScript.bytes.end());
+    (*input.mutable_scripts())[scriptHashHex] = scriptString;
+
+    auto utxo0 = input.add_utxo();
+    auto utxo0Script = parse_hex("0014d53cae7c6fb6c8efe4fd8bfecea36534105b1674");
+    utxo0->set_script(utxo0Script.data(), utxo0Script.size());
+    utxo0->set_amount(99000);
+    
+    auto hash0 = parse_hex("1d4653041a1915b3a52d47aeaa119c8f79ed7634a93692a6e811173067464f03");
+    utxo0->mutable_out_point()->set_hash(hash0.data(), hash0.size());
+    utxo0->mutable_out_point()->set_index(1);
+    utxo0->mutable_out_point()->set_sequence(0xfffffffd);
+
+    // Sign
+    auto txSinger = TransactionSigner<Transaction, TransactionBuilder>(std::move(input));
+    txSinger.transaction.lockTime = 0x00098971;
+    auto result = txSinger.sign();
+
+    ASSERT_TRUE(result) << result.error();;
+    auto signedTx = result.payload();
+
+    Data serialized;
+    signedTx.encode(true, serialized);
+    ASSERT_EQ(hex(serialized),
+        "01000000"
+        "0001"
+        "01"
+            "1d4653041a1915b3a52d47aeaa119c8f79ed7634a93692a6e811173067464f03" "01000000" "00" "fdffffff"
+        "02"
+            "1027000000000000" "160014db746a75d9aae8995d135b1e19a04d7765242a8f"
+            "c65a010000000000" "160014ebae10950c8a35a506e0e265b928305233e802ab"
+        "02"
+            "473044022029b81a6b8f57f76aaf510d8a222ca835bd806936e329aead433f120007d6847002203afa611ff7823ec2a6770359901b0cacf56527cbf947b226ed86b61811545e2b41"
+            "2103e00b5dec8078d526fba090247bd92db6b67a4dd1953b788cea9b52de9471b8cf"
+        "71890900"
+    );
+}
+            


### PR DESCRIPTION
## Description

Bitcoin Gold is already added to the [trustwallet/assets](https://github.com/trustwallet/assets/pull/622). This PR adds the implementation including the address codec and transaction signing logic.

## Testing instructions

Passes unit tests: `./build/tests/tests tests`
Create a new address in walletconsole:

```
> coin btg
Set active coin to: bitcoingold    Use 'coin' to change.  (name: 'bitcoin gold'  symbol: btg  numericalid: 156)
> addrDefault
Result:  btg1q8hnwn2j2vges5u9h9t456zfd46sjxfmxvk3rvl
```

## Types of changes

* New feature (non-breaking change which adds functionality)

## Checklist

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description (e.g. 'Fixes #444 ).
