### PR TITLE
[Ethereum] Add amount to contract and fix data variable in case transfer

### DIFF
--- a/src/Ethereum/Signer.cpp
+++ b/src/Ethereum/Signer.cpp
@@ -85,16 +85,19 @@ Data addressStringToData(const std::string& asString) {
 
 Transaction Signer::build(const Proto::SigningInput &input) {
     Data toAddress = addressStringToData(input.to_address());
+    uint256_t nonce = load(input.nonce());
+    uint256_t gasPrice = load(input.gas_price());
+    uint256_t gasLimit = load(input.gas_limit());
     switch (input.transaction().transaction_oneof_case()) {
         case Proto::Transaction::kTransfer:
             {
-                auto transaction = Transaction::buildTransfer(
-                    /* nonce: */ load(input.nonce()),
-                    /* gasPrice: */ load(input.gas_price()),
-                    /* gasLimit: */ load(input.gas_limit()),
+                auto transaction = Transaction(
+                    /* nonce: */ nonce,
+                    /* gasPrice: */ gasPrice,
+                    /* gasLimit: */ gasLimit,
                     /* to: */ toAddress,
                     /* amount: */ load(input.transaction().transfer().amount()),
-                    /* optionalTransaction: */ Data(input.transaction().contract_generic().data().begin(), input.transaction().contract_generic().data().end()));
+                    /* optionalTransaction: */ Data(input.transaction().transfer().data().begin(), input.transaction().transfer().data().end()));
                 return transaction;
             }
 
@@ -102,9 +105,9 @@ Transaction Signer::build(const Proto::SigningInput &input) {
             {
                 Data tokenToAddress = addressStringToData(input.transaction().erc20_transfer().to());
                 auto transaction = Transaction::buildERC20Transfer(
-                    /* nonce: */ load(input.nonce()),
-                    /* gasPrice: */ load(input.gas_price()),
-                    /* gasLimit: */ load(input.gas_limit()),
+                    /* nonce: */ nonce,
+                    /* gasPrice: */ gasPrice,
+                    /* gasLimit: */ gasLimit,
                     /* tokenContract: */ toAddress,
                     /* toAddress */ tokenToAddress,
                     /* amount: */ load(input.transaction().erc20_transfer().amount()));
@@ -115,9 +118,9 @@ Transaction Signer::build(const Proto::SigningInput &input) {
             {
                 Data spenderAddress = addressStringToData(input.transaction().erc20_approve().spender());
                 auto transaction = Transaction::buildERC20Approve(
-                    /* nonce: */ load(input.nonce()),
-                    /* gasPrice: */ load(input.gas_price()),
-                    /* gasLimit: */ load(input.gas_limit()),
+                    /* nonce: */ nonce,
+                    /* gasPrice: */ gasPrice,
+                    /* gasLimit: */ gasLimit,
                     /* tokenContract: */ toAddress,
                     /* toAddress */ spenderAddress,
                     /* amount: */ load(input.transaction().erc20_transfer().amount()));
@@ -129,9 +132,9 @@ Transaction Signer::build(const Proto::SigningInput &input) {
                 Data tokenToAddress = addressStringToData(input.transaction().erc721_transfer().to());
                 Data tokenFromAddress = addressStringToData(input.transaction().erc721_transfer().from());
                 auto transaction = Transaction::buildERC721Transfer(
-                    /* nonce: */ load(input.nonce()),
-                    /* gasPrice: */ load(input.gas_price()),
-                    /* gasLimit: */ load(input.gas_limit()),
+                    /* nonce: */ nonce,
+                    /* gasPrice: */ gasPrice,
+                    /* gasLimit: */ gasLimit,
                     /* tokenContract: */ toAddress,
                     /* fromAddress: */ tokenFromAddress,
                     /* toAddress */ tokenToAddress,
@@ -142,11 +145,12 @@ Transaction Signer::build(const Proto::SigningInput &input) {
         case Proto::Transaction::kContractGeneric:
         default:
             {
-                auto transaction = Transaction::buildSmartContract(
-                    /* nonce: */ load(input.nonce()),
-                    /* gasPrice: */ load(input.gas_price()),
-                    /* gasLimit: */ load(input.gas_limit()),
+                auto transaction = Transaction(
+                    /* nonce: */ nonce,
+                    /* gasPrice: */ gasPrice,
+                    /* gasLimit: */ gasLimit,
                     /* to: */ toAddress,
+                    /* amount: */ load(input.transaction().contract_generic().amount()),
                     /* transaction: */ Data(input.transaction().contract_generic().data().begin(), input.transaction().contract_generic().data().end()));
                 return transaction;
             }

--- a/src/Ethereum/Transaction.h
+++ b/src/Ethereum/Transaction.h
@@ -27,11 +27,6 @@ public:
     uint256_t s = uint256_t();
 
     // Factory methods
-    // Create a native coin transfer transaction
-    static Transaction buildTransfer(uint256_t nonce, uint256_t gasPrice, uint256_t gasLimit, const Data& to, uint256_t amount, const Data& optionalData = {}) {
-        return Transaction(nonce, gasPrice, gasLimit, to, amount, optionalData);
-    }
-
     // Create an ERC20 token transfer transaction
     static Transaction buildERC20Transfer(uint256_t nonce, uint256_t gasPrice, uint256_t gasLimit,
         const Data& tokenContract, const Data& toAddress, uint256_t amount);
@@ -44,18 +39,13 @@ public:
     static Transaction buildERC721Transfer(uint256_t nonce, uint256_t gasPrice, uint256_t gasLimit,
         const Data& tokenContract, const Data& from, const Data& to, uint256_t tokenId);
 
-    // Create a generic smart contract transaction
-    static Transaction buildSmartContract(uint256_t nonce, uint256_t gasPrice, uint256_t gasLimit, const Data& to, const Data& data) {
-        return Transaction(nonce, gasPrice, gasLimit, to, 0, data);
-    }
-
     // Helpers for building contract calls
     static Data buildERC20TransferCall(const Data& to, uint256_t amount);
     static Data buildERC20ApproveCall(const Data& spender, uint256_t amount);
     static Data buildERC721TransferFromCall(const Data& from, const Data& to, uint256_t tokenId);
 
-private:
-    Transaction(uint256_t nonce, uint256_t gasPrice, uint256_t gasLimit, const Data& to, uint256_t amount, const Data& payload)
+public:
+    Transaction(uint256_t nonce, uint256_t gasPrice, uint256_t gasLimit, const Data& to, uint256_t amount, const Data& payload = {})
         : nonce(std::move(nonce))
         , gasPrice(std::move(gasPrice))
         , gasLimit(std::move(gasLimit))

--- a/src/proto/Ethereum.proto
+++ b/src/proto/Ethereum.proto
@@ -42,8 +42,11 @@ message Transaction {
 
     // Generic smart contract transaction
     message ContractGeneric {
+        // Amount to send in wei (256-bit number)
+        bytes amount = 1;
+
         // Contract call payload data
-        bytes data = 1;
+        bytes data = 2;
     }
 
     oneof transaction_oneof {

--- a/tests/BinanceSmartChain/SignerTests.cpp
+++ b/tests/BinanceSmartChain/SignerTests.cpp
@@ -33,7 +33,7 @@ TEST(BinanceSmartChain, SignNativeTransfer) {
     // https://explorer.binance.org/smart-testnet/tx/0x6da28164f7b3bc255d749c3ae562e2a742be54c12bf1858b014cc2fe5700684e
 
     auto toAddress = parse_hex("0x31BE00EB1fc8e14A696DBC72f746ec3e95f49683");
-    auto transaction = Transaction::buildTransfer(
+    auto transaction = Transaction(
         /* nonce: */ 0,
         /* gasPrice: */ 20000000000,
         /* gasLimit: */ 21000,

--- a/tests/Ethereum/SignerTests.cpp
+++ b/tests/Ethereum/SignerTests.cpp
@@ -23,7 +23,7 @@ public:
 
 TEST(EthereumSigner, Hash) {
     auto address = parse_hex("0x3535353535353535353535353535353535353535");
-    auto transaction = Transaction::buildTransfer(
+    auto transaction = Transaction(
         /* nonce: */ 9,
         /* gasPrice: */ 20000000000,
         /* gasLimit: */ 21000,
@@ -38,7 +38,7 @@ TEST(EthereumSigner, Hash) {
 
 TEST(EthereumSigner, Sign) {
     auto address = parse_hex("0x3535353535353535353535353535353535353535");
-    auto transaction = Transaction::buildTransfer(
+    auto transaction = Transaction(
         /* nonce: */ 9,
         /* gasPrice: */ 20000000000,
         /* gasLimit: */ 21000,

--- a/tests/Wanchain/SignerTests.cpp
+++ b/tests/Wanchain/SignerTests.cpp
@@ -23,7 +23,7 @@ public:
 
 TEST(Signer, Sign) {
     auto address = parse_hex("0x3535353535353535353535353535353535353535");
-    auto transaction = Ethereum::Transaction::buildTransfer(
+    auto transaction = Ethereum::Transaction(
         /* nonce: */ 9,
         /* gasPrice: */ 20000000000,
         /* gasLimit: */ 21000,


### PR DESCRIPTION
#1210 followup

- `transfer` and `contract` underlaying is same, separate cases allow user adding `Transfer`, `Smart Contract Call` easily on UI
- Fix `transfer` case wrong data variable
- some cleanup