### PR TITLE
Eth ABI decoede types mismatch issue fix.

### DIFF
--- a/src/Ethereum/ABI/ParamFactory.cpp
+++ b/src/Ethereum/ABI/ParamFactory.cpp
@@ -15,11 +15,9 @@ using namespace boost::algorithm;
 namespace TW::Ethereum::ABI {
 
 static int parseBitSize(const std::string& type) {
-    if (type.size() == 0){
-        return 256;
-    }
     int size = stoi(type);
-    if (size < 8 || size > 256 || 256 % size != 0) {
+    if (size < 8 || size > 256 || size % 8 != 0 ||
+        size == 8 || size == 16 || size == 32 || size == 64 || size == 256) {
         throw invalid_argument("invalid bit size");
     }
     return size;
@@ -39,6 +37,26 @@ std::shared_ptr<ParamBase> ParamFactory::make(const std::string& type) {
     shared_ptr<ParamBase> param;
     if (type == "address") {
         param = make_shared<ParamAddress>();
+    } else if (type == "uint8") {
+        param = make_shared<ParamUInt8>();
+    } else if (type == "uint16") {
+        param = make_shared<ParamUInt16>();
+    } else if (type == "uint32") {
+        param = make_shared<ParamUInt32>();
+    } else if (type == "uint64") {
+        param = make_shared<ParamUInt64>();
+    } else if (type == "uint256" || type == "uint") {
+        param = make_shared<ParamUInt256>();
+    } else if (type == "int8") {
+        param = make_shared<ParamInt8>();
+    } else if (type == "int16") {
+        param = make_shared<ParamInt16>();
+    } else if (type == "int32") {
+        param = make_shared<ParamInt32>();
+    } else if (type == "int64") {
+        param = make_shared<ParamInt64>();
+    } else if (type == "int256" || type == "int") {
+        param = make_shared<ParamInt256>();
     } else if (starts_with(type, "uint")) {
         param = makeUInt(type.substr(4, type.size() - 1));
     } else if (starts_with(type, "int")) {
@@ -61,6 +79,26 @@ std::string ParamFactory::getValue(const std::shared_ptr<ParamBase>& param, cons
     if (type == "address") {
         auto value = dynamic_pointer_cast<ParamAddress>(param);
         result = hexEncoded(value->getData());
+    } else if (type == "uint8") {
+        result = boost::lexical_cast<std::string>((uint)dynamic_pointer_cast<ParamUInt8>(param)->getVal());
+    } else if (type == "uint16") {
+        result = boost::lexical_cast<std::string>(dynamic_pointer_cast<ParamUInt16>(param)->getVal());
+    } else if (type == "uint32") {
+        result = boost::lexical_cast<std::string>(dynamic_pointer_cast<ParamUInt32>(param)->getVal());
+    } else if (type == "uint64") {
+        result = boost::lexical_cast<std::string>(dynamic_pointer_cast<ParamUInt64>(param)->getVal());
+    } else if (type == "uint256" || type == "uint") {
+        result = boost::lexical_cast<std::string>(dynamic_pointer_cast<ParamUInt256>(param)->getVal());
+    } else if (type == "int8") {
+        result = boost::lexical_cast<std::string>((int)dynamic_pointer_cast<ParamInt8>(param)->getVal());
+    } else if (type == "int16") {
+        result = boost::lexical_cast<std::string>(dynamic_pointer_cast<ParamInt16>(param)->getVal());
+    } else if (type == "int32") {
+        result = boost::lexical_cast<std::string>(dynamic_pointer_cast<ParamInt32>(param)->getVal());
+    } else if (type == "int64") {
+        result = boost::lexical_cast<std::string>(dynamic_pointer_cast<ParamInt64>(param)->getVal());
+    } else if (type == "int256" || type == "int") {
+        result = boost::lexical_cast<std::string>(dynamic_pointer_cast<ParamInt256>(param)->getVal());
     } else if (starts_with(type, "uint")) {
         auto value = dynamic_pointer_cast<ParamUIntN>(param);
         result = boost::lexical_cast<std::string>(value->getVal());

--- a/src/Ethereum/ABI/ParamNumber.cpp
+++ b/src/Ethereum/ABI/ParamNumber.cpp
@@ -28,8 +28,14 @@ bool ParamUIntN::decode(const Data& encoded, size_t& offset_inout) {
 }
 
 void ParamUIntN::init() {
+    _mask = maskForBits(bits);
+}
+
+uint256_t ParamUIntN::maskForBits(size_t bits) {
     assert(bits >= 8 && bits <= 256 && (bits % 8) == 0);
-    _mask = (uint256_t(1) << bits) - 1;
+    // exclude predefined sizes
+    assert(bits != 8 && bits != 16 && bits != 32 && bits != 64 && bits != 256);
+    return (uint256_t(1) << bits) - 1;
 }
 
 void ParamIntN::setVal(int256_t val) {
@@ -57,6 +63,5 @@ bool ParamIntN::decode(const Data& encoded, size_t& offset_inout) {
 
 void ParamIntN::init()
 {
-    assert(bits >= 8 && bits <= 256 && (bits % 8) == 0);
-    _mask = (uint256_t(1) << bits) - 1;
+    _mask = ParamUIntN::maskForBits(bits);
 }

--- a/src/Ethereum/ABI/ParamNumber.h
+++ b/src/Ethereum/ABI/ParamNumber.h
@@ -149,7 +149,8 @@ public:
     virtual std::string getType() const { return "int64"; }
 };
 
-/// Generic parameter class for Uint8, 16, 24, 32, 40, ... 256.  For smaller sizes use the sepcial name like UInt32.
+/// Generic parameter class for all other bit sizes, like UInt24, 40, 48, ... 248.
+/// For predefined sizes (8, 16, 32, 64, 256) use the sepcial types like UInt32.
 /// Stored on 256 bits.
 class ParamUIntN : public ParamBase
 {
@@ -167,6 +168,7 @@ public:
         return ABI::decode(encoded, decoded, offset_inout);
     }
     virtual bool decode(const Data& encoded, size_t& offset_inout);
+    static uint256_t maskForBits(size_t bits);
 
 private:
     void init();
@@ -174,7 +176,8 @@ private:
     uint256_t _mask;
 };
 
-/// Generic parameter class for Int8, 16, 24, 32, 40, ... 256.  For smaller sizes use the sepcial name like Int32.
+/// Generic parameter class for all other bit sizes, like Int24, 40, 48, ... 248.
+/// For predefined sizes (8, 16, 32, 64, 256) use the sepcial types like Int32.
 /// Stored on 256 bits.
 class ParamIntN : public ParamBase
 {

--- a/tests/Ethereum/ContractCallTests.cpp
+++ b/tests/Ethereum/ContractCallTests.cpp
@@ -167,3 +167,21 @@ TEST(ContractCall, Invalid) {
     EXPECT_FALSE(decodeCall(Data(), "{}").has_value());
     EXPECT_FALSE(decodeCall(parse_hex("0xa22cb46500"), "{}").has_value());
 }
+
+TEST(ContractCall, GetAmountsOut) {
+    auto call = parse_hex(
+        "d06ca61f"
+        "0000000000000000000000000000000000000000000000000000000000000064"
+        "0000000000000000000000000000000000000000000000000000000000000040"
+        "0000000000000000000000000000000000000000000000000000000000000001"
+        "000000000000000000000000f784682c82526e245f50975190ef0fff4e4fc077"
+    );
+    auto path = TESTS_ROOT + "/Ethereum/Data/getAmountsOut.json";
+    auto abi = load_json(path);
+
+    auto decoded = decodeCall(call, abi);
+    auto expected =
+        R"|({"function":"getAmountsOut(uint256,address[])","inputs":[{"name":"amountIn","type":"uint256","value":"100"},{"name":"path","type":"address[]","value":["0xf784682c82526e245f50975190ef0fff4e4fc077"]}]})|";
+
+    EXPECT_EQ(decoded.value(), expected);
+}

--- a/tests/Ethereum/Data/getAmountsOut.json
+++ b/tests/Ethereum/Data/getAmountsOut.json
@@ -1,0 +1,26 @@
+{
+    "d06ca61f": {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address[]",
+                "name": "path",
+                "type": "address[]"
+            }
+        ],
+        "name": "getAmountsOut",
+        "outputs": [
+            {
+                "internalType": "uint256[]",
+                "name": "amounts",
+                "type": "uint256[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    }
+}


### PR DESCRIPTION
## Description

There was an overlap of ParamUIntN and ParamUInt<N> types, both ParamUInt256 and ParamUIntN(256) has type "uint256".  This caused nullptr in type conversion.
Now I changed ParamFactory accordingly, and forbid using the generic version for the predefined sizes.
It can be still used for sizes: 24, 40, 48, 56, 72, 80, 88, ..., 248 (probably rarely used).
New tests also added.

Fixes #1129 .

## Testing instructions

Unit tests (esp. EthereumAbi and Contract).

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
