### PR TITLE
Fix Tron TRC20 Transfer overflow

### DIFF
--- a/src/Tron/Signer.cpp
+++ b/src/Tron/Signer.cpp
@@ -157,8 +157,7 @@ protocol::TriggerSmartContract to_internal(const Proto::TriggerSmartContract& tr
 
 protocol::TriggerSmartContract to_internal(const Proto::TransferTRC20Contract& transferTrc20Contract) {
     auto toAddress = Base58::bitcoin.decodeCheck(transferTrc20Contract.to_address());
-    Data amount;
-    encode64BE(transferTrc20Contract.amount(), amount);
+    auto amount = Data(transferTrc20Contract.amount().begin(), transferTrc20Contract.amount().end());
 
     // Encode smart contract call parameters
     auto contract_params = parse_hex(TRANSFER_TOKEN_FUNCTION);

--- a/src/proto/Tron.proto
+++ b/src/proto/Tron.proto
@@ -39,7 +39,7 @@ message TransferTRC20Contract {
     string to_address = 3;
 
     // Amount to send.
-    int64 amount = 4;
+    bytes amount = 4;
 }
 
 message FreezeBalanceContract {

--- a/tests/Tron/SerializationTests.cpp
+++ b/tests/Tron/SerializationTests.cpp
@@ -8,6 +8,7 @@
 #include "Tron/Signer.h"
 #include "PrivateKey.h"
 #include "HexCoding.h"
+#include "BinaryCoding.h"
 
 #include <gtest/gtest.h>
 
@@ -145,13 +146,15 @@ namespace TW::Tron {
     }
 
     TEST(TronSerialization, SignTransferTrc20Contract) {
+        Data amount; 
+        encode64LE(1000, amount);
         auto input = Proto::SigningInput();
         auto& transaction = *input.mutable_transaction();
         auto& transfer_contract = *transaction.mutable_transfer_trc20_contract();
         transfer_contract.set_owner_address("TJRyWwFs9wTFGZg3JbrVriFbNfCug5tDeC");
         transfer_contract.set_contract_address("THTR75o8xXAgCTQqpiot2AFRAjvW1tSbVV");
         transfer_contract.set_to_address("TW1dU4L3eNm7Lw8WvieLKEHpXWAussRG9Z");
-        transfer_contract.set_amount(1000);
+        transfer_contract.set_amount(amount.data(), amount.size());
 
         transaction.set_timestamp(1539295479000);
 

--- a/tests/Tron/SerializationTests.cpp
+++ b/tests/Tron/SerializationTests.cpp
@@ -147,7 +147,7 @@ namespace TW::Tron {
 
     TEST(TronSerialization, SignTransferTrc20Contract) {
         Data amount; 
-        encode64LE(1000, amount);
+        encode64BE(1000, amount);
         auto input = Proto::SigningInput();
         auto& transaction = *input.mutable_transaction();
         auto& transfer_contract = *transaction.mutable_transfer_trc20_contract();

--- a/tests/Tron/SignerTests.cpp
+++ b/tests/Tron/SignerTests.cpp
@@ -7,6 +7,7 @@
 #include "Bitcoin/Address.h"
 #include "HexCoding.h"
 #include "PrivateKey.h"
+#include "BinaryCoding.h"
 #include "proto/Tron.pb.h"
 #include "Tron/Signer.h"
 
@@ -309,13 +310,15 @@ TEST(TronSigner, SignTriggerSmartContract) {
 }
 
 TEST(TronSigner, SignTransferTrc20Contract) {
+    Data amount; 
+    encode64LE(1000, amount);
     auto input = Proto::SigningInput();
     auto& transaction = *input.mutable_transaction();
     auto& transfer_contract = *transaction.mutable_transfer_trc20_contract();
     transfer_contract.set_owner_address("TJRyWwFs9wTFGZg3JbrVriFbNfCug5tDeC");
     transfer_contract.set_contract_address("THTR75o8xXAgCTQqpiot2AFRAjvW1tSbVV");
     transfer_contract.set_to_address("TW1dU4L3eNm7Lw8WvieLKEHpXWAussRG9Z");
-    transfer_contract.set_amount(1000);
+    transfer_contract.set_amount(amount.data(), amount.size());
 
     transaction.set_timestamp(1539295479000);
 

--- a/tests/Tron/SignerTests.cpp
+++ b/tests/Tron/SignerTests.cpp
@@ -311,7 +311,7 @@ TEST(TronSigner, SignTriggerSmartContract) {
 
 TEST(TronSigner, SignTransferTrc20Contract) {
     Data amount; 
-    encode64LE(1000, amount);
+    encode64BE(1000, amount);
     auto input = Proto::SigningInput();
     auto& transaction = *input.mutable_transaction();
     auto& transfer_contract = *transaction.mutable_transfer_trc20_contract();


### PR DESCRIPTION
Fixes #967 

## Changes
- Replaced `int64` to `bytes` on `amount` field to avoid overflow.