### PR TITLE
Eth signing: Add tx hash to SigningOutput

### DIFF
--- a/src/Ethereum/Signer.cpp
+++ b/src/Ethereum/Signer.cpp
@@ -37,8 +37,6 @@ Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) noexcept {
         output.set_data(transaction.payload.data(), transaction.payload.size());
 
         output.set_pre_hash(preHash.data(), preHash.size());
-        auto postHash = Hash::keccak256(encoded);
-        output.set_hash(postHash.data(), postHash.size());
 
         return output;
     } catch (std::exception&) {

--- a/src/proto/Ethereum.proto
+++ b/src/proto/Ethereum.proto
@@ -106,11 +106,9 @@ message SigningOutput {
     bytes r = 3;
     bytes s = 4;
 
-    // The pre-sign tx hash, used for signing
-    bytes pre_hash = 5;
-    // The hash of the signed tx
-    bytes hash = 6;
-
     // The payload part, supplied in the input or assembled from input parameters
-    bytes data = 7;
+    bytes data = 5;
+
+    // The pre-sign tx hash, used for signing
+    bytes pre_hash = 6;
 }

--- a/tests/Ethereum/TWAnySignerTests.cpp
+++ b/tests/Ethereum/TWAnySignerTests.cpp
@@ -72,7 +72,6 @@ TEST(TWAnySignerEthereum, Sign) {
 
         EXPECT_EQ(hex(output.encoded()), expected);
         EXPECT_EQ(hex(output.pre_hash()), "5d2556f7d0e629dc6ce9dbc8a205853a7b89c136791840a39765e34cb5e3466a");
-        EXPECT_EQ(hex(output.hash()), "5e431ce521158c97a83c7068f246c8d237bb2a5796475be7ed71bfff50fba51e");
         EXPECT_EQ(hex(output.data()), hex(data));
     }
 }
@@ -109,7 +108,6 @@ TEST(TWAnySignerEthereum, SignERC20TransferAsERC20) {
     EXPECT_EQ(hex(output.encoded()), expected);
 
     EXPECT_EQ(hex(output.pre_hash()), "3a3fc6df8815e15874cc8d6c65f88ea0643b375e5b22726269d187035a5cb486");
-    EXPECT_EQ(hex(output.hash()), "199a7829fc5149e49b452c2cab76d8fa5a9682fee6e4891b8acb697ac142513e");
 
     // expected payload
     Data payload;


### PR DESCRIPTION
## Description

Extend Ethereum SigninOutput with tx hashes: the tx pre-hash (used for singing), and the final hash of the signed tx (which will be the ID of this tx).  This can be useful in some use cases (e.g. own signing).
Eth proto file is affected.

## Testing instructions

Unit tests, `*Ethereum*`.

## Types of changes

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
