### PR TITLE
HashTypeForCoin: fix return type to uint32

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bitcoin/TestBitcoinSigning.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bitcoin/TestBitcoinSigning.kt
@@ -23,7 +23,7 @@ class TestBitcoinSigning {
     fun testSignP2WPKH() {
         val input = Bitcoin.SigningInput.newBuilder()
             .setAmount(335_790_000)
-            .setHashType(BitcoinScript.hashTypeForCoin(CoinType.BITCOIN).value())
+            .setHashType(BitcoinScript.hashTypeForCoin(CoinType.BITCOIN))
             .setToAddress("1Bp9U1ogV3A14FMvKbRJms7ctyso4Z4Tcx")
             .setChangeAddress("1FQc5LdgGHMHEN9nwkjmz6tWkxhPpxBvBU")
             .setByteFee(1)
@@ -87,7 +87,7 @@ class TestBitcoinSigning {
     fun testSignP2PKH() {
         val input = Bitcoin.SigningInput.newBuilder()
             .setAmount(55_000)
-            .setHashType(BitcoinScript.hashTypeForCoin(CoinType.BITCOIN).value())
+            .setHashType(BitcoinScript.hashTypeForCoin(CoinType.BITCOIN))
             .setToAddress("1GDCMHsTLBkawQXP8dqcZtr8zGgb4XpCug")
             .setChangeAddress("1CSR6tXqngr1CfwVF23V4bQotttJmzXqpf")
             .setByteFee(10)

--- a/include/TrustWalletCore/TWBitcoinScript.h
+++ b/include/TrustWalletCore/TWBitcoinScript.h
@@ -117,6 +117,6 @@ struct TWBitcoinScript *_Nonnull TWBitcoinScriptLockScriptForAddress(TWString *_
 
 // Return the default HashType for the given coin, such as TWBitcoinSigHashTypeAll.
 TW_EXPORT_STATIC_METHOD
-enum TWBitcoinSigHashType TWBitcoinScriptHashTypeForCoin(enum TWCoinType coinType);
+uint32_t TWBitcoinScriptHashTypeForCoin(enum TWCoinType coinType);
 
 TW_EXTERN_C_END

--- a/src/Bitcoin/SigHashType.h
+++ b/src/Bitcoin/SigHashType.h
@@ -16,13 +16,13 @@ namespace TW::Bitcoin {
 static const uint8_t SigHashMask = 0x1f;
 
 // Return the default HashType for the given coin, such as TWBitcoinSigHashTypeAll.
-inline enum TWBitcoinSigHashType hashTypeForCoin(enum TWCoinType coinType) {
+inline uint32_t hashTypeForCoin(enum TWCoinType coinType) {
     // set fork hash type for BCH
     switch (coinType) {
         case TWCoinTypeBitcoinCash:
-            return (enum TWBitcoinSigHashType)((int)TWBitcoinSigHashTypeAll | (int)TWBitcoinSigHashTypeFork);
+            return (uint32_t)TWBitcoinSigHashTypeAll | (uint32_t)TWBitcoinSigHashTypeFork;
         case TWCoinTypeBitcoinGold:
-            return (enum TWBitcoinSigHashType)((int)TWBitcoinSigHashTypeAll | (int)TWBitcoinSigHashTypeForkBTG);
+            return (uint32_t)TWBitcoinSigHashTypeAll | (uint32_t)TWBitcoinSigHashTypeForkBTG;
         default:
             return TWBitcoinSigHashTypeAll;
     }

--- a/src/interface/TWBitcoinScript.cpp
+++ b/src/interface/TWBitcoinScript.cpp
@@ -148,6 +148,6 @@ struct TWBitcoinScript *_Nonnull TWBitcoinScriptLockScriptForAddress(TWString *_
     return new TWBitcoinScript{ .impl = script };
 }
 
-enum TWBitcoinSigHashType TWBitcoinScriptHashTypeForCoin(enum TWCoinType coinType) {
+uint32_t TWBitcoinScriptHashTypeForCoin(enum TWCoinType coinType) {
     return TW::Bitcoin::hashTypeForCoin(coinType);
 }

--- a/swift/Tests/Blockchains/BitcoinTests.swift
+++ b/swift/Tests/Blockchains/BitcoinTests.swift
@@ -107,7 +107,7 @@ class BitcoinTransactionSignerTests: XCTestCase {
         let scriptHash = lockScript.matchPayToScriptHash()!
         let input = BitcoinSigningInput.with {
             $0.toAddress = "3NqULUrjZ7NL36YtBGsSVzqr5q1x9CJWwu"
-            $0.hashType = BitcoinSigHashType.all.rawValue
+            $0.hashType = BitcoinScript.hashTypeForCoin(coinType: .bitcoin)
             $0.coinType = CoinType.bitcoin.rawValue
             $0.scripts = [
                 scriptHash.hexString: BitcoinScript.buildPayToWitnessPubkeyHash(hash: pubkey.bitcoinKeyHash).data

--- a/swift/Tests/Blockchains/BitcoinTests.swift
+++ b/swift/Tests/Blockchains/BitcoinTests.swift
@@ -15,7 +15,7 @@ class BitcoinTransactionSignerTests: XCTestCase {
     func testSignP2WSH() throws {
         // set up input
         var input = BitcoinSigningInput.with {
-            $0.hashType = BitcoinScript.hashTypeForCoin(coinType: .bitcoin).rawValue
+            $0.hashType = BitcoinScript.hashTypeForCoin(coinType: .bitcoin)
             $0.amount = 1000
             $0.byteFee = 1
             $0.toAddress = "1Bp9U1ogV3A14FMvKbRJms7ctyso4Z4Tcx"
@@ -120,5 +120,11 @@ class BitcoinTransactionSignerTests: XCTestCase {
 
         // https://blockchair.com/bitcoin/transaction/da2a9ce5d71ff7490bc9025e2888ca109b68ec0bd0e7d26195e1783305c00117
         XCTAssertEqual(output.encoded.hexString, "01000000000101a3c50b159e3c0e2b1ed0b1a1d95438f76700726d06a41a36eaa4d4c661485f8b00000000171600140a3cca78017f46ac23e463148adb7231aef81956ffffffff01ccab00000000000017a914e7f40472c54fc93078c5129568cf95c27be3b2c287024830450221008dc29a5430facd4078ad93e72517d87b298d7a73b55d2828acab040ccf713ed5022063a13e348655fa7cdcfff084380611629babf165607b529bcc35bf6ddfab1f8101210370386469db8302c3092955724f56bcca9a36f31df82655aa79be46b08744cd1200000000")
+    }
+
+    func testHashTypeForCoin() {
+        XCTAssertEqual(BitcoinScript.hashTypeForCoin(coinType: .bitcoin), TWBitcoinSigHashTypeAll.rawValue)
+        XCTAssertEqual(BitcoinScript.hashTypeForCoin(coinType: .bitcoinCash), 0x41)
+        XCTAssertEqual(BitcoinScript.hashTypeForCoin(coinType: .bitcoinGold), 0x4f41)
     }
 }

--- a/swift/Tests/Blockchains/BitconCashTests.swift
+++ b/swift/Tests/Blockchains/BitconCashTests.swift
@@ -65,7 +65,7 @@ class BitcoinCashTests: XCTestCase {
         }
 
         let input = BitcoinSigningInput.with {
-            $0.hashType = BitcoinSigHashType.all.rawValue | BitcoinSigHashType.fork.rawValue
+            $0.hashType = BitcoinScript.hashTypeForCoin(coinType: .bitcoinCash)
             $0.amount = 600
             $0.byteFee = 1
             $0.toAddress = "1Bp9U1ogV3A14FMvKbRJms7ctyso4Z4Tcx"

--- a/swift/Tests/Blockchains/DecredTests.swift
+++ b/swift/Tests/Blockchains/DecredTests.swift
@@ -45,7 +45,7 @@ class DecredTests: XCTestCase {
         }
 
         let input = BitcoinSigningInput.with {
-            $0.hashType = BitcoinSigHashType.all.rawValue
+            $0.hashType = BitcoinScript.hashTypeForCoin(coinType: .decred)
             $0.amount = amount
             $0.byteFee = 1
             $0.toAddress = "Dsesp1V6DZDEtcq2behmBVKdYqKMdkh96hL"

--- a/swift/Tests/Blockchains/GroestlcoinTransactionSignerTests.swift
+++ b/swift/Tests/Blockchains/GroestlcoinTransactionSignerTests.swift
@@ -14,7 +14,7 @@ class GroestlcoinTransactionSignerTests: XCTestCase {
 
     func testSignP2WPKH() throws {
         var input = BitcoinSigningInput.with {
-            $0.hashType = BitcoinSigHashType.all.rawValue
+            $0.hashType = BitcoinScript.hashTypeForCoin(coinType: .groestlcoin)
             $0.amount = 2500
             $0.byteFee = 1
             $0.toAddress = "31inaRqambLsd9D7Ke4USZmGEVd3PHkh7P"
@@ -67,7 +67,7 @@ class GroestlcoinTransactionSignerTests: XCTestCase {
 
     func testSignP2PKH() throws {
         var input = BitcoinSigningInput.with {
-            $0.hashType = BitcoinSigHashType.all.rawValue
+            $0.hashType = BitcoinScript.hashTypeForCoin(coinType: .groestlcoin)
             $0.amount = 2500
             $0.byteFee = 1
             $0.toAddress = "grs1qw4teyraux2s77nhjdwh9ar8rl9dt7zww8r6lne"
@@ -118,7 +118,7 @@ class GroestlcoinTransactionSignerTests: XCTestCase {
 
     func testSignP2SH_P2WPKH() throws {
         var input = BitcoinSigningInput.with {
-            $0.hashType = BitcoinSigHashType.all.rawValue
+            $0.hashType = BitcoinScript.hashTypeForCoin(coinType: .groestlcoin)
             $0.amount = 5000
             $0.byteFee = 1
             $0.toAddress = "Fj62rBJi8LvbmWu2jzkaUX1NFXLEqDLoZM"

--- a/swift/Tests/Blockchains/LitecoinTests.swift
+++ b/swift/Tests/Blockchains/LitecoinTests.swift
@@ -108,7 +108,7 @@ class LitecoinTests: XCTestCase {
         var input = BitcoinSigningInput.with {
             $0.toAddress = "ltc1qt36tu30tgk35tyzsve6jjq3dnhu2rm8l8v5q00"
             $0.changeAddress = address
-            $0.hashType = BitcoinSigHashType.all.rawValue
+            $0.hashType = BitcoinScript.hashTypeForCoin(coinType: .litecoin)
             $0.amount = 1200000
             $0.coinType = CoinType.litecoin.rawValue
             $0.byteFee = 1

--- a/swift/Tests/Blockchains/ZcashTests.swift
+++ b/swift/Tests/Blockchains/ZcashTests.swift
@@ -51,7 +51,7 @@ class ZcashTests: XCTestCase {
             }
         ]
         let input = BitcoinSigningInput.with {
-            $0.hashType = BitcoinSigHashType.all.rawValue
+            $0.hashType = BitcoinScript.hashTypeForCoin(coinType: .zcash)
             $0.amount = 488000
             $0.toAddress = "t1QahNjDdibyE4EdYkawUSKBBcVTSqv64CS"
             $0.coinType = CoinType.zcash.rawValue

--- a/tests/Bitcoin/TWBitcoinScriptTests.cpp
+++ b/tests/Bitcoin/TWBitcoinScriptTests.cpp
@@ -204,11 +204,11 @@ TEST(TWBitcoinScript, LockScriptForCashAddress) {
 }
 
 TEST(TWBitcoinSigHashType, HashTypeForCoin) {
-    EXPECT_EQ(TWBitcoinScriptHashTypeForCoin(TWCoinTypeBitcoin), TWBitcoinSigHashTypeAll);
-    EXPECT_EQ(TWBitcoinScriptHashTypeForCoin(TWCoinTypeLitecoin), TWBitcoinSigHashTypeAll);
-    EXPECT_EQ(TWBitcoinScriptHashTypeForCoin(TWCoinTypeZcash), TWBitcoinSigHashTypeAll);
-    EXPECT_EQ(TWBitcoinScriptHashTypeForCoin(TWCoinTypeBitcoinCash), (enum TWBitcoinSigHashType)((int)TWBitcoinSigHashTypeAll | (int)TWBitcoinSigHashTypeFork));
-    EXPECT_EQ(TWBitcoinScriptHashTypeForCoin(TWCoinTypeBitcoinGold), (enum TWBitcoinSigHashType)((int)TWBitcoinSigHashTypeAll | (int)TWBitcoinSigHashTypeForkBTG));
+    EXPECT_EQ(TWBitcoinScriptHashTypeForCoin(TWCoinTypeBitcoin), (uint32_t)TWBitcoinSigHashTypeAll);
+    EXPECT_EQ(TWBitcoinScriptHashTypeForCoin(TWCoinTypeLitecoin), (uint32_t)TWBitcoinSigHashTypeAll);
+    EXPECT_EQ(TWBitcoinScriptHashTypeForCoin(TWCoinTypeZcash), (uint32_t)TWBitcoinSigHashTypeAll);
+    EXPECT_EQ(TWBitcoinScriptHashTypeForCoin(TWCoinTypeBitcoinCash), (uint32_t)TWBitcoinSigHashTypeAll | (uint32_t)TWBitcoinSigHashTypeFork);
+    EXPECT_EQ(TWBitcoinScriptHashTypeForCoin(TWCoinTypeBitcoinGold), (uint32_t)TWBitcoinSigHashTypeAll | (uint32_t)TWBitcoinSigHashTypeForkBTG);
 }
 
 TEST(TWBitcoinSigHashType, IsSingle) {

--- a/tests/Bitcoin/TWBitcoinSigningTests.cpp
+++ b/tests/Bitcoin/TWBitcoinSigningTests.cpp
@@ -391,7 +391,7 @@ TEST(BitcoinSigning, EncodeP2WSH) {
     );
 }
 
-Proto::SigningInput buildInputP2WSH(enum TWBitcoinSigHashType hashType, bool omitScript = false, bool omitKeys = false) {
+Proto::SigningInput buildInputP2WSH(uint32_t hashType, bool omitScript = false, bool omitKeys = false) {
     Proto::SigningInput input;
     input.set_hash_type(hashType);
     input.set_amount(1000);
@@ -462,7 +462,7 @@ TEST(BitcoinSigning, SignP2WSH) {
 
 TEST(BitcoinSigning, SignP2WSH_HashNone) {
     // Setup input
-    const auto input = buildInputP2WSH(TWBitcoinSigHashTypeNone);
+    const auto input = buildInputP2WSH((uint32_t)TWBitcoinSigHashTypeNone);
 
     {
         // test plan (but do not reuse plan result)
@@ -497,7 +497,7 @@ TEST(BitcoinSigning, SignP2WSH_HashNone) {
 
 TEST(BitcoinSigning, SignP2WSH_HashSingle) {
     // Setup input
-    const auto input = buildInputP2WSH(TWBitcoinSigHashTypeSingle);
+    const auto input = buildInputP2WSH((uint32_t)TWBitcoinSigHashTypeSingle);
 
     {
         // test plan (but do not reuse plan result)
@@ -532,7 +532,7 @@ TEST(BitcoinSigning, SignP2WSH_HashSingle) {
 
 TEST(BitcoinSigning, SignP2WSH_HashAnyoneCanPay) {
     // Setup input
-    const auto input = buildInputP2WSH(TWBitcoinSigHashTypeAnyoneCanPay);
+    const auto input = buildInputP2WSH((uint32_t)TWBitcoinSigHashTypeAnyoneCanPay);
 
     {
         // test plan (but do not reuse plan result)
@@ -567,7 +567,7 @@ TEST(BitcoinSigning, SignP2WSH_HashAnyoneCanPay) {
 }
 
 TEST(BitcoinSigning, SignP2WSH_NegativeMissingScript) {
-    const auto input = buildInputP2WSH(TWBitcoinSigHashTypeAll, true);
+    const auto input = buildInputP2WSH((uint32_t)TWBitcoinSigHashTypeAll, true);
 
     {
         // test plan (but do not reuse plan result)
@@ -583,7 +583,7 @@ TEST(BitcoinSigning, SignP2WSH_NegativeMissingScript) {
 }
 
 TEST(BitcoinSigning, SignP2WSH_NegativeMissingKeys) {
-    const auto input = buildInputP2WSH(TWBitcoinSigHashTypeAll, false, true);
+    const auto input = buildInputP2WSH((uint32_t)TWBitcoinSigHashTypeAll, false, true);
 
     {
         // test plan (but do not reuse plan result). Plan works even with missing keys.
@@ -600,7 +600,7 @@ TEST(BitcoinSigning, SignP2WSH_NegativeMissingKeys) {
 
 TEST(BitcoinSigning, SignP2WSH_NegativePlanWithNoUTXOs) {
     // Setup input
-    auto input = buildInputP2WSH(TWBitcoinSigHashTypeAll);
+    auto input = buildInputP2WSH((uint32_t)TWBitcoinSigHashTypeAll);
     auto plan = Bitcoin::TransactionPlan();
     input.mutable_plan()->clear_utxos();
 


### PR DESCRIPTION
HashTypeForCoin: fix return type to uint32, invalid enum values did not go through Swift/Kotlin interfaces.

## Description

For BitcoinCash and BitcoinGold, hashtype is two enum values OR'ed together, which itself not a valid enum value.  This works in C/C++, but in Swift/Kotlin it results in invalid/null value.  This is fixed by changing return type to uint32_t.  Fixes #1041 .

## Testing instructions

C++ unit tests, iOS unit tests.

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
