### PR TITLE
Expose ECDH shared key derivation

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestPrivateKey.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestPrivateKey.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 import wallet.core.jni.Curve
 import wallet.core.jni.Hash
 import wallet.core.jni.PrivateKey
-
+import wallet.core.jni.PublicKey
 
 class TestPrivateKey {
     private val validPrivateKeyData = "afeefca74d9a325cf1d6b6911d61a65c32afa8e02bd5e78e2e4ac2910bab45f5".toHexBytes()

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestPrivateKey.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestPrivateKey.kt
@@ -77,8 +77,7 @@ class TestPrivateKey {
         val derivedData = privateKey.getSharedKey(publicKey, Curve.SECP256K1)
         assertNotNull(derivedData)
 
-        val expected = "ef2cf705af8714b35c0855030f358f2bee356ff3579cea2607b2025d80133c3a".toHexBytes()
-        assertEquals(derivedData?.toHex(), expected)
+        assertEquals(derivedData?.toHex(), "0xef2cf705af8714b35c0855030f358f2bee356ff3579cea2607b2025d80133c3a")
     }
 
     @Test
@@ -97,7 +96,7 @@ class TestPrivateKey {
         val derivedData2 = privateKey2.getSharedKey(publicKey1, Curve.SECP256K1)
         assertNotNull(derivedData2)
 
-        assertEquals(derivedData1, derivedData2)
+        assertEquals(derivedData1?.toHex(), derivedData2?.toHex())
     }
 
     @Test

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestPrivateKey.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestPrivateKey.kt
@@ -7,6 +7,7 @@ import wallet.core.jni.Curve
 import wallet.core.jni.Hash
 import wallet.core.jni.PrivateKey
 import wallet.core.jni.PublicKey
+import wallet.core.jni.PublicKeyType
 
 class TestPrivateKey {
     private val validPrivateKeyData = "afeefca74d9a325cf1d6b6911d61a65c32afa8e02bd5e78e2e4ac2910bab45f5".toHexBytes()
@@ -71,7 +72,7 @@ class TestPrivateKey {
         val privateKey = PrivateKey(privateKeyData)!!
         
         val publicKeyData = "02a18a98316b5f52596e75bfa5ca9fa9912edd0c989b86b73d41bb64c9c6adb992".toHexBytes()
-        val publicKey = PublicKey(publicKeyData, Curve.SECP256K1)!!
+        val publicKey = PublicKey(publicKeyData, PublicKeyType.SECP256K1)!!
 
         val derivedData = privateKey.getSharedKey(publicKey, Curve.SECP256K1)
         assertNotNull(derivedData)
@@ -105,7 +106,7 @@ class TestPrivateKey {
         val privateKey = PrivateKey(privateKeyData)!!
         
         val publicKeyData = "02a18a98316b5f52596e75bfa5ca9fa9912edd0c989b86b73d41bb64c9c6adb992".toHexBytes()
-        val publicKey = PublicKey(publicKeyData, Curve.SECP256K1)!!
+        val publicKey = PublicKey(publicKeyData, PublicKeyType.SECP256K1)!!
 
         val derivedData = privateKey.getSharedKey(publicKey, Curve.ED25519)
         assertNull(derivedData)

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestPrivateKey.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestPrivateKey.kt
@@ -64,4 +64,50 @@ class TestPrivateKey {
         }
         assertNotNull(privateKey)
     }
+
+    @Test
+    fun testGetSharedKey() {
+        val privateKeyData = "9cd3b16e10bd574fed3743d8e0de0b7b4e6c69f3245ab5a168ef010d22bfefa0".toHexBytes()
+        val privateKey = PrivateKey(privateKeyData)!!
+        
+        val publicKeyData = "02a18a98316b5f52596e75bfa5ca9fa9912edd0c989b86b73d41bb64c9c6adb992".toHexBytes()
+        val publicKey = PublicKey(publicKeyData, Curve.SECP256K1)!!
+
+        val derivedData = privateKey.getSharedKey(publicKey, Curve.SECP256K1)
+        assertNotNull(derivedData)
+
+        val expected = "ef2cf705af8714b35c0855030f358f2bee356ff3579cea2607b2025d80133c3a".toHexBytes()
+        assertEquals(derivedData?.toHex(), expected)
+    }
+
+    @Test
+    fun testGetSharedKeyBidirectional() {
+        val privateKeyData1 = "9cd3b16e10bd574fed3743d8e0de0b7b4e6c69f3245ab5a168ef010d22bfefa0".toHexBytes()
+        val privateKey1 = PrivateKey(privateKeyData1)!!
+        val publicKey1 = privateKey1.getPublicKeySecp256k1(true)
+        
+        val privateKeyData2 = "ef2cf705af8714b35c0855030f358f2bee356ff3579cea2607b2025d80133c3a".toHexBytes()
+        val privateKey2 = PrivateKey(privateKeyData2)!!
+        val publicKey2 = privateKey2.getPublicKeySecp256k1(true)
+
+        val derivedData1 = privateKey1.getSharedKey(publicKey2, Curve.SECP256K1)
+        assertNotNull(derivedData1)
+
+        val derivedData2 = privateKey2.getSharedKey(publicKey1, Curve.SECP256K1)
+        assertNotNull(derivedData2)
+
+        assertEquals(derivedData1, derivedData2)
+    }
+
+    @Test
+    fun testGetSharedKeyError() {
+        val privateKeyData = "9cd3b16e10bd574fed3743d8e0de0b7b4e6c69f3245ab5a168ef010d22bfefa0".toHexBytes()
+        val privateKey = PrivateKey(privateKeyData)!!
+        
+        val publicKeyData = "02a18a98316b5f52596e75bfa5ca9fa9912edd0c989b86b73d41bb64c9c6adb992".toHexBytes()
+        val publicKey = PublicKey(publicKeyData, Curve.SECP256K1)!!
+
+        val derivedData = privateKey.getSharedKey(publicKey, Curve.ED25519)
+        assertNull(derivedData)
+    }    
 }

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestPrivateKey.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestPrivateKey.kt
@@ -81,6 +81,20 @@ class TestPrivateKey {
     }
 
     @Test
+    fun testGetSharedKeyWycherproof() {
+        val privateKeyData = "f4b7ff7cccc98813a69fae3df222bfe3f4e28f764bf91b4a10d8096ce446b254".toHexBytes()
+        val privateKey = PrivateKey(privateKeyData)!!
+        
+        val publicKeyData = "02d8096af8a11e0b80037e1ee68246b5dcbb0aeb1cf1244fd767db80f3fa27da2b".toHexBytes()
+        val publicKey = PublicKey(publicKeyData, PublicKeyType.SECP256K1)!!
+
+        val derivedData = privateKey.getSharedKey(publicKey, Curve.SECP256K1)
+        assertNotNull(derivedData)
+
+        assertEquals(derivedData?.toHex(), "0x81165066322732362ca5d3f0991d7f1f7d0aad7ea533276496785d369e35159a")
+    }
+
+    @Test
     fun testGetSharedKeyBidirectional() {
         val privateKeyData1 = "9cd3b16e10bd574fed3743d8e0de0b7b4e6c69f3245ab5a168ef010d22bfefa0".toHexBytes()
         val privateKey1 = PrivateKey(privateKeyData1)!!

--- a/include/TrustWalletCore/TWPrivateKey.h
+++ b/include/TrustWalletCore/TWPrivateKey.h
@@ -63,7 +63,7 @@ struct TWPublicKey *_Nonnull TWPrivateKeyGetPublicKeyCurve25519(struct TWPrivate
 /// Computes an EC Diffie-Hellman secret in constant time
 /// Supported curves: secp256k1
 TW_EXPORT_METHOD
-TWData *_Nullable TWPrivateKeyGetSharedKey(struct TWPrivateKey *_Nonnull pk, struct TWPublicKey *_Nonnull publicKey, enum TWCurve curve);
+TWData *_Nullable TWPrivateKeyGetSharedKey(const struct TWPrivateKey *_Nonnull pk, const struct TWPublicKey *_Nonnull publicKey, enum TWCurve curve);
 
 /// Signs a digest using ECDSA and given curve.
 TW_EXPORT_METHOD

--- a/include/TrustWalletCore/TWPrivateKey.h
+++ b/include/TrustWalletCore/TWPrivateKey.h
@@ -63,7 +63,7 @@ struct TWPublicKey *_Nonnull TWPrivateKeyGetPublicKeyCurve25519(struct TWPrivate
 /// Computes an EC Diffie-Hellman secret in constant time
 /// Supported curves: secp256k1
 TW_EXPORT_METHOD
-TWData *_Nullable TWPrivateKeyGetSharedKey(const struct TWPrivateKey *_Nonnull pk, const struct TWPublicKey *_Nonnull publicKey, enum TWCurve curve);
+TWData *_Nullable TWPrivateKeyGetSharedKey(struct TWPrivateKey *_Nonnull pk, struct TWPublicKey *_Nonnull publicKey, enum TWCurve curve);
 
 /// Signs a digest using ECDSA and given curve.
 TW_EXPORT_METHOD

--- a/include/TrustWalletCore/TWPrivateKey.h
+++ b/include/TrustWalletCore/TWPrivateKey.h
@@ -63,7 +63,7 @@ struct TWPublicKey *_Nonnull TWPrivateKeyGetPublicKeyCurve25519(struct TWPrivate
 /// Computes an EC Diffie-Hellman secret in constant time
 /// Supported curves: secp256k1
 TW_EXPORT_METHOD
-TWData *_Nullable TWPrivateKeyGetSharedkey(struct TWPrivateKey *_Nonnull pk, struct TWPublicKey *_Nonnull publicKey, enum TWCurve curve);
+TWData *_Nullable TWPrivateKeyGetSharedKey(struct TWPrivateKey *_Nonnull pk, struct TWPublicKey *_Nonnull publicKey, enum TWCurve curve);
 
 /// Signs a digest using ECDSA and given curve.
 TW_EXPORT_METHOD

--- a/include/TrustWalletCore/TWPrivateKey.h
+++ b/include/TrustWalletCore/TWPrivateKey.h
@@ -60,6 +60,11 @@ struct TWPublicKey *_Nonnull TWPrivateKeyGetPublicKeyEd25519Extended(struct TWPr
 TW_EXPORT_METHOD
 struct TWPublicKey *_Nonnull TWPrivateKeyGetPublicKeyCurve25519(struct TWPrivateKey *_Nonnull pk);
 
+/// Computes an EC Diffie-Hellman secret in constant time
+/// Supported curves: secp256k1
+TW_EXPORT_METHOD
+TWData *_Nullable TWPrivateKeyGetSharedkey(struct TWPrivateKey *_Nonnull pk, struct TWPublicKey *_Nonnull publicKey, enum TWCurve curve);
+
 /// Signs a digest using ECDSA and given curve.
 TW_EXPORT_METHOD
 TWData *_Nullable TWPrivateKeySign(struct TWPrivateKey *_Nonnull pk, TWData *_Nonnull digest, enum TWCurve curve);

--- a/src/PrivateKey.cpp
+++ b/src/PrivateKey.cpp
@@ -9,6 +9,7 @@
 #include "PublicKey.h"
 
 #include <TrezorCrypto/bignum.h>
+#include <TrezorCrypto/curves.h>
 #include <TrezorCrypto/ecdsa.h>
 #include <TrezorCrypto/ed25519-donna/ed25519-blake2b.h>
 #include <TrezorCrypto/memzero.h>
@@ -143,6 +144,18 @@ PublicKey PrivateKey::getPublicKey(TWPublicKeyType type) const {
         break;
     }
     return PublicKey(result, type);
+}
+
+Data PrivateKey::deriveECDH(const PublicKey& pubKey) const {
+    Data result;
+    bool success = false;
+    success = ecdh_multiply(&secp256k1, bytes.data(),
+                            pubKey.bytes.data(), result.data()) == 0;
+
+    if (!success) {
+        return {};
+    }
+    return result;
 }
 
 int ecdsa_sign_digest_checked(const ecdsa_curve *curve, const uint8_t *priv_key, const uint8_t *digest, size_t digest_size, uint8_t *sig, uint8_t *pby, int (*is_canonical)(uint8_t by, uint8_t sig[64])) {

--- a/src/PrivateKey.cpp
+++ b/src/PrivateKey.cpp
@@ -151,8 +151,7 @@ Data PrivateKey::getSharedKey(const PublicKey& pubKey, TWCurve curve) const {
         return {};
     }
 
-    Data result;
-    result.resize(65);
+    Data result(PublicKey::secp256k1ExtendedSize);
     bool success = ecdh_multiply(&secp256k1, bytes.data(),
                                  pubKey.bytes.data(), result.data()) == 0;
 

--- a/src/PrivateKey.cpp
+++ b/src/PrivateKey.cpp
@@ -155,13 +155,13 @@ Data PrivateKey::getSharedKey(const PublicKey& pubKey, TWCurve curve) const {
     bool success = ecdh_multiply(&secp256k1, bytes.data(),
                                  pubKey.bytes.data(), result.data()) == 0;
 
-    if (!success) {
-        return {};
+    if (success) {
+        PublicKey sharedKey(result, TWPublicKeyTypeSECP256k1Extended);
+        auto hash = Hash::sha256(sharedKey.compressed().bytes);
+        return hash;
     }
 
-    PublicKey sharedKey(result, TWPublicKeyTypeSECP256k1Extended);
-    auto hash = Hash::sha256(sharedKey.compressed().bytes);
-    return hash;
+    return {};
 }
 
 int ecdsa_sign_digest_checked(const ecdsa_curve *curve, const uint8_t *priv_key, const uint8_t *digest, size_t digest_size, uint8_t *sig, uint8_t *pby, int (*is_canonical)(uint8_t by, uint8_t sig[64])) {

--- a/src/PrivateKey.h
+++ b/src/PrivateKey.h
@@ -53,8 +53,9 @@ class PrivateKey {
     /// Returns the public key for this private key.
     PublicKey getPublicKey(enum TWPublicKeyType type) const;
 
-    /// Performs ECDH derivation
-    Data deriveECDH(const PublicKey& publicKey) const;
+    /// Computes an EC Diffie-Hellman secret in constant time
+    /// Supported curves: secp256k1
+    Data getSharedKey(const PublicKey& publicKey, TWCurve curve) const;
 
     /// Signs a digest using the given ECDSA curve.
     Data sign(const Data& digest, TWCurve curve) const;

--- a/src/PrivateKey.h
+++ b/src/PrivateKey.h
@@ -53,6 +53,9 @@ class PrivateKey {
     /// Returns the public key for this private key.
     PublicKey getPublicKey(enum TWPublicKeyType type) const;
 
+    /// Performs ECDH derivation
+    Data deriveECDH(const PublicKey& publicKey) const;
+
     /// Signs a digest using the given ECDSA curve.
     Data sign(const Data& digest, TWCurve curve) const;
 

--- a/src/interface/TWPrivateKey.cpp
+++ b/src/interface/TWPrivateKey.cpp
@@ -89,7 +89,7 @@ struct TWPublicKey *_Nonnull TWPrivateKeyGetPublicKeyCurve25519(struct TWPrivate
     return new TWPublicKey{pk->impl.getPublicKey(TWPublicKeyTypeCURVE25519)};
 }
 
-TWData *_Nullable TWPrivateKeyGetSharedkey(struct TWPrivateKey *_Nonnull pk, struct TWPublicKey *_Nonnull publicKey, enum TWCurve curve) {
+TWData *_Nullable TWPrivateKeyGetSharedKey(struct TWPrivateKey *_Nonnull pk, struct TWPublicKey *_Nonnull publicKey, enum TWCurve curve) {
     auto result = pk->impl.getSharedKey(publicKey->impl, curve);
     if (result.empty()) {
         return nullptr;

--- a/src/interface/TWPrivateKey.cpp
+++ b/src/interface/TWPrivateKey.cpp
@@ -89,6 +89,15 @@ struct TWPublicKey *_Nonnull TWPrivateKeyGetPublicKeyCurve25519(struct TWPrivate
     return new TWPublicKey{pk->impl.getPublicKey(TWPublicKeyTypeCURVE25519)};
 }
 
+TWData *_Nullable TWPrivateKeyGetSharedkey(struct TWPrivateKey *_Nonnull pk, struct TWPublicKey *_Nonnull publicKey, enum TWCurve curve) {
+    auto result = pk->impl.getSharedKey(publicKey->impl, curve);
+    if (result.empty()) {
+        return nullptr;
+    } else {
+        return TWDataCreateWithBytes(result.data(), result.size());
+    }
+}
+
 TWData *TWPrivateKeySign(struct TWPrivateKey *_Nonnull pk, TWData *_Nonnull digest, enum TWCurve curve) {
     const auto& d = *reinterpret_cast<const Data*>(digest);
     auto result = pk->impl.sign(d, curve);

--- a/src/interface/TWPrivateKey.cpp
+++ b/src/interface/TWPrivateKey.cpp
@@ -89,7 +89,7 @@ struct TWPublicKey *_Nonnull TWPrivateKeyGetPublicKeyCurve25519(struct TWPrivate
     return new TWPublicKey{pk->impl.getPublicKey(TWPublicKeyTypeCURVE25519)};
 }
 
-TWData *_Nullable TWPrivateKeyGetSharedKey(struct TWPrivateKey *_Nonnull pk, struct TWPublicKey *_Nonnull publicKey, enum TWCurve curve) {
+TWData *_Nullable TWPrivateKeyGetSharedKey(const struct TWPrivateKey *_Nonnull pk, const struct TWPublicKey *_Nonnull publicKey, enum TWCurve curve) {
     auto result = pk->impl.getSharedKey(publicKey->impl, curve);
     if (result.empty()) {
         return nullptr;

--- a/swift/Tests/PrivateKeyTests.swift
+++ b/swift/Tests/PrivateKeyTests.swift
@@ -44,6 +44,15 @@ class PrivateKeyTests: XCTestCase {
         XCTAssertEqual(derivedData.hexString, "ef2cf705af8714b35c0855030f358f2bee356ff3579cea2607b2025d80133c3a")
     }
 
+    func testGetSharedKeyWycherproof() {
+        let privateKey = PrivateKey(data: Data(hexString: "f4b7ff7cccc98813a69fae3df222bfe3f4e28f764bf91b4a10d8096ce446b254")!)!
+        let publicKey = PublicKey(data: Data(hexString: "02d8096af8a11e0b80037e1ee68246b5dcbb0aeb1cf1244fd767db80f3fa27da2b")!, type: .secp256k1)!
+
+        let derivedData = privateKey.getSharedKey(publicKey: publicKey, curve: .secp256k1)!
+
+        XCTAssertEqual(derivedData.hexString, "81165066322732362ca5d3f0991d7f1f7d0aad7ea533276496785d369e35159a")
+    }    
+
     func testGetSharedKeyBidirectional() {
         let privateKey1 = PrivateKey(data: Data(hexString: "9cd3b16e10bd574fed3743d8e0de0b7b4e6c69f3245ab5a168ef010d22bfefa0")!)!
         let publicKey1 = privateKey1.getPublicKeySecp256k1(compressed: false)

--- a/swift/Tests/PrivateKeyTests.swift
+++ b/swift/Tests/PrivateKeyTests.swift
@@ -35,6 +35,35 @@ class PrivateKeyTests: XCTestCase {
         XCTAssertEqual(publicKey.data.hexString, "0499c6f51ad6f98c9c583f8e92bb7758ab2ca9a04110c0a1126ec43e5453d196c166b489a4b7c491e7688e6ebea3a71fc3a1a48d60f98d5ce84c93b65e423fde91")
     }
 
+    func testGetSharedKey() {
+        let privateKey = PrivateKey(data: Data(hexString: "9cd3b16e10bd574fed3743d8e0de0b7b4e6c69f3245ab5a168ef010d22bfefa0")!)!
+        let publicKey = PublicKey(data: Data(hexString: "02a18a98316b5f52596e75bfa5ca9fa9912edd0c989b86b73d41bb64c9c6adb992")!, type: .secp256k1)!
+
+        let derivedData = privateKey.getSharedKey(publicKey: publicKey, curve: .secp256k1)!
+
+        XCTAssertEqual(derivedData.hexString, "ef2cf705af8714b35c0855030f358f2bee356ff3579cea2607b2025d80133c3a")
+    }
+
+    func testGetSharedKeyBidirectional() {
+        let privateKey1 = PrivateKey(data: Data(hexString: "9cd3b16e10bd574fed3743d8e0de0b7b4e6c69f3245ab5a168ef010d22bfefa0")!)!
+        let publicKey1 = privateKey1.getPublicKeySecp256k1(compressed: false)
+        let privateKey2 = PrivateKey(data: Data(hexString: "ef2cf705af8714b35c0855030f358f2bee356ff3579cea2607b2025d80133c3a")!)!
+        let publicKey2 = privateKey2.getPublicKeySecp256k1(compressed: false)
+
+        let derivedData1 = privateKey1.getSharedKey(publicKey: publicKey2, curve: .secp256k1)!
+        let derivedData2 = privateKey2.getSharedKey(publicKey: publicKey1, curve: .secp256k1)!
+
+        XCTAssertEqual(derivedData1.hexString, derivedData2.hexString)
+    }
+
+    func testGetSharedKeyError() {
+        let privateKey = PrivateKey(data: Data(hexString: "9cd3b16e10bd574fed3743d8e0de0b7b4e6c69f3245ab5a168ef010d22bfefa0")!)!
+        let publicKey = PublicKey(data: Data(hexString: "02a18a98316b5f52596e75bfa5ca9fa9912edd0c989b86b73d41bb64c9c6adb992")!, type: .secp256k1)!
+
+        let derivedData = privateKey.getSharedKey(publicKey: publicKey, curve: .ed25519)
+        XCTAssertNil(derivedData)
+    }
+
     func testSignSchnorr() {
         let privateKey = PrivateKey(data: Data(hexString: "afeefca74d9a325cf1d6b6911d61a65c32afa8e02bd5e78e2e4ac2910bab45f5")!)!
         let publicKey = privateKey.getPublicKeySecp256k1(compressed: true)

--- a/tests/PrivateKeyTests.cpp
+++ b/tests/PrivateKeyTests.cpp
@@ -189,6 +189,21 @@ TEST(PrivateKey, PrivateKeyExtendedError) {
     FAIL() << "Should throw Invalid empty key extension";
 }
 
+TEST(PrivateKey, DeriveECDH) {
+    Data privKeyData = parse_hex("afeefca74d9a325cf1d6b6911d61a65c32afa8e02bd5e78e2e4ac2910bab45f5");
+    auto privateKey = PrivateKey(privKeyData);
+
+    const Data pubKeyData = parse_hex("02a18a98316b5f52596e75bfa5ca9fa9912edd0c989b86b73d41bb64c9c6adb992");
+    PublicKey publicKey(pubKeyData, TWPublicKeyTypeSECP256k1);
+
+    const Data derivedKeyData = privateKey.deriveECDH(publicKey);
+
+    EXPECT_EQ(
+        "ef2cf705af8714b35c0855030f358f2bee356ff3579cea2607b2025d80133c3a",
+        hex(derivedKeyData)
+    );
+}
+
 TEST(PrivateKey, SignSECP256k1) {
     Data privKeyData = parse_hex("afeefca74d9a325cf1d6b6911d61a65c32afa8e02bd5e78e2e4ac2910bab45f5");
     auto privateKey = PrivateKey(privKeyData);

--- a/tests/PrivateKeyTests.cpp
+++ b/tests/PrivateKeyTests.cpp
@@ -224,6 +224,19 @@ TEST(PrivateKey, getSharedKeyBidirectional) {
     EXPECT_EQ(hex(derivedKeyData1), hex(derivedKeyData2));
 }
 
+TEST(PrivateKey, getSharedKeyError) {
+    Data privKeyData = parse_hex("9cd3b16e10bd574fed3743d8e0de0b7b4e6c69f3245ab5a168ef010d22bfefa0");
+    auto privateKey = PrivateKey(privKeyData);
+
+    const Data pubKeyData = parse_hex("02a18a98316b5f52596e75bfa5ca9fa9912edd0c989b86b73d41bb64c9c6adb992");
+    PublicKey publicKey(pubKeyData, TWPublicKeyTypeSECP256k1);
+
+    const Data derivedKeyData = privateKey.getSharedKey(publicKey, TWCurveCurve25519);
+    const Data expected = {};
+
+    EXPECT_EQ(expected, derivedKeyData);
+}
+
 TEST(PrivateKey, SignSECP256k1) {
     Data privKeyData = parse_hex("afeefca74d9a325cf1d6b6911d61a65c32afa8e02bd5e78e2e4ac2910bab45f5");
     auto privateKey = PrivateKey(privKeyData);

--- a/tests/PrivateKeyTests.cpp
+++ b/tests/PrivateKeyTests.cpp
@@ -207,6 +207,31 @@ TEST(PrivateKey, getSharedKey) {
     );
 }
 
+/**
+ * Valid test vector from Wycherproof project
+ * Source: https://github.com/google/wycheproof/blob/master/testvectors/ecdh_secp256k1_test.json#L31
+ */
+TEST(PrivateKey, getSharedKeyWycherproof) {
+    // Stripped left-padded zeroes from: `00f4b7ff7cccc98813a69fae3df222bfe3f4e28f764bf91b4a10d8096ce446b254`
+    Data privKeyData = parse_hex("f4b7ff7cccc98813a69fae3df222bfe3f4e28f764bf91b4a10d8096ce446b254");
+    EXPECT_TRUE(PrivateKey::isValid(privKeyData, TWCurveSECP256k1));
+    auto privateKey = PrivateKey(privKeyData);
+
+    // Decoded from ASN.1 & uncompressed `3056301006072a8648ce3d020106052b8104000a03420004d8096af8a11e0b80037e1ee68246b5dcbb0aeb1cf1244fd767db80f3fa27da2b396812ea1686e7472e9692eaf3e958e50e9500d3b4c77243db1f2acd67ba9cc4`
+    const Data pubKeyData = parse_hex("02d8096af8a11e0b80037e1ee68246b5dcbb0aeb1cf1244fd767db80f3fa27da2b");
+    EXPECT_TRUE(PublicKey::isValid(pubKeyData, TWPublicKeyTypeSECP256k1));
+    PublicKey publicKey(pubKeyData, TWPublicKeyTypeSECP256k1);
+    EXPECT_TRUE(publicKey.isCompressed());
+
+    const Data derivedKeyData = privateKey.getSharedKey(publicKey, TWCurveSECP256k1);
+    
+    // SHA-256 of encoded x-coordinate `02544dfae22af6af939042b1d85b71a1e49e9a5614123c4d6ad0c8af65baf87d65`
+    EXPECT_EQ(
+        "81165066322732362ca5d3f0991d7f1f7d0aad7ea533276496785d369e35159a",
+        hex(derivedKeyData)
+    );
+}
+
 TEST(PrivateKey, getSharedKeyBidirectional) {
     Data privKeyData1 = parse_hex("9cd3b16e10bd574fed3743d8e0de0b7b4e6c69f3245ab5a168ef010d22bfefa0");
     EXPECT_TRUE(PrivateKey::isValid(privKeyData1, TWCurveSECP256k1));

--- a/tests/interface/TWPrivateKeyTests.cpp
+++ b/tests/interface/TWPrivateKeyTests.cpp
@@ -98,6 +98,19 @@ TEST(TWPrivateKeyTests, GetSharedKey) {
     ASSERT_EQ(TW::hex(*((TW::Data*)derivedData.get())), "ef2cf705af8714b35c0855030f358f2bee356ff3579cea2607b2025d80133c3a");
 }
 
+TEST(TWPrivateKeyTests, GetSharedKeyWycherproof) {
+    const auto privateKeyHex = "f4b7ff7cccc98813a69fae3df222bfe3f4e28f764bf91b4a10d8096ce446b254";
+    const auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA(privateKeyHex).get()));
+    ASSERT_TRUE(privateKey.get() != nullptr);
+
+    const auto publicKeyHex = "02d8096af8a11e0b80037e1ee68246b5dcbb0aeb1cf1244fd767db80f3fa27da2b";
+    const auto publicKey = WRAP(TWPublicKey, TWPublicKeyCreateWithData(DATA(publicKeyHex).get(), TWPublicKeyTypeSECP256k1));
+    EXPECT_TRUE(publicKey != nullptr);
+
+    const auto derivedData = WRAPD(TWPrivateKeyGetSharedKey(privateKey.get(), publicKey.get(), TWCurveSECP256k1));
+    ASSERT_EQ(TW::hex(*((TW::Data*)derivedData.get())), "81165066322732362ca5d3f0991d7f1f7d0aad7ea533276496785d369e35159a");
+}
+
 TEST(TWPrivateKeyTests, GetSharedKeyBidirectional) {
     const auto privateKeyHex1 = "9cd3b16e10bd574fed3743d8e0de0b7b4e6c69f3245ab5a168ef010d22bfefa0";
     const auto privateKey1 = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA(privateKeyHex1).get()));

--- a/tests/interface/TWPrivateKeyTests.cpp
+++ b/tests/interface/TWPrivateKeyTests.cpp
@@ -98,15 +98,22 @@ TEST(TWPrivateKeyTests, GetSharedKey) {
     ASSERT_EQ(TW::hex(*((TW::Data*)derivedData.get())), "ef2cf705af8714b35c0855030f358f2bee356ff3579cea2607b2025d80133c3a");
 }
 
+/**
+ * Valid test vector from Wycherproof project
+ * Source: https://github.com/google/wycheproof/blob/master/testvectors/ecdh_secp256k1_test.json#L31
+ */
 TEST(TWPrivateKeyTests, GetSharedKeyWycherproof) {
+    // Stripped left-padded zeroes from: `00f4b7ff7cccc98813a69fae3df222bfe3f4e28f764bf91b4a10d8096ce446b254`
     const auto privateKeyHex = "f4b7ff7cccc98813a69fae3df222bfe3f4e28f764bf91b4a10d8096ce446b254";
     const auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA(privateKeyHex).get()));
     ASSERT_TRUE(privateKey.get() != nullptr);
 
+    // Decoded from ASN.1 & uncompressed `3056301006072a8648ce3d020106052b8104000a03420004d8096af8a11e0b80037e1ee68246b5dcbb0aeb1cf1244fd767db80f3fa27da2b396812ea1686e7472e9692eaf3e958e50e9500d3b4c77243db1f2acd67ba9cc4`
     const auto publicKeyHex = "02d8096af8a11e0b80037e1ee68246b5dcbb0aeb1cf1244fd767db80f3fa27da2b";
     const auto publicKey = WRAP(TWPublicKey, TWPublicKeyCreateWithData(DATA(publicKeyHex).get(), TWPublicKeyTypeSECP256k1));
     EXPECT_TRUE(publicKey != nullptr);
 
+    // SHA-256 of encoded x-coordinate `02544dfae22af6af939042b1d85b71a1e49e9a5614123c4d6ad0c8af65baf87d65`
     const auto derivedData = WRAPD(TWPrivateKeyGetSharedKey(privateKey.get(), publicKey.get(), TWCurveSECP256k1));
     ASSERT_EQ(TW::hex(*((TW::Data*)derivedData.get())), "81165066322732362ca5d3f0991d7f1f7d0aad7ea533276496785d369e35159a");
 }

--- a/tests/interface/TWPrivateKeyTests.cpp
+++ b/tests/interface/TWPrivateKeyTests.cpp
@@ -85,6 +85,47 @@ TEST(TWPrivateKeyTests, PublicKey) {
     }
 }
 
+TEST(TWPrivateKeyTests, GetSharedKey) {
+    const auto privateKeyHex = "9cd3b16e10bd574fed3743d8e0de0b7b4e6c69f3245ab5a168ef010d22bfefa0";
+    const auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA(privateKeyHex).get()));
+    ASSERT_TRUE(privateKey.get() != nullptr);
+
+    const auto publicKeyHex = "02a18a98316b5f52596e75bfa5ca9fa9912edd0c989b86b73d41bb64c9c6adb992";
+    const auto publicKey = WRAP(TWPublicKey, TWPublicKeyCreateWithData(DATA(publicKeyHex).get(), TWPublicKeyTypeSECP256k1));
+    EXPECT_TRUE(publicKey != nullptr);
+
+    const auto derivedData = WRAPD(TWPrivateKeyGetSharedKey(privateKey.get(), publicKey.get(), TWCurveSECP256k1));
+    ASSERT_EQ(TW::hex(*((TW::Data*)derivedData.get())), "ef2cf705af8714b35c0855030f358f2bee356ff3579cea2607b2025d80133c3a");
+}
+
+TEST(TWPrivateKeyTests, GetSharedKeyBidirectional) {
+    const auto privateKeyHex1 = "9cd3b16e10bd574fed3743d8e0de0b7b4e6c69f3245ab5a168ef010d22bfefa0";
+    const auto privateKey1 = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA(privateKeyHex1).get()));
+    ASSERT_TRUE(privateKey1.get() != nullptr);
+    auto publicKey1 = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey1.get(), true));
+
+    const auto privateKeyHex2 = "ef2cf705af8714b35c0855030f358f2bee356ff3579cea2607b2025d80133c3a";
+    const auto privateKey2 = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA(privateKeyHex2).get()));
+    ASSERT_TRUE(privateKey2.get() != nullptr);
+    auto publicKey2 = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(privateKey2.get(), true));
+
+    const auto derivedData1 = WRAPD(TWPrivateKeyGetSharedKey(privateKey1.get(), publicKey2.get(), TWCurveSECP256k1));
+    const auto derivedData2 = WRAPD(TWPrivateKeyGetSharedKey(privateKey2.get(), publicKey1.get(), TWCurveSECP256k1));
+    ASSERT_EQ(TW::hex(*((TW::Data*)derivedData1.get())), TW::hex(*((TW::Data*)derivedData2.get())));
+}
+
+TEST(TWPrivateKeyTests, GetSharedKeyError) {
+    const auto privateKeyHex = "9cd3b16e10bd574fed3743d8e0de0b7b4e6c69f3245ab5a168ef010d22bfefa0";
+    const auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA(privateKeyHex).get()));
+    ASSERT_TRUE(privateKey.get() != nullptr);
+
+    const auto publicKeyHex = "02a18a98316b5f52596e75bfa5ca9fa9912edd0c989b86b73d41bb64c9c6adb992";
+    const auto publicKey = WRAP(TWPublicKey, TWPublicKeyCreateWithData(DATA(publicKeyHex).get(), TWPublicKeyTypeSECP256k1));
+    EXPECT_TRUE(publicKey != nullptr);
+
+    const auto derivedData = WRAPD(TWPrivateKeyGetSharedKey(privateKey.get(), publicKey.get(), TWCurveED25519));
+    EXPECT_TRUE(derivedData == nullptr);
+}
 
 TEST(TWPrivateKeyTests, Sign) {
     const auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA("afeefca74d9a325cf1d6b6911d61a65c32afa8e02bd5e78e2e4ac2910bab45f5").get()));


### PR DESCRIPTION
## Description

This PR exposes [ECDH Shared Key Computation](https://cryptobook.nakov.com/asymmetric-key-ciphers/ecdh-key-exchange) function on `PrivateKey` interface, which is commonly used across crypto applications. 

Internally it calls `ecdh_multiply()` from `TrezorCrypto`, computes SHA-256 hash from compressed version of resulting key - [in the same manner as libsecp256k1](https://crypto.stackexchange.com/a/57727)

## Testing instructions

Core library tests:

```sh
$ make -Cbuild
$ ./build/tests/tests tests --gtest_filter="PrivateKey*"
$ ./build/tests/tests tests --gtest_filter="TWPrivateKey*"
```

iOS tests:

```sh
$ ./tools/ios-test
```

Android tests:

```sh
$ ./tools/android-test
```

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
