### PR TITLE
Coin initialization race condition fix.

### DIFF
--- a/src/Coin.cpp
+++ b/src/Coin.cpp
@@ -145,10 +145,9 @@ inline void setupDispatchersIfNeeded() {
     }
     if (!dispatchMapInitialized) {
         setupDispatchers();
+        assert(dispatchMapInitialized);
+        assert(dispatchMap.size() > 0);
     }
-    assert(dispatchMapInitialized);
-    assert(dispatchMap.size() > 0);
-    assert(coinTypes.size() > 0);
     // it is set up by this time, and will not get modified
 }
 

--- a/src/Coin.h
+++ b/src/Coin.h
@@ -24,7 +24,7 @@
 namespace TW {
 
 // Return the set of supported coin types.
-std::set<TWCoinType> getCoinTypes();
+const std::set<TWCoinType>& getCoinTypes();
 
 /// Validates an address for a particular coin.
 bool validateAddress(TWCoinType coin, const std::string& address);

--- a/src/CoinDispatchMap.cpp
+++ b/src/CoinDispatchMap.cpp
@@ -1,0 +1,35 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "CoinDispatchMap.h"
+
+#include <cassert>
+
+using namespace TW;
+using namespace std;
+
+CoinDispatchMap::CoinDispatchMap(const std::vector<CoinEntry*>& dispatchers) {
+    for (auto d : dispatchers) {
+        assert(d != nullptr);
+        auto coins = d->coinTypes();
+        for (auto c : coins) {
+            assert(dispatchMap.find(c) == dispatchMap.end()); // each coin must appear only once
+            dispatchMap[c] = d;
+            if (coinTypes.emplace(c).second != true) {
+                // each coin must appear only once
+                abort();
+            };
+        }
+    }
+}
+
+CoinEntry* CoinDispatchMap::coinDispatcher(TWCoinType coinType) const {
+    // Coin must be present, and not null.  Otherwise that is a fatal code configuration error.
+    auto found = dispatchMap.find(coinType);
+    assert(found != dispatchMap.end()); // coin must be present
+    assert(found->second != nullptr);
+    return found->second;
+}

--- a/src/CoinDispatchMap.h
+++ b/src/CoinDispatchMap.h
@@ -1,0 +1,33 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include <TrustWalletCore/TWCoinType.h>
+#include "CoinEntry.h"
+
+#include <map>
+#include <set>
+#include <vector>
+
+namespace TW {
+
+// Collection of coin dispatchers
+class CoinDispatchMap {
+public: // methods
+    // initialize with the list of dispatcher instances
+    CoinDispatchMap(const std::vector<CoinEntry*>& dispatchers);
+    CoinEntry* coinDispatcher(TWCoinType coinType) const;
+    const std::set<TWCoinType>& getCoinTypes() { return coinTypes; }
+
+private: // fields
+    // Map with coin entry dispatchers, key is coin type
+    std::map<TWCoinType, CoinEntry*> dispatchMap;
+    // List of supported coin types
+    std::set<TWCoinType> coinTypes;
+};
+
+} // namespace TW

--- a/tests/CoinAddressDerivationTests.cpp
+++ b/tests/CoinAddressDerivationTests.cpp
@@ -84,9 +84,9 @@ void useCoinFromThread() {
     const int tryCount = 20;
     for (int i = 0; i < tryCount; ++i) {
         // perform some operations
-        const auto coinTypes = TW::getCoinTypes();
         TW::validateAddress(TWCoinTypeZilliqa, "zil1j2cvtd7j9n7fnxfv2r3neucjw8tp4xz9sp07v4");
         TW::validateAddress(TWCoinTypeEthereum, "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F");
+        const auto coinTypes = TW::getCoinTypes();
     }
     countThreadReadyMutex.lock();
     ++countThreadReady;

--- a/tests/CoinAddressDerivationTests.cpp
+++ b/tests/CoinAddressDerivationTests.cpp
@@ -85,6 +85,7 @@ void useCoinFromThread() {
     for (int i = 0; i < tryCount; ++i) {
         // perform some operations
         const auto coinTypes = TW::getCoinTypes();
+        TW::validateAddress(TWCoinTypeZilliqa, "zil1j2cvtd7j9n7fnxfv2r3neucjw8tp4xz9sp07v4");
         TW::validateAddress(TWCoinTypeEthereum, "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F");
     }
     countThreadReadyMutex.lock();


### PR DESCRIPTION
## Description

Coin initialization has a race condition.  Fixes #1049 .

Best would be to make without a need for any thread synchronization.

Multi-thread initialization relies on the fact that if dispatchMap.size() == 0 it is not initialized, and if it is >0, it is.  However, checking thread is not locked, and it can see a >0 size case, yet it is not completely initialized yet.

I managed to force-reproduce this by putting an extra sleep at the end of the dispatchMap initialization loop.
Solution is to use an 'already initialized' variable.

## Testing instructions

Unit tests.  Testing within android app.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
