### PR TITLE
ThorChain decimals changed to 8

### DIFF
--- a/coins.json
+++ b/coins.json
@@ -1574,7 +1574,7 @@
     "name": "THORChain",
     "coinId": 931,
     "symbol": "RUNE",
-    "decimals": 18,
+    "decimals": 8,
     "blockchain": "Cosmos",
     "derivationPath": "m/44'/931'/0'/0/0",
     "curve": "secp256k1",

--- a/tests/THORChain/TWCoinTypeTests.cpp
+++ b/tests/THORChain/TWCoinTypeTests.cpp
@@ -22,7 +22,7 @@ TEST(TWTHORChainCoinType, TWCoinType) {
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeTHORChain));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeTHORChain));
 
-    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeTHORChain), 18);
+    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeTHORChain), 8);
     ASSERT_EQ(TWBlockchainCosmos, TWCoinTypeBlockchain(TWCoinTypeTHORChain));
     ASSERT_EQ(0x0, TWCoinTypeP2shPrefix(TWCoinTypeTHORChain));
     ASSERT_EQ(0x0, TWCoinTypeStaticPrefix(TWCoinTypeTHORChain));


### PR DESCRIPTION
## Description

ThorChain decimals changed to correct value 8.  It has been changed in assets repo info already.

## Testing instructions

Unit tests.  Retrieve balance from Thorchain RPC.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
