### PR TITLE
Oasis backward changes

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
@@ -90,7 +90,7 @@ class CoinAddressDerivationTests {
         ELROND -> assertEquals("erd1jfcy8aeru6vlx4fe6h3pc3vlpe2cnnur5zetxdhp879yagq7vqvs8na4f8", address)
         BANDCHAIN -> assertEquals("band1624hqgend0s3d94z68fyka2y5jak6vd7u0l50r", address)
         SMARTCHAINLEGACY -> assertEquals("0x49784f90176D8D9d4A3feCDE7C1373dAAb5b13b8", address)
-        OASIS -> assertEquals("oasis1qr2wymrk4mmt4kyjg3rzkn6jsxku3kk6p5jvrvxz", address)
+        OASIS -> assertEquals("oasis1qzcpavvmuw280dk0kd4lxjhtpf0u3ll27yf7sqps", address)
         THORCHAIN -> assertEquals("thor1c8jd7ad9pcw4k3wkuqlkz4auv95mldr2kyhc65", address)
     }
 }

--- a/coins.json
+++ b/coins.json
@@ -1214,7 +1214,6 @@
     "decimals": 9,
     "blockchain": "OasisNetwork",
     "derivationPath": "m/44'/474'/0'",
-    "derivationPath": "m/44'/474'/0'", 
     "curve": "ed25519",
     "publicKeyType": "ed25519",
     "hrp": "oasis",
@@ -1226,10 +1225,10 @@
       "sampleAccount": "oasis1qrx376dmwuckmruzn9vq64n49clw72lywctvxdf4"
     },
     "info": {
-      "url": "https://www.oasislabs.com/",
+      "url": "https://oasisprotocol.org/",
       "client": "https://github.com/oasisprotocol/oasis-core",
-      "clientPublic": "https://rosetta.oasis.dev/api/",
-      "clientDocs": "https://github.com/oasisprotocol/oasis-core/blob/master/docs/oasis-node/rpc.md"
+      "clientPublic": "https://rosetta.oasis.dev/api/v1",
+      "clientDocs": "https://docs.oasis.dev/oasis-core/"
     }
   },
   {

--- a/coins.json
+++ b/coins.json
@@ -1214,6 +1214,7 @@
     "decimals": 9,
     "blockchain": "OasisNetwork",
     "derivationPath": "m/44'/474'/0'",
+    "derivationPath": "m/44'/474'/0'", 
     "curve": "ed25519",
     "publicKeyType": "ed25519",
     "hrp": "oasis",

--- a/coins.json
+++ b/coins.json
@@ -1213,8 +1213,8 @@
     "symbol": "ROSE",
     "decimals": 9,
     "blockchain": "OasisNetwork",
-    "derivationPath": "m/44'/474'/0'/0'/0'",
-    "curve": "ed25519HD",
+    "derivationPath": "m/44'/474'/0'",
+    "curve": "ed25519",
     "publicKeyType": "ed25519",
     "hrp": "oasis",
     "explorer": {

--- a/include/TrustWalletCore/TWCurve.h
+++ b/include/TrustWalletCore/TWCurve.h
@@ -15,7 +15,6 @@ TW_EXPORT_ENUM()
 enum TWCurve {
     TWCurveSECP256k1              /* "secp256k1" */,
     TWCurveED25519                /* "ed25519" */,
-    TWCurveED25519HD              /* "ed25519-hd" */,
     TWCurveED25519Blake2bNano     /* "ed25519-blake2b-nano" */,
     TWCurveCurve25519             /* "curve25519" */,
     TWCurveNIST256p1              /* "nist256p1" */,

--- a/src/HDWallet.cpp
+++ b/src/HDWallet.cpp
@@ -180,8 +180,6 @@ HDWallet::PrivateKeyType HDWallet::getPrivateKeyType(TWCurve curve) {
     case TWCurve::TWCurveED25519Extended:
         // used by Cardano
         return PrivateKeyTypeExtended96;
-    case TWCurve::TWCurveED25519HD:
-        return PrivateKeyTypeHD;
     default:
         // default
         return PrivateKeyTypeDefault32;
@@ -251,7 +249,6 @@ HDNode getNode(const HDWallet& wallet, TWCurve curve, const DerivationPath& deri
     auto node = getMasterNode(wallet, curve);
     for (auto& index : derivationPath.indices) {
         switch (privateKeyType) {
-            case HDWallet::PrivateKeyTypeHD:
             case HDWallet::PrivateKeyTypeExtended96:
                 // special handling for extended
                 hdnode_private_ckd_cardano(&node, index.derivationIndex());
@@ -273,9 +270,6 @@ HDNode getMasterNode(const HDWallet& wallet, TWCurve curve) {
             // special handling for extended, use entropy (not seed)
             hdnode_from_entropy_cardano_icarus((const uint8_t*)"", 0, wallet.entropy.data(), (int)wallet.entropy.size(), &node);
             break;
-        case HDWallet::PrivateKeyTypeHD:
-            hdnode_from_seed_hd(wallet.seed.data(), HDWallet::seedSize, curveName(curve), &node);
-            break;
         case HDWallet::PrivateKeyTypeDefault32:
         default:
             hdnode_from_seed(wallet.seed.data(), HDWallet::seedSize, curveName(curve), &node);
@@ -290,8 +284,6 @@ const char* curveName(TWCurve curve) {
         return SECP256K1_NAME;
     case TWCurveED25519:
         return ED25519_NAME;
-    case TWCurveED25519HD:
-        return ED25519_HD_NAME;
     case TWCurveED25519Blake2bNano:
         return ED25519_BLAKE2B_NANO_NAME;
     case TWCurveED25519Extended:

--- a/src/HDWallet.h
+++ b/src/HDWallet.h
@@ -90,7 +90,6 @@ class HDWallet {
     enum PrivateKeyType {
       PrivateKeyTypeDefault32 = 0, // 32-byte private key
       PrivateKeyTypeExtended96 = 1, // 3*32-byte extended private key
-      PrivateKeyTypeHD = 2,         // 32-byte private key
     };
     
     // obtain privateKeyType used by the coin/curve

--- a/src/PrivateKey.cpp
+++ b/src/PrivateKey.cpp
@@ -181,7 +181,6 @@ Data PrivateKey::sign(const Data& digest, TWCurve curve) const {
         success = ecdsa_sign_digest_checked(&secp256k1, bytes.data(), digest.data(), digest.size(), result.data(),
                                     result.data() + 64, nullptr) == 0;
     } break;
-    case TWCurveED25519HD:
     case TWCurveED25519: {
         result.resize(64);
         const auto publicKey = getPublicKey(TWPublicKeyTypeED25519);

--- a/swift/Tests/CoinAddressDerivationTests.swift
+++ b/swift/Tests/CoinAddressDerivationTests.swift
@@ -203,7 +203,7 @@ class CoinAddressDerivationTests: XCTestCase {
                     let expectedResult = "0x49784f90176D8D9d4A3feCDE7C1373dAAb5b13b8"
                     assertCoinDerivation(coin, expectedResult, derivedAddress, address)
                 case .oasis:
-                    let expectedResult = "oasis1qr2wymrk4mmt4kyjg3rzkn6jsxku3kk6p5jvrvxz"
+                    let expectedResult = "oasis1qzcpavvmuw280dk0kd4lxjhtpf0u3ll27yf7sqps"
                     assertCoinDerivation(coin, expectedResult, derivedAddress, address)
                 case .thorchain:
                     let expectedResult = "thor1c8jd7ad9pcw4k3wkuqlkz4auv95mldr2kyhc65"

--- a/trezor-crypto/crypto/bip32.c
+++ b/trezor-crypto/crypto/bip32.c
@@ -54,16 +54,6 @@
 
 #define CARDANO_MAX_NODE_DEPTH 1048576
 
-// [wallet-core]
-const curve_info ed25519_hd_info = {
-    .bip32_name = "ed25519 seed",
-    .params = NULL,
-    .hasher_base58 = HASHER_SHA2D,
-    .hasher_sign = HASHER_SHA2D,
-    .hasher_pubkey = HASHER_SHA2_RIPEMD,
-    .hasher_script = HASHER_SHA2,
-};
-
 const curve_info ed25519_info = {
     .bip32_name = "ed25519 seed",
     .params = NULL,
@@ -631,8 +621,6 @@ void hdnode_fill_public_key(HDNode *node) {
     node->public_key[0] = 1;
     if (node->curve == &ed25519_info) {
       ed25519_publickey(node->private_key, node->public_key + 1);
-    } else if (node->curve == &ed25519_hd_info) { // [wallet-core]
-      ed25519_publickey_ext(node->private_key, node->private_key_extension, node->public_key + 1);
     } else if (node->curve == &ed25519_sha3_info) {
       ed25519_publickey_sha3(node->private_key, node->public_key + 1);
 #if USE_KECCAK
@@ -792,8 +780,6 @@ int hdnode_sign(HDNode *node, const uint8_t *msg, uint32_t msg_len,
     if (node->curve == &ed25519_info) {
       hdnode_fill_public_key(node);
       ed25519_sign(msg, msg_len, node->private_key, node->public_key + 1, sig);
-		} else if (node->curve == &ed25519_hd_info) { // [wallet-core]
-			ed25519_sign(msg, msg_len, node->private_key, node->public_key + 1, sig);
     } else if (node->curve == &ed25519_sha3_info) {
       hdnode_fill_public_key(node);
       ed25519_sign_sha3(msg, msg_len, node->private_key, node->public_key + 1,

--- a/trezor-crypto/crypto/curves.c
+++ b/trezor-crypto/crypto/curves.c
@@ -28,7 +28,6 @@ const char SECP256K1_GROESTL_NAME[] = "secp256k1-groestl";
 const char SECP256K1_SMART_NAME[] = "secp256k1-smart";
 const char NIST256P1_NAME[] = "nist256p1";
 const char ED25519_NAME[] = "ed25519";
-const char ED25519_HD_NAME[] = "ed25519-hd"; // [wallet-core]
 const char ED25519_CARDANO_NAME[] = "ed25519 cardano seed";
 const char ED25519_BLAKE2B_NANO_NAME[] = "ed25519-blake2b-nano"; // [wallet-core]
 const char ED25519_SHA3_NAME[] = "ed25519-sha3";

--- a/trezor-crypto/crypto/tests/test_check.c
+++ b/trezor-crypto/crypto/tests/test_check.c
@@ -9147,12 +9147,6 @@ Suite *test_suite(void) {
   tcase_add_test(tc, test_output_script);
   suite_add_tcase(s, tc);
 
-  // [wallet-core]
-  tc = tcase_create("bip32-hd");
-  tcase_add_test(tc, test_bip32_hd_hdnode_vector_1);
-  tcase_add_test(tc, test_bip32_hd_hdnode_vector_2);
-  suite_add_tcase(s, tc);
-
 #if USE_ETHEREUM
   tc = tcase_create("ethereum_pubkeyhash");
   tcase_add_test(tc, test_ethereum_pubkeyhash);

--- a/trezor-crypto/crypto/tests/test_check.c
+++ b/trezor-crypto/crypto/tests/test_check.c
@@ -8670,43 +8670,6 @@ START_TEST(test_compress_coords) {
 END_TEST
 
 // [wallet-core]
-START_TEST(test_bip32_hd_hdnode_vector_1)
-{
-  HDNode node;
-
-  uint8_t seed[66];
-  mnemonic_to_seed("ring crime symptom enough erupt lady behave ramp apart settle citizen junk", "", seed, 0);
-  hdnode_from_seed_hd(seed, 64, ED25519_HD_NAME, &node);
-
-  ck_assert_mem_eq(node.chain_code,  fromhex("683eabed80a3fa7a0255f6aa411577340c8a5bfeac3b763cf410f397fb1e8082"), 32);
-  ck_assert_mem_eq(node.private_key, fromhex("d05fbe16dc827df7401690268928789886d8c401f5715a1664f3c48197707659"), 32);
-  ck_assert_mem_eq(node.private_key_extension, fromhex("598b50eb5883cab909add281bb89186c5c5a5c3a953f8d92382590777597a1aa"), 32);
-  hdnode_fill_public_key(&node);
-  ck_assert_mem_eq(node.public_key + 1,  fromhex("ace6781a4165fdc8c582cf2dcd037faae746bc6ac3d071a263df7dbd0a528251"), 32);
-}
-END_TEST
-
-// [wallet-core]
-START_TEST(test_bip32_hd_hdnode_vector_2)
-{
-  HDNode node;
-
-  uint8_t seed[66];
-  mnemonic_to_seed("ring crime symptom enough erupt lady behave ramp apart settle citizen junk", "", seed, 0);
-  hdnode_from_seed_hd(seed, 64, ED25519_HD_NAME, &node);
-
-  uint32_t index = 44 | 0x80000000;
-  hdnode_private_ckd_cardano(&node, index);
-
-  ck_assert_mem_eq(node.chain_code,  fromhex("cd46ff18d03a37e28352ba0bd01b91327734aabebf658ae8a87dd216d99c0fef"), 32);
-  ck_assert_mem_eq(node.private_key, fromhex("a04d196954e1a544f31c5aed15a2ecc7c7905cfb9021f0e979771d3799707659"), 32);
-  ck_assert_mem_eq(node.private_key_extension, fromhex("ff2545c22345d40034af9b6dc1cada9b9d843cd6f9a6d8d7b05a45ba15ad2d59"), 32);
-  hdnode_fill_public_key(&node);
-  ck_assert_mem_eq(node.public_key + 1,  fromhex("5155f089bdb44b6c8df78a3bab2ca53897bc5ad3d349e4f1c7e1c1c4e74458ce"), 32);
-}
-END_TEST
-
-// [wallet-core]
 START_TEST(test_schnorr_sign_verify) {
   static struct {
     const char *message;

--- a/trezor-crypto/include/TrezorCrypto/bip32.h
+++ b/trezor-crypto/include/TrezorCrypto/bip32.h
@@ -74,9 +74,6 @@ int hdnode_from_xprv(uint32_t depth, uint32_t child_num,
 int hdnode_from_seed(const uint8_t *seed, int seed_len, const char *curve,
                      HDNode *out);
 
-// [wallet-core]
-int hdnode_from_seed_hd(const uint8_t *seed, int seed_len, const char *curve, HDNode *out);
-
 #define hdnode_private_ckd_prime(X, I) \
   hdnode_private_ckd((X), ((I) | 0x80000000))
 

--- a/trezor-crypto/include/TrezorCrypto/curves.h
+++ b/trezor-crypto/include/TrezorCrypto/curves.h
@@ -36,7 +36,6 @@ extern const char SECP256K1_SMART_NAME[];
 extern const char NIST256P1_NAME[];
 extern const char ED25519_NAME[];
 // [wallet-core]
-extern const char ED25519_HD_NAME[];
 extern const char ED25519_CARDANO_NAME[];
 // [wallet-core]
 extern const char ED25519_BLAKE2B_NANO_NAME[];


### PR DESCRIPTION
## Description

Oasis has requested that any new address should use a SLIP0010 with a derivation path based on BIP32 and 3 values only.
Given that Trustwallet integration is not available yet, the preference is to support this format only in Trustwallet.
This PR adjust wallet-core functionality according to this.

## Testing instructions

The CI tests will check the addresses generated with the new curve used.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

* Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [ ] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
