### PR TITLE
Add EthereumAbiDecoder

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/ethereum/TestEthereumAbiDecoder.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/ethereum/TestEthereumAbiDecoder.kt
@@ -1,0 +1,28 @@
+package com.trustwallet.core.app.blockchains.ethereum
+
+import com.trustwallet.core.app.utils.toHexByteArray
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import com.trustwallet.core.app.utils.Numeric
+import wallet.core.jni.EthereumAbiValueDecoder
+
+class TestEthereumAbiDecoder {
+
+    init {
+        System.loadLibrary("TrustWalletCore")
+    }
+
+    @Test
+    fun testEthereumAbiDecoder() {
+        val expected = "1234567890987654321"
+        val inputs = listOf(
+            "112210f4b16c1cb1",
+            "000000000000000000000000000000000000000000000000112210f4b16c1cb1",
+            "000000000000000000000000000000000000000000000000112210f4b16c1cb10000000000000000000000000000000000000000000000000000000000000000"
+        )
+        for (input in inputs) {
+            val data = Numeric.hexStringToByteArray(input)
+            assertEquals(expected, EthereumAbiValueDecoder.decodeUInt256(data))
+        }
+    }
+}

--- a/include/TrustWalletCore/TWEthereumAbiValueDecoder.h
+++ b/include/TrustWalletCore/TWEthereumAbiValueDecoder.h
@@ -1,0 +1,22 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "TWBase.h"
+#include "TWData.h"
+#include "TWString.h"
+
+TW_EXTERN_C_BEGIN
+
+TW_EXPORT_CLASS
+struct TWEthereumAbiValueDecoder;
+
+/// Decodes input data (bytes longer than 32 will be truncated) as uint256
+TW_EXPORT_STATIC_METHOD
+TWString* _Nonnull TWEthereumAbiValueDecoderDecodeUInt256(TWData* _Nonnull input);
+
+TW_EXTERN_C_END

--- a/src/Ethereum/ABI/ValueDecoder.cpp
+++ b/src/Ethereum/ABI/ValueDecoder.cpp
@@ -1,0 +1,17 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "ValueDecoder.h"
+
+namespace TW::Ethereum::ABI {
+
+uint256_t ValueDecoder::decodeUInt256(Data& data) {
+    if (data.size() > 32) {
+        return load(subData(data, 0, 32));
+    }
+    return load(data);
+}
+} // namespace TW::Ethereum::ABI

--- a/src/Ethereum/ABI/ValueDecoder.h
+++ b/src/Ethereum/ABI/ValueDecoder.h
@@ -1,0 +1,18 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include <Data.h>
+#include <uint256.h>
+
+namespace TW::Ethereum::ABI {
+
+class ValueDecoder {
+public:
+    static uint256_t decodeUInt256(Data& data);
+};
+} // namespace TW::Ethereum::ABI

--- a/src/interface/TWEthereumAbiValueDecoder.cpp
+++ b/src/interface/TWEthereumAbiValueDecoder.cpp
@@ -1,0 +1,19 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include <TrustWalletCore/TWEthereumAbiValueDecoder.h>
+
+#include <Ethereum/ABI/ValueDecoder.h>
+#include <Data.h>
+
+using namespace TW::Ethereum;
+using namespace TW;
+
+TWString* _Nonnull TWEthereumAbiValueDecoderDecodeUInt256(TWData* _Nonnull input) {
+    auto data = TW::data(TWDataBytes(input), TWDataSize(input));
+    auto decoded = Ethereum::ABI::ValueDecoder::decodeUInt256(data);
+    return TWStringCreateWithUTF8Bytes(TW::toString(decoded).c_str());
+}

--- a/swift/Tests/Blockchains/EthereumAbiTests.swift
+++ b/swift/Tests/Blockchains/EthereumAbiTests.swift
@@ -40,4 +40,17 @@ class EthereumAbiTests: XCTestCase {
         let data2 = EthereumAbiValueEncoder.encodeInt32(value: 69)
         XCTAssertEqual(data2.hexString, "0000000000000000000000000000000000000000000000000000000000000045")
     }
+
+    func testValueDecoder() {
+        let expected = "1234567890987654321"
+        let inputs = [
+            "112210f4b16c1cb1",
+            "000000000000000000000000000000000000000000000000112210f4b16c1cb1",
+            "000000000000000000000000000000000000000000000000112210f4b16c1cb10000000000000000000000000000000000000000000000000000000000000000"
+        ]
+        for input in inputs {
+            let data = Data(hexString: input)!
+            XCTAssertEqual(expected, EthereumAbiValueDecoder.decodeUInt256(input: data))
+        }
+    }
 }

--- a/tests/Ethereum/TWEthereumAbiValueDecoderTests.cpp
+++ b/tests/Ethereum/TWEthereumAbiValueDecoderTests.cpp
@@ -1,0 +1,30 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include <TrustWalletCore/TWEthereumAbiValueDecoder.h>
+
+#include "Data.h"
+#include "HexCoding.h"
+#include "../interface/TWTestUtilities.h"
+#include <gtest/gtest.h>
+
+using namespace TW;
+using namespace std;
+
+TEST(TWEthereumAbiValueDecoder, decodeUInt256) {
+    const char * expected = "10020405371567";
+    auto inputs = vector<string>{
+        "091d0eb3e2af",
+        "0000000000000000000000000000000000000000000000000000091d0eb3e2af",
+        "0000000000000000000000000000000000000000000000000000091d0eb3e2af0000000000000000000000000000000000000000000000000000000000000000",
+        "0000000000000000000000000000000000000000000000000000091d0eb3e2af00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    };
+    for (auto &input: inputs) {
+        auto data =  WRAPD(TWDataCreateWithHexString(STRING(input.c_str()).get()));
+        auto result = WRAPS(TWEthereumAbiValueDecoderDecodeUInt256(data.get()));
+        assertStringsEqual(result, expected);
+    }
+}

--- a/tests/Ethereum/ValueDecoderTests.cpp
+++ b/tests/Ethereum/ValueDecoderTests.cpp
@@ -1,0 +1,27 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Ethereum/ABI/ValueDecoder.h"
+#include <HexCoding.h>
+
+#include <gtest/gtest.h>
+
+using namespace TW;
+using namespace TW::Ethereum;
+
+uint256_t decodeFromHex(std::string s) {
+    auto data = parse_hex(s);
+    return ABI::ValueDecoder::decodeUInt256(data);
+}
+
+TEST(EthereumAbiValueDecoder, decodeUInt256) {
+    EXPECT_EQ(uint256_t(0), decodeFromHex(""));
+    EXPECT_EQ(uint256_t(0), decodeFromHex("0000000000000000000000000000000000000000000000000000000000000000"));
+    EXPECT_EQ(uint256_t(1), decodeFromHex("0000000000000000000000000000000000000000000000000000000000000001"));
+    EXPECT_EQ(uint256_t(123456), decodeFromHex("01e240"));
+    EXPECT_EQ(uint256_t(10020405371567), decodeFromHex("0000000000000000000000000000000000000000000000000000091d0eb3e2af"));
+    EXPECT_EQ(uint256_t(10020405371567), decodeFromHex("0000000000000000000000000000000000000000000000000000091d0eb3e2af00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
+}


### PR DESCRIPTION
A quick fix for cUSDT `balanceOf` parsing, decode hex to big integer string (closes #1002, we can add other types later)