### PR TITLE
BTC Plan: use dynamic dustLevel (for ensuring non-dust change)

### DIFF
--- a/src/Bitcoin/UnspentSelector.cpp
+++ b/src/Bitcoin/UnspentSelector.cpp
@@ -89,36 +89,36 @@ UnspentSelector::select(const T& utxos, int64_t targetValue, int64_t byteFee, in
     //    (1) bigger than what we need
     //    (2) closer to 2x the amount,
     //    (3) and does not produce dust change.
-    for (int64_t numInputs = 1; numInputs <= sortedUtxos.size(); numInputs += 1) {
+    for (int64_t numInputs = 1; numInputs <= sortedUtxos.size(); ++numInputs) {
         const auto fee = feeCalculator.calculate(numInputs, numOutputs, byteFee);
         const auto targetWithFeeAndDust = targetValue + fee + dustThreshold;
         auto slices = slice(sortedUtxos, static_cast<size_t>(numInputs));
-        slices.erase(std::remove_if(slices.begin(), slices.end(),
-                                    [targetWithFeeAndDust](
-                                        const std::vector<Proto::UnspentTransaction>& slice) {
-                                        return sum(slice) < targetWithFeeAndDust;
-                                    }),
-                     slices.end());
+        slices.erase(
+            std::remove_if(slices.begin(), slices.end(),
+                [targetWithFeeAndDust](const std::vector<Proto::UnspentTransaction>& slice) {
+                    return sum(slice) < targetWithFeeAndDust;
+                }),
+            slices.end());
         if (!slices.empty()) {
             std::sort(slices.begin(), slices.end(),
-                      [distFrom2x](const std::vector<Proto::UnspentTransaction>& lhs,
-                                   const std::vector<Proto::UnspentTransaction>& rhs) {
-                          return distFrom2x(sum(lhs)) < distFrom2x(sum(rhs));
-                      });
+                [distFrom2x](const std::vector<Proto::UnspentTransaction>& lhs,
+                            const std::vector<Proto::UnspentTransaction>& rhs) {
+                    return distFrom2x(sum(lhs)) < distFrom2x(sum(rhs));
+                });
             return filterDustInput(slices.front(), byteFee);
         }
     }
 
     // 2. If not, find a valid combination of outputs even if they produce dust change.
-    for (int64_t numInputs = 1; numInputs <= sortedUtxos.size(); numInputs += 1) {
+    for (int64_t numInputs = 1; numInputs <= sortedUtxos.size(); ++numInputs) {
         const auto fee = feeCalculator.calculate(numInputs, numOutputs, byteFee);
         const auto targetWithFee = targetValue + fee;
         auto slices = slice(sortedUtxos, static_cast<size_t>(numInputs));
         slices.erase(
             std::remove_if(slices.begin(), slices.end(),
-                           [targetWithFee](const std::vector<Proto::UnspentTransaction>& slice) {
-                               return sum(slice) < targetWithFee;
-                           }),
+                [targetWithFee](const std::vector<Proto::UnspentTransaction>& slice) {
+                    return sum(slice) < targetWithFee;
+                }),
             slices.end());
         if (!slices.empty()) {
             return filterDustInput(slices.front(), byteFee);

--- a/src/Bitcoin/UnspentSelector.cpp
+++ b/src/Bitcoin/UnspentSelector.cpp
@@ -12,8 +12,6 @@
 using namespace TW;
 using namespace TW::Bitcoin;
 
-const int64_t UnspentSelector::dustThreshold = 3 * 182;
-
 /// A selection of unspent transactions.
 struct Selection {
     std::vector<Proto::UnspentTransaction> utxos;
@@ -84,6 +82,8 @@ UnspentSelector::select(const T& utxos, int64_t targetValue, int64_t byteFee, in
         else
             return doubleTargetValue - val;
     };
+
+    const int64_t dustThreshold = feeCalculator.calculateSingleInput(byteFee);
 
     // 1. Find a combination of the fewest inputs that is
     //    (1) bigger than what we need

--- a/src/Bitcoin/UnspentSelector.h
+++ b/src/Bitcoin/UnspentSelector.h
@@ -17,9 +17,6 @@ namespace TW::Bitcoin {
 
 class UnspentSelector {
   public:
-    /// Maximum allowable transaction dust.
-    static const int64_t dustThreshold;
-
     /// Selects unspent transactions to use given a target transaction value.
     ///
     /// \returns the list of selected utxos or an empty list if there are

--- a/tests/Bitcoin/TransactionPlanTests.cpp
+++ b/tests/Bitcoin/TransactionPlanTests.cpp
@@ -155,15 +155,16 @@ TEST(TransactionPlan, ThreeNoDust) {
     EXPECT_EQ(feeCalculator.calculate(1, 2, 1), 226);
     EXPECT_EQ(feeCalculator.calculate(2, 2, 1), 374);
 
-    // Now 100'000 fits with no dust; 546 is the dust limit
-    sigingInput = buildSigningInput(100'000 - 226 - 546, 1, utxos);
+    const auto dustLimit = 148;
+    // Now 100'000 fits with no dust
+    sigingInput = buildSigningInput(100'000 - 226 - dustLimit, 1, utxos);
     txPlan = TransactionBuilder::plan(sigingInput);
-    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 100'000 - 226 - 546, 147));
+    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 100'000 - 226 - dustLimit, 147));
 
     // One more and we are over dust limit
-    sigingInput = buildSigningInput(100'000 - 226 - 546 + 1, 1, utxos);
+    sigingInput = buildSigningInput(100'000 - 226 - dustLimit + 1, 1, utxos);
     txPlan = TransactionBuilder::plan(sigingInput);
-    EXPECT_TRUE(verifyPlan(txPlan, {75'000, 100'000}, 100'000 - 226 - 546 + 1, 215));
+    EXPECT_TRUE(verifyPlan(txPlan, {75'000, 100'000}, 100'000 - 226 - dustLimit + 1, 215));
 }
 
 TEST(TransactionPlan, TenThree) {

--- a/tests/Bitcoin/UnspentSelectorTests.cpp
+++ b/tests/Bitcoin/UnspentSelectorTests.cpp
@@ -183,12 +183,13 @@ TEST(BitcoinUnspentSelector, SelectThreeNoDust) {
     // 100'000 would fit with dust; instead two UTXOs are selected not to leave dust
     EXPECT_TRUE(verifySelectedUTXOs(selected, {75'000, 100'000}));
     
-    // Now 100'000 fits with no dust; 546 is the dust limit
-    selected = selector.select(utxos, 100'000 - 226 - 546, 1);
+    const auto dustLimit = 148;
+    // Now 100'000 fits with no dust
+    selected = selector.select(utxos, 100'000 - 226 - dustLimit, 1);
     EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000}));
 
     // One more and we are over dust limit
-    selected = selector.select(utxos, 100'000 - 226 - 546 + 1, 1);
+    selected = selector.select(utxos, 100'000 - 226 - dustLimit + 1, 1);
     EXPECT_TRUE(verifySelectedUTXOs(selected, {75'000, 100'000}));
 }
 
@@ -242,14 +243,15 @@ TEST(BitcoinUnspentSelector, SelectTenThreeExact) {
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
     auto selector = UnspentSelector(feeCalculator);
-    auto selected = selector.select(utxos, 375'000 - 522 - 546, 1);
+    const auto dustLimit = 148;
+    auto selected = selector.select(utxos, 375'000 - 522 - dustLimit, 1);
 
     EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000, 125'000, 150'000}));
 
     ASSERT_EQ(feeCalculator.calculate(3, 2, 1), 522);
 
     // one more, and it's too much
-    selected = selector.select(utxos, 375'000 - 522 - 546 + 1, 1);
+    selected = selector.select(utxos, 375'000 - 522 - dustLimit + 1, 1);
 
     EXPECT_TRUE(verifySelectedUTXOs(selected, {7'000, 100'000, 125'000, 150'000}));
 }


### PR DESCRIPTION
## Description

Bitcoin Plan: use dynamic dustLevel (for ensuring non-dust change).  So far the hardcoded value of 3*182 was used.  Now singleInputFee is used, multiplied with the current byteFee.
Note that the exact value of the change dustLevel is not critical, because if no input selection is found that would result in non-dust change, as a fallback we use a selection disregarding the non-dust change condition.

## Testing instructions

Unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
