### PR TITLE
Remove unnecessary null terminator

### DIFF
--- a/include/TrustWalletCore/TWString.h
+++ b/include/TrustWalletCore/TWString.h
@@ -34,7 +34,7 @@ size_t TWStringSize(TWString *_Nonnull string);
 /// Returns the byte at the provided index.
 char TWStringGet(TWString *_Nonnull string, size_t index);
 
-/// Returns the raw pointer to the string's UTF8 bytes.
+/// Returns the raw pointer to the string's UTF8 bytes (null-terminated).
 const char *_Nonnull TWStringUTF8Bytes(TWString *_Nonnull string);
 
 /// Deletes a string created with a `TWStringCreate*` method.  After delete it must not be used (can segfault)!

--- a/src/interface/TWString.cpp
+++ b/src/interface/TWString.cpp
@@ -30,7 +30,7 @@ char TWStringGet(TWString *_Nonnull string, size_t index) {
 
 const char *_Nonnull TWStringUTF8Bytes(TWString *_Nonnull string) {
     auto s = reinterpret_cast<const std::string*>(string);
-    return s->data();
+    return s->c_str();
 }
 
 void TWStringDelete(TWString *_Nonnull string) {

--- a/src/interface/TWString.cpp
+++ b/src/interface/TWString.cpp
@@ -15,8 +15,6 @@ TWString *_Nonnull TWStringCreateWithUTF8Bytes(const char *_Nonnull bytes) {
 
 TWString *_Nonnull TWStringCreateWithRawBytes(const uint8_t *_Nonnull bytes, size_t size) {
     auto s = new std::string(bytes, bytes + size);
-    // append null terminator
-    s->append(size, '\0');
     return s;
 }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

No need to append `size` number of '\0' in function TWStringCreateWithRawBytes. TWStringSize would output `2 * size` without this fix, I think this is unnecessary.
```
TWString *_Nonnull TWStringCreateWithUTF8Bytes(const char *_Nonnull bytes) {
    auto s = new std::string(bytes);
    return s;
}

TWString *_Nonnull TWStringCreateWithRawBytes(const uint8_t *_Nonnull bytes, size_t size) {
    auto s = new std::string(bytes, bytes + size);
    // append null terminator
    s->append(size, '\0');                     // Don't need this
    return s;
}
```
Just like TWStringCreateWithUTF8Bytes, we don't append '\0'. We also no need to append '\0' in function TWStringCreateWithRawBytes.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
