### PR TITLE
Fix compiler warnings.

### DIFF
--- a/codegen/lib/templates/jni/method_forward.erb
+++ b/codegen/lib/templates/jni/method_forward.erb
@@ -19,7 +19,9 @@
     }
 <%  end -%>
     result = TWDataJByteArray(resultData, env);
+<%  if method.return_type.is_nullable %>
 cleanup:
+<%  end -%>
 <%= render('jni/parameter_release.erb', { method: method }) -%>
 <%  if !method.static %>
 <%= render('jni/instance_release.erb', { entity: entity }) %>
@@ -36,7 +38,9 @@ cleanup:
     }
 <%  end -%>
     result = TWStringJString(resultString, env);
+<%  if method.return_type.is_nullable %>
 cleanup:
+<%  end -%>
 <%= render('jni/parameter_release.erb', { method: method }) -%>
 <%  if !method.static %>
 <%= render('jni/instance_release.erb', { entity: entity }) %>

--- a/src/Algorand/BinaryCoding.h
+++ b/src/Algorand/BinaryCoding.h
@@ -11,6 +11,8 @@
 
 namespace TW::Algorand {
 
+#pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+
 static inline void encodeString(std::string string, Data& data) {
     // encode string header
     auto bytes = Data(string.begin(), string.end());
@@ -25,7 +27,7 @@ static inline void encodeString(std::string string, Data& data) {
         // str 16
         data.push_back(static_cast<uint8_t>(0xda));
         encode16BE(static_cast<uint16_t>(bytes.size()), data);
-    } else if (bytes.size() < 0x100000000) {
+    } else if (bytes.size() < 0x100000000) { // depending on size_t size on platform, may be always true 
         // str 32
         data.push_back(static_cast<uint8_t>(0xdb));
         encode32BE(static_cast<uint32_t>(bytes.size()), data);

--- a/src/Ethereum/RLP.cpp
+++ b/src/Ethereum/RLP.cpp
@@ -80,27 +80,27 @@ Data RLP::encodeHeader(uint64_t size, uint8_t smallTag, uint8_t largeTag) noexce
 
 Data RLP::putint(uint64_t i) noexcept {
     // clang-format off
-    if (i < (1l << 8))
+    if (i < (1ULL << 8))
         return {static_cast<uint8_t>(i)};
-    if (i < (1l << 16))
+    if (i < (1ULL << 16))
         return {
             static_cast<uint8_t>(i >> 8),
             static_cast<uint8_t>(i),
         };
-    if (i < (1l << 24))
+    if (i < (1ULL << 24))
         return {
             static_cast<uint8_t>(i >> 16),
             static_cast<uint8_t>(i >> 8),
             static_cast<uint8_t>(i),
         };
-    if (i < (1l << 32))
+    if (i < (1ULL << 32))
         return {
             static_cast<uint8_t>(i >> 24),
             static_cast<uint8_t>(i >> 16),
             static_cast<uint8_t>(i >> 8),
             static_cast<uint8_t>(i),
         };
-    if (i < (1l << 40))
+    if (i < (1ULL << 40))
         return {
             static_cast<uint8_t>(i >> 32),
             static_cast<uint8_t>(i >> 24),
@@ -108,7 +108,7 @@ Data RLP::putint(uint64_t i) noexcept {
             static_cast<uint8_t>(i >> 8),
             static_cast<uint8_t>(i),
         };
-    if (i < (1l << 48))
+    if (i < (1ULL << 48))
         return {
             static_cast<uint8_t>(i >> 40),
             static_cast<uint8_t>(i >> 32),
@@ -117,7 +117,7 @@ Data RLP::putint(uint64_t i) noexcept {
             static_cast<uint8_t>(i >> 8),
             static_cast<uint8_t>(i),
         };
-    if (i < (1l << 56))
+    if (i < (1ULL << 56))
         return {
             static_cast<uint8_t>(i >> 48),
             static_cast<uint8_t>(i >> 40),

--- a/src/Keystore/EncryptionParameters.cpp
+++ b/src/Keystore/EncryptionParameters.cpp
@@ -28,8 +28,6 @@ static Data computeMAC(Iter begin, Iter end, const Data& key) {
     return Hash::keccak256(data);
 }
 
-#pragma GCC diagnostic ignored "-Wunused-variable"
-
 EncryptionParameters::EncryptionParameters(const Data& password, const Data& data) : mac() {
     auto scryptParams = boost::get<ScryptParameters>(kdfParams);
     auto derivedKey = Data(scryptParams.desiredKeyLength);
@@ -38,14 +36,15 @@ EncryptionParameters::EncryptionParameters(const Data& password, const Data& dat
            scryptParams.desiredKeyLength);
 
     aes_encrypt_ctx ctx;
-    auto result = aes_encrypt_key(derivedKey.data(), 16, &ctx);
-    assert(result != EXIT_FAILURE);
+    auto result = aes_encrypt_key128(derivedKey.data(), &ctx);
+    assert(result == EXIT_SUCCESS);
+    if (result == EXIT_SUCCESS) {
+        Data iv = cipherParams.iv;
+        encrypted = Data(data.size());
+        aes_ctr_encrypt(data.data(), encrypted.data(), static_cast<int>(data.size()), iv.data(), aes_ctr_cbuf_inc, &ctx);
 
-    Data iv = cipherParams.iv;
-    encrypted = Data(data.size());
-    aes_ctr_encrypt(data.data(), encrypted.data(), static_cast<int>(data.size()), iv.data(), aes_ctr_cbuf_inc, &ctx);
-
-    mac = computeMAC(derivedKey.end() - 16, derivedKey.end(), encrypted);
+        mac = computeMAC(derivedKey.end() - 16, derivedKey.end(), encrypted);
+    }
 }
 
 EncryptionParameters::~EncryptionParameters() {

--- a/src/Keystore/EncryptionParameters.cpp
+++ b/src/Keystore/EncryptionParameters.cpp
@@ -28,6 +28,8 @@ static Data computeMAC(Iter begin, Iter end, const Data& key) {
     return Hash::keccak256(data);
 }
 
+#pragma GCC diagnostic ignored "-Wunused-variable"
+
 EncryptionParameters::EncryptionParameters(const Data& password, const Data& data) : mac() {
     auto scryptParams = boost::get<ScryptParameters>(kdfParams);
     auto derivedKey = Data(scryptParams.desiredKeyLength);

--- a/src/Keystore/ScryptParameters.cpp
+++ b/src/Keystore/ScryptParameters.cpp
@@ -16,8 +16,10 @@ ScryptParameters::ScryptParameters() : salt(32) {
     random_buffer(salt.data(), salt.size());
 }
 
+#pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+
 std::optional<ScryptValidationError> ScryptParameters::validate() const {
-    if (desiredKeyLength > ((static_cast<uint64_t>(1) << 32) - 1) * 32) {
+    if (desiredKeyLength > ((1ULL << 32) - 1) * 32) { // depending on size_t size on platform, may be always false 
         return ScryptValidationError::desiredKeyLengthTooLarge;
     }
     if (static_cast<uint64_t>(r) * static_cast<uint64_t>(p) >= (1 << 30)) {


### PR DESCRIPTION
## Description

Fix compiler warnings, Android build.  Fixes #993 .
- Unused 'cleanup' label in generated code: refine code generator to include when it is used
- always true (or false) comparisons (platform dependent!) -- add pragma warning and comment
- unused variable: used in assert only, which is ignored on release -- add pragma warning
- shift overflow: use 1ULL for correct larger size.

## Testing instructions

Android compile  /tools/android-build

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
