### PR TITLE
BTC plan: Treat MaxAmount, reqAmount=0 as not error

### DIFF
--- a/src/Bitcoin/TransactionBuilder.cpp
+++ b/src/Bitcoin/TransactionBuilder.cpp
@@ -68,7 +68,7 @@ TransactionPlan TransactionBuilder::plan(const Bitcoin::Proto::SigningInput& inp
     auto unspentSelector = UnspentSelector(feeCalculator);
     bool maxAmount = input.use_max_amount();
 
-    if (input.amount() == 0) {
+    if (input.amount() == 0 && !maxAmount) {
         plan.error = "Zero amount requested";
     } else if (input.utxo().empty()) {
         plan.error = "Missing input UTXOs";


### PR DESCRIPTION
## Description

In BTC plan, if MaxAmount is requested, the requested amount has no meaning, can be anything.  However, the reqAmount=0 case triggered an earlier sanity check, resulting an error.  This is a valid input combination, not error now.
This is a minor change in a low-prob edge case, the apps are not setting reqAmount to 0.

## Testing instructions

Unit tests; TransactionPlan.MaxAmountRequestedZero.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
