### PR TITLE
BTC plan/sign: if requested amount is same or more than avail, use max

### DIFF
--- a/src/Bitcoin/TransactionBuilder.cpp
+++ b/src/Bitcoin/TransactionBuilder.cpp
@@ -75,7 +75,9 @@ TransactionPlan TransactionBuilder::plan(const Bitcoin::Proto::SigningInput& inp
     } else {
         // select UTXOs
         plan.amount = input.amount();
-        // if amount requested is the same or more than available, treat it as MaxAmount
+
+        // if amount requested is the same or more than available amount, it cannot be satisifed, but
+        // treat this case as MaxAmount, and send maximum available (which will be less)
         if (!maxAmount && input.amount() >= UnspentSelector::sum(input.utxo())) {
             maxAmount = true;
         }

--- a/src/Bitcoin/TransactionBuilder.cpp
+++ b/src/Bitcoin/TransactionBuilder.cpp
@@ -75,6 +75,11 @@ TransactionPlan TransactionBuilder::plan(const Bitcoin::Proto::SigningInput& inp
     } else {
         // select UTXOs
         plan.amount = input.amount();
+        // if amount requested is the same or more than available, treat it as MaxAmount
+        if (!maxAmount && input.amount() >= UnspentSelector::sum(input.utxo())) {
+            maxAmount = true;
+        }
+
         auto output_size = 2;
         if (!maxAmount) {
             output_size = 2; // output + change
@@ -93,6 +98,7 @@ TransactionPlan TransactionBuilder::plan(const Bitcoin::Proto::SigningInput& inp
             // Compute fee.
             // must preliminary set change so that there is a second output
             if (!maxAmount) {
+                assert(input.amount() <= plan.availableAmount);
                 plan.amount = input.amount();
                 plan.fee = 0;
                 plan.change = plan.availableAmount - plan.amount;

--- a/src/proto/Bitcoin.proto
+++ b/src/proto/Bitcoin.proto
@@ -67,7 +67,9 @@ message SigningInput {
     // Hash type to use when signing.
     uint32 hash_type = 1;
 
-    // Amount to send.
+    // Amount to send.  Transaction created will have this amount in its output, 
+    // except when use_max_amount is set, in that case this amount is not relevant, maximum possible amount will be used (max avail less fee).
+    // If amount is equal or more than the available amount, also max amount will be used.
     int64 amount = 2;
 
     // Transaction fee per byte.

--- a/tests/Bitcoin/TransactionPlanTests.cpp
+++ b/tests/Bitcoin/TransactionPlanTests.cpp
@@ -39,7 +39,8 @@ TEST(TransactionPlan, OneInsufficient) {
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {}, 0, 0, ErrorTextNotEnoughUtxos));
+    // Max is returned
+    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 99'887, 113));
 }
 
 TEST(TransactionPlan, OneInsufficientEqual) {
@@ -48,7 +49,8 @@ TEST(TransactionPlan, OneInsufficientEqual) {
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {}, 0, 0, ErrorTextNotEnoughUtxos));
+    // Max is returned
+    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 99'887, 113));
 }
 
 TEST(TransactionPlan, OneInsufficientLower100) {
@@ -78,6 +80,17 @@ TEST(TransactionPlan, OneInsufficientLower300) {
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
     EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 100'000 - 300, 147));
+}
+
+TEST(TransactionPlan, OneMoreRequested) {
+    auto utxos = buildTestUTXOs({100'000});
+    auto byteFee = 1;
+    auto sigingInput = buildSigningInput(150'000, byteFee, utxos);
+
+    auto txPlan = TransactionBuilder::plan(sigingInput);
+
+    // Max is returned
+    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 99'887, 113));
 }
 
 TEST(TransactionPlan, OneFitsExactly) {
@@ -193,7 +206,8 @@ TEST(TransactionPlan, UnspentsInsufficient) {
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {}, 0, 0, ErrorTextNotEnoughUtxos));
+    // Max is returned
+    EXPECT_TRUE(verifyPlan(txPlan, {4000, 4000, 4000}, 11751, 249));
 }
 
 TEST(TransactionPlan, SelectionSuboptimal_ExtraSmallUtxo) {
@@ -357,13 +371,13 @@ TEST(TransactionPlan, MaxAmountOne) {
 }
 
 TEST(TransactionPlan, AmountEqualsMaxButNotUseMax) {
-    // amount is set to max, but UseMax is not set --> cannot be satisfied
+    // amount is set to max, but UseMax is not set --> Max is returned
     auto utxos = buildTestUTXOs({10189534});
     auto sigingInput = buildSigningInput(10189534, 1, utxos, false);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {}, 0, 0, ErrorTextNotEnoughUtxos));
+    EXPECT_TRUE(verifyPlan(txPlan, {10189534}, 10189421, 113));
 }
 
 TEST(TransactionPlan, MaxAmountLowerRequested) {

--- a/tests/Decred/SignerTests.cpp
+++ b/tests/Decred/SignerTests.cpp
@@ -76,11 +76,17 @@ TEST(DecredSigner, SignP2PKH) {
     auto txOut = TransactionOutput();
     redeemTx.outputs.push_back(txOut);
 
+    auto plan = input.mutable_plan();
+    plan->set_amount(100'000'000);
+    plan->set_available_amount(100'000'000);
+    plan->set_fee(0);
+    plan->set_change(0);
+    auto utxop0 = plan->add_utxos();
+    *utxop0 = *utxo0;
 
     // Sign
     auto signer = Signer(std::move(input));
     signer.transaction = redeemTx;
-    signer.txPlan.utxos.push_back(*utxo0);
     signer.txPlan.amount = 100'000'000;
     const auto result = signer.sign();
 
@@ -165,6 +171,13 @@ TEST(DecredSigner, SignP2SH) {
     utxo0->mutable_out_point()->set_hash(originTx.hash().data(), originTx.hash().size());
     utxo0->mutable_out_point()->set_index(0);
 
+    auto plan = input.mutable_plan();
+    plan->set_amount(100'000'000);
+    plan->set_available_amount(100'000'000);
+    plan->set_fee(0);
+    plan->set_change(0);
+    auto utxop0 = plan->add_utxos();
+    *utxop0 = *utxo0;
 
 	// Create the transaction to redeem the fake transaction.
     auto redeemTx = Transaction();
@@ -181,7 +194,6 @@ TEST(DecredSigner, SignP2SH) {
     // Sign
     auto signer = Signer(std::move(input));
     signer.transaction = redeemTx;
-    signer.txPlan.utxos.push_back(*utxo0);
     signer.txPlan.amount = 100'000'000;
     const auto result = signer.sign();
 


### PR DESCRIPTION
## Description

BTC signing/planning has two modes:
- UseMax -- TX is prepared with max amount possible, input.amount has no relevance.  Amount will be max available minus fee, with no change.
- Non-max amount: TX is prepared with sent amount equal to requested amount, if possible (fail otherwise).

If UseMax=false, but requested amount equals or is more than available, currently wallet-core returns an error, as it is impossible to send the requested amount.

Change this behavior to be more robust with the caller, and treat this case **as UseMax case**.

No change in the app is needed.

This is an edge case. Some cases when this is relevant, when app behaves differently, may be:
- requested amount == available, but the app forgets to set UseMax amount, or 
- some UTXO is prefiltered by app as dust, but the original requested amount is not adjusted.

With this change overall behaviour will be more robust with the app.

<!--- Describe your changes in detail -->

Unit tests, `*Plan*`.

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
