### PR TITLE
Enable Solana pay-to-self transactions

### DIFF
--- a/src/Solana/Transaction.h
+++ b/src/Solana/Transaction.h
@@ -58,9 +58,9 @@ struct CompiledInstruction {
         : programIdIndex(programIdIndex), accounts(accounts), data(data) {}
 
     // This constructor creates a default System Transfer instruction
-    CompiledInstruction(uint8_t programIdIndex, uint64_t value) : programIdIndex(programIdIndex) {
-        std::vector<uint8_t> accounts = {0, 1};
-        this->accounts = accounts;
+    CompiledInstruction(uint8_t programIdIndex, Data accountIndexes, uint64_t value)
+        : programIdIndex(programIdIndex) {
+        this->accounts = accountIndexes;
         SystemInstruction type = Transfer;
         auto data = Data();
         encode32LE(static_cast<uint32_t>(type), data);
@@ -198,10 +198,21 @@ class Message {
         MessageHeader header = {1, 0, 1};
         this->header = header;
         auto programId = Address("11111111111111111111111111111111");
-        std::vector<Address> accountKeys = {from, to, programId};
+        std::vector<Address> accountKeys;
+        Data accountIndexes;
+        uint8_t programIdIndex;
+        if (from.vector() != to.vector()) {
+            accountKeys = {from, to, programId};
+            accountIndexes = {0, 1};
+            programIdIndex = 2;
+        } else {
+            accountKeys = {from, programId};
+            accountIndexes = {0, 0};
+            programIdIndex = 1;
+        }
         this->accountKeys = accountKeys;
         std::vector<CompiledInstruction> instructions;
-        auto instruction = CompiledInstruction(2, value);
+        auto instruction = CompiledInstruction(programIdIndex, accountIndexes, value);
         instructions.push_back(instruction);
         this->instructions = instructions;
     }

--- a/tests/Solana/SignerTests.cpp
+++ b/tests/Solana/SignerTests.cpp
@@ -54,6 +54,35 @@ TEST(SolanaSigner, SingleSignTransaction) {
     }
 }
 
+TEST(SolanaSigner, SignTransactionToSelf) {
+    const auto privateKey =
+        PrivateKey(Base58::bitcoin.decode("AevJ4EWcvQ6dptBDvF2Ri5pU6QSBjkzSGHMfbLFKa746"));
+    const auto publicKey = privateKey.getPublicKey(TWPublicKeyTypeED25519);
+    ASSERT_EQ(Data(publicKey.bytes.begin(), publicKey.bytes.end()),
+              Base58::bitcoin.decode("zVSpQnbBZ7dyUWzXhrUQRsTYYNzoAdJWHsHSqhPj3Xu"));
+
+    const auto from = Address(publicKey);
+    auto to = Address("zVSpQnbBZ7dyUWzXhrUQRsTYYNzoAdJWHsHSqhPj3Xu");
+    Solana::Hash recentBlockhash("11111111111111111111111111111111");
+    auto transaction = Transaction(from, to, 42, recentBlockhash);
+
+    std::vector<PrivateKey> signerKeys;
+    signerKeys.push_back(privateKey);
+    Signer::sign(signerKeys, transaction);
+
+    std::vector<Signature> expectedSignatures;
+    Signature expectedSignature(
+        "3CFWDEK51noPJP4v2t8JZ3qj7kC7kLKyws9akfHMyuJnQ35EtzBptHqvaHfeswiLsvUSxzMVNoj4CuRxWtDD9zB1");
+    expectedSignatures.push_back(expectedSignature);
+    ASSERT_EQ(transaction.signatures, expectedSignatures);
+
+    auto expectedString =
+        "EKUmihvvUPKVN4GSCFwZRtz8WiyAuPvthW69Smo19SCjcPLQ6T7EVZd1HU71WAoe1bfgmPNS5JhU7ZLA9XKG3qbZqe"
+        "EFJ1xmRwW9ZKw8SKMAL6VRWxp87oLu7PSmf5b8R34vCaww3XLKtZkoP49a7TUK31DqPN5xJCceMB3BZJyaojQaKU8n"
+        "UkzSGf89LY6abZXp9krKAebvc6bSMzTP8SHSvbmZbf3VtejmpQeN9X6e7WVDn6oDa2bGT";
+    ASSERT_EQ(transaction.serialize(), expectedString);
+}
+
 TEST(SolanaSigner, MultipleSignTransaction) {
     const auto privateKey0 =
         PrivateKey(Base58::bitcoin.decode("96PKHuMPtniu1T74RvUNkbDPXPPRZ8Mg1zXwciCAyaDq"));

--- a/tests/Solana/TWAnySignerTests.cpp
+++ b/tests/Solana/TWAnySignerTests.cpp
@@ -36,6 +36,26 @@ TEST(TWAnySignerSolana, SignTransfer) {
     ASSERT_EQ(output.encoded(), expectedString);
 }
 
+TEST(TWAnySignerSolana, SignTransferToSelf) {
+    auto privateKey = Base58::bitcoin.decode("AevJ4EWcvQ6dptBDvF2Ri5pU6QSBjkzSGHMfbLFKa746");
+    auto input = Proto::SigningInput();
+
+    auto& message = *input.mutable_transfer_transaction();
+    message.set_recipient("zVSpQnbBZ7dyUWzXhrUQRsTYYNzoAdJWHsHSqhPj3Xu");
+    message.set_value((uint64_t)42L);
+    input.set_private_key(privateKey.data(), privateKey.size());
+    input.set_recent_blockhash("11111111111111111111111111111111");
+
+    Proto::SigningOutput output;
+    ANY_SIGN(input, TWCoinTypeSolana);
+
+    auto expectedString =
+        "EKUmihvvUPKVN4GSCFwZRtz8WiyAuPvthW69Smo19SCjcPLQ6T7EVZd1HU71WAoe1bfgmPNS5JhU7ZLA9XKG3qbZqe"
+        "EFJ1xmRwW9ZKw8SKMAL6VRWxp87oLu7PSmf5b8R34vCaww3XLKtZkoP49a7TUK31DqPN5xJCceMB3BZJyaojQaKU8n"
+        "UkzSGf89LY6abZXp9krKAebvc6bSMzTP8SHSvbmZbf3VtejmpQeN9X6e7WVDn6oDa2bGT";
+    ASSERT_EQ(output.encoded(), expectedString);
+}
+
 TEST(TWAnySignerSolana, SignDelegateStakeTransaction) {
     auto privateKey = Base58::bitcoin.decode("AevJ4EWcvQ6dptBDvF2Ri5pU6QSBjkzSGHMfbLFKa746");
     auto input = Solana::Proto::SigningInput();

--- a/tests/Solana/TransactionTests.cpp
+++ b/tests/Solana/TransactionTests.cpp
@@ -48,6 +48,23 @@ TEST(SolanaTransaction, TransferSerializeTransaction) {
     ASSERT_EQ(transaction.serialize(), expectedString);
 }
 
+TEST(SolanaTransaction, TransferTransactionPayToSelf) {
+    auto from = Address("zVSpQnbBZ7dyUWzXhrUQRsTYYNzoAdJWHsHSqhPj3Xu");
+    auto to = Address("zVSpQnbBZ7dyUWzXhrUQRsTYYNzoAdJWHsHSqhPj3Xu");
+    Solana::Hash recentBlockhash("11111111111111111111111111111111");
+    auto transaction = Transaction(from, to, 42, recentBlockhash);
+    Signature signature(
+        "3CFWDEK51noPJP4v2t8JZ3qj7kC7kLKyws9akfHMyuJnQ35EtzBptHqvaHfeswiLsvUSxzMVNoj4CuRxWtDD9zB1");
+    transaction.signatures.clear();
+    transaction.signatures.push_back(signature);
+
+    auto expectedString =
+        "EKUmihvvUPKVN4GSCFwZRtz8WiyAuPvthW69Smo19SCjcPLQ6T7EVZd1HU71WAoe1bfgmPNS5JhU7ZLA9XKG3qbZqe"
+        "EFJ1xmRwW9ZKw8SKMAL6VRWxp87oLu7PSmf5b8R34vCaww3XLKtZkoP49a7TUK31DqPN5xJCceMB3BZJyaojQaKU8n"
+        "UkzSGf89LY6abZXp9krKAebvc6bSMzTP8SHSvbmZbf3VtejmpQeN9X6e7WVDn6oDa2bGT";
+    ASSERT_EQ(transaction.serialize(), expectedString);
+}
+
 TEST(SolanaTransaction, StakeSerializeTransaction) {
     auto signer = Address("zVSpQnbBZ7dyUWzXhrUQRsTYYNzoAdJWHsHSqhPj3Xu");
     auto voteAddress = Address("4jpwTqt1qZoR7u6u639z2AngYFGN3nakvKhowcnRZDEC");


### PR DESCRIPTION
## Description

Users may transfer to self as test. For this to succeed on solana, we need an update to node runtime (merged, included in next solana release) and update the transaction format in wallet-core to index the same account twice. This pr implements proper account indexing when pay-to-self is requested.

<!--- Describe your changes in detail -->

## Testing instructions

Unit tests.
Integration: Once Solana cluster updates to the next v1.1 release, attempt TrustWallet app payment to self. Transaction should succeed, account should see fees deducted.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
