### PR TITLE
[TestOnly] Proper memory freeing in all tests

### DIFF
--- a/codegen/lib/templates/TWCoinTypeTests.cpp.erb
+++ b/codegen/lib/templates/TWCoinTypeTests.cpp.erb
@@ -15,10 +15,10 @@
 
 TEST(TW<%= format_name(coin['name']) %>CoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinType<%= format_name(coin['name']) %>));
-    auto txId = TWStringCreateWithUTF8Bytes("<%= explorer_sample_tx(coin) %>");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinType<%= format_name(coin['name']) %>, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("<%= explorer_sample_account(coin) %>");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinType<%= format_name(coin['name']) %>, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("<%= explorer_sample_tx(coin) %>"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinType<%= format_name(coin['name']) %>, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("<%= explorer_sample_account(coin) %>"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinType<%= format_name(coin['name']) %>, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinType<%= format_name(coin['name']) %>));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinType<%= format_name(coin['name']) %>));
 

--- a/codegen/lib/templates/TWCoinTypeTests.cpp.erb
+++ b/codegen/lib/templates/TWCoinTypeTests.cpp.erb
@@ -15,10 +15,10 @@
 
 TEST(TW<%= format_name(coin['name']) %>CoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinType<%= format_name(coin['name']) %>));
-    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("<%= explorer_sample_tx(coin) %>"));
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinType<%= format_name(coin['name']) %>, txId.get()));
-    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("<%= explorer_sample_account(coin) %>"));
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinType<%= format_name(coin['name']) %>, accId.get()));
+    auto txId = TWStringCreateWithUTF8Bytes("<%= explorer_sample_tx(coin) %>");
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinType<%= format_name(coin['name']) %>, txId));
+    auto accId = TWStringCreateWithUTF8Bytes("<%= explorer_sample_account(coin) %>");
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinType<%= format_name(coin['name']) %>, accId));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinType<%= format_name(coin['name']) %>));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinType<%= format_name(coin['name']) %>));
 

--- a/tests/Aeternity/TWAeternityAddressTests.cpp
+++ b/tests/Aeternity/TWAeternityAddressTests.cpp
@@ -19,8 +19,8 @@ TEST(TWAeternityAddress, HDWallet) {
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(STRING(mnemonic).get(), STRING(passphrase).get()));
 
     auto privateKey = WRAP(TWPrivateKey, TWHDWalletGetKey(wallet.get(), TWCoinTypeAeternity, TWCoinTypeDerivationPath(TWCoinTypeAeternity)));
-    auto publicKey = TWPrivateKeyGetPublicKeyEd25519(privateKey.get());
-    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey, TWCoinTypeAeternity));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeyEd25519(privateKey.get()));
+    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeAeternity));
     auto addressStr = WRAPS(TWAnyAddressDescription(address.get()));
 
     assertStringsEqual(addressStr, "ak_QDHJSfvHG9sDHBobaWt2TAGhuhipYjEqZEH34bWugpJfJc3GN");

--- a/tests/Aeternity/TWAeternityAddressTests.cpp
+++ b/tests/Aeternity/TWAeternityAddressTests.cpp
@@ -18,7 +18,7 @@ TEST(TWAeternityAddress, HDWallet) {
 
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(STRING(mnemonic).get(), STRING(passphrase).get()));
 
-    auto privateKey = WRAP(TWPrivateKey, TWHDWalletGetKey(wallet.get(), TWCoinTypeAeternity, TWCoinTypeDerivationPath(TWCoinTypeAeternity)));
+    auto privateKey = WRAP(TWPrivateKey, TWHDWalletGetKey(wallet.get(), TWCoinTypeAeternity, WRAPS(TWCoinTypeDerivationPath(TWCoinTypeAeternity)).get()));
     auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeyEd25519(privateKey.get()));
     auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeAeternity));
     auto addressStr = WRAPS(TWAnyAddressDescription(address.get()));

--- a/tests/Aeternity/TWCoinTypeTests.cpp
+++ b/tests/Aeternity/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWAeternityCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeAeternity));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeAeternity, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeAeternity, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeAeternity, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeAeternity, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeAeternity));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeAeternity));
 

--- a/tests/Aion/TWCoinTypeTests.cpp
+++ b/tests/Aion/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWAionCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeAion));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeAion, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeAion, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeAion, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeAion, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeAion));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeAion));
 

--- a/tests/Algorand/TWCoinTypeTests.cpp
+++ b/tests/Algorand/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWAlgorandCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeAlgorand));
-    auto txId = TWStringCreateWithUTF8Bytes("CR7POXFTYDLC7TV3IXHA7AZKWABUJC52BACLHJQNXAKZJGRPQY3A");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeAlgorand, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("J4AEINCSSLDA7LNBNWM4ZXFCTLTOZT5LG3F5BLMFPJYGFWVCMU37EZI2AM");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeAlgorand, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("CR7POXFTYDLC7TV3IXHA7AZKWABUJC52BACLHJQNXAKZJGRPQY3A"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeAlgorand, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("J4AEINCSSLDA7LNBNWM4ZXFCTLTOZT5LG3F5BLMFPJYGFWVCMU37EZI2AM"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeAlgorand, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeAlgorand));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeAlgorand));
 

--- a/tests/BandChain/TWCoinTypeTests.cpp
+++ b/tests/BandChain/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWBandChainCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeBandChain));
-    auto txId = TWStringCreateWithUTF8Bytes("473264551D3063A9EC64EC251C61BE92DDDFCF6CC46D026D1E574D83D5447173");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeBandChain, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("band12nmsm9khdsv0tywge43q3zwj8kkj3hvup9rltp");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeBandChain, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("473264551D3063A9EC64EC251C61BE92DDDFCF6CC46D026D1E574D83D5447173"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeBandChain, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("band12nmsm9khdsv0tywge43q3zwj8kkj3hvup9rltp"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeBandChain, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeBandChain));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeBandChain));
 

--- a/tests/Binance/TWCoinTypeTests.cpp
+++ b/tests/Binance/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWBinanceCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeBinance));
-    auto txId = TWStringCreateWithUTF8Bytes("A93625C9F9ABEA1A8E31585B30BBB16C34FAE0D172EB5B6B2F834AF077BF06BB");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeBinance, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("bnb1u7jm0cll5h3224y0tapwn6gf6pr49ytewx4gsz");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeBinance, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("A93625C9F9ABEA1A8E31585B30BBB16C34FAE0D172EB5B6B2F834AF077BF06BB"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeBinance, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("bnb1u7jm0cll5h3224y0tapwn6gf6pr49ytewx4gsz"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeBinance, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeBinance));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeBinance));
 

--- a/tests/BinanceSmartChain/TWAnyAddressTests.cpp
+++ b/tests/BinanceSmartChain/TWAnyAddressTests.cpp
@@ -15,10 +15,10 @@ using namespace TW;
 TEST(TWBinanceSmartChain, Address) {
 
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("727f677b390c151caf9c206fd77f77918f56904b5504243db9b21e51182c4c06").get()));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), false);
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), false));
     auto string = "0xf3d468DBb386aaD46E92FF222adDdf872C8CC064";
     
-    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey, TWCoinTypeSmartChain));
+    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeSmartChain));
     auto expected = WRAP(TWAnyAddress, TWAnyAddressCreateWithString(STRING(string).get(), TWCoinTypeSmartChain));
 
     auto addressString = WRAPS(TWAnyAddressDescription(address.get()));

--- a/tests/BinanceSmartChain/TWCoinTypeTests.cpp
+++ b/tests/BinanceSmartChain/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWBinanceSmartChainCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeSmartChain));
-    auto txId = TWStringCreateWithUTF8Bytes("0xb9ae2e808fe8e57171f303ad8f6e3fd17d949b0bfc7b4db6e8e30a71cc517d7e");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeSmartChain, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("0x35552c16704d214347f29Fa77f77DA6d75d7C752");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeSmartChain, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("0xb9ae2e808fe8e57171f303ad8f6e3fd17d949b0bfc7b4db6e8e30a71cc517d7e"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeSmartChain, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("0x35552c16704d214347f29Fa77f77DA6d75d7C752"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeSmartChain, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeSmartChain));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeSmartChain));
 

--- a/tests/Bitcoin/TWBitcoinAddressTests.cpp
+++ b/tests/Bitcoin/TWBitcoinAddressTests.cpp
@@ -44,7 +44,7 @@ TEST(TWBitcoinAddress, CreateWithPublicKey) {
 TEST(TWBitcoinAddress, Description) {
     const auto addr = WRAP(TWBitcoinAddress, TWBitcoinAddressCreateWithString(STRING(addr1Valid).get()));
     EXPECT_TRUE(addr.get() != nullptr);
-    EXPECT_EQ(std::string(TWStringUTF8Bytes(TWBitcoinAddressDescription(addr.get()))), addr1Valid);
+    EXPECT_EQ(std::string(TWStringUTF8Bytes(WRAPS(TWBitcoinAddressDescription(addr.get())).get())), addr1Valid);
 }
 
 TEST(TWBitcoinAddress, PrefixAndHash) {

--- a/tests/Bitcoin/TWBitcoinScriptTests.cpp
+++ b/tests/Bitcoin/TWBitcoinScriptTests.cpp
@@ -11,18 +11,18 @@
 
 #include <gtest/gtest.h>
 
-const auto PayToScriptHash = TWBitcoinScriptCreateWithData(DATA("a914" "4733f37cf4db86fbc2efed2500b4f4e49f312023" "87").get());
-const auto PayToWitnessScriptHash = TWBitcoinScriptCreateWithData(DATA("0020" "ff25429251b5a84f452230a3c75fd886b7fc5a7865ce4a7bb7a9d7c5be6da3db").get());
-const auto PayToWitnessPublicKeyHash = TWBitcoinScriptCreateWithData(DATA("0014" "79091972186c449eb1ded22b78e40d009bdf0089").get());
-const auto PayToPublicKeySecp256k1 = TWBitcoinScriptCreateWithData(DATA("21" "03c9f4836b9a4f77fc0d81f7bcb01b7f1b35916864b9476c241ce9fc198bd25432" "ac").get());
-const auto PayToPublicKeyHash = TWBitcoinScriptCreateWithData(DATA("76a914" "79091972186c449eb1ded22b78e40d009bdf0089" "88ac").get());
+const auto PayToScriptHash = WRAP(TWBitcoinScript, TWBitcoinScriptCreateWithData(DATA("a914" "4733f37cf4db86fbc2efed2500b4f4e49f312023" "87").get()));
+const auto PayToWitnessScriptHash = WRAP(TWBitcoinScript, TWBitcoinScriptCreateWithData(DATA("0020" "ff25429251b5a84f452230a3c75fd886b7fc5a7865ce4a7bb7a9d7c5be6da3db").get()));
+const auto PayToWitnessPublicKeyHash = WRAP(TWBitcoinScript, TWBitcoinScriptCreateWithData(DATA("0014" "79091972186c449eb1ded22b78e40d009bdf0089").get()));
+const auto PayToPublicKeySecp256k1 = WRAP(TWBitcoinScript, TWBitcoinScriptCreateWithData(DATA("21" "03c9f4836b9a4f77fc0d81f7bcb01b7f1b35916864b9476c241ce9fc198bd25432" "ac").get()));
+const auto PayToPublicKeyHash = WRAP(TWBitcoinScript, TWBitcoinScriptCreateWithData(DATA("76a914" "79091972186c449eb1ded22b78e40d009bdf0089" "88ac").get()));
 
 TEST(TWBitcoinScript, Create) {
     auto data = DATA("a9144733f37cf4db86fbc2efed2500b4f4e49f31202387");
     {
-        auto script = TWBitcoinScriptCreateWithData(data.get());
-        ASSERT_TRUE(script != nullptr);
-        ASSERT_EQ(TWBitcoinScriptSize(script), 23);
+        auto script = WRAP(TWBitcoinScript, TWBitcoinScriptCreateWithData(data.get()));
+        ASSERT_TRUE(script.get() != nullptr);
+        ASSERT_EQ(TWBitcoinScriptSize(script.get()), 23);
     }
     {
         auto script = WRAP(TWBitcoinScript, TWBitcoinScriptCreateWithBytes(TWDataBytes(data.get()), TWDataSize(data.get())));
@@ -43,70 +43,70 @@ TEST(TWBitcoinScript, Equals) {
 }
 
 TEST(TWBitcoinScript, IsPayToScriptHash) {
-    ASSERT_TRUE(TWBitcoinScriptIsPayToScriptHash(PayToScriptHash));
+    ASSERT_TRUE(TWBitcoinScriptIsPayToScriptHash(PayToScriptHash.get()));
 }
 
 TEST(TWBitcoinScript, IsPayToWitnessScriptHash) {
-    ASSERT_TRUE(TWBitcoinScriptIsPayToWitnessScriptHash(PayToWitnessScriptHash));
+    ASSERT_TRUE(TWBitcoinScriptIsPayToWitnessScriptHash(PayToWitnessScriptHash.get()));
 }
 
 TEST(TWBitcoinScript, IsPayToWitnessPublicKeyHash) {
-    ASSERT_TRUE(TWBitcoinScriptIsPayToWitnessPublicKeyHash(PayToWitnessPublicKeyHash));
+    ASSERT_TRUE(TWBitcoinScriptIsPayToWitnessPublicKeyHash(PayToWitnessPublicKeyHash.get()));
 }
 
 TEST(TWBitcoinScript, IsWitnessProgram) {
-    ASSERT_TRUE(TWBitcoinScriptIsWitnessProgram(PayToWitnessScriptHash));
-    ASSERT_TRUE(TWBitcoinScriptIsWitnessProgram(PayToWitnessPublicKeyHash));
-    ASSERT_FALSE(TWBitcoinScriptIsWitnessProgram(PayToScriptHash));
+    ASSERT_TRUE(TWBitcoinScriptIsWitnessProgram(PayToWitnessScriptHash.get()));
+    ASSERT_TRUE(TWBitcoinScriptIsWitnessProgram(PayToWitnessPublicKeyHash.get()));
+    ASSERT_FALSE(TWBitcoinScriptIsWitnessProgram(PayToScriptHash.get()));
 }
 
 TEST(TWBitcoinScript, MatchPayToPubkey) {
-    const auto res = WRAPD(TWBitcoinScriptMatchPayToPubkey(PayToPublicKeySecp256k1));
+    const auto res = WRAPD(TWBitcoinScriptMatchPayToPubkey(PayToPublicKeySecp256k1.get()));
     ASSERT_TRUE(res.get() != nullptr);
     const auto hexRes = WRAPS(TWStringCreateWithHexData(res.get()));
     ASSERT_STREQ(TWStringUTF8Bytes(hexRes.get()), "03c9f4836b9a4f77fc0d81f7bcb01b7f1b35916864b9476c241ce9fc198bd25432");
 
-    ASSERT_EQ(TWBitcoinScriptMatchPayToPubkey(PayToScriptHash), nullptr);
+    ASSERT_EQ(TWBitcoinScriptMatchPayToPubkey(PayToScriptHash.get()), nullptr);
 }
 
 TEST(TWBitcoinScript, TWBitcoinScriptMatchPayToPubkeyHash) {
-    const auto res = WRAPD(TWBitcoinScriptMatchPayToPubkeyHash(PayToPublicKeyHash));
+    const auto res = WRAPD(TWBitcoinScriptMatchPayToPubkeyHash(PayToPublicKeyHash.get()));
     ASSERT_TRUE(res.get() != nullptr);
     const auto hexRes = WRAPS(TWStringCreateWithHexData(res.get()));
     ASSERT_STREQ(TWStringUTF8Bytes(hexRes.get()), "79091972186c449eb1ded22b78e40d009bdf0089");
 
-    ASSERT_EQ(TWBitcoinScriptMatchPayToPubkeyHash(PayToScriptHash), nullptr);
+    ASSERT_EQ(TWBitcoinScriptMatchPayToPubkeyHash(PayToScriptHash.get()), nullptr);
 }
 
 TEST(TWBitcoinScript, MatchPayToScriptHash) {
-    const auto res = WRAPD(TWBitcoinScriptMatchPayToScriptHash(PayToScriptHash));
+    const auto res = WRAPD(TWBitcoinScriptMatchPayToScriptHash(PayToScriptHash.get()));
     ASSERT_TRUE(res.get() != nullptr);
     const auto hexRes = WRAPS(TWStringCreateWithHexData(res.get()));
     ASSERT_STREQ(TWStringUTF8Bytes(hexRes.get()), "4733f37cf4db86fbc2efed2500b4f4e49f312023");
 
-    ASSERT_EQ(TWBitcoinScriptMatchPayToScriptHash(PayToPublicKeySecp256k1), nullptr);
+    ASSERT_EQ(TWBitcoinScriptMatchPayToScriptHash(PayToPublicKeySecp256k1.get()), nullptr);
 }
 
 TEST(TWBitcoinScript, MatchPayToWitnessPublicKeyHash) {
-    const auto res = WRAPD(TWBitcoinScriptMatchPayToWitnessPublicKeyHash(PayToWitnessPublicKeyHash));
+    const auto res = WRAPD(TWBitcoinScriptMatchPayToWitnessPublicKeyHash(PayToWitnessPublicKeyHash.get()));
     ASSERT_TRUE(res.get() != nullptr);
     const auto hexRes = WRAPS(TWStringCreateWithHexData(res.get()));
     ASSERT_STREQ(TWStringUTF8Bytes(hexRes.get()), "79091972186c449eb1ded22b78e40d009bdf0089");
 
-    ASSERT_EQ(TWBitcoinScriptMatchPayToWitnessPublicKeyHash(PayToPublicKeySecp256k1), nullptr);
+    ASSERT_EQ(TWBitcoinScriptMatchPayToWitnessPublicKeyHash(PayToPublicKeySecp256k1.get()), nullptr);
 }
 
 TEST(TWBitcoinScript, MatchPayToWitnessScriptHash) {
-    const auto res = WRAPD(TWBitcoinScriptMatchPayToWitnessScriptHash(PayToWitnessScriptHash));
+    const auto res = WRAPD(TWBitcoinScriptMatchPayToWitnessScriptHash(PayToWitnessScriptHash.get()));
     ASSERT_TRUE(res.get() != nullptr);
     const auto hexRes = WRAPS(TWStringCreateWithHexData(res.get()));
     ASSERT_STREQ(TWStringUTF8Bytes(hexRes.get()), "ff25429251b5a84f452230a3c75fd886b7fc5a7865ce4a7bb7a9d7c5be6da3db");
 
-    ASSERT_EQ(TWBitcoinScriptMatchPayToWitnessScriptHash(PayToPublicKeySecp256k1), nullptr);
+    ASSERT_EQ(TWBitcoinScriptMatchPayToWitnessScriptHash(PayToPublicKeySecp256k1.get()), nullptr);
 }
 
 TEST(TWBitcoinScript, Encode) {
-    const auto res = WRAPD(TWBitcoinScriptEncode(PayToScriptHash));
+    const auto res = WRAPD(TWBitcoinScriptEncode(PayToScriptHash.get()));
     ASSERT_TRUE(res.get() != nullptr);
     const auto hexRes = WRAPS(TWStringCreateWithHexData(res.get()));
     ASSERT_STREQ(TWStringUTF8Bytes(hexRes.get()), "17a9144733f37cf4db86fbc2efed2500b4f4e49f31202387");
@@ -122,9 +122,9 @@ TEST(TWBitcoinScript, BuildPayToWitnessPubkeyHash) {
 
 TEST(TWBitcoinScript, BuildPayToWitnessScriptHash) {
     const auto hash = DATA("ff25429251b5a84f452230a3c75fd886b7fc5a7865ce4a7bb7a9d7c5be6da3db");
-    const auto script = TWBitcoinScriptBuildPayToWitnessScriptHash(hash.get());
-    ASSERT_TRUE(script != nullptr);
-    const auto hex = WRAPS(TWStringCreateWithHexData(WRAPD(TWBitcoinScriptData(script)).get()));
+    const auto script = WRAP(TWBitcoinScript, TWBitcoinScriptBuildPayToWitnessScriptHash(hash.get()));
+    ASSERT_TRUE(script.get() != nullptr);
+    const auto hex = WRAPS(TWStringCreateWithHexData(WRAPD(TWBitcoinScriptData(script.get())).get()));
     ASSERT_STREQ(TWStringUTF8Bytes(hex.get()), "0020" "ff25429251b5a84f452230a3c75fd886b7fc5a7865ce4a7bb7a9d7c5be6da3db");
 }
 

--- a/tests/Bitcoin/TWBitcoinScriptTests.cpp
+++ b/tests/Bitcoin/TWBitcoinScriptTests.cpp
@@ -25,21 +25,21 @@ TEST(TWBitcoinScript, Create) {
         ASSERT_EQ(TWBitcoinScriptSize(script), 23);
     }
     {
-        auto script = TWBitcoinScriptCreateWithBytes(TWDataBytes(data.get()), TWDataSize(data.get()));
-        ASSERT_TRUE(script != nullptr);
-        ASSERT_EQ(TWBitcoinScriptSize(script), 23);
+        auto script = WRAP(TWBitcoinScript, TWBitcoinScriptCreateWithBytes(TWDataBytes(data.get()), TWDataSize(data.get())));
+        ASSERT_TRUE(script.get() != nullptr);
+        ASSERT_EQ(TWBitcoinScriptSize(script.get()), 23);
 
-        auto scriptCopy = TWBitcoinScriptCreateCopy(script);
-        ASSERT_TRUE(scriptCopy != nullptr);
-        ASSERT_EQ(TWBitcoinScriptSize(scriptCopy), 23);
+        auto scriptCopy = WRAP(TWBitcoinScript, TWBitcoinScriptCreateCopy(script.get()));
+        ASSERT_TRUE(scriptCopy.get() != nullptr);
+        ASSERT_EQ(TWBitcoinScriptSize(scriptCopy.get()), 23);
     }
 }
 
 TEST(TWBitcoinScript, Equals) {
     auto data = DATA("a9144733f37cf4db86fbc2efed2500b4f4e49f31202387");
-    auto script = TWBitcoinScriptCreateWithBytes(TWDataBytes(data.get()), TWDataSize(data.get()));
-    auto scriptCopy = TWBitcoinScriptCreateCopy(script);
-    ASSERT_TRUE(TWBitcoinScriptEqual(script, scriptCopy));
+    auto script = WRAP(TWBitcoinScript, TWBitcoinScriptCreateWithBytes(TWDataBytes(data.get()), TWDataSize(data.get())));
+    auto scriptCopy = WRAP(TWBitcoinScript, TWBitcoinScriptCreateCopy(script.get()));
+    ASSERT_TRUE(TWBitcoinScriptEqual(script.get(), scriptCopy.get()));
 }
 
 TEST(TWBitcoinScript, IsPayToScriptHash) {
@@ -114,9 +114,9 @@ TEST(TWBitcoinScript, Encode) {
 
 TEST(TWBitcoinScript, BuildPayToWitnessPubkeyHash) {
     const auto hash = DATA("79091972186c449eb1ded22b78e40d009bdf0089");
-    const auto script = TWBitcoinScriptBuildPayToWitnessPubkeyHash(hash.get());
-    ASSERT_TRUE(script != nullptr);
-    const auto hex = WRAPS(TWStringCreateWithHexData(WRAPD(TWBitcoinScriptData(script)).get()));
+    const auto script = WRAP(TWBitcoinScript, TWBitcoinScriptBuildPayToWitnessPubkeyHash(hash.get()));
+    ASSERT_TRUE(script.get() != nullptr);
+    const auto hex = WRAPS(TWStringCreateWithHexData(WRAPD(TWBitcoinScriptData(script.get())).get()));
     ASSERT_STREQ(TWStringUTF8Bytes(hex.get()), "0014" "79091972186c449eb1ded22b78e40d009bdf0089");
 }
 

--- a/tests/Bitcoin/TWCoinTypeTests.cpp
+++ b/tests/Bitcoin/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWBitcoinCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeBitcoin));
-    auto txId = TWStringCreateWithUTF8Bytes("0607f62530b68cfcc91c57a1702841dd399a899d0eecda8e31ecca3f52f01df2");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeBitcoin, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("17A16QmavnUfCW11DAApiJxp7ARnxN5pGX");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeBitcoin, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("0607f62530b68cfcc91c57a1702841dd399a899d0eecda8e31ecca3f52f01df2"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeBitcoin, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("17A16QmavnUfCW11DAApiJxp7ARnxN5pGX"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeBitcoin, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeBitcoin));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeBitcoin));
 

--- a/tests/BitcoinCash/TWBitcoinCashTests.cpp
+++ b/tests/BitcoinCash/TWBitcoinCashTests.cpp
@@ -52,16 +52,14 @@ TEST(BitcoinCash, LegacyToCashAddr) {
 
 TEST(BitcoinCash, LockScript) {
     auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithString(STRING("bitcoincash:qpk05r5kcd8uuzwqunn8rlx5xvuvzjqju5rch3tc0u").get(), TWCoinTypeBitcoinCash));
-    auto data = TWAnyAddressData(address.get());
-    auto rawData = TWDataCreateWithSize(0);
-    TWDataAppendByte(rawData, 0x00);
-    TWDataAppendData(rawData, data);
+    auto data = WRAPD(TWAnyAddressData(address.get()));
+    auto rawData = WRAPD(TWDataCreateWithSize(0));
+    TWDataAppendByte(rawData.get(), 0x00);
+    TWDataAppendData(rawData.get(), data.get());
 
-    auto legacyAddress = TWBitcoinAddressCreateWithData(rawData);
+    auto legacyAddress = TWBitcoinAddressCreateWithData(rawData.get());
     auto legacyString = WRAPS(TWBitcoinAddressDescription(legacyAddress));
     assertStringsEqual(legacyString, "1AwDXywmyhASpCCFWkqhySgZf8KiswFoGh");
-    TWDataDelete(data);
-    TWDataDelete(rawData);
 
     auto keyHash = WRAPD(TWDataCreateWithBytes(legacyAddress->impl.bytes.data() + 1, 20));
     auto script = WRAP(TWBitcoinScript, TWBitcoinScriptBuildPayToPublicKeyHash(keyHash.get()));

--- a/tests/BitcoinCash/TWBitcoinCashTests.cpp
+++ b/tests/BitcoinCash/TWBitcoinCashTests.cpp
@@ -41,8 +41,8 @@ TEST(BitcoinCash, ValidAddress) {
 TEST(BitcoinCash, LegacyToCashAddr) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("28071bf4e2b0340db41b807ed8a5514139e5d6427ff9d58dbd22b7ed187103a4").get()));
     auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
-    auto address = TWBitcoinAddressCreateWithPublicKey(publicKey.get(), 0);
-    auto addressString = WRAPS(TWBitcoinAddressDescription(address));
+    auto address = WRAP(TWBitcoinAddress, TWBitcoinAddressCreateWithPublicKey(publicKey.get(), 0));
+    auto addressString = WRAPS(TWBitcoinAddressDescription(address.get()));
     assertStringsEqual(addressString, "1PeUvjuxyf31aJKX6kCXuaqxhmG78ZUdL1");
 
     auto cashAddress = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeBitcoinCash));
@@ -57,11 +57,11 @@ TEST(BitcoinCash, LockScript) {
     TWDataAppendByte(rawData.get(), 0x00);
     TWDataAppendData(rawData.get(), data.get());
 
-    auto legacyAddress = TWBitcoinAddressCreateWithData(rawData.get());
-    auto legacyString = WRAPS(TWBitcoinAddressDescription(legacyAddress));
+    auto legacyAddress = WRAP(TWBitcoinAddress, TWBitcoinAddressCreateWithData(rawData.get()));
+    auto legacyString = WRAPS(TWBitcoinAddressDescription(legacyAddress.get()));
     assertStringsEqual(legacyString, "1AwDXywmyhASpCCFWkqhySgZf8KiswFoGh");
 
-    auto keyHash = WRAPD(TWDataCreateWithBytes(legacyAddress->impl.bytes.data() + 1, 20));
+    auto keyHash = WRAPD(TWDataCreateWithBytes(legacyAddress.get()->impl.bytes.data() + 1, 20));
     auto script = WRAP(TWBitcoinScript, TWBitcoinScriptBuildPayToPublicKeyHash(keyHash.get()));
     auto scriptData = WRAPD(TWBitcoinScriptData(script.get()));
     assertHexEqual(scriptData, "76a9146cfa0e96c34fce09c0e4e671fcd43338c14812e588ac");

--- a/tests/BitcoinCash/TWBitcoinCashTests.cpp
+++ b/tests/BitcoinCash/TWBitcoinCashTests.cpp
@@ -40,12 +40,12 @@ TEST(BitcoinCash, ValidAddress) {
 
 TEST(BitcoinCash, LegacyToCashAddr) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("28071bf4e2b0340db41b807ed8a5514139e5d6427ff9d58dbd22b7ed187103a4").get()));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
-    auto address = TWBitcoinAddressCreateWithPublicKey(publicKey, 0);
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
+    auto address = TWBitcoinAddressCreateWithPublicKey(publicKey.get(), 0);
     auto addressString = WRAPS(TWBitcoinAddressDescription(address));
     assertStringsEqual(addressString, "1PeUvjuxyf31aJKX6kCXuaqxhmG78ZUdL1");
 
-    auto cashAddress = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey, TWCoinTypeBitcoinCash));
+    auto cashAddress = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeBitcoinCash));
     auto cashAddressString = WRAPS(TWAnyAddressDescription(cashAddress.get()));
     assertStringsEqual(cashAddressString, "bitcoincash:qruxj7zq6yzpdx8dld0e9hfvt7u47zrw9gfr5hy0vh");
 }

--- a/tests/BitcoinCash/TWCoinTypeTests.cpp
+++ b/tests/BitcoinCash/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWBitcoinCashCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeBitcoinCash));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeBitcoinCash, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeBitcoinCash, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeBitcoinCash, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeBitcoinCash, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeBitcoinCash));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeBitcoinCash));
 

--- a/tests/BitcoinGold/TWCoinTypeTests.cpp
+++ b/tests/BitcoinGold/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWBitcoinGoldCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeBitcoinGold));
-    auto txId = TWStringCreateWithUTF8Bytes("2f807d7734de35d2236a1b3d8704eb12954f5f82ea66987949b10e94d9999b23");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeBitcoinGold, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("GJjz2Du9BoJQ3CPcoyVTHUJZSj62i1693U");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeBitcoinGold, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("2f807d7734de35d2236a1b3d8704eb12954f5f82ea66987949b10e94d9999b23"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeBitcoinGold, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("GJjz2Du9BoJQ3CPcoyVTHUJZSj62i1693U"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeBitcoinGold, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeBitcoinGold));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeBitcoinGold));
 

--- a/tests/Callisto/TWCoinTypeTests.cpp
+++ b/tests/Callisto/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWCallistoCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeCallisto));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeCallisto, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeCallisto, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeCallisto, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeCallisto, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeCallisto));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeCallisto));
 

--- a/tests/Cardano/TWCardanoAddressTests.cpp
+++ b/tests/Cardano/TWCardanoAddressTests.cpp
@@ -16,10 +16,10 @@
 TEST(TWCardano, Address) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("b0884d248cb301edd1b34cf626ba6d880bb3ae8fd91b4696446999dc4f0b5744309941d56938e943980d11643c535e046653ca6f498c014b88f2ad9fd6e71effbf36a8fa9f5e11eb7a852c41e185e3969d518e66e6893c81d3fc7227009952d4").get()));
     ASSERT_NE(nullptr, privateKey.get());
-    auto publicKey = TWPrivateKeyGetPublicKeyEd25519Extended(privateKey.get());
-    ASSERT_NE(nullptr, publicKey);
-    ASSERT_EQ(64, publicKey->impl.bytes.size());
-    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey, TWCoinTypeCardano));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeyEd25519Extended(privateKey.get()));
+    ASSERT_NE(nullptr, publicKey.get());
+    ASSERT_EQ(64, publicKey.get()->impl.bytes.size());
+    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeCardano));
     auto addressString = WRAPS(TWAnyAddressDescription(address.get()));
     assertStringsEqual(addressString, "addr1s3tl64970vuthz2j0qkz7kd2ya5j3fxuhdnv333vu38e6c37e4dq80ek4raf7hs3adag2tzpuxz7895a2x8xde5f8jqa8lrjyuqfj5k50pm668");
 

--- a/tests/Cardano/TWCoinTypeTests.cpp
+++ b/tests/Cardano/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWCardanoCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeCardano));
-    auto txId = TWStringCreateWithUTF8Bytes("b7a6c5cadab0f64bdc89c77ee4a351463aba5c33f2cef6bbd6542a74a90a3af3");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeCardano, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("DdzFFzCqrhstpwKc8WMvPwwBb5oabcTW9zc5ykA37wJR4tYQucvsR9dXb2kEGNXkFJz2PtrpzfRiZkx8R1iNo8NYqdsukVmv7EAybFwC");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeCardano, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("b7a6c5cadab0f64bdc89c77ee4a351463aba5c33f2cef6bbd6542a74a90a3af3"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeCardano, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("DdzFFzCqrhstpwKc8WMvPwwBb5oabcTW9zc5ykA37wJR4tYQucvsR9dXb2kEGNXkFJz2PtrpzfRiZkx8R1iNo8NYqdsukVmv7EAybFwC"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeCardano, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeCardano));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeCardano));
 

--- a/tests/Cosmos/TWCoinTypeTests.cpp
+++ b/tests/Cosmos/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWCosmosCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeCosmos));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeCosmos, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeCosmos, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeCosmos, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeCosmos, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeCosmos));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeCosmos));
 

--- a/tests/Dash/TWCoinTypeTests.cpp
+++ b/tests/Dash/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWDashCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeDash));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeDash, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeDash, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeDash, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeDash, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeDash));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeDash));
 

--- a/tests/Decred/TWCoinTypeTests.cpp
+++ b/tests/Decred/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWDecredCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeDecred));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeDecred, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeDecred, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeDecred, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeDecred, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeDecred));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeDecred));
 

--- a/tests/DigiByte/TWCoinTypeTests.cpp
+++ b/tests/DigiByte/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWDigiByteCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeDigiByte));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeDigiByte, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeDigiByte, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeDigiByte, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeDigiByte, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeDigiByte));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeDigiByte));
 

--- a/tests/Dogecoin/TWCoinTypeTests.cpp
+++ b/tests/Dogecoin/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWDogecoinCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeDogecoin));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeDogecoin, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeDogecoin, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeDogecoin, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeDogecoin, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeDogecoin));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeDogecoin));
 

--- a/tests/EOS/TWCoinTypeTests.cpp
+++ b/tests/EOS/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWEOSCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeEOS));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeEOS, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeEOS, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeEOS, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeEOS, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeEOS));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeEOS));
 

--- a/tests/Elrond/TWCoinTypeTests.cpp
+++ b/tests/Elrond/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWElrondCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeElrond));
-    auto txId = TWStringCreateWithUTF8Bytes("1fc9785cb8bea0129a16cf7bddc97630c176a556ea566f0e72923c882b5cb3c8");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeElrond, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("erd12yne790km8ezwetkz7m3hmqy9utdc6vdkgsunfzpwguec6v04p2qtk9uqj");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeElrond, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("1fc9785cb8bea0129a16cf7bddc97630c176a556ea566f0e72923c882b5cb3c8"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeElrond, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("erd12yne790km8ezwetkz7m3hmqy9utdc6vdkgsunfzpwguec6v04p2qtk9uqj"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeElrond, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeElrond));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeElrond));
 

--- a/tests/Ethereum/TWCoinTypeTests.cpp
+++ b/tests/Ethereum/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWEthereumCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeEthereum));
-    auto txId = TWStringCreateWithUTF8Bytes("0x9edaf0f7d9c6629c31bbf0471fc07d696c73b566b93783f7e25d8d5d2b62fa4f");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeEthereum, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("0x5bb497e8d9fe26e92dd1be01e32076c8e024d167");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeEthereum, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("0x9edaf0f7d9c6629c31bbf0471fc07d696c73b566b93783f7e25d8d5d2b62fa4f"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeEthereum, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("0x5bb497e8d9fe26e92dd1be01e32076c8e024d167"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeEthereum, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeEthereum));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeEthereum));
 

--- a/tests/Ethereum/TWEthereumAbiTests.cpp
+++ b/tests/Ethereum/TWEthereumAbiTests.cpp
@@ -65,8 +65,8 @@ TEST(TWEthereumAbi, FuncCreate2) {
     EXPECT_EQ(0, p2index);
 
     // check back get value
-    TWData* p2val2 = TWEthereumAbiFunctionGetParamUInt256(func, p2index, true);
-    Data p2val3 = data(TWDataBytes(p2val2), TWDataSize(p2val2));
+    auto p2val2 = WRAPD(TWEthereumAbiFunctionGetParamUInt256(func, p2index, true));
+    Data p2val3 = data(TWDataBytes(p2val2.get()), TWDataSize(p2val2.get()));
     EXPECT_EQ("00", hex(p2val3));
 
     auto type = WRAPS(TWEthereumAbiFunctionGetType(func));
@@ -189,7 +189,7 @@ TEST(TWEthereumAbi, EncodeFuncMonster) {
     EXPECT_EQ(1, TWEthereumAbiFunctionGetParamUInt8(func, 0, false));
     EXPECT_EQ(4, TWEthereumAbiFunctionGetParamUInt64(func, 3, false));
     EXPECT_EQ(true, TWEthereumAbiFunctionGetParamBool(func, 12, false));
-    EXPECT_EQ(std::string("Hello, world!"), std::string(TWStringUTF8Bytes(TWEthereumAbiFunctionGetParamString(func, 13, false))));
+    EXPECT_EQ(std::string("Hello, world!"), std::string(TWStringUTF8Bytes(WRAPS(TWEthereumAbiFunctionGetParamString(func, 13, false)).get())));
     WRAPD(TWEthereumAbiFunctionGetParamAddress(func, 14, false));
 
     auto type = WRAPS(TWEthereumAbiFunctionGetType(func));
@@ -243,17 +243,17 @@ TEST(TWEthereumAbi, GetParamWrongType) {
     // GetParameter with wrong type, default value (0) is returned
     EXPECT_EQ(0, TWEthereumAbiFunctionGetParamUInt8(func, 1, true));
     EXPECT_EQ(0, TWEthereumAbiFunctionGetParamUInt64(func, 0, true));
-    EXPECT_EQ("00", hex(*(static_cast<const Data*>(TWEthereumAbiFunctionGetParamUInt256(func, 0, true)))));
+    EXPECT_EQ("00", hex(*(static_cast<const Data*>(WRAPD(TWEthereumAbiFunctionGetParamUInt256(func, 0, true)).get()))));
     EXPECT_EQ(false, TWEthereumAbiFunctionGetParamBool(func, 0, true));
-    EXPECT_EQ("", std::string(TWStringUTF8Bytes(TWEthereumAbiFunctionGetParamString(func, 0, true))));
+    EXPECT_EQ("", std::string(TWStringUTF8Bytes(WRAPS(TWEthereumAbiFunctionGetParamString(func, 0, true)).get())));
     EXPECT_EQ("", hex(*(static_cast<const Data*>(WRAPD(TWEthereumAbiFunctionGetParamAddress(func, 0, true)).get()))));
 
     // GetParameter with wrong index, default value (0) is returned
     EXPECT_EQ(0, TWEthereumAbiFunctionGetParamUInt8(func, 99, true));
     EXPECT_EQ(0, TWEthereumAbiFunctionGetParamUInt64(func, 99, true));
-    EXPECT_EQ("00", hex(*(static_cast<const Data*>(TWEthereumAbiFunctionGetParamUInt256(func, 99, true)))));
+    EXPECT_EQ("00", hex(*(static_cast<const Data*>(WRAPD(TWEthereumAbiFunctionGetParamUInt256(func, 99, true)).get()))));
     EXPECT_EQ(false, TWEthereumAbiFunctionGetParamBool(func, 99, true));
-    EXPECT_EQ("", std::string(TWStringUTF8Bytes(TWEthereumAbiFunctionGetParamString(func, 99, true))));
+    EXPECT_EQ("", std::string(TWStringUTF8Bytes(WRAPS(TWEthereumAbiFunctionGetParamString(func, 99, true)).get())));
     EXPECT_EQ("", hex(*(static_cast<const Data*>(WRAPD(TWEthereumAbiFunctionGetParamAddress(func, 99, true)).get()))));
 
     // delete

--- a/tests/Ethereum/TWEthereumAbiTests.cpp
+++ b/tests/Ethereum/TWEthereumAbiTests.cpp
@@ -23,8 +23,8 @@ TEST(TWEthereumAbi, FuncCreateEmpty) {
     TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(TWStringCreateWithUTF8Bytes("baz"));
     EXPECT_TRUE(func != nullptr);
 
-    TWString* type = TWEthereumAbiFunctionGetType(func);
-    std::string type2 = TWStringUTF8Bytes(type);
+    auto type = WRAPS(TWEthereumAbiFunctionGetType(func));
+    std::string type2 = TWStringUTF8Bytes(type.get());
     EXPECT_EQ("baz()", type2);
 
     // delete
@@ -43,8 +43,8 @@ TEST(TWEthereumAbi, FuncCreate1) {
     auto p2val2 = TWEthereumAbiFunctionGetParamUInt64(func, p2index, true);
     EXPECT_EQ(9, p2val2);
 
-    TWString* type = TWEthereumAbiFunctionGetType(func);
-    std::string type2 = TWStringUTF8Bytes(type);
+    auto type = WRAPS(TWEthereumAbiFunctionGetType(func));
+    std::string type2 = TWStringUTF8Bytes(type.get());
     EXPECT_EQ("baz(uint64)", type2);
 
     // delete
@@ -69,8 +69,8 @@ TEST(TWEthereumAbi, FuncCreate2) {
     Data p2val3 = data(TWDataBytes(p2val2), TWDataSize(p2val2));
     EXPECT_EQ("00", hex(p2val3));
 
-    TWString* type = TWEthereumAbiFunctionGetType(func);
-    EXPECT_EQ("baz(uint256)", std::string(TWStringUTF8Bytes(type)));
+    auto type = WRAPS(TWEthereumAbiFunctionGetType(func));
+    EXPECT_EQ("baz(uint256)", std::string(TWStringUTF8Bytes(type.get())));
 
     // delete
     TWEthereumAbiFunctionDelete(func);
@@ -88,11 +88,11 @@ TEST(TWEthereumAbi, EncodeFuncCase1) {
     EXPECT_EQ(1, TWEthereumAbiFunctionAddInArrayParamUInt256(func, paramArrIdx, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("02"))).get()));
     EXPECT_EQ(2, TWEthereumAbiFunctionAddInArrayParamUInt256(func, paramArrIdx, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("03"))).get()));
 
-    TWString* type = TWEthereumAbiFunctionGetType(func);
-    EXPECT_EQ("sam(bytes,bool,uint256[])", std::string(TWStringUTF8Bytes(type)));
+    auto type = WRAPS(TWEthereumAbiFunctionGetType(func));
+    EXPECT_EQ("sam(bytes,bool,uint256[])", std::string(TWStringUTF8Bytes(type.get())));
 
-    TWData* encoded = TWEthereumAbiEncode(func);
-    Data enc2 = data(TWDataBytes(encoded), TWDataSize(encoded));
+    auto encoded = WRAPD(TWEthereumAbiEncode(func));
+    Data enc2 = data(TWDataBytes(encoded.get()), TWDataSize(encoded.get()));
     EXPECT_EQ("a5643bf2"
         "0000000000000000000000000000000000000000000000000000000000000060"
         "0000000000000000000000000000000000000000000000000000000000000001"
@@ -121,11 +121,11 @@ TEST(TWEthereumAbi, EncodeFuncCase2) {
     EXPECT_EQ(2, TWEthereumAbiFunctionAddParamBytesFix(func, 10, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("31323334353637383930"))).get(), false));
     EXPECT_EQ(3, TWEthereumAbiFunctionAddParamString(func, TWStringCreateWithUTF8Bytes("Hello, world!"), false));
 
-    TWString* type = TWEthereumAbiFunctionGetType(func);
-    EXPECT_EQ("f(uint256,uint32[],bytes10,string)", std::string(TWStringUTF8Bytes(type)));
+    auto type = WRAPS(TWEthereumAbiFunctionGetType(func));
+    EXPECT_EQ("f(uint256,uint32[],bytes10,string)", std::string(TWStringUTF8Bytes(type.get())));
 
-    TWData* encoded = TWEthereumAbiEncode(func);
-    Data enc2 = data(TWDataBytes(encoded), TWDataSize(encoded));
+    auto encoded = WRAPD(TWEthereumAbiEncode(func));
+    Data enc2 = data(TWDataBytes(encoded.get()), TWDataSize(encoded.get()));
     EXPECT_EQ("47b941bf"
         "0000000000000000000000000000000000000000000000000000000000000123"
         "0000000000000000000000000000000000000000000000000000000000000080"
@@ -190,16 +190,16 @@ TEST(TWEthereumAbi, EncodeFuncMonster) {
     EXPECT_EQ(4, TWEthereumAbiFunctionGetParamUInt64(func, 3, false));
     EXPECT_EQ(true, TWEthereumAbiFunctionGetParamBool(func, 12, false));
     EXPECT_EQ(std::string("Hello, world!"), std::string(TWStringUTF8Bytes(TWEthereumAbiFunctionGetParamString(func, 13, false))));
-    TWEthereumAbiFunctionGetParamAddress(func, 14, false);
+    WRAPD(TWEthereumAbiFunctionGetParamAddress(func, 14, false));
 
-    TWString* type = TWEthereumAbiFunctionGetType(func);
+    auto type = WRAPS(TWEthereumAbiFunctionGetType(func));
     EXPECT_EQ(
         "monster(uint8,uint16,uint32,uint64,uint168,uint256,int8,int16,int32,int64,int168,int256,bool,string,address,bytes,bytes5,"
         "uint8[],uint16[],uint32[],uint64[],uint168[],uint256[],int8[],int16[],int32[],int64[],int168[],int256[],bool[],string[],address[],bytes[],bytes5[])",
-        std::string(TWStringUTF8Bytes(type)));
+        std::string(TWStringUTF8Bytes(type.get())));
 
-    TWData* encoded = TWEthereumAbiEncode(func);
-    Data enc2 = data(TWDataBytes(encoded), TWDataSize(encoded));
+    auto encoded = WRAPD(TWEthereumAbiEncode(func));
+    Data enc2 = data(TWDataBytes(encoded.get()), TWDataSize(encoded.get()));
     EXPECT_EQ(4 + 76 * 32, enc2.size());
 
     // delete
@@ -211,7 +211,7 @@ TEST(TWEthereumAbi, DecodeOutputFuncCase1) {
     EXPECT_TRUE(func != nullptr);
 
     TWEthereumAbiFunctionAddParamAddress(func, 
-        TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("f784682c82526e245f50975190ef0fff4e4fc077")), false);
+        WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("f784682c82526e245f50975190ef0fff4e4fc077"))).get(), false);
     TWEthereumAbiFunctionAddParamUInt64(func, 1000, false);
     EXPECT_EQ(0, TWEthereumAbiFunctionAddParamUInt64(func, 0, true));
 
@@ -219,8 +219,8 @@ TEST(TWEthereumAbi, DecodeOutputFuncCase1) {
     EXPECT_EQ(0, TWEthereumAbiFunctionGetParamUInt64(func, 0, true));
 
     // decode
-    auto encoded = TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0000000000000000000000000000000000000000000000000000000000000045"));
-    EXPECT_EQ(true, TWEthereumAbiDecodeOutput(func, encoded));
+    auto encoded = WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0000000000000000000000000000000000000000000000000000000000000045")));
+    EXPECT_EQ(true, TWEthereumAbiDecodeOutput(func, encoded.get()));
 
     // new output value
     EXPECT_EQ(0x45, TWEthereumAbiFunctionGetParamUInt64(func, 0, true));
@@ -246,7 +246,7 @@ TEST(TWEthereumAbi, GetParamWrongType) {
     EXPECT_EQ("00", hex(*(static_cast<const Data*>(TWEthereumAbiFunctionGetParamUInt256(func, 0, true)))));
     EXPECT_EQ(false, TWEthereumAbiFunctionGetParamBool(func, 0, true));
     EXPECT_EQ("", std::string(TWStringUTF8Bytes(TWEthereumAbiFunctionGetParamString(func, 0, true))));
-    EXPECT_EQ("", hex(*(static_cast<const Data*>(TWEthereumAbiFunctionGetParamAddress(func, 0, true)))));
+    EXPECT_EQ("", hex(*(static_cast<const Data*>(WRAPD(TWEthereumAbiFunctionGetParamAddress(func, 0, true)).get()))));
 
     // GetParameter with wrong index, default value (0) is returned
     EXPECT_EQ(0, TWEthereumAbiFunctionGetParamUInt8(func, 99, true));
@@ -254,7 +254,7 @@ TEST(TWEthereumAbi, GetParamWrongType) {
     EXPECT_EQ("00", hex(*(static_cast<const Data*>(TWEthereumAbiFunctionGetParamUInt256(func, 99, true)))));
     EXPECT_EQ(false, TWEthereumAbiFunctionGetParamBool(func, 99, true));
     EXPECT_EQ("", std::string(TWStringUTF8Bytes(TWEthereumAbiFunctionGetParamString(func, 99, true))));
-    EXPECT_EQ("", hex(*(static_cast<const Data*>(TWEthereumAbiFunctionGetParamAddress(func, 99, true)))));
+    EXPECT_EQ("", hex(*(static_cast<const Data*>(WRAPD(TWEthereumAbiFunctionGetParamAddress(func, 99, true)).get()))));
 
     // delete
     TWEthereumAbiFunctionDelete(func);

--- a/tests/Ethereum/TWEthereumAbiTests.cpp
+++ b/tests/Ethereum/TWEthereumAbiTests.cpp
@@ -55,12 +55,12 @@ TEST(TWEthereumAbi, FuncCreate2) {
     TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(TWStringCreateWithUTF8Bytes("baz"));
     EXPECT_TRUE(func != nullptr);
 
-    TWString* p1valStr = TWStringCreateWithUTF8Bytes("0045");
-    TWData* p1val = TWDataCreateWithHexString(p1valStr);
+    auto p1valStr = WRAPS(TWStringCreateWithUTF8Bytes("0045"));
+    TWData* p1val = TWDataCreateWithHexString(p1valStr.get());
     auto p1index = TWEthereumAbiFunctionAddParamUInt256(func, p1val, false);
     EXPECT_EQ(0, p1index);
     //TWDataDelete(p1val);
-    TWStringDelete(p1valStr);
+    TWStringDelete(p1valStr.get());
 
     Data dummy(0);
     auto p2index = TWEthereumAbiFunctionAddParamUInt256(func, &dummy, true);

--- a/tests/Ethereum/TWEthereumAbiTests.cpp
+++ b/tests/Ethereum/TWEthereumAbiTests.cpp
@@ -20,7 +20,7 @@
 namespace TW::Ethereum {
 
 TEST(TWEthereumAbi, FuncCreateEmpty) {
-    TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(TWStringCreateWithUTF8Bytes("baz"));
+    TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(WRAPS(TWStringCreateWithUTF8Bytes("baz")).get());
     EXPECT_TRUE(func != nullptr);
 
     auto type = WRAPS(TWEthereumAbiFunctionGetType(func));
@@ -32,7 +32,7 @@ TEST(TWEthereumAbi, FuncCreateEmpty) {
 }
 
 TEST(TWEthereumAbi, FuncCreate1) {
-    TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(TWStringCreateWithUTF8Bytes("baz"));
+    TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(WRAPS(TWStringCreateWithUTF8Bytes("baz")).get());
     EXPECT_TRUE(func != nullptr);
 
     auto p1index = TWEthereumAbiFunctionAddParamUInt64(func, 69, false);
@@ -52,7 +52,7 @@ TEST(TWEthereumAbi, FuncCreate1) {
 }
 
 TEST(TWEthereumAbi, FuncCreate2) {
-    TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(TWStringCreateWithUTF8Bytes("baz"));
+    TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(WRAPS(TWStringCreateWithUTF8Bytes("baz")).get());
     EXPECT_TRUE(func != nullptr);
 
     auto p1valStr = WRAPS(TWStringCreateWithUTF8Bytes("0045"));
@@ -77,16 +77,16 @@ TEST(TWEthereumAbi, FuncCreate2) {
 }
 
 TEST(TWEthereumAbi, EncodeFuncCase1) {
-    TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(TWStringCreateWithUTF8Bytes("sam"));
+    TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(WRAPS(TWStringCreateWithUTF8Bytes("sam")).get());
     EXPECT_TRUE(func != nullptr);
     
-    EXPECT_EQ(0, TWEthereumAbiFunctionAddParamBytes(func, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("64617665"))).get(), false));
+    EXPECT_EQ(0, TWEthereumAbiFunctionAddParamBytes(func, WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("64617665")).get())).get(), false));
     EXPECT_EQ(1, TWEthereumAbiFunctionAddParamBool(func, true, false));
     auto paramArrIdx = TWEthereumAbiFunctionAddParamArray(func, false);
     EXPECT_EQ(2, paramArrIdx);
-    EXPECT_EQ(0, TWEthereumAbiFunctionAddInArrayParamUInt256(func, paramArrIdx, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("01"))).get()));
-    EXPECT_EQ(1, TWEthereumAbiFunctionAddInArrayParamUInt256(func, paramArrIdx, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("02"))).get()));
-    EXPECT_EQ(2, TWEthereumAbiFunctionAddInArrayParamUInt256(func, paramArrIdx, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("03"))).get()));
+    EXPECT_EQ(0, TWEthereumAbiFunctionAddInArrayParamUInt256(func, paramArrIdx, WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("01")).get())).get()));
+    EXPECT_EQ(1, TWEthereumAbiFunctionAddInArrayParamUInt256(func, paramArrIdx, WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("02")).get())).get()));
+    EXPECT_EQ(2, TWEthereumAbiFunctionAddInArrayParamUInt256(func, paramArrIdx, WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("03")).get())).get()));
 
     auto type = WRAPS(TWEthereumAbiFunctionGetType(func));
     EXPECT_EQ("sam(bytes,bool,uint256[])", std::string(TWStringUTF8Bytes(type.get())));
@@ -110,16 +110,16 @@ TEST(TWEthereumAbi, EncodeFuncCase1) {
 }
 
 TEST(TWEthereumAbi, EncodeFuncCase2) {
-    TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(TWStringCreateWithUTF8Bytes("f"));
+    TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(WRAPS(TWStringCreateWithUTF8Bytes("f")).get());
     EXPECT_TRUE(func != nullptr);
     
-    EXPECT_EQ(0, TWEthereumAbiFunctionAddParamUInt256(func, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123"))).get(), false));
+    EXPECT_EQ(0, TWEthereumAbiFunctionAddParamUInt256(func, WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("0123")).get())).get(), false));
     auto paramArrIdx = TWEthereumAbiFunctionAddParamArray(func, false);
     EXPECT_EQ(1, paramArrIdx);
     EXPECT_EQ(0, TWEthereumAbiFunctionAddInArrayParamUInt32(func, paramArrIdx, 0x456));
     EXPECT_EQ(1, TWEthereumAbiFunctionAddInArrayParamUInt32(func, paramArrIdx, 0x789));
-    EXPECT_EQ(2, TWEthereumAbiFunctionAddParamBytesFix(func, 10, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("31323334353637383930"))).get(), false));
-    EXPECT_EQ(3, TWEthereumAbiFunctionAddParamString(func, TWStringCreateWithUTF8Bytes("Hello, world!"), false));
+    EXPECT_EQ(2, TWEthereumAbiFunctionAddParamBytesFix(func, 10, WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("31323334353637383930")).get())).get(), false));
+    EXPECT_EQ(3, TWEthereumAbiFunctionAddParamString(func, WRAPS(TWStringCreateWithUTF8Bytes("Hello, world!")).get(), false));
 
     auto type = WRAPS(TWEthereumAbiFunctionGetType(func));
     EXPECT_EQ("f(uint256,uint32[],bytes10,string)", std::string(TWStringUTF8Bytes(type.get())));
@@ -144,46 +144,46 @@ TEST(TWEthereumAbi, EncodeFuncCase2) {
 
 TEST(TWEthereumAbi, EncodeFuncMonster) {
     // Monster function with all parameters types
-    TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(TWStringCreateWithUTF8Bytes("monster"));
+    TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(WRAPS(TWStringCreateWithUTF8Bytes("monster")).get());
     EXPECT_TRUE(func != nullptr);
     
     TWEthereumAbiFunctionAddParamUInt8(func, 1, false);
     TWEthereumAbiFunctionAddParamUInt16(func, 2, false);
     TWEthereumAbiFunctionAddParamUInt32(func, 3, false);
     TWEthereumAbiFunctionAddParamUInt64(func, 4, false);
-    TWEthereumAbiFunctionAddParamUIntN(func, 168, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123"))).get(), false);
-    TWEthereumAbiFunctionAddParamUInt256(func, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123"))).get(), false);
+    TWEthereumAbiFunctionAddParamUIntN(func, 168, WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("0123")).get())).get(), false);
+    TWEthereumAbiFunctionAddParamUInt256(func, WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("0123")).get())).get(), false);
     TWEthereumAbiFunctionAddParamInt8(func, 1, false);
     TWEthereumAbiFunctionAddParamInt16(func, 2, false);
     TWEthereumAbiFunctionAddParamInt32(func, 3, false);
     TWEthereumAbiFunctionAddParamInt64(func, 4, false);
-    TWEthereumAbiFunctionAddParamIntN(func, 168, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123"))).get(), false);
-    TWEthereumAbiFunctionAddParamInt256(func, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123"))).get(), false);
+    TWEthereumAbiFunctionAddParamIntN(func, 168, WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("0123")).get())).get(), false);
+    TWEthereumAbiFunctionAddParamInt256(func, WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("0123")).get())).get(), false);
     TWEthereumAbiFunctionAddParamBool(func, true, false);
-    TWEthereumAbiFunctionAddParamString(func, TWStringCreateWithUTF8Bytes("Hello, world!"), false);
+    TWEthereumAbiFunctionAddParamString(func, WRAPS(TWStringCreateWithUTF8Bytes("Hello, world!")).get(), false);
     TWEthereumAbiFunctionAddParamAddress(func,
-        WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("f784682c82526e245f50975190ef0fff4e4fc077"))).get(), false);
-    TWEthereumAbiFunctionAddParamBytes(func, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("3132333435"))).get(), false);
-    TWEthereumAbiFunctionAddParamBytesFix(func, 5, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("3132333435"))).get(), false);
+        WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("f784682c82526e245f50975190ef0fff4e4fc077")).get())).get(), false);
+    TWEthereumAbiFunctionAddParamBytes(func, WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("3132333435")).get())).get(), false);
+    TWEthereumAbiFunctionAddParamBytesFix(func, 5, WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("3132333435")).get())).get(), false);
     
     TWEthereumAbiFunctionAddInArrayParamUInt8(func, TWEthereumAbiFunctionAddParamArray(func, false), 1);
     TWEthereumAbiFunctionAddInArrayParamUInt16(func, TWEthereumAbiFunctionAddParamArray(func, false), 2);
     TWEthereumAbiFunctionAddInArrayParamUInt32(func, TWEthereumAbiFunctionAddParamArray(func, false), 3);
     TWEthereumAbiFunctionAddInArrayParamUInt64(func, TWEthereumAbiFunctionAddParamArray(func, false), 4);
-    TWEthereumAbiFunctionAddInArrayParamUIntN(func, TWEthereumAbiFunctionAddParamArray(func, false), 168, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123"))).get());
-    TWEthereumAbiFunctionAddInArrayParamUInt256(func, TWEthereumAbiFunctionAddParamArray(func, false), WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123"))).get());
+    TWEthereumAbiFunctionAddInArrayParamUIntN(func, TWEthereumAbiFunctionAddParamArray(func, false), 168, WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("0123")).get())).get());
+    TWEthereumAbiFunctionAddInArrayParamUInt256(func, TWEthereumAbiFunctionAddParamArray(func, false), WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("0123")).get())).get());
     TWEthereumAbiFunctionAddInArrayParamInt8(func, TWEthereumAbiFunctionAddParamArray(func, false), 1);
     TWEthereumAbiFunctionAddInArrayParamInt16(func, TWEthereumAbiFunctionAddParamArray(func, false), 2);
     TWEthereumAbiFunctionAddInArrayParamInt32(func, TWEthereumAbiFunctionAddParamArray(func, false), 3);
     TWEthereumAbiFunctionAddInArrayParamInt64(func, TWEthereumAbiFunctionAddParamArray(func, false), 4);
-    TWEthereumAbiFunctionAddInArrayParamIntN(func, TWEthereumAbiFunctionAddParamArray(func, false), 168, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123"))).get());
-    TWEthereumAbiFunctionAddInArrayParamInt256(func, TWEthereumAbiFunctionAddParamArray(func, false), WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123"))).get());
+    TWEthereumAbiFunctionAddInArrayParamIntN(func, TWEthereumAbiFunctionAddParamArray(func, false), 168, WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("0123")).get())).get());
+    TWEthereumAbiFunctionAddInArrayParamInt256(func, TWEthereumAbiFunctionAddParamArray(func, false), WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("0123")).get())).get());
     TWEthereumAbiFunctionAddInArrayParamBool(func, TWEthereumAbiFunctionAddParamArray(func, false), true);
-    TWEthereumAbiFunctionAddInArrayParamString(func, TWEthereumAbiFunctionAddParamArray(func, false), TWStringCreateWithUTF8Bytes("Hello, world!"));
+    TWEthereumAbiFunctionAddInArrayParamString(func, TWEthereumAbiFunctionAddParamArray(func, false), WRAPS(TWStringCreateWithUTF8Bytes("Hello, world!")).get());
     TWEthereumAbiFunctionAddInArrayParamAddress(func, TWEthereumAbiFunctionAddParamArray(func, false), 
-        WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("f784682c82526e245f50975190ef0fff4e4fc077"))).get());
-    TWEthereumAbiFunctionAddInArrayParamBytes(func, TWEthereumAbiFunctionAddParamArray(func, false), WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("3132333435"))).get());
-    TWEthereumAbiFunctionAddInArrayParamBytesFix(func, TWEthereumAbiFunctionAddParamArray(func, false), 5, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("3132333435"))).get());
+        WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("f784682c82526e245f50975190ef0fff4e4fc077")).get())).get());
+    TWEthereumAbiFunctionAddInArrayParamBytes(func, TWEthereumAbiFunctionAddParamArray(func, false), WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("3132333435")).get())).get());
+    TWEthereumAbiFunctionAddInArrayParamBytesFix(func, TWEthereumAbiFunctionAddParamArray(func, false), 5, WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("3132333435")).get())).get());
 
     // check back out params
     EXPECT_EQ(1, TWEthereumAbiFunctionGetParamUInt8(func, 0, false));
@@ -207,11 +207,11 @@ TEST(TWEthereumAbi, EncodeFuncMonster) {
 }
 
 TEST(TWEthereumAbi, DecodeOutputFuncCase1) {
-    TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(TWStringCreateWithUTF8Bytes("readout"));
+    TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(WRAPS(TWStringCreateWithUTF8Bytes("readout")).get());
     EXPECT_TRUE(func != nullptr);
 
     TWEthereumAbiFunctionAddParamAddress(func, 
-        WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("f784682c82526e245f50975190ef0fff4e4fc077"))).get(), false);
+        WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("f784682c82526e245f50975190ef0fff4e4fc077")).get())).get(), false);
     TWEthereumAbiFunctionAddParamUInt64(func, 1000, false);
     EXPECT_EQ(0, TWEthereumAbiFunctionAddParamUInt64(func, 0, true));
 
@@ -219,7 +219,7 @@ TEST(TWEthereumAbi, DecodeOutputFuncCase1) {
     EXPECT_EQ(0, TWEthereumAbiFunctionGetParamUInt64(func, 0, true));
 
     // decode
-    auto encoded = WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0000000000000000000000000000000000000000000000000000000000000045")));
+    auto encoded = WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("0000000000000000000000000000000000000000000000000000000000000045")).get()));
     EXPECT_EQ(true, TWEthereumAbiDecodeOutput(func, encoded.get()));
 
     // new output value
@@ -230,7 +230,7 @@ TEST(TWEthereumAbi, DecodeOutputFuncCase1) {
 }
 
 TEST(TWEthereumAbi, GetParamWrongType) {
-    TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(TWStringCreateWithUTF8Bytes("func"));
+    TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(WRAPS(TWStringCreateWithUTF8Bytes("func")).get());
     ASSERT_TRUE(func != nullptr);
     // add parameters
     EXPECT_EQ(0, TWEthereumAbiFunctionAddParamUInt8(func, 1, true));

--- a/tests/Ethereum/TWEthereumAbiTests.cpp
+++ b/tests/Ethereum/TWEthereumAbiTests.cpp
@@ -80,13 +80,13 @@ TEST(TWEthereumAbi, EncodeFuncCase1) {
     TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(TWStringCreateWithUTF8Bytes("sam"));
     EXPECT_TRUE(func != nullptr);
     
-    EXPECT_EQ(0, TWEthereumAbiFunctionAddParamBytes(func, TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("64617665")), false));
+    EXPECT_EQ(0, TWEthereumAbiFunctionAddParamBytes(func, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("64617665"))).get(), false));
     EXPECT_EQ(1, TWEthereumAbiFunctionAddParamBool(func, true, false));
     auto paramArrIdx = TWEthereumAbiFunctionAddParamArray(func, false);
     EXPECT_EQ(2, paramArrIdx);
-    EXPECT_EQ(0, TWEthereumAbiFunctionAddInArrayParamUInt256(func, paramArrIdx, TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("01"))));
-    EXPECT_EQ(1, TWEthereumAbiFunctionAddInArrayParamUInt256(func, paramArrIdx, TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("02"))));
-    EXPECT_EQ(2, TWEthereumAbiFunctionAddInArrayParamUInt256(func, paramArrIdx, TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("03"))));
+    EXPECT_EQ(0, TWEthereumAbiFunctionAddInArrayParamUInt256(func, paramArrIdx, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("01"))).get()));
+    EXPECT_EQ(1, TWEthereumAbiFunctionAddInArrayParamUInt256(func, paramArrIdx, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("02"))).get()));
+    EXPECT_EQ(2, TWEthereumAbiFunctionAddInArrayParamUInt256(func, paramArrIdx, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("03"))).get()));
 
     TWString* type = TWEthereumAbiFunctionGetType(func);
     EXPECT_EQ("sam(bytes,bool,uint256[])", std::string(TWStringUTF8Bytes(type)));
@@ -113,12 +113,12 @@ TEST(TWEthereumAbi, EncodeFuncCase2) {
     TWEthereumAbiFunction* func = TWEthereumAbiFunctionCreateWithString(TWStringCreateWithUTF8Bytes("f"));
     EXPECT_TRUE(func != nullptr);
     
-    EXPECT_EQ(0, TWEthereumAbiFunctionAddParamUInt256(func, TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123")), false));
+    EXPECT_EQ(0, TWEthereumAbiFunctionAddParamUInt256(func, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123"))).get(), false));
     auto paramArrIdx = TWEthereumAbiFunctionAddParamArray(func, false);
     EXPECT_EQ(1, paramArrIdx);
     EXPECT_EQ(0, TWEthereumAbiFunctionAddInArrayParamUInt32(func, paramArrIdx, 0x456));
     EXPECT_EQ(1, TWEthereumAbiFunctionAddInArrayParamUInt32(func, paramArrIdx, 0x789));
-    EXPECT_EQ(2, TWEthereumAbiFunctionAddParamBytesFix(func, 10, TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("31323334353637383930")), false));
+    EXPECT_EQ(2, TWEthereumAbiFunctionAddParamBytesFix(func, 10, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("31323334353637383930"))).get(), false));
     EXPECT_EQ(3, TWEthereumAbiFunctionAddParamString(func, TWStringCreateWithUTF8Bytes("Hello, world!"), false));
 
     TWString* type = TWEthereumAbiFunctionGetType(func);
@@ -151,39 +151,39 @@ TEST(TWEthereumAbi, EncodeFuncMonster) {
     TWEthereumAbiFunctionAddParamUInt16(func, 2, false);
     TWEthereumAbiFunctionAddParamUInt32(func, 3, false);
     TWEthereumAbiFunctionAddParamUInt64(func, 4, false);
-    TWEthereumAbiFunctionAddParamUIntN(func, 168, TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123")), false);
-    TWEthereumAbiFunctionAddParamUInt256(func, TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123")), false);
+    TWEthereumAbiFunctionAddParamUIntN(func, 168, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123"))).get(), false);
+    TWEthereumAbiFunctionAddParamUInt256(func, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123"))).get(), false);
     TWEthereumAbiFunctionAddParamInt8(func, 1, false);
     TWEthereumAbiFunctionAddParamInt16(func, 2, false);
     TWEthereumAbiFunctionAddParamInt32(func, 3, false);
     TWEthereumAbiFunctionAddParamInt64(func, 4, false);
-    TWEthereumAbiFunctionAddParamIntN(func, 168, TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123")), false);
-    TWEthereumAbiFunctionAddParamInt256(func, TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123")), false);
+    TWEthereumAbiFunctionAddParamIntN(func, 168, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123"))).get(), false);
+    TWEthereumAbiFunctionAddParamInt256(func, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123"))).get(), false);
     TWEthereumAbiFunctionAddParamBool(func, true, false);
     TWEthereumAbiFunctionAddParamString(func, TWStringCreateWithUTF8Bytes("Hello, world!"), false);
-    TWEthereumAbiFunctionAddParamAddress(func, 
-        TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("f784682c82526e245f50975190ef0fff4e4fc077")), false);
-    TWEthereumAbiFunctionAddParamBytes(func, TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("3132333435")), false);
-    TWEthereumAbiFunctionAddParamBytesFix(func, 5, TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("3132333435")), false);
+    TWEthereumAbiFunctionAddParamAddress(func,
+        WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("f784682c82526e245f50975190ef0fff4e4fc077"))).get(), false);
+    TWEthereumAbiFunctionAddParamBytes(func, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("3132333435"))).get(), false);
+    TWEthereumAbiFunctionAddParamBytesFix(func, 5, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("3132333435"))).get(), false);
     
     TWEthereumAbiFunctionAddInArrayParamUInt8(func, TWEthereumAbiFunctionAddParamArray(func, false), 1);
     TWEthereumAbiFunctionAddInArrayParamUInt16(func, TWEthereumAbiFunctionAddParamArray(func, false), 2);
     TWEthereumAbiFunctionAddInArrayParamUInt32(func, TWEthereumAbiFunctionAddParamArray(func, false), 3);
     TWEthereumAbiFunctionAddInArrayParamUInt64(func, TWEthereumAbiFunctionAddParamArray(func, false), 4);
-    TWEthereumAbiFunctionAddInArrayParamUIntN(func, TWEthereumAbiFunctionAddParamArray(func, false), 168, TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123")));
-    TWEthereumAbiFunctionAddInArrayParamUInt256(func, TWEthereumAbiFunctionAddParamArray(func, false), TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123")));
+    TWEthereumAbiFunctionAddInArrayParamUIntN(func, TWEthereumAbiFunctionAddParamArray(func, false), 168, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123"))).get());
+    TWEthereumAbiFunctionAddInArrayParamUInt256(func, TWEthereumAbiFunctionAddParamArray(func, false), WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123"))).get());
     TWEthereumAbiFunctionAddInArrayParamInt8(func, TWEthereumAbiFunctionAddParamArray(func, false), 1);
     TWEthereumAbiFunctionAddInArrayParamInt16(func, TWEthereumAbiFunctionAddParamArray(func, false), 2);
     TWEthereumAbiFunctionAddInArrayParamInt32(func, TWEthereumAbiFunctionAddParamArray(func, false), 3);
     TWEthereumAbiFunctionAddInArrayParamInt64(func, TWEthereumAbiFunctionAddParamArray(func, false), 4);
-    TWEthereumAbiFunctionAddInArrayParamIntN(func, TWEthereumAbiFunctionAddParamArray(func, false), 168, TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123")));
-    TWEthereumAbiFunctionAddInArrayParamInt256(func, TWEthereumAbiFunctionAddParamArray(func, false), TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123")));
+    TWEthereumAbiFunctionAddInArrayParamIntN(func, TWEthereumAbiFunctionAddParamArray(func, false), 168, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123"))).get());
+    TWEthereumAbiFunctionAddInArrayParamInt256(func, TWEthereumAbiFunctionAddParamArray(func, false), WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0123"))).get());
     TWEthereumAbiFunctionAddInArrayParamBool(func, TWEthereumAbiFunctionAddParamArray(func, false), true);
     TWEthereumAbiFunctionAddInArrayParamString(func, TWEthereumAbiFunctionAddParamArray(func, false), TWStringCreateWithUTF8Bytes("Hello, world!"));
     TWEthereumAbiFunctionAddInArrayParamAddress(func, TWEthereumAbiFunctionAddParamArray(func, false), 
-        TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("f784682c82526e245f50975190ef0fff4e4fc077")));
-    TWEthereumAbiFunctionAddInArrayParamBytes(func, TWEthereumAbiFunctionAddParamArray(func, false), TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("3132333435")));
-    TWEthereumAbiFunctionAddInArrayParamBytesFix(func, TWEthereumAbiFunctionAddParamArray(func, false), 5, TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("3132333435")));
+        WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("f784682c82526e245f50975190ef0fff4e4fc077"))).get());
+    TWEthereumAbiFunctionAddInArrayParamBytes(func, TWEthereumAbiFunctionAddParamArray(func, false), WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("3132333435"))).get());
+    TWEthereumAbiFunctionAddInArrayParamBytesFix(func, TWEthereumAbiFunctionAddParamArray(func, false), 5, WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("3132333435"))).get());
 
     // check back out params
     EXPECT_EQ(1, TWEthereumAbiFunctionGetParamUInt8(func, 0, false));

--- a/tests/Ethereum/TWEthereumAbiTests.cpp
+++ b/tests/Ethereum/TWEthereumAbiTests.cpp
@@ -56,11 +56,9 @@ TEST(TWEthereumAbi, FuncCreate2) {
     EXPECT_TRUE(func != nullptr);
 
     auto p1valStr = WRAPS(TWStringCreateWithUTF8Bytes("0045"));
-    TWData* p1val = TWDataCreateWithHexString(p1valStr.get());
-    auto p1index = TWEthereumAbiFunctionAddParamUInt256(func, p1val, false);
+    auto p1val = WRAPD(TWDataCreateWithHexString(p1valStr.get()));
+    auto p1index = TWEthereumAbiFunctionAddParamUInt256(func, p1val.get(), false);
     EXPECT_EQ(0, p1index);
-    //TWDataDelete(p1val);
-    TWStringDelete(p1valStr.get());
 
     Data dummy(0);
     auto p2index = TWEthereumAbiFunctionAddParamUInt256(func, &dummy, true);

--- a/tests/Ethereum/TWEthereumAbiValueEncodeTests.cpp
+++ b/tests/Ethereum/TWEthereumAbiValueEncodeTests.cpp
@@ -38,12 +38,12 @@ TEST(TWEthereumAbiValue, encodeInt) {
         "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeUInt32(69)).get())),
         "0000000000000000000000000000000000000000000000000000000000000045");
-    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeUInt256(buildUInt256(uint256_t(69)))).get())),
+    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeUInt256(WRAPD(buildUInt256(uint256_t(69))).get())).get())),
         "0000000000000000000000000000000000000000000000000000000000000045");
-    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeInt256(buildUInt256(uint256_t(69)))).get())),
+    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeInt256(WRAPD(buildUInt256(uint256_t(69))).get())).get())),
         "0000000000000000000000000000000000000000000000000000000000000045");
     // int256(-1)
-    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeInt256(buildUInt256(~uint256_t(0)))).get())),
+    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeInt256(WRAPD(buildUInt256(~uint256_t(0))).get())).get())),
         "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 }
 

--- a/tests/Ethereum/TWEthereumAbiValueEncodeTests.cpp
+++ b/tests/Ethereum/TWEthereumAbiValueEncodeTests.cpp
@@ -66,6 +66,10 @@ TEST(TWEthereumAbiValue, encodeBytes) {
 
 TEST(TWEthereumAbiValue, encodeBytesDyn) {
     std::string valueStr = "trustwallet";
-    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeBytesDyn(TWDataCreateWithBytes(reinterpret_cast<const unsigned char*>(valueStr.c_str()), valueStr.length()))).get())),
-        "31924c4e2bb082322d1efa718bf67c73ca297b481dac9f76ad35670cff0056a3");
+    EXPECT_EQ(
+        hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeBytesDyn(WRAPD(
+            TWDataCreateWithBytes(reinterpret_cast<const unsigned char*>(valueStr.c_str()), valueStr.length())
+        ).get())).get())),
+        "31924c4e2bb082322d1efa718bf67c73ca297b481dac9f76ad35670cff0056a3"
+    );
 }

--- a/tests/Ethereum/TWEthereumAbiValueEncodeTests.cpp
+++ b/tests/Ethereum/TWEthereumAbiValueEncodeTests.cpp
@@ -48,7 +48,7 @@ TEST(TWEthereumAbiValue, encodeInt) {
 }
 
 TEST(TWEthereumAbiValue, encodeAddress) {
-    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeAddress(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed")))).get())),
+    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeAddress(WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"))).get())).get())),
         "0000000000000000000000005aaeb6053f3e94c9b9a09f33669435e7ef1beaed");
 }
 
@@ -58,9 +58,9 @@ TEST(TWEthereumAbiValue, encodeString) {
 }
 
 TEST(TWEthereumAbiValue, encodeBytes) {
-    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeBytes(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("45")))).get())),
+    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeBytes(WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("45"))).get())).get())),
         "4500000000000000000000000000000000000000000000000000000000000000");
-    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeBytes(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed")))).get())),
+    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeBytes(WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"))).get())).get())),
         "5aaeb6053f3e94c9b9a09f33669435e7ef1beaed000000000000000000000000");
 }
 

--- a/tests/Ethereum/TWEthereumAbiValueEncodeTests.cpp
+++ b/tests/Ethereum/TWEthereumAbiValueEncodeTests.cpp
@@ -48,19 +48,19 @@ TEST(TWEthereumAbiValue, encodeInt) {
 }
 
 TEST(TWEthereumAbiValue, encodeAddress) {
-    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeAddress(WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"))).get())).get())),
+    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeAddress(WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed")).get())).get())).get())),
         "0000000000000000000000005aaeb6053f3e94c9b9a09f33669435e7ef1beaed");
 }
 
 TEST(TWEthereumAbiValue, encodeString) {
-    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeString(TWStringCreateWithUTF8Bytes("trustwallet"))).get())),
+    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeString(WRAPS(TWStringCreateWithUTF8Bytes("trustwallet")).get())).get())),
         "31924c4e2bb082322d1efa718bf67c73ca297b481dac9f76ad35670cff0056a3");
 }
 
 TEST(TWEthereumAbiValue, encodeBytes) {
-    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeBytes(WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("45"))).get())).get())),
+    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeBytes(WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("45")).get())).get())).get())),
         "4500000000000000000000000000000000000000000000000000000000000000");
-    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeBytes(WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes("5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"))).get())).get())),
+    EXPECT_EQ(hex(*reinterpret_cast<const Data*>(WRAPD(TWEthereumAbiValueEncodeBytes(WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes("5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed")).get())).get())).get())),
         "5aaeb6053f3e94c9b9a09f33669435e7ef1beaed000000000000000000000000");
 }
 

--- a/tests/EthereumClassic/TWCoinTypeTests.cpp
+++ b/tests/EthereumClassic/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWEthereumClassicCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeEthereumClassic));
-    auto txId = TWStringCreateWithUTF8Bytes("0x66004165d3901819dc22e568931591d2e4287bda54995f4ce2701a12016f5997");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeEthereumClassic, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("0x9eab4b0fc468a7f5d46228bf5a76cb52370d068d");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeEthereumClassic, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("0x66004165d3901819dc22e568931591d2e4287bda54995f4ce2701a12016f5997"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeEthereumClassic, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("0x9eab4b0fc468a7f5d46228bf5a76cb52370d068d"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeEthereumClassic, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeEthereumClassic));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeEthereumClassic));
 

--- a/tests/FIO/TWCoinTypeTests.cpp
+++ b/tests/FIO/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWFIOCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeFIO));
-    auto txId = TWStringCreateWithUTF8Bytes("930d1d3cf8988b39b5f64b64e9d61314a3e05a155d9e3505bdf863aab1adddf3");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeFIO, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("f5axfpgffiqz");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeFIO, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("930d1d3cf8988b39b5f64b64e9d61314a3e05a155d9e3505bdf863aab1adddf3"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeFIO, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("f5axfpgffiqz"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeFIO, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeFIO));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeFIO));
 

--- a/tests/FIO/TWFIOTests.cpp
+++ b/tests/FIO/TWFIOTests.cpp
@@ -24,10 +24,10 @@ using namespace std;
 TEST(TWFIO, Address) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("ba0828d5734b65e3bcc2c51c93dfc26dd71bd666cc0273adee77d73d9a322035").get()));
     ASSERT_NE(nullptr, privateKey.get());
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), false);
-    ASSERT_NE(nullptr, publicKey);
-    ASSERT_EQ(65, publicKey->impl.bytes.size());
-    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey, TWCoinTypeFIO));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), false));
+    ASSERT_NE(nullptr, publicKey.get());
+    ASSERT_EQ(65, publicKey.get()->impl.bytes.size());
+    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeFIO));
     auto addressString = WRAPS(TWAnyAddressDescription(address.get()));
     assertStringsEqual(addressString, "FIO6m1fMdTpRkRBnedvYshXCxLFiC5suRU8KDfx8xxtXp2hntxpnf");
 

--- a/tests/Filecoin/TWCoinTypeTests.cpp
+++ b/tests/Filecoin/TWCoinTypeTests.cpp
@@ -14,11 +14,11 @@
 
 TEST(TWFilecoinCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeFilecoin));
-    auto txId = TWStringCreateWithUTF8Bytes(
-        "bafy2bzacecbm3ofxjjzcl2rg32ninphza34mm3ijr55zjsamwfqmz4ib63mqe");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeFilecoin, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("t1nbb73vhk5dtmnsgeaetbo76daepqjtrfoccn74i");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeFilecoin, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes(
+        "bafy2bzacecbm3ofxjjzcl2rg32ninphza34mm3ijr55zjsamwfqmz4ib63mqe"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeFilecoin, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("t1nbb73vhk5dtmnsgeaetbo76daepqjtrfoccn74i"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeFilecoin, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeFilecoin));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeFilecoin));
 

--- a/tests/GoChain/TWCoinTypeTests.cpp
+++ b/tests/GoChain/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWGoChainCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeGoChain));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeGoChain, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeGoChain, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeGoChain, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeGoChain, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeGoChain));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeGoChain));
 

--- a/tests/Groestlcoin/TWCoinTypeTests.cpp
+++ b/tests/Groestlcoin/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWGroestlcoinCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeGroestlcoin));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeGroestlcoin, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeGroestlcoin, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeGroestlcoin, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeGroestlcoin, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeGroestlcoin));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeGroestlcoin));
 

--- a/tests/Groestlcoin/TWGroestlcoinTests.cpp
+++ b/tests/Groestlcoin/TWGroestlcoinTests.cpp
@@ -18,8 +18,8 @@
 
 TEST(Groestlcoin, Address) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("3c3385ddc6fd95ba7282051aeb440bc75820b8c10db5c83c052d7586e3e98e84").get()));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
-    auto address = WRAP(TWGroestlcoinAddress, TWGroestlcoinAddressCreateWithPublicKey(publicKey, TWCoinTypeP2pkhPrefix(TWCoinTypeGroestlcoin)));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
+    auto address = WRAP(TWGroestlcoinAddress, TWGroestlcoinAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeGroestlcoin)));
     auto addressString = WRAPS(TWGroestlcoinAddressDescription(address.get()));
     assertStringsEqual(addressString, "Fj62rBJi8LvbmWu2jzkaUX1NFXLEqDLoZM");
 

--- a/tests/Harmony/TWCoinTypeTests.cpp
+++ b/tests/Harmony/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWHarmonyCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeHarmony));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeHarmony, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeHarmony, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeHarmony, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeHarmony, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeHarmony));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeHarmony));
 

--- a/tests/ICON/TWCoinTypeTests.cpp
+++ b/tests/ICON/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWICONCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeICON));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeICON, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeICON, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeICON, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeICON, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeICON));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeICON));
 

--- a/tests/IoTeX/StakingTests.cpp
+++ b/tests/IoTeX/StakingTests.cpp
@@ -131,16 +131,21 @@ TEST(TWIoTeXStaking, CandidateUpdate) {
                           "326e756b7034766763776b32676e6335637539617964");
 }
 
-TEST(TWIoTeXStaking, SignAll) {
+Proto::SigningInput createSigningInput()
+{
     auto keyhex = parse_hex("cfa6ef757dee2e50351620dca002d32b9c090cfda55fb81f37f1d26b273743f1");
+    auto input = Proto::SigningInput();
+    input.set_version(1);
+    input.set_nonce(0);
+    input.set_gaslimit(1000000);
+    input.set_gasprice("10");
+    input.set_privatekey(keyhex.data(), keyhex.size());
+    return input;
+}
 
+TEST(TWIoTeXStaking, SignAll) {
     { // sign stakecreate
-        auto input = Proto::SigningInput();
-        input.set_version(1);
-        input.set_nonce(0);
-        input.set_gaslimit(1000000);
-        input.set_gasprice("10");
-        input.set_privatekey(keyhex.data(), keyhex.size());
+        auto input = createSigningInput();
         Proto::SigningOutput output;
         auto& action = *input.mutable_stakecreate();
         action.set_candidatename("io19d0p3ah4g8ww9d7kcxfq87yxe7fnr8rpth5shj");
@@ -164,12 +169,7 @@ TEST(TWIoTeXStaking, SignAll) {
                   "f1785e47b4200c752bb6518bd18097a41e075438b8c18c9cb00e1ae2f38ce767");
     }
     { // sign stakeadddeposit
-        auto input = Proto::SigningInput();
-        input.set_version(1);
-        input.set_nonce(0);
-        input.set_gaslimit(1000000);
-        input.set_gasprice("10");
-        input.set_privatekey(keyhex.data(), keyhex.size());
+        auto input = createSigningInput();
         Proto::SigningOutput output;
         auto& action = *input.mutable_stakeadddeposit();
         action.set_bucketindex(10);
@@ -187,12 +187,7 @@ TEST(TWIoTeXStaking, SignAll) {
                   "ca8937d6f224a4e4bf93cb5605581de2d26fb0481e1dfc1eef384ee7ccf94b73");
     }
     { // sign stakeunstake
-        auto input = Proto::SigningInput();
-        input.set_version(1);
-        input.set_nonce(0);
-        input.set_gaslimit(1000000);
-        input.set_gasprice("10");
-        input.set_privatekey(keyhex.data(), keyhex.size());
+        auto input = createSigningInput();
         Proto::SigningOutput output;
         auto& action = *input.mutable_stakeunstake();
         action.set_bucketindex(10);
@@ -209,12 +204,7 @@ TEST(TWIoTeXStaking, SignAll) {
                   "bed58b64a6c4e959eca60a86f0b2149ce0e1dd527ac5fd26aef725ebf7c22a7d");
     }
     { // sign stakewithdraw
-        auto input = Proto::SigningInput();
-        input.set_version(1);
-        input.set_nonce(0);
-        input.set_gaslimit(1000000);
-        input.set_gasprice("10");
-        input.set_privatekey(keyhex.data(), keyhex.size());
+        auto input = createSigningInput();
         Proto::SigningOutput output;
         auto& action = *input.mutable_stakewithdraw();
         action.set_bucketindex(10);
@@ -231,12 +221,7 @@ TEST(TWIoTeXStaking, SignAll) {
                   "28049348cf34f1aa927caa250e7a1b08778c44efaf73b565b6fa9abe843871b4");
     }
     { // sign stakerestake
-        auto input = Proto::SigningInput();
-        input.set_version(1);
-        input.set_nonce(0);
-        input.set_gaslimit(1000000);
-        input.set_gasprice("10");
-        input.set_privatekey(keyhex.data(), keyhex.size());
+        auto input = createSigningInput();
         Proto::SigningOutput output;
         auto& action = *input.mutable_stakerestake();
         action.set_bucketindex(10);
@@ -255,12 +240,7 @@ TEST(TWIoTeXStaking, SignAll) {
                   "8816e8f784a1fce40b54d1cd172bb6976fd9552f1570c73d1d9fcdc5635424a9");
     }
     { // sign stakechangecandidate
-        auto input = Proto::SigningInput();
-        input.set_version(1);
-        input.set_nonce(0);
-        input.set_gaslimit(1000000);
-        input.set_gasprice("10");
-        input.set_privatekey(keyhex.data(), keyhex.size());
+        auto input = createSigningInput();
         Proto::SigningOutput output;
         auto& action = *input.mutable_stakechangecandidate();
         action.set_bucketindex(10);
@@ -279,12 +259,7 @@ TEST(TWIoTeXStaking, SignAll) {
                   "186526b5b9fe74e25beb52c83c41780a69108160bef2ddaf3bffb9f1f1e5e73a");
     }
     { // sign staketransfer
-        auto input = Proto::SigningInput();
-        input.set_version(1);
-        input.set_nonce(0);
-        input.set_gaslimit(1000000);
-        input.set_gasprice("10");
-        input.set_privatekey(keyhex.data(), keyhex.size());
+        auto input = createSigningInput();
         Proto::SigningOutput output;
         auto& action = *input.mutable_staketransferownership();
         action.set_bucketindex(10);
@@ -303,12 +278,7 @@ TEST(TWIoTeXStaking, SignAll) {
                   "74b2e1d6a09ba5d1298fa422d5850991ae516865077282196295a38f93c78b85");
     }
     { // sign candidateupdate
-        auto input = Proto::SigningInput();
-        input.set_version(1);
-        input.set_nonce(0);
-        input.set_gaslimit(1000000);
-        input.set_gasprice("10");
-        input.set_privatekey(keyhex.data(), keyhex.size());
+        auto input = createSigningInput();
         Proto::SigningOutput output;
         auto& action = *input.mutable_candidateupdate();
         action.set_name("test");
@@ -328,12 +298,7 @@ TEST(TWIoTeXStaking, SignAll) {
                   "ca1a28f0e9a58ffc67037cc75066dbdd8e024aa2b2e416e4d6ce16c3d86282e5");
     }
     { // sign candidateregister
-        auto input = Proto::SigningInput();
-        input.set_version(1);
-        input.set_nonce(0);
-        input.set_gaslimit(1000000);
-        input.set_gasprice("10");
-        input.set_privatekey(keyhex.data(), keyhex.size());
+        auto input = createSigningInput();
         Proto::SigningOutput output;
         input.set_gasprice("1000");
         auto& cbi = *input.mutable_candidateregister()->mutable_candidate();

--- a/tests/IoTeX/StakingTests.cpp
+++ b/tests/IoTeX/StakingTests.cpp
@@ -132,16 +132,16 @@ TEST(TWIoTeXStaking, CandidateUpdate) {
 }
 
 TEST(TWIoTeXStaking, SignAll) {
-    auto input = Proto::SigningInput();
-    input.set_version(1);
-    input.set_nonce(0);
-    input.set_gaslimit(1000000);
-    input.set_gasprice("10");
     auto keyhex = parse_hex("cfa6ef757dee2e50351620dca002d32b9c090cfda55fb81f37f1d26b273743f1");
-    input.set_privatekey(keyhex.data(), keyhex.size());
-    Proto::SigningOutput output;
 
     { // sign stakecreate
+        auto input = Proto::SigningInput();
+        input.set_version(1);
+        input.set_nonce(0);
+        input.set_gaslimit(1000000);
+        input.set_gasprice("10");
+        input.set_privatekey(keyhex.data(), keyhex.size());
+        Proto::SigningOutput output;
         auto& action = *input.mutable_stakecreate();
         action.set_candidatename("io19d0p3ah4g8ww9d7kcxfq87yxe7fnr8rpth5shj");
         action.set_stakedamount("100");
@@ -162,11 +162,18 @@ TEST(TWIoTeXStaking, SignAll) {
         // signed action's hash
         ASSERT_EQ(hex(output.hash()),
                   "f1785e47b4200c752bb6518bd18097a41e075438b8c18c9cb00e1ae2f38ce767");
-        input.release_stakecreate();
-        output.release_encoded();
-        output.release_hash();
+        //input.release_stakecreate();
+        //output.release_encoded();
+        //output.release_hash();
     }
     { // sign stakeadddeposit
+        auto input = Proto::SigningInput();
+        input.set_version(1);
+        input.set_nonce(0);
+        input.set_gaslimit(1000000);
+        input.set_gasprice("10");
+        input.set_privatekey(keyhex.data(), keyhex.size());
+        Proto::SigningOutput output;
         auto& action = *input.mutable_stakeadddeposit();
         action.set_bucketindex(10);
         action.set_amount("10");
@@ -181,11 +188,18 @@ TEST(TWIoTeXStaking, SignAll) {
         // signed action's hash
         ASSERT_EQ(hex(output.hash()),
                   "ca8937d6f224a4e4bf93cb5605581de2d26fb0481e1dfc1eef384ee7ccf94b73");
-        input.release_stakeadddeposit();
-        output.release_encoded();
-        output.release_hash();
+        //input.release_stakeadddeposit();
+        //output.release_encoded();
+        //output.release_hash();
     }
     { // sign stakeunstake
+        auto input = Proto::SigningInput();
+        input.set_version(1);
+        input.set_nonce(0);
+        input.set_gaslimit(1000000);
+        input.set_gasprice("10");
+        input.set_privatekey(keyhex.data(), keyhex.size());
+        Proto::SigningOutput output;
         auto& action = *input.mutable_stakeunstake();
         action.set_bucketindex(10);
         action.set_payload("payload");
@@ -199,11 +213,18 @@ TEST(TWIoTeXStaking, SignAll) {
         // signed action's hash
         ASSERT_EQ(hex(output.hash()),
                   "bed58b64a6c4e959eca60a86f0b2149ce0e1dd527ac5fd26aef725ebf7c22a7d");
-        input.release_stakeunstake();
-        output.release_encoded();
-        output.release_hash();
+        //input.release_stakeadddeposit();
+        //output.release_encoded();
+        //output.release_hash();
     }
     { // sign stakewithdraw
+        auto input = Proto::SigningInput();
+        input.set_version(1);
+        input.set_nonce(0);
+        input.set_gaslimit(1000000);
+        input.set_gasprice("10");
+        input.set_privatekey(keyhex.data(), keyhex.size());
+        Proto::SigningOutput output;
         auto& action = *input.mutable_stakewithdraw();
         action.set_bucketindex(10);
         action.set_payload("payload");
@@ -217,11 +238,18 @@ TEST(TWIoTeXStaking, SignAll) {
         // signed action's hash
         ASSERT_EQ(hex(output.hash()),
                   "28049348cf34f1aa927caa250e7a1b08778c44efaf73b565b6fa9abe843871b4");
-        input.release_stakewithdraw();
-        output.release_encoded();
-        output.release_hash();
+        //input.release_stakeadddeposit();
+        //output.release_encoded();
+        //output.release_hash();
     }
     { // sign stakerestake
+        auto input = Proto::SigningInput();
+        input.set_version(1);
+        input.set_nonce(0);
+        input.set_gaslimit(1000000);
+        input.set_gasprice("10");
+        input.set_privatekey(keyhex.data(), keyhex.size());
+        Proto::SigningOutput output;
         auto& action = *input.mutable_stakerestake();
         action.set_bucketindex(10);
         action.set_stakedduration(1000);
@@ -237,11 +265,18 @@ TEST(TWIoTeXStaking, SignAll) {
         // signed action's hash
         ASSERT_EQ(hex(output.hash()),
                   "8816e8f784a1fce40b54d1cd172bb6976fd9552f1570c73d1d9fcdc5635424a9");
-        input.release_stakerestake();
-        output.release_encoded();
-        output.release_hash();
+        //input.release_stakeadddeposit();
+        //output.release_encoded();
+        //output.release_hash();
     }
     { // sign stakechangecandidate
+        auto input = Proto::SigningInput();
+        input.set_version(1);
+        input.set_nonce(0);
+        input.set_gaslimit(1000000);
+        input.set_gasprice("10");
+        input.set_privatekey(keyhex.data(), keyhex.size());
+        Proto::SigningOutput output;
         auto& action = *input.mutable_stakechangecandidate();
         action.set_bucketindex(10);
         action.set_candidatename("io1xpq62aw85uqzrccg9y5hnryv8ld2nkpycc3gza");
@@ -257,11 +292,18 @@ TEST(TWIoTeXStaking, SignAll) {
         // signed action's hash
         ASSERT_EQ(hex(output.hash()),
                   "186526b5b9fe74e25beb52c83c41780a69108160bef2ddaf3bffb9f1f1e5e73a");
-        input.release_stakechangecandidate();
-        output.release_encoded();
-        output.release_hash();
+        //input.release_stakeadddeposit();
+        //output.release_encoded();
+        //output.release_hash();
     }
     { // sign staketransfer
+        auto input = Proto::SigningInput();
+        input.set_version(1);
+        input.set_nonce(0);
+        input.set_gaslimit(1000000);
+        input.set_gasprice("10");
+        input.set_privatekey(keyhex.data(), keyhex.size());
+        Proto::SigningOutput output;
         auto& action = *input.mutable_staketransferownership();
         action.set_bucketindex(10);
         action.set_voteraddress("io1xpq62aw85uqzrccg9y5hnryv8ld2nkpycc3gza");
@@ -277,11 +319,18 @@ TEST(TWIoTeXStaking, SignAll) {
         // signed action's hash
         ASSERT_EQ(hex(output.hash()),
                   "74b2e1d6a09ba5d1298fa422d5850991ae516865077282196295a38f93c78b85");
-        input.release_staketransferownership();
-        output.release_encoded();
-        output.release_hash();
+        //input.release_stakeadddeposit();
+        //output.release_encoded();
+        //output.release_hash();
     }
     { // sign candidateupdate
+        auto input = Proto::SigningInput();
+        input.set_version(1);
+        input.set_nonce(0);
+        input.set_gaslimit(1000000);
+        input.set_gasprice("10");
+        input.set_privatekey(keyhex.data(), keyhex.size());
+        Proto::SigningOutput output;
         auto& action = *input.mutable_candidateupdate();
         action.set_name("test");
         action.set_operatoraddress("io1cl6rl2ev5dfa988qmgzg2x4hfazmp9vn2g66ng");
@@ -298,11 +347,18 @@ TEST(TWIoTeXStaking, SignAll) {
         // signed action's hash
         ASSERT_EQ(hex(output.hash()),
                   "ca1a28f0e9a58ffc67037cc75066dbdd8e024aa2b2e416e4d6ce16c3d86282e5");
-        input.release_candidateupdate();
-        output.release_encoded();
-        output.release_hash();
+        //input.release_stakeadddeposit();
+        //output.release_encoded();
+        //output.release_hash();
     }
     { // sign candidateregister
+        auto input = Proto::SigningInput();
+        input.set_version(1);
+        input.set_nonce(0);
+        input.set_gaslimit(1000000);
+        input.set_gasprice("10");
+        input.set_privatekey(keyhex.data(), keyhex.size());
+        Proto::SigningOutput output;
         input.set_gasprice("1000");
         auto& cbi = *input.mutable_candidateregister()->mutable_candidate();
         cbi.set_name("test");

--- a/tests/IoTeX/StakingTests.cpp
+++ b/tests/IoTeX/StakingTests.cpp
@@ -162,9 +162,6 @@ TEST(TWIoTeXStaking, SignAll) {
         // signed action's hash
         ASSERT_EQ(hex(output.hash()),
                   "f1785e47b4200c752bb6518bd18097a41e075438b8c18c9cb00e1ae2f38ce767");
-        //input.release_stakecreate();
-        //output.release_encoded();
-        //output.release_hash();
     }
     { // sign stakeadddeposit
         auto input = Proto::SigningInput();
@@ -188,9 +185,6 @@ TEST(TWIoTeXStaking, SignAll) {
         // signed action's hash
         ASSERT_EQ(hex(output.hash()),
                   "ca8937d6f224a4e4bf93cb5605581de2d26fb0481e1dfc1eef384ee7ccf94b73");
-        //input.release_stakeadddeposit();
-        //output.release_encoded();
-        //output.release_hash();
     }
     { // sign stakeunstake
         auto input = Proto::SigningInput();
@@ -213,9 +207,6 @@ TEST(TWIoTeXStaking, SignAll) {
         // signed action's hash
         ASSERT_EQ(hex(output.hash()),
                   "bed58b64a6c4e959eca60a86f0b2149ce0e1dd527ac5fd26aef725ebf7c22a7d");
-        //input.release_stakeadddeposit();
-        //output.release_encoded();
-        //output.release_hash();
     }
     { // sign stakewithdraw
         auto input = Proto::SigningInput();
@@ -238,9 +229,6 @@ TEST(TWIoTeXStaking, SignAll) {
         // signed action's hash
         ASSERT_EQ(hex(output.hash()),
                   "28049348cf34f1aa927caa250e7a1b08778c44efaf73b565b6fa9abe843871b4");
-        //input.release_stakeadddeposit();
-        //output.release_encoded();
-        //output.release_hash();
     }
     { // sign stakerestake
         auto input = Proto::SigningInput();
@@ -265,9 +253,6 @@ TEST(TWIoTeXStaking, SignAll) {
         // signed action's hash
         ASSERT_EQ(hex(output.hash()),
                   "8816e8f784a1fce40b54d1cd172bb6976fd9552f1570c73d1d9fcdc5635424a9");
-        //input.release_stakeadddeposit();
-        //output.release_encoded();
-        //output.release_hash();
     }
     { // sign stakechangecandidate
         auto input = Proto::SigningInput();
@@ -292,9 +277,6 @@ TEST(TWIoTeXStaking, SignAll) {
         // signed action's hash
         ASSERT_EQ(hex(output.hash()),
                   "186526b5b9fe74e25beb52c83c41780a69108160bef2ddaf3bffb9f1f1e5e73a");
-        //input.release_stakeadddeposit();
-        //output.release_encoded();
-        //output.release_hash();
     }
     { // sign staketransfer
         auto input = Proto::SigningInput();
@@ -319,9 +301,6 @@ TEST(TWIoTeXStaking, SignAll) {
         // signed action's hash
         ASSERT_EQ(hex(output.hash()),
                   "74b2e1d6a09ba5d1298fa422d5850991ae516865077282196295a38f93c78b85");
-        //input.release_stakeadddeposit();
-        //output.release_encoded();
-        //output.release_hash();
     }
     { // sign candidateupdate
         auto input = Proto::SigningInput();
@@ -347,9 +326,6 @@ TEST(TWIoTeXStaking, SignAll) {
         // signed action's hash
         ASSERT_EQ(hex(output.hash()),
                   "ca1a28f0e9a58ffc67037cc75066dbdd8e024aa2b2e416e4d6ce16c3d86282e5");
-        //input.release_stakeadddeposit();
-        //output.release_encoded();
-        //output.release_hash();
     }
     { // sign candidateregister
         auto input = Proto::SigningInput();

--- a/tests/IoTeX/StakingTests.cpp
+++ b/tests/IoTeX/StakingTests.cpp
@@ -142,12 +142,12 @@ TEST(TWIoTeXStaking, SignAll) {
     Proto::SigningOutput output;
 
     { // sign stakecreate
-        auto action = input.mutable_stakecreate();
-        action->set_candidatename("io19d0p3ah4g8ww9d7kcxfq87yxe7fnr8rpth5shj");
-        action->set_stakedamount("100");
-        action->set_stakedduration(10000);
-        action->set_autostake(true);
-        action->set_payload("payload");
+        auto& action = *input.mutable_stakecreate();
+        action.set_candidatename("io19d0p3ah4g8ww9d7kcxfq87yxe7fnr8rpth5shj");
+        action.set_stakedamount("100");
+        action.set_stakedduration(10000);
+        action.set_autostake(true);
+        action.set_payload("payload");
         ANY_SIGN(input, TWCoinTypeIoTeX);
         ASSERT_EQ(hex(output.encoded()),
                   "0a4b080118c0843d22023130c2023e0a29696f313964307033616834673877773964376b63786671"
@@ -167,10 +167,10 @@ TEST(TWIoTeXStaking, SignAll) {
         output.release_hash();
     }
     { // sign stakeadddeposit
-        auto action = input.mutable_stakeadddeposit();
-        action->set_bucketindex(10);
-        action->set_amount("10");
-        action->set_payload("payload");
+        auto& action = *input.mutable_stakeadddeposit();
+        action.set_bucketindex(10);
+        action.set_amount("10");
+        action.set_payload("payload");
         ANY_SIGN(input, TWCoinTypeIoTeX);
         ASSERT_EQ(
             hex(output.encoded()),
@@ -186,9 +186,9 @@ TEST(TWIoTeXStaking, SignAll) {
         output.release_hash();
     }
     { // sign stakeunstake
-        auto action = input.mutable_stakeunstake();
-        action->set_bucketindex(10);
-        action->set_payload("payload");
+        auto& action = *input.mutable_stakeunstake();
+        action.set_bucketindex(10);
+        action.set_payload("payload");
         ANY_SIGN(input, TWCoinTypeIoTeX);
         ASSERT_EQ(
             hex(output.encoded()),
@@ -204,9 +204,9 @@ TEST(TWIoTeXStaking, SignAll) {
         output.release_hash();
     }
     { // sign stakewithdraw
-        auto action = input.mutable_stakewithdraw();
-        action->set_bucketindex(10);
-        action->set_payload("payload");
+        auto& action = *input.mutable_stakewithdraw();
+        action.set_bucketindex(10);
+        action.set_payload("payload");
         ANY_SIGN(input, TWCoinTypeIoTeX);
         ASSERT_EQ(
             hex(output.encoded()),
@@ -222,11 +222,11 @@ TEST(TWIoTeXStaking, SignAll) {
         output.release_hash();
     }
     { // sign stakerestake
-        auto action = input.mutable_stakerestake();
-        action->set_bucketindex(10);
-        action->set_stakedduration(1000);
-        action->set_autostake(true);
-        action->set_payload("payload");
+        auto& action = *input.mutable_stakerestake();
+        action.set_bucketindex(10);
+        action.set_stakedduration(1000);
+        action.set_autostake(true);
+        action.set_payload("payload");
         ANY_SIGN(input, TWCoinTypeIoTeX);
         ASSERT_EQ(
             hex(output.encoded()),
@@ -242,10 +242,10 @@ TEST(TWIoTeXStaking, SignAll) {
         output.release_hash();
     }
     { // sign stakechangecandidate
-        auto action = input.mutable_stakechangecandidate();
-        action->set_bucketindex(10);
-        action->set_candidatename("io1xpq62aw85uqzrccg9y5hnryv8ld2nkpycc3gza");
-        action->set_payload("payload");
+        auto& action = *input.mutable_stakechangecandidate();
+        action.set_bucketindex(10);
+        action.set_candidatename("io1xpq62aw85uqzrccg9y5hnryv8ld2nkpycc3gza");
+        action.set_payload("payload");
         ANY_SIGN(input, TWCoinTypeIoTeX);
         ASSERT_EQ(
             hex(output.encoded()),
@@ -262,10 +262,10 @@ TEST(TWIoTeXStaking, SignAll) {
         output.release_hash();
     }
     { // sign staketransfer
-        auto action = input.mutable_staketransferownership();
-        action->set_bucketindex(10);
-        action->set_voteraddress("io1xpq62aw85uqzrccg9y5hnryv8ld2nkpycc3gza");
-        action->set_payload("payload");
+        auto& action = *input.mutable_staketransferownership();
+        action.set_bucketindex(10);
+        action.set_voteraddress("io1xpq62aw85uqzrccg9y5hnryv8ld2nkpycc3gza");
+        action.set_payload("payload");
         ANY_SIGN(input, TWCoinTypeIoTeX);
         ASSERT_EQ(
             hex(output.encoded()),
@@ -282,10 +282,10 @@ TEST(TWIoTeXStaking, SignAll) {
         output.release_hash();
     }
     { // sign candidateupdate
-        auto action = input.mutable_candidateupdate();
-        action->set_name("test");
-        action->set_operatoraddress("io1cl6rl2ev5dfa988qmgzg2x4hfazmp9vn2g66ng");
-        action->set_rewardaddress("io1juvx5g063eu4ts832nukp4vgcwk2gnc5cu9ayd");
+        auto& action = *input.mutable_candidateupdate();
+        action.set_name("test");
+        action.set_operatoraddress("io1cl6rl2ev5dfa988qmgzg2x4hfazmp9vn2g66ng");
+        action.set_rewardaddress("io1juvx5g063eu4ts832nukp4vgcwk2gnc5cu9ayd");
         ANY_SIGN(input, TWCoinTypeIoTeX);
         ASSERT_EQ(
             hex(output.encoded()),
@@ -304,17 +304,17 @@ TEST(TWIoTeXStaking, SignAll) {
     }
     { // sign candidateregister
         input.set_gasprice("1000");
-        auto cbi = input.mutable_candidateregister()->mutable_candidate();
-        cbi->set_name("test");
-        cbi->set_operatoraddress("io10a298zmzvrt4guq79a9f4x7qedj59y7ery84he");
-        cbi->set_rewardaddress("io13sj9mzpewn25ymheukte4v39hvjdtrfp00mlyv");
+        auto& cbi = *input.mutable_candidateregister()->mutable_candidate();
+        cbi.set_name("test");
+        cbi.set_operatoraddress("io10a298zmzvrt4guq79a9f4x7qedj59y7ery84he");
+        cbi.set_rewardaddress("io13sj9mzpewn25ymheukte4v39hvjdtrfp00mlyv");
 
-        auto action = input.mutable_candidateregister();
-        action->set_stakedamount("100");
-        action->set_stakedduration(10000);
-        action->set_autostake(false);
-        action->set_owneraddress("io19d0p3ah4g8ww9d7kcxfq87yxe7fnr8rpth5shj");
-        action->set_payload("payload");
+        auto& action = *input.mutable_candidateregister();
+        action.set_stakedamount("100");
+        action.set_stakedduration(10000);
+        action.set_autostake(false);
+        action.set_owneraddress("io19d0p3ah4g8ww9d7kcxfq87yxe7fnr8rpth5shj");
+        action.set_payload("payload");
         ANY_SIGN(input, TWCoinTypeIoTeX);
         ASSERT_EQ(hex(output.encoded()),
                   "0aaa01080118c0843d220431303030fa029a010a5c0a04746573741229696f3130613239387a6d7a"

--- a/tests/IoTeX/TWCoinTypeTests.cpp
+++ b/tests/IoTeX/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWIoTeXCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeIoTeX));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeIoTeX, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeIoTeX, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeIoTeX, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeIoTeX, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeIoTeX));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeIoTeX));
 

--- a/tests/Kava/TWCoinTypeTests.cpp
+++ b/tests/Kava/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWKavaCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeKava));
-    auto txId = TWStringCreateWithUTF8Bytes("2988DF83FCBFAA38179D583A96734CBD071541D6768221BB23111BC8136D5E6A");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeKava, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("kava1jf9aaj9myrzsnmpdr7twecnaftzmku2mdpy2a7");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeKava, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("2988DF83FCBFAA38179D583A96734CBD071541D6768221BB23111BC8136D5E6A"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeKava, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("kava1jf9aaj9myrzsnmpdr7twecnaftzmku2mdpy2a7"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeKava, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeKava));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeKava));
 

--- a/tests/Kin/TWCoinTypeTests.cpp
+++ b/tests/Kin/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWKinCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeKin));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeKin, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeKin, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeKin, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeKin, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeKin));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeKin));
 

--- a/tests/Kusama/TWCoinTypeTests.cpp
+++ b/tests/Kusama/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWKusamaCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeKusama));
-    auto txId = TWStringCreateWithUTF8Bytes("0xcbe0c2e2851c1245bedaae4d52f06eaa6b4784b786bea2f0bff11af7715973dd");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeKusama, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("DbCNECPna3k6MXFWWNZa5jGsuWycqEE6zcUxZYkxhVofrFk");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeKusama, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("0xcbe0c2e2851c1245bedaae4d52f06eaa6b4784b786bea2f0bff11af7715973dd"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeKusama, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("DbCNECPna3k6MXFWWNZa5jGsuWycqEE6zcUxZYkxhVofrFk"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeKusama, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeKusama));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeKusama));
 

--- a/tests/Litecoin/TWCoinTypeTests.cpp
+++ b/tests/Litecoin/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWLitecoinCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeLitecoin));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeLitecoin, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeLitecoin, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeLitecoin, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeLitecoin, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeLitecoin));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeLitecoin));
 

--- a/tests/Litecoin/TWLitecoinTests.cpp
+++ b/tests/Litecoin/TWLitecoinTests.cpp
@@ -17,16 +17,16 @@
 
 TEST(Litecoin, LegacyAddress) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("a22ddec5c567b4488bb00f69b6146c50da2ee883e2c096db098726394d585730").get()));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
-    auto address = TWBitcoinAddressCreateWithPublicKey(publicKey, TWCoinTypeP2pkhPrefix(TWCoinTypeLitecoin));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
+    auto address = TWBitcoinAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeLitecoin));
     auto addressString = WRAPS(TWBitcoinAddressDescription(address));
     assertStringsEqual(addressString, "LV7LV7Z4bWDEjYkfx9dQo6k6RjGbXsg6hS");
 }
 
 TEST(Litecoin, Address) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("55f9cbb0376c422946fa28397c1219933ac60b312ede41bfacaf701ecd546625").get()));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
-    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey, TWCoinTypeLitecoin));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
+    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeLitecoin));
     auto string = WRAPS(TWAnyAddressDescription(address.get()));
 
     assertStringsEqual(string, "ltc1qytnqzjknvv03jwfgrsmzt0ycmwqgl0asjnaxwu");

--- a/tests/Litecoin/TWLitecoinTests.cpp
+++ b/tests/Litecoin/TWLitecoinTests.cpp
@@ -18,8 +18,8 @@
 TEST(Litecoin, LegacyAddress) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("a22ddec5c567b4488bb00f69b6146c50da2ee883e2c096db098726394d585730").get()));
     auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
-    auto address = TWBitcoinAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeLitecoin));
-    auto addressString = WRAPS(TWBitcoinAddressDescription(address));
+    auto address = WRAP(TWBitcoinAddress, TWBitcoinAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeLitecoin)));
+    auto addressString = WRAPS(TWBitcoinAddressDescription(address.get()));
     assertStringsEqual(addressString, "LV7LV7Z4bWDEjYkfx9dQo6k6RjGbXsg6hS");
 }
 

--- a/tests/Monacoin/TWCoinTypeTests.cpp
+++ b/tests/Monacoin/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWMonacoinCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeMonacoin));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeMonacoin, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeMonacoin, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeMonacoin, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeMonacoin, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeMonacoin));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeMonacoin));
 

--- a/tests/Monacoin/TWMonacoinAddressTests.cpp
+++ b/tests/Monacoin/TWMonacoinAddressTests.cpp
@@ -18,16 +18,16 @@
 
 TEST(Monacoin, LegacyAddress) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("a22ddec5c567b4488bb00f69b6146c50da2ee883e2c096db098726394d585730").get()));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
-    auto address = TWBitcoinAddressCreateWithPublicKey(publicKey, TWCoinTypeP2pkhPrefix(TWCoinTypeMonacoin));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
+    auto address = TWBitcoinAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeMonacoin));
     auto addressString = WRAPS(TWBitcoinAddressDescription(address));
     assertStringsEqual(addressString, "MHnYTL9e1s8zNR2qzzJ3mMHfgjnUzyMscd");
 }
 
 TEST(Monacoin, Address) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("55f9cbb0376c422946fa28397c1219933ac60b312ede41bfacaf701ecd546625").get()));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
-    auto address = WRAP(TWSegwitAddress, TWSegwitAddressCreateWithPublicKey(TWHRPMonacoin, publicKey));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
+    auto address = WRAP(TWSegwitAddress, TWSegwitAddressCreateWithPublicKey(TWHRPMonacoin, publicKey.get()));
     auto string = WRAPS(TWSegwitAddressDescription(address.get()));
 
     assertStringsEqual(string, "mona1qytnqzjknvv03jwfgrsmzt0ycmwqgl0asju3qmd");

--- a/tests/Monacoin/TWMonacoinAddressTests.cpp
+++ b/tests/Monacoin/TWMonacoinAddressTests.cpp
@@ -19,8 +19,8 @@
 TEST(Monacoin, LegacyAddress) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("a22ddec5c567b4488bb00f69b6146c50da2ee883e2c096db098726394d585730").get()));
     auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
-    auto address = TWBitcoinAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeMonacoin));
-    auto addressString = WRAPS(TWBitcoinAddressDescription(address));
+    auto address = WRAP(TWBitcoinAddress, TWBitcoinAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeMonacoin)));
+    auto addressString = WRAPS(TWBitcoinAddressDescription(address.get()));
     assertStringsEqual(addressString, "MHnYTL9e1s8zNR2qzzJ3mMHfgjnUzyMscd");
 }
 
@@ -83,11 +83,11 @@ TEST(Monacoin, DeriveFromXpub) {
     auto pubKey2 = WRAP(TWPublicKey, TWHDWalletGetPublicKeyFromExtended(xpub.get(), TWCoinTypeMonacoin, STRING("m/44'/22'/0'/0/2").get()));
     auto pubKey9 = WRAP(TWPublicKey, TWHDWalletGetPublicKeyFromExtended(xpub.get(), TWCoinTypeMonacoin, STRING("m/44'/22'/0'/0/9").get()));
 
-    auto address2 = TWBitcoinAddressCreateWithPublicKey(pubKey2.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeMonacoin));
-    auto address2String = WRAPS(TWBitcoinAddressDescription(address2));
+    auto address2 = WRAP(TWBitcoinAddress, TWBitcoinAddressCreateWithPublicKey(pubKey2.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeMonacoin)));
+    auto address2String = WRAPS(TWBitcoinAddressDescription(address2.get()));
 
-    auto address9 = TWBitcoinAddressCreateWithPublicKey(pubKey9.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeMonacoin));
-    auto address9String = WRAPS(TWBitcoinAddressDescription(address9));
+    auto address9 = WRAP(TWBitcoinAddress, TWBitcoinAddressCreateWithPublicKey(pubKey9.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeMonacoin)));
+    auto address9String = WRAPS(TWBitcoinAddressDescription(address9.get()));
 
     assertStringsEqual(address2String, "MCoYzbqdsMYTBbjr7rd2zJsSF32QMgZCSj");
     assertStringsEqual(address9String, "MAtduu1Fvtv1Frx6vbg5tZDZwirCA3y8qq");

--- a/tests/NEAR/TWCoinTypeTests.cpp
+++ b/tests/NEAR/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWNEARCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeNEAR));
-    auto txId = TWStringCreateWithUTF8Bytes("FPQAMaVnvFHNwNBJWnTttXfdJhp5FvMGGDJEesB8gvbL");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeNEAR, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("test-trust.vlad.near");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeNEAR, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("FPQAMaVnvFHNwNBJWnTttXfdJhp5FvMGGDJEesB8gvbL"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeNEAR, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("test-trust.vlad.near"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeNEAR, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeNEAR));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeNEAR));
 

--- a/tests/NEO/TWCoinTypeTests.cpp
+++ b/tests/NEO/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWNEOCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeNEO));
-    auto txId = TWStringCreateWithUTF8Bytes("e0ddf7c81c732df26180aca0c36d5868ad009fdbbe6e7a56ebafc14bba41cd53");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeNEO, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("AcxuqWhTureEQGeJgbmtSWNAtssjMLU7pb");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeNEO, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("e0ddf7c81c732df26180aca0c36d5868ad009fdbbe6e7a56ebafc14bba41cd53"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeNEO, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("AcxuqWhTureEQGeJgbmtSWNAtssjMLU7pb"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeNEO, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeNEO));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeNEO));
 

--- a/tests/NULS/TWCoinTypeTests.cpp
+++ b/tests/NULS/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWNULSCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeNULS));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeNULS, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeNULS, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeNULS, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeNULS, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeNULS));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeNULS));
 

--- a/tests/Nano/TWCoinTypeTests.cpp
+++ b/tests/Nano/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWNanoCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeNano));
-    auto txId = TWStringCreateWithUTF8Bytes("C264DB7BF40738F0CEFF19B606746CB925B713E4B8699A055699E0DC8ABBC70F");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeNano, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("nano_1wpj616kwhe1y38y1mspd8aub8i334cwybqco511iyuxm55zx8d67ptf1tsf");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeNano, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("C264DB7BF40738F0CEFF19B606746CB925B713E4B8699A055699E0DC8ABBC70F"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeNano, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("nano_1wpj616kwhe1y38y1mspd8aub8i334cwybqco511iyuxm55zx8d67ptf1tsf"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeNano, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeNano));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeNano));
 

--- a/tests/Nano/TWNanoAddressTests.cpp
+++ b/tests/Nano/TWNanoAddressTests.cpp
@@ -24,12 +24,12 @@ TEST(Nano, DeriveAddress) {
 
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), passphrase.get()));
     auto key = WRAP(TWPrivateKey, TWHDWalletGetKeyForCoin(wallet.get(), TWCoinTypeNano));
-    auto publicKey = TWPrivateKeyGetPublicKeyEd25519Blake2b(key.get());
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeyEd25519Blake2b(key.get()));
 
     ASSERT_EQ(TW::hex(key->impl.bytes), "3be4fc2ef3f3b7374e6fc4fb6e7bb153f8a2998b3b3dab50853eabe128024143");
-    ASSERT_EQ(TW::hex(publicKey->impl.bytes), "5b65b0e8173ee0802c2c3e6c9080d1a16b06de1176c938a924f58670904e82c4");
+    ASSERT_EQ(TW::hex(publicKey.get()->impl.bytes), "5b65b0e8173ee0802c2c3e6c9080d1a16b06de1176c938a924f58670904e82c4");
 
-    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey, TWCoinTypeNano));
+    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeNano));
     auto addressString = WRAPS(TWAnyAddressDescription(address.get()));
 
     assertStringsEqual(addressString, "nano_1pu7p5n3ghq1i1p4rhmek41f5add1uh34xpb94nkbxe8g4a6x1p69emk8y1d");

--- a/tests/Nebulas/TWCoinTypeTests.cpp
+++ b/tests/Nebulas/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWNebulasCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeNebulas));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeNebulas, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeNebulas, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeNebulas, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeNebulas, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeNebulas));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeNebulas));
 

--- a/tests/Nebulas/TWNebulasAddressTests.cpp
+++ b/tests/Nebulas/TWNebulasAddressTests.cpp
@@ -15,8 +15,8 @@
 
 TEST(Nebulas, Address) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("d2fd0ec9f6268fc8d1f563e3e976436936708bdf0dc60c66f35890f5967a8d2b").get()));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), false);
-    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey, TWCoinTypeNebulas));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), false));
+    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeNebulas));
     auto addressString = WRAPS(TWAnyAddressDescription(address.get()));
     assertStringsEqual(addressString, "n1V5bB2tbaM3FUiL4eRwpBLgEredS5C2wLY");
 }

--- a/tests/Nimiq/TWCoinTypeTests.cpp
+++ b/tests/Nimiq/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWNimiqCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeNimiq));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeNimiq, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeNimiq, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeNimiq, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeNimiq, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeNimiq));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeNimiq));
 

--- a/tests/Ontology/TWCoinTypeTests.cpp
+++ b/tests/Ontology/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWOntologyCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeOntology));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeOntology, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeOntology, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeOntology, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeOntology, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeOntology));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeOntology));
 

--- a/tests/POANetwork/TWCoinTypeTests.cpp
+++ b/tests/POANetwork/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWPOANetworkCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypePOANetwork));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypePOANetwork, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypePOANetwork, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypePOANetwork, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypePOANetwork, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypePOANetwork));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypePOANetwork));
 

--- a/tests/Polkadot/TWCoinTypeTests.cpp
+++ b/tests/Polkadot/TWCoinTypeTests.cpp
@@ -16,10 +16,10 @@
 TEST(TWPolkadotCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypePolkadot));
 
-    auto txId = TWStringCreateWithUTF8Bytes("0xb96f97d8ee508f420e606e1a6dcc74b88844713ddec2bd7cf4e3aa6b1d6beef4");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypePolkadot, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("13hJFqnkqQbmgnGQteGntjMjTdmTBRE8Z93JqxsrpgT7Yjd2");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypePolkadot, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("0xb96f97d8ee508f420e606e1a6dcc74b88844713ddec2bd7cf4e3aa6b1d6beef4"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypePolkadot, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("13hJFqnkqQbmgnGQteGntjMjTdmTBRE8Z93JqxsrpgT7Yjd2"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypePolkadot, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypePolkadot));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypePolkadot));
 

--- a/tests/Qtum/TWCoinTypeTests.cpp
+++ b/tests/Qtum/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWQtumCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeQtum));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeQtum, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeQtum, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeQtum, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeQtum, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeQtum));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeQtum));
 

--- a/tests/Qtum/TWQtumAddressTests.cpp
+++ b/tests/Qtum/TWQtumAddressTests.cpp
@@ -19,8 +19,8 @@
 TEST(Qtum, LegacyAddress) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("a22ddec5c567b4488bb00f69b6146c50da2ee883e2c096db098726394d585730").get()));
     auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
-    auto address = TWBitcoinAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeQtum));
-    auto addressString = WRAPS(TWBitcoinAddressDescription(address));
+    auto address = WRAP(TWBitcoinAddress, TWBitcoinAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeQtum)));
+    auto addressString = WRAPS(TWBitcoinAddressDescription(address.get()));
     assertStringsEqual(addressString, "QWVNLCXwhJqzut9YCLxbeMTximr2hmw7Vr");
 }
 
@@ -79,11 +79,11 @@ TEST(Qtum, DeriveFromXpub) {
     auto pubKey2 = WRAP(TWPublicKey, TWHDWalletGetPublicKeyFromExtended(xpub.get(), TWCoinTypeQtum, STRING("m/44'/2301'/0'/0/2").get()));
     auto pubKey9 = WRAP(TWPublicKey, TWHDWalletGetPublicKeyFromExtended(xpub.get(), TWCoinTypeQtum, STRING("m/44'/2301'/0'/0/9").get()));
 
-    auto address2 = TWBitcoinAddressCreateWithPublicKey(pubKey2.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeQtum));
-    auto address2String = WRAPS(TWBitcoinAddressDescription(address2));
+    auto address2 = WRAP(TWBitcoinAddress, TWBitcoinAddressCreateWithPublicKey(pubKey2.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeQtum)));
+    auto address2String = WRAPS(TWBitcoinAddressDescription(address2.get()));
 
-    auto address9 = TWBitcoinAddressCreateWithPublicKey(pubKey9.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeQtum));
-    auto address9String = WRAPS(TWBitcoinAddressDescription(address9));
+    auto address9 = WRAP(TWBitcoinAddress, TWBitcoinAddressCreateWithPublicKey(pubKey9.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeQtum)));
+    auto address9String = WRAPS(TWBitcoinAddressDescription(address9.get()));
 
     assertStringsEqual(address2String, "QStYeAAfiYKxsABzY9yugHDpm5bsynYPqc");
     assertStringsEqual(address9String, "QfbKFChfhx1s4VXS9BzaVJgyKw5a1hnFg4");

--- a/tests/Qtum/TWQtumAddressTests.cpp
+++ b/tests/Qtum/TWQtumAddressTests.cpp
@@ -18,16 +18,16 @@
 
 TEST(Qtum, LegacyAddress) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("a22ddec5c567b4488bb00f69b6146c50da2ee883e2c096db098726394d585730").get()));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
-    auto address = TWBitcoinAddressCreateWithPublicKey(publicKey, TWCoinTypeP2pkhPrefix(TWCoinTypeQtum));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
+    auto address = TWBitcoinAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeQtum));
     auto addressString = WRAPS(TWBitcoinAddressDescription(address));
     assertStringsEqual(addressString, "QWVNLCXwhJqzut9YCLxbeMTximr2hmw7Vr");
 }
 
 TEST(Qtum, Address) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("55f9cbb0376c422946fa28397c1219933ac60b312ede41bfacaf701ecd546625").get()));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
-    auto address = WRAP(TWSegwitAddress, TWSegwitAddressCreateWithPublicKey(TWHRPQtum, publicKey));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
+    auto address = WRAP(TWSegwitAddress, TWSegwitAddressCreateWithPublicKey(TWHRPQtum, publicKey.get()));
     auto string = WRAPS(TWSegwitAddressDescription(address.get()));
 
     assertStringsEqual(string, "qc1qytnqzjknvv03jwfgrsmzt0ycmwqgl0as6uywkk");

--- a/tests/Ravencoin/TWCoinTypeTests.cpp
+++ b/tests/Ravencoin/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWRavencoinCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeRavencoin));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeRavencoin, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeRavencoin, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeRavencoin, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeRavencoin, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeRavencoin));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeRavencoin));
 

--- a/tests/Ripple/TWCoinTypeTests.cpp
+++ b/tests/Ripple/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWXRPCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeXRP));
-    auto txId = TWStringCreateWithUTF8Bytes("E26AB8F3372D2FC02DEC1FD5674ADAB762D684BFFDBBDF5D674E9D7CF4A47054");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeXRP, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("rfkH7EuS1XcSkB9pocy1R6T8F4CsNYixYU");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeXRP, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("E26AB8F3372D2FC02DEC1FD5674ADAB762D684BFFDBBDF5D674E9D7CF4A47054"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeXRP, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("rfkH7EuS1XcSkB9pocy1R6T8F4CsNYixYU"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeXRP, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeXRP));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeXRP));
 

--- a/tests/Solana/TWCoinTypeTests.cpp
+++ b/tests/Solana/TWCoinTypeTests.cpp
@@ -14,10 +14,10 @@
 
 TEST(TWSolanaCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeSolana));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeSolana, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeSolana, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeSolana, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeSolana, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeSolana));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeSolana));
 

--- a/tests/Solana/TWSolanaAddressTests.cpp
+++ b/tests/Solana/TWSolanaAddressTests.cpp
@@ -18,7 +18,7 @@ TEST(TWSolanaAddress, HDWallet) {
 
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(STRING(mnemonic).get(), STRING(passphrase).get()));
 
-    auto privateKey = WRAP(TWPrivateKey, TWHDWalletGetKey(wallet.get(), TWCoinTypeSolana, TWCoinTypeDerivationPath(TWCoinTypeSolana)));
+    auto privateKey = WRAP(TWPrivateKey, TWHDWalletGetKey(wallet.get(), TWCoinTypeSolana, WRAPS(TWCoinTypeDerivationPath(TWCoinTypeSolana)).get()));
     auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeyEd25519(privateKey.get()));
     auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeSolana));
     auto addressStr = WRAPS(TWAnyAddressDescription(address.get()));

--- a/tests/Solana/TWSolanaAddressTests.cpp
+++ b/tests/Solana/TWSolanaAddressTests.cpp
@@ -19,8 +19,8 @@ TEST(TWSolanaAddress, HDWallet) {
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(STRING(mnemonic).get(), STRING(passphrase).get()));
 
     auto privateKey = WRAP(TWPrivateKey, TWHDWalletGetKey(wallet.get(), TWCoinTypeSolana, TWCoinTypeDerivationPath(TWCoinTypeSolana)));
-    auto publicKey = TWPrivateKeyGetPublicKeyEd25519(privateKey.get());
-    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey, TWCoinTypeSolana));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeyEd25519(privateKey.get()));
+    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeSolana));
     auto addressStr = WRAPS(TWAnyAddressDescription(address.get()));
 
     assertStringsEqual(addressStr, "2bUBiBNZyD29gP1oV6de7nxowMLoDBtopMMTGgMvjG5m");

--- a/tests/Stellar/TWCoinTypeTests.cpp
+++ b/tests/Stellar/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWStellarCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeStellar));
-    auto txId = TWStringCreateWithUTF8Bytes("d9aeabfa9d24df8c5755125f8af243b74cd3ff878656cfa72c566a8824bf6e84");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeStellar, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("GCILJZQ3CKBKBUJWW4TAM6Q37LJA5MQX6GMSFSQN75BPLWIZ33OPRG52");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeStellar, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("d9aeabfa9d24df8c5755125f8af243b74cd3ff878656cfa72c566a8824bf6e84"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeStellar, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("GCILJZQ3CKBKBUJWW4TAM6Q37LJA5MQX6GMSFSQN75BPLWIZ33OPRG52"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeStellar, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeStellar));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeStellar));
 

--- a/tests/Stellar/TWStellarAddressTests.cpp
+++ b/tests/Stellar/TWStellarAddressTests.cpp
@@ -19,9 +19,9 @@ TEST(Stellar, DeriveAddress) {
 
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), passphrase.get()));
     auto key = WRAP(TWPrivateKey, TWHDWalletGetKeyForCoin(wallet.get(), TWCoinTypeStellar));
-    auto publicKey = TWPrivateKeyGetPublicKeyEd25519(key.get());
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeyEd25519(key.get()));
 
-    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey, TWCoinTypeStellar));
+    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeStellar));
     auto addressString = WRAPS(TWAnyAddressDescription(address.get()));
 
     assertStringsEqual(addressString, "GAE2SZV4VLGBAPRYRFV2VY7YYLYGYIP5I7OU7BSP6DJT7GAZ35OKFDYI");

--- a/tests/TON/TWCoinTypeTests.cpp
+++ b/tests/TON/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWTONCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeTON));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeTON, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeTON, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeTON, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeTON, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeTON));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeTON));
 

--- a/tests/TON/TWTONAddressTests.cpp
+++ b/tests/TON/TWTONAddressTests.cpp
@@ -44,9 +44,9 @@ TEST(TWTONAddress, CreateWithPublicKey) {
     auto pkData = DATA("F61CF0BC8E891AD7636E0CD35229D579323AA2DA827EB85D8071407464DC2FA3");
     auto publicKey = WRAP(TWPublicKey, TWPublicKeyCreateWithData(pkData.get(), TWPublicKeyTypeED25519));
     auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeTON));
-    auto addressStr = TWAnyAddressDescription(address.get());
+    auto addressStr = WRAPS(TWAnyAddressDescription(address.get()));
 
-    EXPECT_EQ(std::string("EQAkAJCrZkWb9uYePf1D97nB8efUvYHTsqSscyPMGpcHUx3Y"), TWStringUTF8Bytes(addressStr));
+    EXPECT_EQ(std::string("EQAkAJCrZkWb9uYePf1D97nB8efUvYHTsqSscyPMGpcHUx3Y"), TWStringUTF8Bytes(addressStr.get()));
 }
 
 TEST(TWTONAddress, HDWallet) {
@@ -55,7 +55,7 @@ TEST(TWTONAddress, HDWallet) {
 
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(STRING(mnemonic).get(), STRING(passphrase).get()));
 
-    auto privateKey = WRAP(TWPrivateKey, TWHDWalletGetKey(wallet.get(), TWCoinTypeTON, TWCoinTypeDerivationPath(TWCoinTypeTON)));
+    auto privateKey = WRAP(TWPrivateKey, TWHDWalletGetKey(wallet.get(), TWCoinTypeTON, WRAPS(TWCoinTypeDerivationPath(TWCoinTypeTON)).get()));
     auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeyEd25519(privateKey.get()));
     auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeTON));
     auto addressStr = WRAPS(TWAnyAddressDescription(address.get()));

--- a/tests/TON/TWTONAddressTests.cpp
+++ b/tests/TON/TWTONAddressTests.cpp
@@ -56,8 +56,8 @@ TEST(TWTONAddress, HDWallet) {
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(STRING(mnemonic).get(), STRING(passphrase).get()));
 
     auto privateKey = WRAP(TWPrivateKey, TWHDWalletGetKey(wallet.get(), TWCoinTypeTON, TWCoinTypeDerivationPath(TWCoinTypeTON)));
-    auto publicKey = TWPrivateKeyGetPublicKeyEd25519(privateKey.get());
-    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey, TWCoinTypeTON));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeyEd25519(privateKey.get()));
+    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeTON));
     auto addressStr = WRAPS(TWAnyAddressDescription(address.get()));
 
     ASSERT_EQ(std::string("EQAmXWk7P7avw96EViZULpA85Lz6Si3MeWG-vFXmbEjpL-fo"), TWStringUTF8Bytes(addressStr.get()));

--- a/tests/TON/TWTONAddressTests.cpp
+++ b/tests/TON/TWTONAddressTests.cpp
@@ -31,7 +31,7 @@ TEST(TWTONAddress, CreateWithString) {
 
     {
         // create a second one, also invoke compare
-        auto address2 = TWAnyAddressCreateWithString(TWStringCreateWithUTF8Bytes(expect), TWCoinTypeTON);
+        auto address2 = TWAnyAddressCreateWithString(WRAPS(TWStringCreateWithUTF8Bytes(expect)).get(), TWCoinTypeTON);
         ASSERT_TRUE(TWAnyAddressEqual(address, address2));
 
         TWAnyAddressDelete(address2);

--- a/tests/Terra/TWCoinTypeTests.cpp
+++ b/tests/Terra/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWTerraCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeTerra));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeTerra, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeTerra, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeTerra, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeTerra, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeTerra));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeTerra));
 

--- a/tests/Tezos/TWCoinTypeTests.cpp
+++ b/tests/Tezos/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWTezosCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeTezos));
-    auto txId = TWStringCreateWithUTF8Bytes("onk3Z6V4StyfiXTPSHwZFvTKVAaws37cHmZacmULPr3VbVHpKrg");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeTezos, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("tz1SiPXX4MYGNJNDsRc7n8hkvUqFzg8xqF9m");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeTezos, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("onk3Z6V4StyfiXTPSHwZFvTKVAaws37cHmZacmULPr3VbVHpKrg"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeTezos, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("tz1SiPXX4MYGNJNDsRc7n8hkvUqFzg8xqF9m"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeTezos, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeTezos));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeTezos));
 

--- a/tests/Theta/TWCoinTypeTests.cpp
+++ b/tests/Theta/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWThetaCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeTheta));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeTheta, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeTheta, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeTheta, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeTheta, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeTheta));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeTheta));
 

--- a/tests/ThunderToken/TWCoinTypeTests.cpp
+++ b/tests/ThunderToken/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWThunderTokenCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeThunderToken));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeThunderToken, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeThunderToken, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeThunderToken, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeThunderToken, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeThunderToken));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeThunderToken));
 

--- a/tests/TomoChain/TWCoinTypeTests.cpp
+++ b/tests/TomoChain/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWTomoChainCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeTomoChain));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeTomoChain, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeTomoChain, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeTomoChain, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeTomoChain, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeTomoChain));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeTomoChain));
 

--- a/tests/Tron/TWCoinTypeTests.cpp
+++ b/tests/Tron/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWTronCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeTron));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeTron, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeTron, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeTron, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeTron, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeTron));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeTron));
 

--- a/tests/VeChain/TWCoinTypeTests.cpp
+++ b/tests/VeChain/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWVeChainCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeVeChain));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeVeChain, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeVeChain, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeVeChain, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeVeChain, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeVeChain));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeVeChain));
 

--- a/tests/Viacoin/TWCoinTypeTests.cpp
+++ b/tests/Viacoin/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWViacoinCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeViacoin));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeViacoin, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeViacoin, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeViacoin, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeViacoin, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeViacoin));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeViacoin));
 

--- a/tests/Viacoin/TWViacoinAddressTests.cpp
+++ b/tests/Viacoin/TWViacoinAddressTests.cpp
@@ -19,8 +19,8 @@
 TEST(Viacoin, LegacyAddress) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("a22ddec5c567b4488bb00f69b6146c50da2ee883e2c096db098726394d585730").get()));
     auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
-    auto address = TWBitcoinAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeViacoin));
-    auto addressString = WRAPS(TWBitcoinAddressDescription(address));
+    auto address = WRAP(TWBitcoinAddress, TWBitcoinAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeViacoin)));
+    auto addressString = WRAPS(TWBitcoinAddressDescription(address.get()));
     assertStringsEqual(addressString, "VjtD8cQgvesPYWxfWoHjwz1BuLCHwDn7PA");
 }
 
@@ -77,11 +77,11 @@ TEST(Viacoin, DeriveFromXpub) {
     auto pubKey2 = WRAP(TWPublicKey, TWHDWalletGetPublicKeyFromExtended(xpub.get(), TWCoinTypeViacoin, STRING("m/44'/14'/0'/0/2").get()));
     auto pubKey9 = WRAP(TWPublicKey, TWHDWalletGetPublicKeyFromExtended(xpub.get(), TWCoinTypeViacoin, STRING("m/44'/14'/0'/0/9").get()));
 
-    auto address2 = TWBitcoinAddressCreateWithPublicKey(pubKey2.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeViacoin));
-    auto address2String = WRAPS(TWBitcoinAddressDescription(address2));
+    auto address2 = WRAP(TWBitcoinAddress, TWBitcoinAddressCreateWithPublicKey(pubKey2.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeViacoin)));
+    auto address2String = WRAPS(TWBitcoinAddressDescription(address2.get()));
 
-    auto address9 = TWBitcoinAddressCreateWithPublicKey(pubKey9.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeViacoin));
-    auto address9String = WRAPS(TWBitcoinAddressDescription(address9));
+    auto address9 = WRAP(TWBitcoinAddress, TWBitcoinAddressCreateWithPublicKey(pubKey9.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeViacoin)));
+    auto address9String = WRAPS(TWBitcoinAddressDescription(address9.get()));
 
     assertStringsEqual(address2String, "VvN4z8c2zQA9gNnTTdxZkgYqagpVjkdb8z");
     assertStringsEqual(address9String, "VnUgk2EA8upaSFMfFwsT2kJbBKmWher7pC");

--- a/tests/Viacoin/TWViacoinAddressTests.cpp
+++ b/tests/Viacoin/TWViacoinAddressTests.cpp
@@ -18,16 +18,16 @@
 
 TEST(Viacoin, LegacyAddress) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("a22ddec5c567b4488bb00f69b6146c50da2ee883e2c096db098726394d585730").get()));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
-    auto address = TWBitcoinAddressCreateWithPublicKey(publicKey, TWCoinTypeP2pkhPrefix(TWCoinTypeViacoin));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
+    auto address = TWBitcoinAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeViacoin));
     auto addressString = WRAPS(TWBitcoinAddressDescription(address));
     assertStringsEqual(addressString, "VjtD8cQgvesPYWxfWoHjwz1BuLCHwDn7PA");
 }
 
 TEST(Viacoin, Address) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("55f9cbb0376c422946fa28397c1219933ac60b312ede41bfacaf701ecd546625").get()));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
-    auto address = WRAP(TWSegwitAddress, TWSegwitAddressCreateWithPublicKey(TWHRPViacoin, publicKey));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
+    auto address = WRAP(TWSegwitAddress, TWSegwitAddressCreateWithPublicKey(TWHRPViacoin, publicKey.get()));
     auto string = WRAPS(TWSegwitAddressDescription(address.get()));
 
     assertStringsEqual(string, "via1qytnqzjknvv03jwfgrsmzt0ycmwqgl0asu2r3d2");

--- a/tests/Wanchain/TWCoinTypeTests.cpp
+++ b/tests/Wanchain/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWWanchainCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeWanchain));
-    auto txId = TWStringCreateWithUTF8Bytes("0x180ea96a3218b82b9b35d796823266d8a425c182507adfe5eeffc96e6a14d856");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeWanchain, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("0x69b492d57BB777E97AA7044d0575228434E2e8b1");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeWanchain, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("0x180ea96a3218b82b9b35d796823266d8a425c182507adfe5eeffc96e6a14d856"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeWanchain, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("0x69b492d57BB777E97AA7044d0575228434E2e8b1"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeWanchain, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeWanchain));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeWanchain));
 

--- a/tests/Waves/TWCoinTypeTests.cpp
+++ b/tests/Waves/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWWavesCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeWaves));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeWaves, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeWaves, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeWaves, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeWaves, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeWaves));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeWaves));
 

--- a/tests/Zcash/TWCoinTypeTests.cpp
+++ b/tests/Zcash/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWZcashCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeZcash));
-    auto txId = TWStringCreateWithUTF8Bytes("f2438a93039faf08d39bd3df1f7b5f19a2c29ffe8753127e2956ab4461adab35");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeZcash, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("t1Yfrf1dssDLmaMBsq2LFKWPbS5vH3nGpa2");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeZcash, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("f2438a93039faf08d39bd3df1f7b5f19a2c29ffe8753127e2956ab4461adab35"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeZcash, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("t1Yfrf1dssDLmaMBsq2LFKWPbS5vH3nGpa2"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeZcash, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeZcash));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeZcash));
 

--- a/tests/Zcash/TWZcashAddressTests.cpp
+++ b/tests/Zcash/TWZcashAddressTests.cpp
@@ -20,8 +20,8 @@
 
 TEST(TWZcash, TransparentAddress) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("987919d988ef94e678bce254c932e7a7a76744b2c008467448406d4246513132").get()));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
-    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey, TWCoinTypeZcash));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
+    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeZcash));
     auto addressString = WRAPS(TWAnyAddressDescription(address.get()));
     assertStringsEqual(addressString, "t1RygJmrLdNGgi98gUgEJDTVaELTAYWoMBy");
 }
@@ -33,9 +33,9 @@ TEST(TWZcash, DeriveTransparentAddress) {
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), passphrase.get()));
     auto derivationPath = STRING("m/44'/133'/0'/0/5");
     auto key = WRAP(TWPrivateKey, TWHDWalletGetKey(wallet.get(), TWCoinTypeZcash, derivationPath.get()));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(key.get(), true);
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(key.get(), true));
 
-    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey, TWCoinTypeZcash));
+    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeZcash));
     auto addressString = WRAPS(TWAnyAddressDescription(address.get()));
 
     assertStringsEqual(addressString, "t1TWk2mmvESDnE4dmCfT7MQ97ij6ZqLpNVU");

--- a/tests/Zcoin/TWCoinTypeTests.cpp
+++ b/tests/Zcoin/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWZcoinCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeZcoin));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeZcoin, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeZcoin, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeZcoin, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeZcoin, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeZcoin));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeZcoin));
 

--- a/tests/Zcoin/TWZCoinAddressTests.cpp
+++ b/tests/Zcoin/TWZCoinAddressTests.cpp
@@ -19,8 +19,8 @@
 TEST(TWZCoin, Address) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("a22ddec5c567b4488bb00f69b6146c50da2ee883e2c096db098726394d585730").get()));
     auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
-    auto address = TWBitcoinAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeZcoin));
-    auto addressString = WRAPS(TWBitcoinAddressDescription(address));
+    auto address = WRAP(TWBitcoinAddress, TWBitcoinAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeZcoin)));
+    auto addressString = WRAPS(TWBitcoinAddressDescription(address.get()));
     assertStringsEqual(addressString, "aAbqxogrjdy2YHVcnQxFHMzqpt2fhjCTVT");
 }
 
@@ -42,11 +42,11 @@ TEST(TWZcoin, DeriveFromXpub) {
     auto pubKey3 = WRAP(TWPublicKey, TWHDWalletGetPublicKeyFromExtended(xpub.get(), TWCoinTypeZcoin, STRING("m/44'/136'/0'/0/3").get()));
     auto pubKey5 = WRAP(TWPublicKey, TWHDWalletGetPublicKeyFromExtended(xpub.get(), TWCoinTypeZcoin, STRING("m/44'/136'/0'/0/5").get()));
 
-    auto address3 = TWBitcoinAddressCreateWithPublicKey(pubKey3.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeZcoin));
-    auto address3String = WRAPS(TWBitcoinAddressDescription(address3));
+    auto address3 = WRAP(TWBitcoinAddress, TWBitcoinAddressCreateWithPublicKey(pubKey3.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeZcoin)));
+    auto address3String = WRAPS(TWBitcoinAddressDescription(address3.get()));
 
-    auto address5 = TWBitcoinAddressCreateWithPublicKey(pubKey5.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeZcoin));
-    auto address5String = WRAPS(TWBitcoinAddressDescription(address5));
+    auto address5 = WRAP(TWBitcoinAddress, TWBitcoinAddressCreateWithPublicKey(pubKey5.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeZcoin)));
+    auto address5String = WRAPS(TWBitcoinAddressDescription(address5.get()));
 
     assertStringsEqual(address3String, "aLnztJEbyACnxF9H7SFC8YjUxedwyQsgVm");
     assertStringsEqual(address5String, "aJj2jdMzHyKFJLEFTxhpn379avEqRKFUyw");

--- a/tests/Zcoin/TWZCoinAddressTests.cpp
+++ b/tests/Zcoin/TWZCoinAddressTests.cpp
@@ -18,8 +18,8 @@
 
 TEST(TWZCoin, Address) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("a22ddec5c567b4488bb00f69b6146c50da2ee883e2c096db098726394d585730").get()));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
-    auto address = TWBitcoinAddressCreateWithPublicKey(publicKey, TWCoinTypeP2pkhPrefix(TWCoinTypeZcoin));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
+    auto address = TWBitcoinAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeP2pkhPrefix(TWCoinTypeZcoin));
     auto addressString = WRAPS(TWBitcoinAddressDescription(address));
     assertStringsEqual(addressString, "aAbqxogrjdy2YHVcnQxFHMzqpt2fhjCTVT");
 }

--- a/tests/Zelcash/TWCoinTypeTests.cpp
+++ b/tests/Zelcash/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWZelcashCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeZelcash));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeZelcash, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeZelcash, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeZelcash, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeZelcash, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeZelcash));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeZelcash));
 

--- a/tests/Zelcash/TWZelcashAddressTests.cpp
+++ b/tests/Zelcash/TWZelcashAddressTests.cpp
@@ -17,8 +17,8 @@
 
 TEST(TWZelcash, TransparentAddress) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("987919d988ef94e678bce254c932e7a7a76744b2c008467448406d4246513132").get()));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
-    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey, TWCoinTypeZelcash));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
+    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeZelcash));
     auto addressString = WRAPS(TWAnyAddressDescription(address.get()));
     assertStringsEqual(addressString, "t1RygJmrLdNGgi98gUgEJDTVaELTAYWoMBy");
 }
@@ -30,9 +30,9 @@ TEST(TWZelcash, DeriveTransparentAddress) {
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), passphrase.get()));
     auto derivationPath = STRING("m/44'/19167'/0'/0/5");
     auto key = WRAP(TWPrivateKey, TWHDWalletGetKey(wallet.get(), TWCoinTypeZelcash, derivationPath.get()));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(key.get(), true);
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(key.get(), true));
 
-    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey, TWCoinTypeZelcash));
+    auto address = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(publicKey.get(), TWCoinTypeZelcash));
     auto addressString = WRAPS(TWAnyAddressDescription(address.get()));
 
     assertStringsEqual(addressString, "t1Trs2rNPzL4Jm24foTd89KpPWqLtLSciDY");

--- a/tests/Zilliqa/SignatureTests.cpp
+++ b/tests/Zilliqa/SignatureTests.cpp
@@ -17,13 +17,13 @@ using namespace TW;
 TEST(ZilliqaSignature, Signing) {
     auto keyData = WRAPD(TWDataCreateWithHexString(STRING("0xafeefca74d9a325cf1d6b6911d61a65c32afa8e02bd5e78e2e4ac2910bab45f5").get()));
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(keyData.get()));
-    auto pubKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
+    auto pubKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
 
     auto message = "hello schnorr";
     auto messageData = WRAPD(TWDataCreateWithBytes((uint8_t *)message, strnlen(message, 13)));
     auto signatureData = WRAPD(TWPrivateKeySignSchnorr(privateKey.get(), messageData.get(), TWCurveSECP256k1));
     auto signature = data(TWDataBytes(signatureData.get()), TWDataSize(signatureData.get()));
 
-    ASSERT_TRUE(TWPublicKeyVerifySchnorr(pubKey, signatureData.get(), messageData.get()));
+    ASSERT_TRUE(TWPublicKeyVerifySchnorr(pubKey.get(), signatureData.get(), messageData.get()));
     EXPECT_EQ(hex(signature), "d166b1ae7892c5ef541461dc12a50214d0681b63d8037cda29a3fe6af8bb973e4ea94624d85bc0010bdc1b38d05198328fae21254adc2bf5feaf2804d54dba55");
 }

--- a/tests/Zilliqa/TWCoinTypeTests.cpp
+++ b/tests/Zilliqa/TWCoinTypeTests.cpp
@@ -15,10 +15,10 @@
 
 TEST(TWZilliqaCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeZilliqa));
-    auto txId = TWStringCreateWithUTF8Bytes("t123");
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeZilliqa, txId));
-    auto accId = TWStringCreateWithUTF8Bytes("a12");
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeZilliqa, accId));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeZilliqa, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeZilliqa, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeZilliqa));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeZilliqa));
 

--- a/tests/interface/TWBase58Tests.cpp
+++ b/tests/interface/TWBase58Tests.cpp
@@ -30,7 +30,7 @@ TEST(TWBase58, EncodeNoCheck2) {
 
 TEST(TWBase58, Decode) {
     const auto input = STRING("1Bp9U1ogV3A14FMvKbRJms7ctyso4Z4Tcx");
-    auto result = WRAPS(TWBase58Decode(input.get()));
+    auto result = WRAPD(TWBase58Decode(input.get()));
     assertHexEqual(result, "00769bdff96a02f9135a1d19b749db6a78fe07dc90");
 }
 
@@ -42,7 +42,7 @@ TEST(TWBase58, DecodeNoCheck) {
 
 TEST(TWBase58, Decode_WrongChecksum) {
     const auto input = STRING("1Bp9U1ogV3A14FMvKbRJms7ctyso5FdSz2");
-    auto result = WRAPS(TWBase58Decode(input.get()));
+    auto result = WRAPD(TWBase58Decode(input.get()));
     ASSERT_EQ(result.get(), nullptr);
 }
 
@@ -56,7 +56,7 @@ TEST(TWBase58, DecodeNoCheck_WrongChecksum) {
 TEST(TWBase58, Decode_InvalidChar) {
     // 0 is invalid
     const auto input = STRING("1Bp9U1ogV3A14FMvKbRJms7ctyso4Z4Tc0");
-    auto result = WRAPS(TWBase58Decode(input.get()));
+    auto result = WRAPD(TWBase58Decode(input.get()));
     ASSERT_EQ(result.get(), nullptr);
 }
 

--- a/tests/interface/TWBase58Tests.cpp
+++ b/tests/interface/TWBase58Tests.cpp
@@ -36,7 +36,7 @@ TEST(TWBase58, Decode) {
 
 TEST(TWBase58, DecodeNoCheck) {
     const auto input = STRING("1Bp9U1ogV3A14FMvKbRJms7ctyso4Z4Tcx");
-    auto result = WRAPS(TWBase58DecodeNoCheck(input.get()));
+    auto result = WRAPD(TWBase58DecodeNoCheck(input.get()));
     assertHexEqual(result, "00769bdff96a02f9135a1d19b749db6a78fe07dc90c3507da5");
 }
 
@@ -48,7 +48,7 @@ TEST(TWBase58, Decode_WrongChecksum) {
 
 TEST(TWBase58, DecodeNoCheck_WrongChecksum) {
     const auto input = STRING("1Bp9U1ogV3A14FMvKbRJms7ctyso5FdSz2");
-    auto result = WRAPS(TWBase58DecodeNoCheck(input.get()));
+    auto result = WRAPD(TWBase58DecodeNoCheck(input.get()));
     // decodes despite wrong checksum
     assertHexEqual(result, "00769bdff96a02f9135a1d19b749db6a78fe07dc90deadbeef");
 }
@@ -63,6 +63,6 @@ TEST(TWBase58, Decode_InvalidChar) {
 TEST(TWBase58, DecodeNoCheck_InvalidChar) {
     // 0 is invalid
     const auto input = STRING("1Bp9U1ogV3A14FMvKbRJms7ctyso4Z4Tc0");
-    auto result = WRAPS(TWBase58DecodeNoCheck(input.get()));
+    auto result = WRAPD(TWBase58DecodeNoCheck(input.get()));
     ASSERT_EQ(result.get(), nullptr);
 }

--- a/tests/interface/TWHDWalletTests.cpp
+++ b/tests/interface/TWHDWalletTests.cpp
@@ -103,8 +103,8 @@ TEST(HDWallet, Derive) {
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), passphrase.get()));
     auto key0 = WRAP(TWPrivateKey, TWHDWalletGetKeyForCoin(wallet.get(), TWCoinTypeEthereum));
 
-    auto publicKey0 = TWPrivateKeyGetPublicKeySecp256k1(key0.get(), false);
-    auto publicKey0Data = WRAPD(TWPublicKeyData(publicKey0));
+    auto publicKey0 = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(key0.get(), false));
+    auto publicKey0Data = WRAPD(TWPublicKeyData(publicKey0.get()));
 
     assertHexEqual(publicKey0Data, "0414acbe5a06c68210fcbb77763f9612e45a526990aeb69d692d705f276f558a5ae68268e9389bb099ed5ac84d8d6861110f63644f6e5b447e3f86b4bab5dee011");
 }
@@ -112,8 +112,8 @@ TEST(HDWallet, Derive) {
 TEST(HDWallet, DeriveBitcoinNonextended) {
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), passphrase.get()));
     auto key = WRAP(TWPrivateKey, TWHDWalletGetKeyForCoin(wallet.get(), TWCoinTypeBitcoin));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(key.get(), false);
-    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(key.get(), false));
+    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey.get()));
 
     assertHexEqual(publicKeyData, "047ea5dff03f677502c4a1d73c5ac897200e56b155e876774c8fba0cc22f80b9414ec07cda7b1c9a84c2e04ea2746c21afacc5e91b47427c453c3f1a4a3e983ce5");
     // Note: address derivation does not work with nonextended public key
@@ -122,12 +122,12 @@ TEST(HDWallet, DeriveBitcoinNonextended) {
 TEST(HDWallet, DeriveBitcoinExtended) {
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), passphrase.get()));
     auto key = WRAP(TWPrivateKey, TWHDWalletGetKeyForCoin(wallet.get(), TWCoinTypeBitcoin));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(key.get(), true);
-    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(key.get(), true));
+    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey.get()));
 
     assertHexEqual(publicKeyData, "037ea5dff03f677502c4a1d73c5ac897200e56b155e876774c8fba0cc22f80b941");
 
-    auto address = WRAPS(TWCoinTypeDeriveAddressFromPublicKey(TWCoinTypeBitcoin, publicKey));
+    auto address = WRAPS(TWCoinTypeDeriveAddressFromPublicKey(TWCoinTypeBitcoin, publicKey.get()));
     assertStringsEqual(address, "bc1qumwjg8danv2vm29lp5swdux4r60ezptzz7ce85");
 }
 
@@ -142,12 +142,12 @@ TEST(HDWallet, DeriveEthereum) {
     auto key = WRAP(TWPrivateKey, TWHDWalletGetKeyForCoin(wallet.get(), TWCoinTypeEthereum));
     auto key2 = WRAP(TWPrivateKey, TWHDWalletGetKeyForCoin(wallet.get(), TWCoinTypeSmartChain));
 
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(key.get(), false);
-    auto publicKey2 = TWPrivateKeyGetPublicKeySecp256k1(key2.get(), false);
-    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(key.get(), false));
+    auto publicKey2 = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(key2.get(), false));
+    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey.get()));
 
-    auto address = WRAPS(TWCoinTypeDeriveAddressFromPublicKey(TWCoinTypeEthereum, publicKey));
-    auto address2 = WRAPS(TWCoinTypeDeriveAddressFromPublicKey(TWCoinTypeSmartChain, publicKey2));
+    auto address = WRAPS(TWCoinTypeDeriveAddressFromPublicKey(TWCoinTypeEthereum, publicKey.get()));
+    auto address2 = WRAPS(TWCoinTypeDeriveAddressFromPublicKey(TWCoinTypeSmartChain, publicKey2.get()));
 
     assertHexEqual(publicKeyData, "0414acbe5a06c68210fcbb77763f9612e45a526990aeb69d692d705f276f558a5ae68268e9389bb099ed5ac84d8d6861110f63644f6e5b447e3f86b4bab5dee011");
     assertStringsEqual(address, "0x27Ef5cDBe01777D62438AfFeb695e33fC2335979");
@@ -170,8 +170,8 @@ TEST(HDWallet, DeriveCosmos) {
 
     assertHexEqual(privateKeyData, "80e81ea269e66a0a05b11236df7919fb7fbeedba87452d667489d7403a02f005");
 
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
-    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
+    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey.get()));
 
     assertHexEqual(publicKeyData, "0257286ec3f37d33557bbbaa000b27744ac9023aa9967cae75a181d1ff91fa9dc5");
 }
@@ -197,8 +197,8 @@ TEST(HDWallet, DeriveTezos) {
 TEST(HDWallet, DeriveDoge) {
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), passphrase.get()));
     auto key = WRAP(TWPrivateKey, TWHDWalletGetKeyForCoin(wallet.get(), TWCoinTypeDogecoin));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(key.get(), true);
-    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(key.get(), true));
+    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey.get()));
 
     assertHexEqual(publicKeyData, "039fc134623a37c8ee44881f088a599cc44ba8a95f91f860b99d9d3b11f487e4c0");
 
@@ -212,8 +212,8 @@ TEST(HDWallet, DeriveDoge) {
 TEST(HDWallet, DeriveZilliqa) {
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), passphrase.get()));
     auto key = WRAP(TWPrivateKey, TWHDWalletGetKeyForCoin(wallet.get(), TWCoinTypeZilliqa));
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(key.get(), true);
-    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(key.get(), true));
+    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey.get()));
 
     assertHexEqual(publicKeyData, "0262746d4988c63b9972c63272461e9fa080d4dfa2a1fda3dd01285620c0a60c22");
 }

--- a/tests/interface/TWHDWalletTests.cpp
+++ b/tests/interface/TWHDWalletTests.cpp
@@ -179,8 +179,8 @@ TEST(HDWallet, DeriveCosmos) {
 TEST(HDWallet, DeriveNimiq) {
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), passphrase.get()));
     auto key = WRAP(TWPrivateKey, TWHDWalletGetKeyForCoin(wallet.get(), TWCoinTypeNimiq));
-    auto publicKey = TWPrivateKeyGetPublicKeyEd25519(key.get());
-    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeyEd25519(key.get()));
+    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey.get()));
 
     assertHexEqual(publicKeyData, "1937063865fe3294ccf3017837207bb3fea71a53720ae631b77bf9d5ca4f7f4c");
 }
@@ -188,8 +188,8 @@ TEST(HDWallet, DeriveNimiq) {
 TEST(HDWallet, DeriveTezos) {
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), passphrase.get()));
     auto key = WRAP(TWPrivateKey, TWHDWalletGetKeyForCoin(wallet.get(), TWCoinTypeTezos));
-    auto publicKey = TWPrivateKeyGetPublicKeyEd25519(key.get());
-    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeyEd25519(key.get()));
+    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey.get()));
 
     assertHexEqual(publicKeyData, "c834147f97bcf95bf01f234455646a197f70b25e93089591ffde8122370ad371");
 }

--- a/tests/interface/TWPrivateKeyTests.cpp
+++ b/tests/interface/TWPrivateKeyTests.cpp
@@ -72,16 +72,16 @@ TEST(TWPrivateKeyTests, IsValid) {
 TEST(TWPrivateKeyTests, PublicKey) {
     const auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("afeefca74d9a325cf1d6b6911d61a65c32afa8e02bd5e78e2e4ac2910bab45f5").get()));
     {
-        const auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), false);
-        ASSERT_EQ(TW::hex(publicKey->impl.bytes), "0499c6f51ad6f98c9c583f8e92bb7758ab2ca9a04110c0a1126ec43e5453d196c166b489a4b7c491e7688e6ebea3a71fc3a1a48d60f98d5ce84c93b65e423fde91");
+        const auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), false));
+        ASSERT_EQ(TW::hex(publicKey.get()->impl.bytes), "0499c6f51ad6f98c9c583f8e92bb7758ab2ca9a04110c0a1126ec43e5453d196c166b489a4b7c491e7688e6ebea3a71fc3a1a48d60f98d5ce84c93b65e423fde91");
     }
     {
-        const auto publicKey = TWPrivateKeyGetPublicKeyNist256p1(privateKey.get());
-        ASSERT_EQ(TW::hex(publicKey->impl.bytes), "026d786ab8fda678cf50f71d13641049a393b325063b8c0d4e5070de48a2caf9ab");
+        const auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeyNist256p1(privateKey.get()));
+        ASSERT_EQ(TW::hex(publicKey.get()->impl.bytes), "026d786ab8fda678cf50f71d13641049a393b325063b8c0d4e5070de48a2caf9ab");
     }
     {
-        const auto publicKey = TWPrivateKeyGetPublicKeyCurve25519(privateKey.get());
-        ASSERT_EQ(TW::hex(publicKey->impl.bytes), "686cfce9108566dd43fc6aa75e31f9a9f319c9e9c04d6ad0a52505b86bc17c3a");
+        const auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeyCurve25519(privateKey.get()));
+        ASSERT_EQ(TW::hex(publicKey.get()->impl.bytes), "686cfce9108566dd43fc6aa75e31f9a9f319c9e9c04d6ad0a52505b86bc17c3a");
     }
 }
 

--- a/tests/interface/TWPublicKeyTests.cpp
+++ b/tests/interface/TWPublicKeyTests.cpp
@@ -53,13 +53,13 @@ TEST(TWPublicKeyTests, CompressedExtended) {
     EXPECT_EQ(TWPublicKeyIsCompressed(publicKey.get()), true);
     EXPECT_TRUE(TWPublicKeyIsValid(publicKey.get(), TWPublicKeyTypeSECP256k1));
 
-    auto extended = TWPublicKeyUncompressed(publicKey.get());
-    EXPECT_EQ(TWPublicKeyKeyType(extended), TWPublicKeyTypeSECP256k1Extended);
-    EXPECT_EQ(extended->impl.bytes.size(), 65);
-    EXPECT_EQ(TWPublicKeyIsCompressed(extended), false);
-    EXPECT_TRUE(TWPublicKeyIsValid(extended, TWPublicKeyTypeSECP256k1Extended));
+    auto extended = WRAP(TWPublicKey, TWPublicKeyUncompressed(publicKey.get()));
+    EXPECT_EQ(TWPublicKeyKeyType(extended.get()), TWPublicKeyTypeSECP256k1Extended);
+    EXPECT_EQ(extended.get()->impl.bytes.size(), 65);
+    EXPECT_EQ(TWPublicKeyIsCompressed(extended.get()), false);
+    EXPECT_TRUE(TWPublicKeyIsValid(extended.get(), TWPublicKeyTypeSECP256k1Extended));
 
-    auto compressed = WRAP(TWPublicKey, TWPublicKeyCompressed(extended));
+    auto compressed = WRAP(TWPublicKey, TWPublicKeyCompressed(extended.get()));
     //EXPECT_TRUE(compressed == publicKey.get());
     EXPECT_EQ(TWPublicKeyKeyType(compressed.get()), TWPublicKeyTypeSECP256k1);
     EXPECT_EQ(compressed.get()->impl.bytes.size(), 33);

--- a/tests/interface/TWPublicKeyTests.cpp
+++ b/tests/interface/TWPublicKeyTests.cpp
@@ -59,12 +59,12 @@ TEST(TWPublicKeyTests, CompressedExtended) {
     EXPECT_EQ(TWPublicKeyIsCompressed(extended), false);
     EXPECT_TRUE(TWPublicKeyIsValid(extended, TWPublicKeyTypeSECP256k1Extended));
 
-    auto compressed = TWPublicKeyCompressed(extended);
+    auto compressed = WRAP(TWPublicKey, TWPublicKeyCompressed(extended));
     //EXPECT_TRUE(compressed == publicKey.get());
-    EXPECT_EQ(TWPublicKeyKeyType(compressed), TWPublicKeyTypeSECP256k1);
-    EXPECT_EQ(compressed->impl.bytes.size(), 33);
-    EXPECT_EQ(TWPublicKeyIsCompressed(compressed), true);
-    EXPECT_TRUE(TWPublicKeyIsValid(compressed, TWPublicKeyTypeSECP256k1));
+    EXPECT_EQ(TWPublicKeyKeyType(compressed.get()), TWPublicKeyTypeSECP256k1);
+    EXPECT_EQ(compressed.get()->impl.bytes.size(), 33);
+    EXPECT_EQ(TWPublicKeyIsCompressed(compressed.get()), true);
+    EXPECT_TRUE(TWPublicKeyIsValid(compressed.get(), TWPublicKeyTypeSECP256k1));
 }
 
 TEST(TWPublicKeyTests, Verify) {

--- a/tests/interface/TWPublicKeyTests.cpp
+++ b/tests/interface/TWPublicKeyTests.cpp
@@ -29,16 +29,14 @@ TEST(TWPublicKeyTests, Create) {
 TEST(TWPublicKeyTests, CreateFromPrivateSecp256k1) {
     const PrivateKey key(parse_hex("afeefca74d9a325cf1d6b6911d61a65c32afa8e02bd5e78e2e4ac2910bab45f5"));
     const auto privateKey = WRAP(TWPrivateKey, new TWPrivateKey{ key });
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
 
-    EXPECT_EQ(publicKey->impl.bytes.size(), TWPublicKeyCompressedSize);
-    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey));
+    EXPECT_EQ(publicKey.get()->impl.bytes.size(), TWPublicKeyCompressedSize);
+    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey.get()));
     EXPECT_EQ(hex(*((Data*)(publicKeyData.get()))), "0399c6f51ad6f98c9c583f8e92bb7758ab2ca9a04110c0a1126ec43e5453d196c1");
-    EXPECT_EQ(*((std::string*)(WRAPS(TWPublicKeyDescription(publicKey)).get())), "0399c6f51ad6f98c9c583f8e92bb7758ab2ca9a04110c0a1126ec43e5453d196c1");
-    EXPECT_TRUE(TWPublicKeyIsValid(publicKey, TWPublicKeyTypeSECP256k1));
-    EXPECT_TRUE(TWPublicKeyIsCompressed(publicKey));
-
-    TWPublicKeyDelete(publicKey);
+    EXPECT_EQ(*((std::string*)(WRAPS(TWPublicKeyDescription(publicKey.get())).get())), "0399c6f51ad6f98c9c583f8e92bb7758ab2ca9a04110c0a1126ec43e5453d196c1");
+    EXPECT_TRUE(TWPublicKeyIsValid(publicKey.get(), TWPublicKeyTypeSECP256k1));
+    EXPECT_TRUE(TWPublicKeyIsCompressed(publicKey.get()));
 }
 
 TEST(TWPublicKeyTests, CreateInvalid) {
@@ -49,20 +47,20 @@ TEST(TWPublicKeyTests, CreateInvalid) {
 TEST(TWPublicKeyTests, CompressedExtended) {
     const PrivateKey key(parse_hex("afeefca74d9a325cf1d6b6911d61a65c32afa8e02bd5e78e2e4ac2910bab45f5"));
     const auto privateKey = WRAP(TWPrivateKey, new TWPrivateKey{ key });
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true);
-    EXPECT_EQ(TWPublicKeyKeyType(publicKey), TWPublicKeyTypeSECP256k1);
-    EXPECT_EQ(publicKey->impl.bytes.size(), 33);
-    EXPECT_EQ(TWPublicKeyIsCompressed(publicKey), true);
-    EXPECT_TRUE(TWPublicKeyIsValid(publicKey, TWPublicKeyTypeSECP256k1));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), true));
+    EXPECT_EQ(TWPublicKeyKeyType(publicKey.get()), TWPublicKeyTypeSECP256k1);
+    EXPECT_EQ(publicKey.get()->impl.bytes.size(), 33);
+    EXPECT_EQ(TWPublicKeyIsCompressed(publicKey.get()), true);
+    EXPECT_TRUE(TWPublicKeyIsValid(publicKey.get(), TWPublicKeyTypeSECP256k1));
 
-    auto extended = TWPublicKeyUncompressed(publicKey);
+    auto extended = TWPublicKeyUncompressed(publicKey.get());
     EXPECT_EQ(TWPublicKeyKeyType(extended), TWPublicKeyTypeSECP256k1Extended);
     EXPECT_EQ(extended->impl.bytes.size(), 65);
     EXPECT_EQ(TWPublicKeyIsCompressed(extended), false);
     EXPECT_TRUE(TWPublicKeyIsValid(extended, TWPublicKeyTypeSECP256k1Extended));
 
     auto compressed = TWPublicKeyCompressed(extended);
-    //EXPECT_TRUE(compressed == publicKey);
+    //EXPECT_TRUE(compressed == publicKey.get());
     EXPECT_EQ(TWPublicKeyKeyType(compressed), TWPublicKeyTypeSECP256k1);
     EXPECT_EQ(compressed->impl.bytes.size(), 33);
     EXPECT_EQ(TWPublicKeyIsCompressed(compressed), true);
@@ -79,8 +77,8 @@ TEST(TWPublicKeyTests, Verify) {
 
     auto signature = WRAPD(TWPrivateKeySign(privateKey.get(), digest.get(), TWCurveSECP256k1));
 
-    auto publicKey = TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), false);
-    ASSERT_TRUE(TWPublicKeyVerify(publicKey, signature.get(), digest.get()));
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey.get(), false));
+    ASSERT_TRUE(TWPublicKeyVerify(publicKey.get(), signature.get(), digest.get()));
 }
 
 TEST(TWPublicKeyTests, VerifyEd25519) {

--- a/tests/interface/TWPublicKeyTests.cpp
+++ b/tests/interface/TWPublicKeyTests.cpp
@@ -90,13 +90,13 @@ TEST(TWPublicKeyTests, VerifyEd25519) {
     auto digest = WRAPD(TWHashSHA256(messageData.get()));
 
     auto signature = WRAPD(TWPrivateKeySign(privateKey.get(), digest.get(), TWCurveED25519));
-    auto publicKey = TWPrivateKeyGetPublicKeyEd25519(privateKey.get());
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeyEd25519(privateKey.get()));
 
     auto signature2 = WRAPD(TWPrivateKeySign(privateKey.get(), digest.get(), TWCurveED25519Blake2bNano));
-    auto publicKey2 = TWPrivateKeyGetPublicKeyEd25519Blake2b(privateKey.get());
+    auto publicKey2 = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeyEd25519Blake2b(privateKey.get()));
 
-    ASSERT_TRUE(TWPublicKeyVerify(publicKey, signature.get(), digest.get()));
-    ASSERT_TRUE(TWPublicKeyVerify(publicKey2, signature2.get(), digest.get()));
+    ASSERT_TRUE(TWPublicKeyVerify(publicKey.get(), signature.get(), digest.get()));
+    ASSERT_TRUE(TWPublicKeyVerify(publicKey2.get(), signature2.get(), digest.get()));
 }
 
 TEST(TWPublicKeyTests, Recover) {

--- a/tests/interface/TWStoredKeyTests.cpp
+++ b/tests/interface/TWStoredKeyTests.cpp
@@ -66,7 +66,7 @@ TEST(TWStoredKey, createWallet) {
 
 TEST(TWStoredKey, importPrivateKey) {
     const auto privateKeyHex = "3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266";
-    const auto privateKey = WRAPD(TWDataCreateWithHexString(TWStringCreateWithUTF8Bytes(privateKeyHex)));
+    const auto privateKey = WRAPD(TWDataCreateWithHexString(WRAPS(TWStringCreateWithUTF8Bytes(privateKeyHex)).get()));
     const auto name = WRAPS(TWStringCreateWithUTF8Bytes("name"));
     const auto passwordString = WRAPS(TWStringCreateWithUTF8Bytes("password"));
     const auto password = WRAPD(TWDataCreateWithBytes(reinterpret_cast<const uint8_t *>(TWStringUTF8Bytes(passwordString.get())), TWStringSize(passwordString.get())));
@@ -157,7 +157,7 @@ TEST(TWStoredKey, storeAndImportJSON) {
     // read the slow way, ifs.read gave some false warnings with codacy 
     while (!ifs.eof() && idx < length) { char c = ifs.get(); json[idx++] = (uint8_t)c; }
 
-    const auto key2 = WRAP(TWStoredKey, TWStoredKeyImportJSON(TWDataCreateWithData(&json)));
+    const auto key2 = WRAP(TWStoredKey, TWStoredKeyImportJSON(WRAPD(TWDataCreateWithData(&json)).get()));
     const auto name2 = WRAPS(TWStoredKeyName(key2.get()));
     EXPECT_EQ(string(TWStringUTF8Bytes(name2.get())), "name");
 }


### PR DESCRIPTION
## Description

Fix memory deallocations in tests so that there are no detected memory leaks after tests.  Many C-interface methods (TW*) return dynamically allocated objects, and for many of those, deallocations were missing.  Related to #1170.

Only test CPP files are affected (90 of them).

## Testing instructions

Unit tests, with ASAN memory leak detection (--> see PR #1196)

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Test-only bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
