### PR TITLE
Fix unsafe pointer return to object return

### DIFF
--- a/src/Keystore/StoredKey.h
+++ b/src/Keystore/StoredKey.h
@@ -71,10 +71,10 @@ public:
 
     /// Returns the account for a specific coin, creating it if necessary and
     /// the provided wallet is not `nullptr`.
-    const Account* account(TWCoinType coin, const HDWallet* wallet);
+    std::optional<const Account> account(TWCoinType coin, const HDWallet* wallet);
 
     /// Returns the account for a specific coin if it exists.
-    const Account* account(TWCoinType coin) const;
+    std::optional<const Account> account(TWCoinType coin) const;
     
     /// Add an account
     void addAccount(const std::string& address, TWCoinType coin, const DerivationPath& derivationPath, const std::string& extetndedPublicKey);

--- a/src/interface/TWStoredKey.cpp
+++ b/src/interface/TWStoredKey.cpp
@@ -97,7 +97,8 @@ struct TWAccount* _Nullable TWStoredKeyAccount(struct TWStoredKey* _Nonnull key,
 struct TWAccount* _Nullable TWStoredKeyAccountForCoin(struct TWStoredKey* _Nonnull key, enum TWCoinType coin, struct TWHDWallet* _Nullable wallet) {
     try {
         const auto account = key->impl.account(coin, (wallet ? &wallet->impl : nullptr));
-        return (!account.has_value()) ? nullptr : new TWAccount{ account.value() };
+        // Note: std::optional.value() si not available in XCode with target < iOS 12, using *
+        return (!account.has_value()) ? nullptr : new TWAccount{ *account };
     } catch (...) {
         return nullptr;
     }

--- a/src/interface/TWStoredKey.cpp
+++ b/src/interface/TWStoredKey.cpp
@@ -97,7 +97,7 @@ struct TWAccount* _Nullable TWStoredKeyAccount(struct TWStoredKey* _Nonnull key,
 struct TWAccount* _Nullable TWStoredKeyAccountForCoin(struct TWStoredKey* _Nonnull key, enum TWCoinType coin, struct TWHDWallet* _Nullable wallet) {
     try {
         const auto account = key->impl.account(coin, (wallet ? &wallet->impl : nullptr));
-        return (account == nullptr) ? nullptr : new TWAccount{ *account };
+        return (!account.has_value()) ? nullptr : new TWAccount{ account.value() };
     } catch (...) {
         return nullptr;
     }

--- a/src/interface/TWStoredKey.cpp
+++ b/src/interface/TWStoredKey.cpp
@@ -97,7 +97,7 @@ struct TWAccount* _Nullable TWStoredKeyAccount(struct TWStoredKey* _Nonnull key,
 struct TWAccount* _Nullable TWStoredKeyAccountForCoin(struct TWStoredKey* _Nonnull key, enum TWCoinType coin, struct TWHDWallet* _Nullable wallet) {
     try {
         const auto account = key->impl.account(coin, (wallet ? &wallet->impl : nullptr));
-        // Note: std::optional.value() si not available in XCode with target < iOS 12, using *
+        // Note: std::optional.value() is not available in XCode with target < iOS 12, using *
         return (!account.has_value()) ? nullptr : new TWAccount{ *account };
     } catch (...) {
         return nullptr;

--- a/tests/Keystore/StoredKeyTests.cpp
+++ b/tests/Keystore/StoredKeyTests.cpp
@@ -105,37 +105,61 @@ TEST(StoredKey, AccountGetCreate) {
     EXPECT_EQ(key.accounts.size(), 0);
 
     // not exists
-    EXPECT_EQ(key.account(coinTypeBc), nullptr);
+    EXPECT_FALSE(key.account(coinTypeBc).has_value());
     EXPECT_EQ(key.accounts.size(), 0);
 
     auto wallet = key.wallet(password);
     // not exists, wallet null, not create
-    EXPECT_EQ(key.account(coinTypeBc, nullptr), nullptr);
+    EXPECT_FALSE(key.account(coinTypeBc, nullptr).has_value());
     EXPECT_EQ(key.accounts.size(), 0);
 
     // not exists, wallet nonnull, create
-    const Account* acc3 = key.account(coinTypeBc, &wallet);
-    EXPECT_TRUE(acc3 != nullptr);
+    std::optional<Account> acc3 = key.account(coinTypeBc, &wallet);
+    EXPECT_TRUE(acc3.has_value());
     EXPECT_EQ(acc3->coin, coinTypeBc); 
     EXPECT_EQ(key.accounts.size(), 1);
 
     // exists
-    const Account* acc4 = key.account(coinTypeBc);
-    EXPECT_TRUE(acc4 != nullptr);
+    std::optional<Account> acc4 = key.account(coinTypeBc);
+    EXPECT_TRUE(acc4.has_value());
     EXPECT_EQ(acc4->coin, coinTypeBc); 
     EXPECT_EQ(key.accounts.size(), 1);
 
     // exists, wallet nonnull, not create
-    const Account* acc5 = key.account(coinTypeBc, &wallet);
-    EXPECT_TRUE(acc5 != nullptr);
+    std::optional<Account> acc5 = key.account(coinTypeBc, &wallet);
+    EXPECT_TRUE(acc5.has_value());
     EXPECT_EQ(acc5->coin, coinTypeBc); 
     EXPECT_EQ(key.accounts.size(), 1);
 
     // exists, wallet null, not create
-    const Account* acc6 = key.account(coinTypeBc, nullptr);
-    EXPECT_TRUE(acc6 != nullptr);
+    std::optional<Account> acc6 = key.account(coinTypeBc, nullptr);
+    EXPECT_TRUE(acc6.has_value());
     EXPECT_EQ(acc6->coin, coinTypeBc); 
     EXPECT_EQ(key.accounts.size(), 1);
+}
+
+TEST(StoredKey, AccountGetDoesntChange) {
+    auto key = StoredKey::createWithMnemonic("name", password, mnemonic);
+    auto wallet = key.wallet(password);
+    EXPECT_EQ(key.accounts.size(), 0);
+
+    vector<TWCoinType> coins = {coinTypeBc, coinTypeEth, coinTypeBnb};
+    // retrieve multiple accounts, which will be created
+    vector<Account> accounts;
+    for (auto coin: coins) {
+        std::optional<Account> account = key.account(coin, &wallet);
+        accounts.push_back(account.value());
+
+        // check
+        ASSERT_TRUE(account.has_value());
+        EXPECT_EQ(account->coin, coin);
+    }
+
+    // Check again; make sure returned references don't change
+    for (auto i = 0; i < accounts.size(); ++i) {
+        // check
+        EXPECT_EQ(accounts[i].coin, coins[i]);
+    }
 }
 
 TEST(StoredKey, AddRemoveAccount) {

--- a/tests/Keystore/StoredKeyTests.cpp
+++ b/tests/Keystore/StoredKeyTests.cpp
@@ -148,7 +148,7 @@ TEST(StoredKey, AccountGetDoesntChange) {
     vector<Account> accounts;
     for (auto coin: coins) {
         std::optional<Account> account = key.account(coin, &wallet);
-        accounts.push_back(account.value());
+        accounts.push_back(*account);
 
         // check
         ASSERT_TRUE(account.has_value());


### PR DESCRIPTION
## Description

Instead of a pointer return (which may become unsafe), the object is returned (with optional, as null return is a valid case).
Only 2 internal classes affected, the C inerface and swift/kotlin not.
Fixes #1164 .

## Testing instructions

Standard unit tests; new unit test  `StoredKey.AccountGetDoesntChange`

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue) 

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
