### PR TITLE
[WIP] Bitcoin TX signing with multiple output support

### DIFF
--- a/src/Bitcoin/TransactionBuilder.cpp
+++ b/src/Bitcoin/TransactionBuilder.cpp
@@ -15,8 +15,8 @@
 namespace TW::Bitcoin {
 
 /// Estimate encoded size by simple formula
-int64_t estimateSimpleFee(FeeCalculator& feeCalculator, const TransactionPlan& plan, int outputSize, const Bitcoin::Proto::SigningInput& input) {
-    return feeCalculator.calculate(plan.utxos.size(), outputSize, input.byte_fee());
+int64_t estimateSimpleFee(FeeCalculator& feeCalculator, const TransactionPlan& plan, int outputSize, int64_t byteFee) {
+    return feeCalculator.calculate(plan.utxos.size(), outputSize, byteFee);
 }
 
 /// Estimate encoded size by invoking sign(sizeOnly), get actual size
@@ -24,7 +24,7 @@ int64_t estimateSegwitFee(FeeCalculator& feeCalculator, const TransactionPlan& p
     TWPurpose coinPurpose = TW::purpose(static_cast<TWCoinType>(input.coin_type()));
     if (coinPurpose != TWPurposeBIP84) {
         // not segwit, return default simple estimate
-        return estimateSimpleFee(feeCalculator, plan, outputSize, input);
+        return estimateSimpleFee(feeCalculator, plan, outputSize, input.byte_fee());
     }
 
     // duplicate input, with the current plan
@@ -35,7 +35,7 @@ int64_t estimateSegwitFee(FeeCalculator& feeCalculator, const TransactionPlan& p
     auto result = signer.sign();
     if (!result) {
         // signing failed; return default simple estimate
-        return estimateSimpleFee(feeCalculator, plan, outputSize, input);
+        return estimateSimpleFee(feeCalculator, plan, outputSize, input.byte_fee());
     }
 
     // Obtain the encoded size
@@ -65,12 +65,13 @@ TransactionPlan TransactionBuilder::plan(const Bitcoin::Proto::SigningInput& inp
     auto plan = TransactionPlan();
     plan.amount = input.amount();
 
-    auto output_size = 2;
     auto& feeCalculator = getFeeCalculator(static_cast<TWCoinType>(input.coin_type()));
     auto unspentSelector = UnspentSelector(feeCalculator);
+    const bool maxAmount = input.use_max_amount();
 
     // select UTXOs
-    if (!input.use_max_amount()) {
+    auto output_size = 2;
+    if (!maxAmount) {
         output_size = 2; // output + change
         plan.utxos = unspentSelector.select(input.utxo(), plan.amount, input.byte_fee(), output_size);
     } else {
@@ -82,7 +83,7 @@ TransactionPlan TransactionBuilder::plan(const Bitcoin::Proto::SigningInput& inp
 
     // Compute fee.
     // must preliminary set change so that there is a second output
-    if (!input.use_max_amount()) {
+    if (!maxAmount) {
         plan.amount = input.amount();
         plan.fee = 0;
         plan.change = plan.availableAmount - plan.amount;
@@ -97,7 +98,7 @@ TransactionPlan TransactionBuilder::plan(const Bitcoin::Proto::SigningInput& inp
     assert(plan.fee >= 0 && plan.fee <= plan.availableAmount);
     
     // adjust/compute amount
-    if (!input.use_max_amount()) {
+    if (!maxAmount) {
         // reduce amount if needed
         plan.amount = std::max(Amount(0), std::min(plan.amount, plan.availableAmount - plan.fee));
     } else {
@@ -109,7 +110,7 @@ TransactionPlan TransactionBuilder::plan(const Bitcoin::Proto::SigningInput& inp
     // compute change
     plan.change = plan.availableAmount - plan.amount - plan.fee;
     assert(plan.change >= 0 && plan.change <= plan.availableAmount);
-    assert(!input.use_max_amount() || plan.change == 0); // change is 0 in max amount case
+    assert(!maxAmount || plan.change == 0); // change is 0 in max amount case
 
     assert(plan.amount + plan.change + plan.fee == plan.availableAmount);
 

--- a/src/Bitcoin/TransactionBuilder.cpp
+++ b/src/Bitcoin/TransactionBuilder.cpp
@@ -15,12 +15,12 @@
 namespace TW::Bitcoin {
 
 /// Estimate encoded size by simple formula
-int64_t estimateSimpleFee(FeeCalculator& feeCalculator, const TransactionPlan& plan, int outputSize, int64_t byteFee) {
+int64_t estimateSimpleFee(const FeeCalculator& feeCalculator, const TransactionPlan& plan, int outputSize, int64_t byteFee) {
     return feeCalculator.calculate(plan.utxos.size(), outputSize, byteFee);
 }
 
 /// Estimate encoded size by invoking sign(sizeOnly), get actual size
-int64_t estimateSegwitFee(FeeCalculator& feeCalculator, const TransactionPlan& plan, int outputSize, const Bitcoin::Proto::SigningInput& input) {
+int64_t estimateSegwitFee(const FeeCalculator& feeCalculator, const TransactionPlan& plan, int outputSize, const Bitcoin::Proto::SigningInput& input) {
     TWPurpose coinPurpose = TW::purpose(static_cast<TWCoinType>(input.coin_type()));
     if (coinPurpose != TWPurposeBIP84) {
         // not segwit, return default simple estimate
@@ -73,7 +73,7 @@ TransactionPlan TransactionBuilder::plan(const Bitcoin::Proto::SigningInput& inp
     auto plan = TransactionPlan();
     plan.amount = getTotalAmountFromInput(input);
 
-    auto& feeCalculator = getFeeCalculator(static_cast<TWCoinType>(input.coin_type()));
+    const auto& feeCalculator = getFeeCalculator(static_cast<TWCoinType>(input.coin_type()));
     auto unspentSelector = UnspentSelector(feeCalculator);
 
     auto dest_output_count = 1 + input.extra_outputs_size();

--- a/src/Bitcoin/TransactionPlan.h
+++ b/src/Bitcoin/TransactionPlan.h
@@ -13,7 +13,7 @@ namespace TW::Bitcoin {
 
 /// Describes a preliminary transaction plan.
 struct TransactionPlan {
-    /// Amount to be received at the other end.
+    /// Amount to be received at the other end (or ends)
     Amount amount = 0;
 
     /// Maximum available amount.

--- a/src/Bitcoin/TransactionSigner.h
+++ b/src/Bitcoin/TransactionSigner.h
@@ -55,8 +55,20 @@ class TransactionSigner {
       } else {
         plan = TransactionBuilder::plan(input);
       }
+  
+      std::vector<std::pair<std::string, int64_t>> outputs;
+      if (input.extra_outputs_size() == 0) {
+        // standard one-destination case, take amount from plan
+        outputs.emplace_back(std::pair<std::string, int64_t>{input.to_address(), plan.amount});
+      } else {
+        // multi-output case
+        outputs.emplace_back(std::pair<std::string, int64_t>{input.to_address(), input.amount()});
+        for (auto i = 0; i < input.extra_outputs_size(); ++i) {
+          outputs.emplace_back(std::pair<std::string, int64_t>(input.extra_outputs(i).to_address(), input.extra_outputs(i).amount()));
+        }
+      }
       transaction = TransactionBuilder::template build<Transaction>(
-        plan, input.to_address(), input.change_address(), TWCoinType(input.coin_type())
+        plan, outputs, input.change_address(), TWCoinType(input.coin_type())
       );
     }
 

--- a/src/Bitcoin/UnspentSelector.h
+++ b/src/Bitcoin/UnspentSelector.h
@@ -34,7 +34,7 @@ class UnspentSelector {
     std::vector<Proto::UnspentTransaction> selectMaxAmount(const T& utxos, int64_t byteFee);
 
     /// Construct, using provided feeCalculator (see getFeeCalculator()).
-    explicit UnspentSelector(FeeCalculator& feeCalculator) : feeCalculator(feeCalculator) {}
+    explicit UnspentSelector(const FeeCalculator& feeCalculator) : feeCalculator(feeCalculator) {}
     UnspentSelector() : UnspentSelector(getFeeCalculator(TWCoinTypeBitcoin)) {}
 
     template <typename T>
@@ -47,7 +47,7 @@ class UnspentSelector {
     }
 
   private:
-    FeeCalculator& feeCalculator;
+    const FeeCalculator& feeCalculator;
     template <typename T> std::vector<Proto::UnspentTransaction> filterDustInput(const T& selectedUtxos, int64_t byteFee);
 };
 

--- a/src/Zcash/TransactionBuilder.h
+++ b/src/Zcash/TransactionBuilder.h
@@ -25,11 +25,13 @@ struct TransactionBuilder {
 
     /// Builds a transaction by selecting UTXOs and calculating fees.
     template <typename Transaction>
-    static Transaction build(const Bitcoin::TransactionPlan& plan, const std::string& toAddress,
-                             const std::string& changeAddress, enum TWCoinType coin) {
+    static Transaction build(const Bitcoin::TransactionPlan& plan,
+        const std::vector<std::pair<std::string, int64_t>>& outputs,
+        const std::string& changeAddress, enum TWCoinType coin)
+    {
         coin = TWCoinTypeZcash;
         Transaction tx =
-            Bitcoin::TransactionBuilder::build<Transaction>(plan, toAddress, changeAddress, coin);
+            Bitcoin::TransactionBuilder::build<Transaction>(plan, outputs, changeAddress, coin);
         // if not set, always use latest consensus branch id
         if (plan.branchId.empty()) {
             std::copy(BlossomBranchID.begin(), BlossomBranchID.end(), tx.branchId.begin());

--- a/src/proto/Bitcoin.proto
+++ b/src/proto/Bitcoin.proto
@@ -50,13 +50,29 @@ message TransactionOutput {
     bytes script = 2;
 }
 
+// An unspent transaction output, that can serve as input to a transaction
 message UnspentTransaction {
+    // The unspent output
     OutPoint out_point = 1;
+
+    // Script for claiming this UTXO
     bytes script = 2;
+
+    // Amount of the UTXO
     int64 amount = 3;
 }
 
+// Pair of destination address and amount, used for extra outputs
+message OutputAddress {
+    // Destination address
+    string to_address = 1;
+
+    // Amount to be paid to this output
+    int64 amount = 2;
+}
+
 // Input data necessary to create a signed transaction.
+// Outputs will be: one for to_address, optionally one for each extra_outputs, nad optionally one for change_address if there is leftover amount
 message SigningInput {
     // Hash type to use when signing.
     uint32 hash_type = 1;
@@ -90,6 +106,9 @@ message SigningInput {
 
     // Optional transaction plan
     TransactionPlan plan = 11;
+
+    // Optional additional destination addresses, additional to first to_address output
+    repeated OutputAddress extra_outputs = 12;
 }
 
 // Describes a preliminary transaction plan.

--- a/src/proto/Bitcoin.proto
+++ b/src/proto/Bitcoin.proto
@@ -74,22 +74,22 @@ message SigningInput {
     string change_address = 5;
 
     // Available private keys.
-    repeated bytes private_key = 10;
+    repeated bytes private_key = 6;
 
     // Available redeem scripts indexed by script hash.
-    map<string, bytes> scripts = 11;
+    map<string, bytes> scripts = 7;
 
     // Available unspent transaction outputs.
-    repeated UnspentTransaction utxo = 12;
+    repeated UnspentTransaction utxo = 8;
 
     // If sending max amount.
-    bool use_max_amount = 13;
+    bool use_max_amount = 9;
 
     // Coin type (forks).
-    uint32 coin_type = 14;
+    uint32 coin_type = 10;
 
     // Optional transaction plan
-    TransactionPlan plan = 15;
+    TransactionPlan plan = 11;
 }
 
 // Describes a preliminary transaction plan.

--- a/swift/Tests/Blockchains/BitcoinTests.swift
+++ b/swift/Tests/Blockchains/BitcoinTests.swift
@@ -122,6 +122,95 @@ class BitcoinTransactionSignerTests: XCTestCase {
         XCTAssertEqual(output.encoded.hexString, "01000000000101a3c50b159e3c0e2b1ed0b1a1d95438f76700726d06a41a36eaa4d4c661485f8b00000000171600140a3cca78017f46ac23e463148adb7231aef81956ffffffff01ccab00000000000017a914e7f40472c54fc93078c5129568cf95c27be3b2c287024830450221008dc29a5430facd4078ad93e72517d87b298d7a73b55d2828acab040ccf713ed5022063a13e348655fa7cdcfff084380611629babf165607b529bcc35bf6ddfab1f8101210370386469db8302c3092955724f56bcca9a36f31df82655aa79be46b08744cd1200000000")
     }
 
+    func testSignThreeOutput() throws {
+        let coin: CoinType = .litecoin
+        let ownAddress = "ltc1qt36tu30tgk35tyzsve6jjq3dnhu2rm8l8v5q00"
+        let ownPrivateKey = "b820f41f96c8b7442f3260acd23b3897e1450b8c7c6580136a3c2d3a14e34674"
+        let toAddress0 = "ltc1qgknskahmm6svn42e33gum5wc4dz44wt9vc76q4"
+        let toAddress1 = "ltc1qulgtqdgxyd9nxnn5yxft6jykskz0ffl30nu32z"
+        let utxo0Amount: Int64 = 3_851_829;
+        let toAmount0: Int64 = 1_000_000;
+        let toAmount1: Int64 = 2_000_000;
+
+        // set up input
+        var input = BitcoinSigningInput.with {
+            $0.coinType = coin.rawValue
+            $0.hashType = BitcoinScript.hashTypeForCoin(coinType: coin)
+            // output 0: in to_address/amount
+            $0.toAddress = toAddress0
+            $0.amount = toAmount0
+            // output 1: in extra_outputs, below
+            // output 2: change in change_address, amount will be computed
+            $0.changeAddress = ownAddress
+            $0.useMaxAmount = false
+            $0.byteFee = 1
+        }
+        // output 1: in extra_outputs
+        let output1 = BitcoinOutputAddress.with {
+            $0.toAddress = toAddress1
+            $0.amount = toAmount1
+        }
+        input.extraOutputs.append(output1)
+
+        let utxo0Script = BitcoinScript.lockScriptForAddress(address: ownAddress, coin: coin)
+        let keyHash0 = utxo0Script.matchPayToWitnessPublicKeyHash()!
+        XCTAssertEqual(keyHash0.hexString, "5c74be45eb45a3459050667529022d9df8a1ecff")
+
+        let redeemScript = BitcoinScript.buildPayToPublicKeyHash(hash: keyHash0)
+        input.scripts[keyHash0.hexString] = redeemScript.data
+
+        let utxo0 = BitcoinUnspentTransaction.with {
+            $0.script = utxo0Script.data
+            $0.amount = utxo0Amount
+            $0.outPoint.hash = Data(Data(hexString: "bbe736ada63c4678025dff0ff24d5f38970a3e4d7a2f77808689ed68004f55fe")!.reversed())
+            $0.outPoint.index = 0
+            $0.outPoint.sequence = UInt32.max
+        }
+        input.utxo.append(utxo0)
+
+        // Plan
+        let plan: BitcoinTransactionPlan = AnySigner.plan(input: input, coin: coin)
+
+        XCTAssertEqual(plan.amount, 3000000)
+        XCTAssertEqual(plan.fee, 172)
+        XCTAssertEqual(plan.change, 851657)
+
+        // Extend input with private key
+        input.privateKey.append(Data(hexString: ownPrivateKey)!)
+
+        // Sign
+        let output: BitcoinSigningOutput = AnySigner.sign(input: input, coin: coin)
+        XCTAssertTrue(output.error.isEmpty)
+
+        let signedTx = output.transaction
+        XCTAssertEqual(signedTx.version, 1)
+
+        XCTAssertEqual(signedTx.inputs.count, 1)
+
+        XCTAssertEqual(signedTx.outputs.count, 3) // 3 outputs
+        XCTAssertEqual(signedTx.outputs[0].value, 1000000)
+        XCTAssertEqual(signedTx.outputs[1].value, 2000000)
+        XCTAssertEqual(signedTx.outputs[2].value, 851657)
+
+        let encoded = output.encoded
+        // https://blockchair.com/litecoin/transaction/9e3fe98565a904d2da5ec1b3ba9d2b3376dfc074f43d113ce1caac01bf51b34c
+        XCTAssertEqual(encoded.hexString,
+            "01000000" + // version
+            "0001" + // marker & flag
+            "01" + // inputs
+                "fe554f0068ed898680772f7a4d3e0a97385f4df20fff5d0278463ca6ad36e7bb" + "00000000" + "00" + "" + "ffffffff" +
+            "03" + // outputs
+                "40420f0000000000" + "16" + "001445a70b76fbdea0c9d5598c51cdd1d8ab455ab965" +
+                "80841e0000000000" + "16" + "0014e7d0b03506234b334e742192bd48968584f4a7f1" +
+                "c9fe0c0000000000" + "16" + "00145c74be45eb45a3459050667529022d9df8a1ecff" +
+            // witness
+                "02" +
+                    "48" + "30450221008d88197a37ffcb51ecacc7e826aa588cb1068a107a82373c4b54ec42318a395c02204abbf5408504614d8f943d67e7873506c575e85a5e1bd92a02cd345e5192a82701" +
+                    "21" + "036739829f2cfec79cfe6aaf1c22ecb7d4867dfd8ab4deb7121b36a00ab646caed" +
+            "00000000" // nLockTime
+        )
+    }
+
     func testHashTypeForCoin() {
         XCTAssertEqual(BitcoinScript.hashTypeForCoin(coinType: .bitcoin), TWBitcoinSigHashTypeAll.rawValue)
         XCTAssertEqual(BitcoinScript.hashTypeForCoin(coinType: .bitcoinCash), 0x41)

--- a/tests/Bitcoin/TWBitcoinSigningTests.cpp
+++ b/tests/Bitcoin/TWBitcoinSigningTests.cpp
@@ -1143,17 +1143,17 @@ TEST(BitcoinSigning, PlanAndSign_LitecoinReal_8435) {
 
 TEST(BitcoinSigning, EncodeThreeOutput) {
     auto coin = TWCoinTypeLitecoin;
-    auto ownAddress = "ltc1q0dvup9kzplv6yulzgzzxkge8d35axkq4n45hum";
-    auto ownPrivateKey = "690b34763f34e0226ad2a4d47098269322e0402f847c97166e8f39959fcaff5a";
-    auto toAddress0 = "ltc1qt36tu30tgk35tyzsve6jjq3dnhu2rm8l8v5q00";
-    auto toAddress1 = "ltc1q890j9tkhftmfh347y6sdtpr8d7ep9cl6jpmr9n";
-    auto utxo0Amount = 3'899'774;
-    auto toAmount0 = 1'200'000;
-    auto toAmount1 = 800'000;
+    auto ownAddress = "ltc1qt36tu30tgk35tyzsve6jjq3dnhu2rm8l8v5q00";
+    auto ownPrivateKey = "b820f41f96c8b7442f3260acd23b3897e1450b8c7c6580136a3c2d3a14e34674";
+    auto toAddress0 = "ltc1qgknskahmm6svn42e33gum5wc4dz44wt9vc76q4";
+    auto toAddress1 = "ltc1qulgtqdgxyd9nxnn5yxft6jykskz0ffl30nu32z";
+    auto utxo0Amount = 3'851'829;
+    auto toAmount0 = 1'000'000;
+    auto toAmount1 = 2'000'000;
 
     auto unsignedTx = Transaction(1, 0);
 
-    auto hash0 = parse_hex("a85fd6a9a7f2f54cacb57e83dfd408e51c0a5fc82885e3fa06be8692962bc407");
+    auto hash0 = parse_hex("bbe736ada63c4678025dff0ff24d5f38970a3e4d7a2f77808689ed68004f55fe");
     std::reverse(hash0.begin(), hash0.end());
     auto outpoint0 = TW::Bitcoin::OutPoint(hash0, 0);
     unsignedTx.inputs.emplace_back(outpoint0, Script(), UINT32_MAX);
@@ -1169,15 +1169,15 @@ TEST(BitcoinSigning, EncodeThreeOutput) {
     Data unsignedData;
     unsignedTx.encode(unsignedData, Transaction::SegwitFormatMode::Segwit);
     EXPECT_EQ(unsignedData.size(), 147);
-    EXPECT_EQ(hex(unsignedData),
+    EXPECT_EQ(hex(unsignedData), // printed using prettyPrintTransaction
         "01000000" // version
         "0001" // marker & flag
         "01" // inputs
-            "07c42b969286be06fae38528c85f0a1ce508d4df837eb5ac4cf5f2a7a9d65fa8"  "00000000"  "00"  ""  "ffffffff"
+            "fe554f0068ed898680772f7a4d3e0a97385f4df20fff5d0278463ca6ad36e7bb"  "00000000"  "00"  ""  "ffffffff"
         "03" // outputs
-            "804f120000000000"  "16"  "00145c74be45eb45a3459050667529022d9df8a1ecff"
-            "00350c0000000000"  "16"  "0014395f22aed74af69bc6be26a0d584676fb212e3fa"
-            "52fc1c0000000000"  "16"  "00147b59c096c20fd9a273e240846b23276c69d35815"
+            "40420f0000000000"  "16"  "001445a70b76fbdea0c9d5598c51cdd1d8ab455ab965"
+            "80841e0000000000"  "16"  "0014e7d0b03506234b334e742192bd48968584f4a7f1"
+            "c9fe0c0000000000"  "16"  "00145c74be45eb45a3459050667529022d9df8a1ecff"
         // witness
             "00"
         "00000000" // nLockTime
@@ -1187,15 +1187,15 @@ TEST(BitcoinSigning, EncodeThreeOutput) {
 
     auto privkey = PrivateKey(parse_hex(ownPrivateKey));
     auto pubkey = PrivateKey(privkey).getPublicKey(TWPublicKeyTypeSECP256k1);
-    EXPECT_EQ(hex(pubkey.bytes), "02499e327a05cc8bb4b3c34c8347ecfcb152517c9927c092fa273be5379fde3226");
+    EXPECT_EQ(hex(pubkey.bytes), "036739829f2cfec79cfe6aaf1c22ecb7d4867dfd8ab4deb7121b36a00ab646caed");
 
     auto utxo0Script = Script::lockScriptForAddress(ownAddress, coin); // buildPayToWitnessProgram()
     Data keyHashIn0;
     EXPECT_TRUE(utxo0Script.matchPayToWitnessPublicKeyHash(keyHashIn0));
-    EXPECT_EQ(hex(keyHashIn0), "7b59c096c20fd9a273e240846b23276c69d35815");
+    EXPECT_EQ(hex(keyHashIn0), "5c74be45eb45a3459050667529022d9df8a1ecff");
 
     auto redeemScript0 = Script::buildPayToPublicKeyHash(keyHashIn0);
-    EXPECT_EQ(hex(redeemScript0.bytes), "76a9147b59c096c20fd9a273e240846b23276c69d3581588ac");
+    EXPECT_EQ(hex(redeemScript0.bytes), "76a9145c74be45eb45a3459050667529022d9df8a1ecff88ac");
 
     auto hashType = TWBitcoinSigHashType::TWBitcoinSigHashTypeAll;
     Data sighash = unsignedTx.getSignatureHash(redeemScript0, unsignedTx.inputs[0].previousOutput.index,
@@ -1203,7 +1203,7 @@ TEST(BitcoinSigning, EncodeThreeOutput) {
     auto sig = privkey.signAsDER(sighash, TWCurveSECP256k1);
     ASSERT_FALSE(sig.empty());
     sig.push_back(hashType);
-    EXPECT_EQ(hex(sig), "3045022100b366dc7cbd27fc269a866d08080a1b9369cc4a3abc0d0052da76091c80eda87702203ff7f209c0938f93eae4ee2dbad22c2575b011da64a688dd6788b07908e0e08f01");
+    EXPECT_EQ(hex(sig), "30450221008d88197a37ffcb51ecacc7e826aa588cb1068a107a82373c4b54ec42318a395c02204abbf5408504614d8f943d67e7873506c575e85a5e1bd92a02cd345e5192a82701");
     
     // add witness stack
     unsignedTx.inputs[0].scriptWitness.push_back(sig);
@@ -1212,32 +1212,32 @@ TEST(BitcoinSigning, EncodeThreeOutput) {
     unsignedData.clear();
     unsignedTx.encode(unsignedData, Transaction::SegwitFormatMode::Segwit);
     EXPECT_EQ(unsignedData.size(), 254);
-    EXPECT_EQ(hex(unsignedData),
+    EXPECT_EQ(hex(unsignedData), // printed using prettyPrintTransaction
         "01000000" // version
         "0001" // marker & flag
         "01" // inputs
-            "07c42b969286be06fae38528c85f0a1ce508d4df837eb5ac4cf5f2a7a9d65fa8"  "00000000"  "00"  ""  "ffffffff"
+            "fe554f0068ed898680772f7a4d3e0a97385f4df20fff5d0278463ca6ad36e7bb"  "00000000"  "00"  ""  "ffffffff"
         "03" // outputs
-            "804f120000000000"  "16"  "00145c74be45eb45a3459050667529022d9df8a1ecff"
-            "00350c0000000000"  "16"  "0014395f22aed74af69bc6be26a0d584676fb212e3fa"
-            "52fc1c0000000000"  "16"  "00147b59c096c20fd9a273e240846b23276c69d35815"
+            "40420f0000000000"  "16"  "001445a70b76fbdea0c9d5598c51cdd1d8ab455ab965"
+            "80841e0000000000"  "16"  "0014e7d0b03506234b334e742192bd48968584f4a7f1"
+            "c9fe0c0000000000"  "16"  "00145c74be45eb45a3459050667529022d9df8a1ecff"
         // witness
             "02"
-                "48"  "3045022100b366dc7cbd27fc269a866d08080a1b9369cc4a3abc0d0052da76091c80eda87702203ff7f209c0938f93eae4ee2dbad22c2575b011da64a688dd6788b07908e0e08f01"
-                "21"  "02499e327a05cc8bb4b3c34c8347ecfcb152517c9927c092fa273be5379fde3226"
+                "48"  "30450221008d88197a37ffcb51ecacc7e826aa588cb1068a107a82373c4b54ec42318a395c02204abbf5408504614d8f943d67e7873506c575e85a5e1bd92a02cd345e5192a82701"
+                "21"  "036739829f2cfec79cfe6aaf1c22ecb7d4867dfd8ab4deb7121b36a00ab646caed"
         "00000000" // nLockTime
     );
 }
 
 TEST(BitcoinSigning, PlanAndSign_ThreeOutput) {
     auto coin = TWCoinTypeLitecoin;
-    auto ownAddress = "ltc1q0dvup9kzplv6yulzgzzxkge8d35axkq4n45hum";
-    auto ownPrivateKey = "690b34763f34e0226ad2a4d47098269322e0402f847c97166e8f39959fcaff5a";
-    auto toAddress0 = "ltc1qt36tu30tgk35tyzsve6jjq3dnhu2rm8l8v5q00";
-    auto toAddress1 = "ltc1q890j9tkhftmfh347y6sdtpr8d7ep9cl6jpmr9n";
-    auto utxo0Amount = 3'899'774;
-    auto toAmount0 = 1'200'000;
-    auto toAmount1 = 800'000;
+    auto ownAddress = "ltc1qt36tu30tgk35tyzsve6jjq3dnhu2rm8l8v5q00";
+    auto ownPrivateKey = "b820f41f96c8b7442f3260acd23b3897e1450b8c7c6580136a3c2d3a14e34674";
+    auto toAddress0 = "ltc1qgknskahmm6svn42e33gum5wc4dz44wt9vc76q4";
+    auto toAddress1 = "ltc1qulgtqdgxyd9nxnn5yxft6jykskz0ffl30nu32z";
+    auto utxo0Amount = 3'851'829;
+    auto toAmount0 = 1'000'000;
+    auto toAmount1 = 2'000'000;
 
     // Setup input for Plan
     Proto::SigningInput input;
@@ -1258,7 +1258,7 @@ TEST(BitcoinSigning, PlanAndSign_ThreeOutput) {
     auto utxo0Script = Script::lockScriptForAddress(ownAddress, coin);
     Data keyHash0;
     EXPECT_TRUE(utxo0Script.matchPayToWitnessPublicKeyHash(keyHash0));
-    EXPECT_EQ(hex(keyHash0), "7b59c096c20fd9a273e240846b23276c69d35815");
+    EXPECT_EQ(hex(keyHash0), "5c74be45eb45a3459050667529022d9df8a1ecff");
 
     auto redeemScript = Script::buildPayToPublicKeyHash(keyHash0);
     auto scriptString = std::string(redeemScript.bytes.begin(), redeemScript.bytes.end());
@@ -1267,7 +1267,7 @@ TEST(BitcoinSigning, PlanAndSign_ThreeOutput) {
     auto utxo0 = input.add_utxo();
     utxo0->set_script(utxo0Script.bytes.data(), utxo0Script.bytes.size());
     utxo0->set_amount(utxo0Amount);
-    auto hash0 = parse_hex("a85fd6a9a7f2f54cacb57e83dfd408e51c0a5fc82885e3fa06be8692962bc407");
+    auto hash0 = parse_hex("bbe736ada63c4678025dff0ff24d5f38970a3e4d7a2f77808689ed68004f55fe");
     std::reverse(hash0.begin(), hash0.end());
     utxo0->mutable_out_point()->set_hash(hash0.data(), hash0.size());
     utxo0->mutable_out_point()->set_index(0);
@@ -1275,7 +1275,7 @@ TEST(BitcoinSigning, PlanAndSign_ThreeOutput) {
 
     // Plan
     auto plan = TransactionBuilder::plan(input);
-    EXPECT_TRUE(verifyPlan(plan, {3'899'774}, 2'000'000, 172));
+    EXPECT_TRUE(verifyPlan(plan, {3'851'829}, 3'000'000, 172));
 
     // Extend input with keys and plan, for Sign
     auto privKey = parse_hex(ownPrivateKey);
@@ -1294,19 +1294,20 @@ TEST(BitcoinSigning, PlanAndSign_ThreeOutput) {
     EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{254, 144, 172}));
     EXPECT_TRUE(validateEstimatedSize(signedTx, -1, 1));
 
+    // https://blockchair.com/litecoin/transaction/9e3fe98565a904d2da5ec1b3ba9d2b3376dfc074f43d113ce1caac01bf51b34c
     ASSERT_EQ(hex(serialized), // printed using prettyPrintTransaction
         "01000000" // version
         "0001" // marker & flag
         "01" // inputs
-            "07c42b969286be06fae38528c85f0a1ce508d4df837eb5ac4cf5f2a7a9d65fa8"  "00000000"  "00"  ""  "ffffffff"
+            "fe554f0068ed898680772f7a4d3e0a97385f4df20fff5d0278463ca6ad36e7bb"  "00000000"  "00"  ""  "ffffffff"
         "03" // outputs
-            "804f120000000000"  "16"  "00145c74be45eb45a3459050667529022d9df8a1ecff"
-            "00350c0000000000"  "16"  "0014395f22aed74af69bc6be26a0d584676fb212e3fa"
-            "52fc1c0000000000"  "16"  "00147b59c096c20fd9a273e240846b23276c69d35815"
+            "40420f0000000000"  "16"  "001445a70b76fbdea0c9d5598c51cdd1d8ab455ab965"
+            "80841e0000000000"  "16"  "0014e7d0b03506234b334e742192bd48968584f4a7f1"
+            "c9fe0c0000000000"  "16"  "00145c74be45eb45a3459050667529022d9df8a1ecff"
         // witness
             "02"
-                "48"  "3045022100b366dc7cbd27fc269a866d08080a1b9369cc4a3abc0d0052da76091c80eda87702203ff7f209c0938f93eae4ee2dbad22c2575b011da64a688dd6788b07908e0e08f01"
-                "21"  "02499e327a05cc8bb4b3c34c8347ecfcb152517c9927c092fa273be5379fde3226"
+                "48"  "30450221008d88197a37ffcb51ecacc7e826aa588cb1068a107a82373c4b54ec42318a395c02204abbf5408504614d8f943d67e7873506c575e85a5e1bd92a02cd345e5192a82701"
+                "21"  "036739829f2cfec79cfe6aaf1c22ecb7d4867dfd8ab4deb7121b36a00ab646caed"
         "00000000" // nLockTime
     );
 }


### PR DESCRIPTION
## Description

Extend bitcoin signing to support transactions with more than one destination address.
Fixes #1091
SigningInput has been extended with an optional array of address/amount pairs, for the extra outputs (2nd, 3rd, ...).
Fee estimation has been also adapted a bit (note: MaxAmount mode is not compatible with multiple outputs).

## Testing instructions

Standard unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
