### PR TITLE
Bluzelle Chain Support

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
@@ -92,5 +92,6 @@ class CoinAddressDerivationTests {
         SMARTCHAINLEGACY -> assertEquals("0x49784f90176D8D9d4A3feCDE7C1373dAAb5b13b8", address)
         OASIS -> assertEquals("oasis1qzcpavvmuw280dk0kd4lxjhtpf0u3ll27yf7sqps", address)
         THORCHAIN -> assertEquals("thor1c8jd7ad9pcw4k3wkuqlkz4auv95mldr2kyhc65", address)
+        BLUZELLE -> assertEquals("bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund", address)
     }
 }

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
@@ -96,6 +96,6 @@ class CoinAddressDerivationTests {
         SMARTCHAINLEGACY -> assertEquals("0x49784f90176D8D9d4A3feCDE7C1373dAAb5b13b8", address)
         OASIS -> assertEquals("oasis1qzcpavvmuw280dk0kd4lxjhtpf0u3ll27yf7sqps", address)
         THORCHAIN -> assertEquals("thor1c8jd7ad9pcw4k3wkuqlkz4auv95mldr2kyhc65", address)
-        BLUZELLE -> assertEquals("bluzelle142j9u5eaduzd7faumygud6ruhdwme98q9ufmsz", address)
+        BLUZELLE -> assertEquals("bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund", address)
     }
 }

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
@@ -92,6 +92,6 @@ class CoinAddressDerivationTests {
         SMARTCHAINLEGACY -> assertEquals("0x49784f90176D8D9d4A3feCDE7C1373dAAb5b13b8", address)
         OASIS -> assertEquals("oasis1qzcpavvmuw280dk0kd4lxjhtpf0u3ll27yf7sqps", address)
         THORCHAIN -> assertEquals("thor1c8jd7ad9pcw4k3wkuqlkz4auv95mldr2kyhc65", address)
-        BLUZELLE -> assertEquals("bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund", address)
+        BLUZELLE -> assertEquals("bluzelle142j9u5eaduzd7faumygud6ruhdwme98q9ufmsz", address)
     }
 }

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bluzelle/TestBluzelleAddress.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bluzelle/TestBluzelleAddress.kt
@@ -1,0 +1,44 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+package com.trustwallet.core.app.blockchains.bluzelle
+
+import com.trustwallet.core.app.utils.toHex
+import com.trustwallet.core.app.utils.toHexByteArray
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import wallet.core.jni.*
+
+class TestBluzelleAddress {
+
+    init {
+        System.loadLibrary("TrustWalletCore")
+    }
+
+    @Test
+    fun testAddressPublicKey() {
+
+        val key = PrivateKey("1037f828ca313f4c9e120316e8e9ff25e17f07fe66ba557d5bc5e2eeb7cba8f6".toHexByteArray())
+        val pubkey = key.publicKeyEd25519
+        val address = AnyAddress(pubkey, CoinType.BLUZELLE)
+        val expected = AnyAddress("bluzelle1yhtq5zm293m2r3sp2guj9m5pg5e273n6r0szul", CoinType.BLUZELLE)
+
+        assertEquals(pubkey.data().toHex(), "0x381207e7f7fa7c44564534b0f47dfef3fc942e42defc10b2bf614e4dfa773e5a")
+        assertEquals(address.description(), expected.description())
+    }
+
+    @Test
+    fun testAddressValidation() {
+        val addr = listOf(
+            "bluzelle1yhtq5zm293m2r3sp2guj9m5pg5e273n6r0szul",
+            "bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"
+        )
+        addr.forEach {
+            assert(CoinType.BLUZELLE.validate(it))
+            assertEquals(it, AnyAddress(it, CoinType.BLUZELLE).description())
+        }
+    }
+}

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bluzelle/TestBluzelleAddress.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bluzelle/TestBluzelleAddress.kt
@@ -22,12 +22,15 @@ class TestBluzelleAddress {
     fun testAddressPublicKey() {
 
         val key = PrivateKey("1037f828ca313f4c9e120316e8e9ff25e17f07fe66ba557d5bc5e2eeb7cba8f6".toHexByteArray())
-        val pubkey = key.publicKeyEd25519
-        val address = AnyAddress(pubkey, CoinType.BLUZELLE)
-        val expected = AnyAddress("bluzelle1yhtq5zm293m2r3sp2guj9m5pg5e273n6r0szul", CoinType.BLUZELLE)
+        val publicKey = key.getPublicKeySecp256k1(true)
+        val expectedAddress = "bluzelle1jf9aaj9myrzsnmpdr7twecnaftzmku2myvn4dg"
+        val actualAddress = AnyAddress(publicKey, CoinType.BLUZELLE).description()
 
-        assertEquals(pubkey.data().toHex(), "0x381207e7f7fa7c44564534b0f47dfef3fc942e42defc10b2bf614e4dfa773e5a")
-        assertEquals(address.description(), expected.description())
+        val expectedPublicKeyData = "0x035df185566521d6a7802319ee06e1a28e97b7772dfb5fdd13ca6f0575518968e4"
+        val actualPublicKeyData = publicKey.data().toHex()
+
+        assertEquals(expectedAddress, actualAddress)
+        assertEquals(expectedPublicKeyData, actualPublicKeyData)
     }
 
     @Test

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bluzelle/TestBluzelleSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bluzelle/TestBluzelleSigner.kt
@@ -26,7 +26,7 @@ class TestBluzelleSigner {
         System.loadLibrary("TrustWalletCore")
     }
 
-@Test
+    @Test
     fun testSigningTransaction() {
         val key =
             PrivateKey("80e81ea269e66a0a05b11236df7919fb7fbeedba87452d667489d7403a02f005".toHexByteArray())

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bluzelle/TestBluzelleSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bluzelle/TestBluzelleSigner.kt
@@ -1,0 +1,116 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+package com.trustwallet.core.app.blockchains.bluzelle
+
+import com.google.protobuf.ByteString
+import com.trustwallet.core.app.utils.Numeric
+import com.trustwallet.core.app.utils.toHexByteArray
+import com.trustwallet.core.app.utils.toHexBytes
+import com.trustwallet.core.app.utils.toHexBytesInByteString
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import wallet.core.java.AnySigner
+import wallet.core.jni.AnyAddress
+import wallet.core.jni.CoinType.BLUZELLE
+import wallet.core.jni.PrivateKey
+import wallet.core.jni.proto.Cosmos
+import wallet.core.jni.proto.Cosmos.SigningOutput
+
+class TestBluzelleSigner {
+
+    init {
+        System.loadLibrary("TrustWalletCore")
+    }
+
+@Test
+    fun testSigningTransaction() {
+        val key =
+            PrivateKey("80e81ea269e66a0a05b11236df7919fb7fbeedba87452d667489d7403a02f005".toHexByteArray())
+        val publicKey = key.getPublicKeySecp256k1(true)
+        val from = AnyAddress(publicKey, BLUZELLE).description()
+
+        val txAmount = Cosmos.Amount.newBuilder().apply {
+            amount = 1
+            denom = "ubnt"
+        }.build()
+
+        val sendCoinsMsg = Cosmos.Message.Send.newBuilder().apply {
+            fromAddress = from
+            toAddress = "bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"
+            addAllAmounts(listOf(txAmount))
+        }.build()
+
+        val message = Cosmos.Message.newBuilder().apply {
+            sendCoinsMessage = sendCoinsMsg
+        }.build()
+
+        val feeAmount = Cosmos.Amount.newBuilder().apply {
+            amount = 200
+            denom = "ubnt"
+        }.build()
+
+        val cosmosFee = Cosmos.Fee.newBuilder().apply {
+            gas = 200000
+            addAllAmounts(listOf(feeAmount))
+        }.build()
+
+        val signingInput = Cosmos.SigningInput.newBuilder().apply {
+            accountNumber = 1037
+            chainId = "band-wenchang-testnet2"
+            memo = ""
+            sequence = 8
+            fee = cosmosFee
+            privateKey = ByteString.copyFrom(key.data())
+            addAllMessages(listOf(message))
+        }.build()
+
+        val output = AnySigner.sign(signingInput, BLUZELLE, SigningOutput.parser())
+        val jsonPayload = output.json
+
+        val expectedJsonPayload = """{"mode":"block","tx":{"fee":{"amount":[{"amount":"200","denom":"ubnt"}],"gas":"200000"},"memo":"","msg":[{"type":"cosmos-sdk/MsgSend","value":{"amount":[{"amount":"1","denom":"ubnt"}],"from_address":"bluzelle1hsk6jryyqjfhp5dhc55tc9jtckygx0epzzw0fm","to_address":"bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"}}],"signatures":[{"pub_key":{"type":"tendermint/PubKeySecp256k1","value":"AlcobsPzfTNVe7uqAAsndErJAjqplnyudaGB0f+R+p3F"},"signature":"B8s3xp3hkkKMqJSGp9sPvUtSjEJ2rKmDzERP/FD/cz09Ot//ERMhUEnIr3jsWVuwj+jv5QYQ15B43Uz3CWx9wg=="}]}}"""
+        assertEquals(expectedJsonPayload, jsonPayload)
+
+    }
+
+    @Test
+    fun testSigningJSON() {
+
+        val myPrivateKey = "80e81ea269e66a0a05b11236df7919fb7fbeedba87452d667489d7403a02f005"
+        val myAddress = "bluzelle1hsk6jryyqjfhp5dhc55tc9jtckygx0epzzw0fm"
+
+        val toAddress = "bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"
+        val json = """
+        {
+            "accountNumber": "8733",
+            "chainId": "bluzelle",
+            "fee": {
+                "amounts": [{
+                    "denom": "ubnt",
+                    "amount": "5000"
+                }],
+                "gas": "200000"
+            },
+            "memo": "Testing",
+            "messages": [{
+                "sendCoinsMessage": {
+                    "fromAddress": "$myAddress",
+                    "toAddress": "$toAddress",
+                    "amounts": [{
+                        "denom": "ubnt",
+                        "amount": "995000"
+                    }]
+                }
+            }]
+        }
+        """
+        val key = myPrivateKey.toHexByteArray()
+        val actualResult  = AnySigner.signJSON(json, key, BLUZELLE.value())
+
+        val expectedResult = """{"mode":"block","tx":{"fee":{"amount":[{"amount":"5000","denom":"ubnt"}],"gas":"200000"},"memo":"Testing","msg":[{"type":"cosmos-sdk/MsgSend","value":{"amount":[{"amount":"995000","denom":"ubnt"}],"from_address":"$myAddress","to_address":"$toAddress"}}],"signatures":[{"pub_key":{"type":"tendermint/PubKeySecp256k1","value":"AlcobsPzfTNVe7uqAAsndErJAjqplnyudaGB0f+R+p3F"},"signature":"gKWKk5lku9H/wosvnsD6auWUt7AGNjLEudWS+Fdv4TQr16HUBVpkq9A6gZYqZIawFukq2I/qrtyw9MKR4pVkhg=="}]}}"""
+        assertEquals(expectedResult, actualResult)
+    }
+}

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bluzelle/TestBluzelleSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bluzelle/TestBluzelleSigner.kt
@@ -60,7 +60,7 @@ class TestBluzelleSigner {
 
         val signingInput = Cosmos.SigningInput.newBuilder().apply {
             accountNumber = 1037
-            chainId = "band-wenchang-testnet2"
+            chainId = "bluzelle"
             memo = ""
             sequence = 8
             fee = cosmosFee
@@ -71,7 +71,7 @@ class TestBluzelleSigner {
         val output = AnySigner.sign(signingInput, BLUZELLE, SigningOutput.parser())
         val jsonPayload = output.json
 
-        val expectedJsonPayload = """{"mode":"block","tx":{"fee":{"amount":[{"amount":"200","denom":"ubnt"}],"gas":"200000"},"memo":"","msg":[{"type":"cosmos-sdk/MsgSend","value":{"amount":[{"amount":"1","denom":"ubnt"}],"from_address":"bluzelle1hsk6jryyqjfhp5dhc55tc9jtckygx0epzzw0fm","to_address":"bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"}}],"signatures":[{"pub_key":{"type":"tendermint/PubKeySecp256k1","value":"AlcobsPzfTNVe7uqAAsndErJAjqplnyudaGB0f+R+p3F"},"signature":"B8s3xp3hkkKMqJSGp9sPvUtSjEJ2rKmDzERP/FD/cz09Ot//ERMhUEnIr3jsWVuwj+jv5QYQ15B43Uz3CWx9wg=="}]}}"""
+        val expectedJsonPayload = """{"mode":"block","tx":{"fee":{"amount":[{"amount":"200","denom":"ubnt"}],"gas":"200000"},"memo":"","msg":[{"type":"cosmos-sdk/MsgSend","value":{"amount":[{"amount":"1","denom":"ubnt"}],"from_address":"bluzelle1hsk6jryyqjfhp5dhc55tc9jtckygx0epzzw0fm","to_address":"bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"}}],"signatures":[{"pub_key":{"type":"tendermint/PubKeySecp256k1","value":"AlcobsPzfTNVe7uqAAsndErJAjqplnyudaGB0f+R+p3F"},"signature":"0StN9LHr4fIbEzCzyx5bzWJmfgiUqkwoavYGNUDm2shXKmAFogVtOviC4zMNNHKBtFTnHQ07DO1UjqEEWS/2BA=="}]}}"""
         assertEquals(expectedJsonPayload, jsonPayload)
 
     }

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bluzelle/TestBluzelleSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bluzelle/TestBluzelleSigner.kt
@@ -28,6 +28,8 @@ class TestBluzelleSigner {
 
     @Test
     fun testSigningTransaction() {
+
+        // Submitted Realworld tx for the following test : https://bigdipper.net.bluzelle.com/transactions/B3A7F30539CCDF72D210BC995FAF65B43F9BE04FA9F8AFAE0EC969660744002F
         val key =
             PrivateKey("80e81ea269e66a0a05b11236df7919fb7fbeedba87452d667489d7403a02f005".toHexByteArray())
         val publicKey = key.getPublicKeySecp256k1(true)
@@ -49,20 +51,20 @@ class TestBluzelleSigner {
         }.build()
 
         val feeAmount = Cosmos.Amount.newBuilder().apply {
-            amount = 200
+            amount = 1000
             denom = "ubnt"
         }.build()
 
         val cosmosFee = Cosmos.Fee.newBuilder().apply {
-            gas = 200000
+            gas = 500000
             addAllAmounts(listOf(feeAmount))
         }.build()
 
         val signingInput = Cosmos.SigningInput.newBuilder().apply {
-            accountNumber = 1037
-            chainId = "bluzelle"
+            accountNumber = 590
+            chainId = "net-6"
             memo = ""
-            sequence = 8
+            sequence = 2
             fee = cosmosFee
             privateKey = ByteString.copyFrom(key.data())
             addAllMessages(listOf(message))
@@ -71,7 +73,7 @@ class TestBluzelleSigner {
         val output = AnySigner.sign(signingInput, BLUZELLE, SigningOutput.parser())
         val jsonPayload = output.json
 
-        val expectedJsonPayload = """{"mode":"block","tx":{"fee":{"amount":[{"amount":"200","denom":"ubnt"}],"gas":"200000"},"memo":"","msg":[{"type":"cosmos-sdk/MsgSend","value":{"amount":[{"amount":"1","denom":"ubnt"}],"from_address":"bluzelle1hsk6jryyqjfhp5dhc55tc9jtckygx0epzzw0fm","to_address":"bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"}}],"signatures":[{"pub_key":{"type":"tendermint/PubKeySecp256k1","value":"AlcobsPzfTNVe7uqAAsndErJAjqplnyudaGB0f+R+p3F"},"signature":"0StN9LHr4fIbEzCzyx5bzWJmfgiUqkwoavYGNUDm2shXKmAFogVtOviC4zMNNHKBtFTnHQ07DO1UjqEEWS/2BA=="}]}}"""
+        val expectedJsonPayload = """{"mode":"block","tx":{"fee":{"amount":[{"amount":"1000","denom":"ubnt"}],"gas":"500000"},"memo":"","msg":[{"type":"cosmos-sdk/MsgSend","value":{"amount":[{"amount":"1","denom":"ubnt"}],"from_address":"bluzelle1hsk6jryyqjfhp5dhc55tc9jtckygx0epzzw0fm","to_address":"bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"}}],"signatures":[{"pub_key":{"type":"tendermint/PubKeySecp256k1","value":"AlcobsPzfTNVe7uqAAsndErJAjqplnyudaGB0f+R+p3F"},"signature":"5e3e13x1F+Y4+cPNvE1jQ/Mrz0J2RQCY69re3g4xuTY3Gw7MNGQ+8E34d9DgvcNLPM05nehdOv/0SvekY/ihIQ=="}]}}"""
         assertEquals(expectedJsonPayload, jsonPayload)
 
     }
@@ -79,20 +81,22 @@ class TestBluzelleSigner {
     @Test
     fun testSigningJSON() {
 
+        // Submitted realworld tx for the following test : https://bigdipper.net.bluzelle.com/transactions/DEF394BE0DD1075CDC8B8618A7858AAA4A03A43D04476381224E316E06FD3A5B
         val myPrivateKey = "80e81ea269e66a0a05b11236df7919fb7fbeedba87452d667489d7403a02f005"
         val myAddress = "bluzelle1hsk6jryyqjfhp5dhc55tc9jtckygx0epzzw0fm"
 
         val toAddress = "bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"
         val json = """
         {
-            "accountNumber": "8733",
-            "chainId": "bluzelle",
+            "accountNumber": "590",
+            "chainId": "net-6",
+            "sequence": "3",
             "fee": {
                 "amounts": [{
                     "denom": "ubnt",
-                    "amount": "5000"
+                    "amount": "1000"
                 }],
-                "gas": "200000"
+                "gas": "500000"
             },
             "memo": "Testing",
             "messages": [{
@@ -101,7 +105,7 @@ class TestBluzelleSigner {
                     "toAddress": "$toAddress",
                     "amounts": [{
                         "denom": "ubnt",
-                        "amount": "995000"
+                        "amount": "2"
                     }]
                 }
             }]
@@ -110,7 +114,7 @@ class TestBluzelleSigner {
         val key = myPrivateKey.toHexByteArray()
         val actualResult  = AnySigner.signJSON(json, key, BLUZELLE.value())
 
-        val expectedResult = """{"mode":"block","tx":{"fee":{"amount":[{"amount":"5000","denom":"ubnt"}],"gas":"200000"},"memo":"Testing","msg":[{"type":"cosmos-sdk/MsgSend","value":{"amount":[{"amount":"995000","denom":"ubnt"}],"from_address":"$myAddress","to_address":"$toAddress"}}],"signatures":[{"pub_key":{"type":"tendermint/PubKeySecp256k1","value":"AlcobsPzfTNVe7uqAAsndErJAjqplnyudaGB0f+R+p3F"},"signature":"gKWKk5lku9H/wosvnsD6auWUt7AGNjLEudWS+Fdv4TQr16HUBVpkq9A6gZYqZIawFukq2I/qrtyw9MKR4pVkhg=="}]}}"""
+        val expectedResult = """{"mode":"block","tx":{"fee":{"amount":[{"amount":"1000","denom":"ubnt"}],"gas":"500000"},"memo":"Testing","msg":[{"type":"cosmos-sdk/MsgSend","value":{"amount":[{"amount":"2","denom":"ubnt"}],"from_address":"bluzelle1hsk6jryyqjfhp5dhc55tc9jtckygx0epzzw0fm","to_address":"bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"}}],"signatures":[{"pub_key":{"type":"tendermint/PubKeySecp256k1","value":"AlcobsPzfTNVe7uqAAsndErJAjqplnyudaGB0f+R+p3F"},"signature":"2JcfVwq9N3UAk5Lfki7+CngqcefgjfH1q/8chtJMJvEHRe6PvuYKMv5pjeN0Z5Vk2BArJT3V3EHxbpbiY2eLWw=="}]}}"""
         assertEquals(expectedResult, actualResult)
     }
 }

--- a/coins.json
+++ b/coins.json
@@ -966,8 +966,8 @@
     "hrp": "bluzelle",
     "explorer": {
       "url": "https://bigdipper.net.bluzelle.com/",
-      "txPath": "/transactions/",
-      "accountPath": "/account/",
+      "txPath": "transactions/",
+      "accountPath": "account/",
       "sampleTx": "AC026E0EC6E33A77D5EA6B9CEF9810699BC2AD8C5582E007E7857457C6D3B819",
       "sampleAccount": "bluzelle1q9cryfal7u3jvnq6er5ufety20xtzw6ycx2te9"
     },

--- a/coins.json
+++ b/coins.json
@@ -965,9 +965,9 @@
     "publicKeyType": "secp256k1",
     "hrp": "bluzelle",
     "explorer": {
-      "url": "https://bigdipper.net.bluzelle.com/",
-      "txPath": "transactions/",
-      "accountPath": "account/",
+      "url": "https://bigdipper.net.bluzelle.com",
+      "txPath": "/transactions/",
+      "accountPath": "/account/",
       "sampleTx": "AC026E0EC6E33A77D5EA6B9CEF9810699BC2AD8C5582E007E7857457C6D3B819",
       "sampleAccount": "bluzelle1q9cryfal7u3jvnq6er5ufety20xtzw6ycx2te9"
     },

--- a/coins.json
+++ b/coins.json
@@ -954,6 +954,31 @@
     }
   },
   {
+    "id": "bluzelle",
+    "name": "Bluzelle",
+    "coinId": 483,
+    "symbol": "BLZ",
+    "decimals": 6,
+    "blockchain": "Cosmos",
+    "derivationPath": "m/44'/118'/0'/0/0",
+    "curve": "secp256k1",
+    "publicKeyType": "secp256k1",
+    "hrp": "bluzelle",
+    "explorer": {
+      "url": "https://bigdipper.net.bluzelle.com/",
+      "txPath": "/transactions/",
+      "accountPath": "/account/",
+      "sampleTx": "AC026E0EC6E33A77D5EA6B9CEF9810699BC2AD8C5582E007E7857457C6D3B819",
+      "sampleAccount": "bluzelle1q9cryfal7u3jvnq6er5ufety20xtzw6ycx2te9"
+    },
+    "info": {
+      "url": "https://bluzelle.com",
+      "client": "https://github.com/bluzelle",
+      "clientPublic": "https://bluzelle.github.io/api/",
+      "clientDocs": "https://docs.bluzelle.com/developers/"
+    }
+  },
+  {
     "id": "band",
     "name": "BandChain",
     "symbol": "BAND",

--- a/coins.json
+++ b/coins.json
@@ -960,7 +960,7 @@
     "symbol": "BLZ",
     "decimals": 6,
     "blockchain": "Cosmos",
-    "derivationPath": "m/44'/118'/0'/0/0",
+    "derivationPath": "m/44'/483'/0'/0/0",
     "curve": "secp256k1",
     "publicKeyType": "secp256k1",
     "hrp": "bluzelle",

--- a/docs/coins.md
+++ b/docs/coins.md
@@ -43,6 +43,7 @@ This list is generated from [./coins.json](../coins.json)
 | 459     | Kava             | KAVA   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/kava/info/logo.png" width="32" />         | <https://kava.io>             |
 | 461     | Filecoin         | FIL    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/filecoin/info/logo.png" width="32" />     | <https://filecoin.io/>        |
 | 474     | Oasis            | ROSE   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/oasis/info/logo.png" width="32" />        | <https://oasisprotocol.org/>  |
+| 483     | Bluzelle         | BLZ    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/bluzelle/info/logo.png" width="32" />     | <https://bluzelle.com>        |
 | 494     | BandChain        | BAND   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/band/info/logo.png" width="32" />         | <https://bandprotocol.com/>   |
 | 500     | Theta            | THETA  | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/theta/info/logo.png" width="32" />        | <https://www.thetatoken.org>  |
 | 501     | Solana           | SOL    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/solana/info/logo.png" width="32" />       | <https://solana.com>          |

--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -87,6 +87,7 @@ enum TWCoinType {
     TWCoinTypeOasis = 474,
     TWCoinTypePolygon = 966,
     TWCoinTypeTHORChain = 931,
+    TWCoinTypeBluzelle = 483,
 };
 
 /// Returns the blockchain for a coin type.

--- a/src/Coin.cpp
+++ b/src/Coin.cpp
@@ -125,6 +125,7 @@ CoinEntry* coinDispatcher(TWCoinType coinType) {
         case TWCoinTypeKava: entry = &cosmosDP; break;
         case TWCoinTypeTerra: entry = &cosmosDP; break;
         case TWCoinTypeBandChain: entry = &cosmosDP; break;
+        case TWCoinTypeBluzelle: entry = &cosmosDP; break;
         case TWCoinTypeElrond: entry = &elrondDP; break;
         case TWCoinTypeEOS: entry = &eosDP; break;
         case TWCoinTypeCallisto: entry = &ethereumDP; break;

--- a/src/Cosmos/Entry.h
+++ b/src/Cosmos/Entry.h
@@ -20,6 +20,7 @@ public:
             TWCoinTypeKava,
             TWCoinTypeTerra,
             TWCoinTypeBandChain,
+            TWCoinTypeBluzelle
         };
     }
     virtual bool validateAddress(TWCoinType coin, const std::string& address, TW::byte p2pkh, TW::byte p2sh, const char* hrp) const;

--- a/src/interface/TWAnyAddress.cpp
+++ b/src/interface/TWAnyAddress.cpp
@@ -79,6 +79,7 @@ TWData* _Nonnull TWAnyAddressData(struct TWAnyAddress* _Nonnull address) {
     case TWCoinTypeTerra:
     case TWCoinTypeBandChain:
     case TWCoinTypeTHORChain:
+    case TWCoinTypeBluzelle:
     case TWCoinTypeIoTeX: {
         Cosmos::Address addr;
         if (!Cosmos::Address::decode(string, addr)) {

--- a/swift/Tests/Blockchains/BluzelleTests.swift
+++ b/swift/Tests/Blockchains/BluzelleTests.swift
@@ -1,0 +1,193 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+import XCTest
+import WalletCore
+
+class BluzelleAddressTests: XCTestCase {
+    func testAddressValidation() {
+        let bluzelle = CoinType.bluzelle
+        for address in [
+            "bluzelle1yhtq5zm293m2r3sp2guj9m5pg5e273n6r0szul",
+            "bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund",
+        ] {
+            XCTAssertTrue(bluzelle.validate(address: address))
+            XCTAssertEqual(bluzelle.address(string: address)?.description, address)
+        }
+    }
+}
+
+class BluzelleSignerTests: XCTestCase {
+
+    let privateKeyData = Data(hexString: "80e81ea269e66a0a05b11236df7919fb7fbeedba87452d667489d7403a02f005")!
+    let myAddress = "bluzelle1hsk6jryyqjfhp5dhc55tc9jtckygx0epzzw0fm"
+    
+    
+    func testSigningJSON() {
+        
+        let toAddress = "bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"
+        let inputJson =
+        """
+        {
+          "accountNumber": "8733",
+          "chainId": "bluzelle",
+          "fee": {
+            "amounts": [
+              {
+                "denom": "ubnt",
+                "amount": "5000"
+              }
+            ],
+            "gas": "200000"
+          },
+          "memo": "Testing",
+          "messages": [
+            {
+              "sendCoinsMessage": {
+                "fromAddress": "\(myAddress)",
+                "toAddress": "\(toAddress)",
+                "amounts": [
+                  {
+                    "denom": "ubnt",
+                    "amount": "995000"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+        """
+        
+        let expectedSignedJson =
+        """
+        {
+          "mode": "block",
+          "tx": {
+            "fee": {
+              "amount": [
+                {
+                  "amount": "5000",
+                  "denom": "ubnt"
+                }
+              ],
+              "gas": "200000"
+            },
+            "memo": "Testing",
+            "msg": [
+              {
+                "type": "cosmos-sdk/MsgSend",
+                "value": {
+                  "amount": [
+                    {
+                      "amount": "995000",
+                      "denom": "ubnt"
+                    }
+                  ],
+                  "from_address": "bluzelle1hsk6jryyqjfhp5dhc55tc9jtckygx0epzzw0fm",
+                  "to_address": "bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"
+                }
+              }
+            ],
+            "signatures": [
+              {
+                "pub_key": {
+                  "type": "tendermint/PubKeySecp256k1",
+                  "value": "AlcobsPzfTNVe7uqAAsndErJAjqplnyudaGB0f+R+p3F"
+                },
+                "signature": "gKWKk5lku9H/wosvnsD6auWUt7AGNjLEudWS+Fdv4TQr16HUBVpkq9A6gZYqZIawFukq2I/qrtyw9MKR4pVkhg=="
+              }
+            ]
+          }
+        }
+        """
+
+        let actualSignedJson = AnySigner.signJSON(inputJson, key: privateKeyData, coin: .bluzelle)
+        
+        XCTAssertJSONEqual(expectedSignedJson, actualSignedJson)
+
+    }
+
+    func testSigningMessage() {
+        let privateKey = PrivateKey(data: privateKeyData)!
+
+        let sendCoinsMessage = CosmosMessage.Send.with {
+            $0.fromAddress = myAddress
+            $0.toAddress = "bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"
+            $0.amounts = [CosmosAmount.with {
+                $0.amount = 1
+                $0.denom = "ubnt"
+            }]
+        }
+
+        let message = CosmosMessage.with {
+            $0.sendCoinsMessage = sendCoinsMessage
+        }
+
+        let fee = CosmosFee.with {
+            $0.gas = 200000
+            $0.amounts = [CosmosAmount.with {
+                $0.amount = 200
+                $0.denom = "ubnt"
+            }]
+        }
+
+        let input = CosmosSigningInput.with {
+            $0.accountNumber = 1037
+            $0.chainID = "bluzelle"
+            $0.memo = ""
+            $0.sequence = 8
+            $0.messages = [message]
+            $0.fee = fee
+            $0.privateKey = privateKey.data
+        }
+
+        let output: CosmosSigningOutput = AnySigner.sign(input: input, coin: .bluzelle)
+
+        let expectedJSON: String =
+        """
+        {
+          "mode": "block",
+          "tx": {
+            "fee": {
+              "amount": [
+                {
+                  "amount": "200",
+                  "denom": "ubnt"
+                }
+              ],
+              "gas": "200000"
+            },
+            "memo": "",
+            "msg": [
+              {
+                "type": "cosmos-sdk/MsgSend",
+                "value": {
+                  "amount": [
+                    {
+                      "amount": "1",
+                      "denom": "ubnt"
+                    }
+                  ],
+                  "from_address": "bluzelle1hsk6jryyqjfhp5dhc55tc9jtckygx0epzzw0fm",
+                  "to_address": "bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"
+                }
+              }
+            ],
+            "signatures": [
+              {
+                "pub_key": {
+                  "type": "tendermint/PubKeySecp256k1",
+                  "value": "AlcobsPzfTNVe7uqAAsndErJAjqplnyudaGB0f+R+p3F"
+                },
+                "signature": "0StN9LHr4fIbEzCzyx5bzWJmfgiUqkwoavYGNUDm2shXKmAFogVtOviC4zMNNHKBtFTnHQ07DO1UjqEEWS/2BA=="
+              }
+            ]
+          }
+        }
+        """
+
+        XCTAssertJSONEqual(expectedJSON, output.json)
+    }
+}

--- a/swift/Tests/Blockchains/BluzelleTests.swift
+++ b/swift/Tests/Blockchains/BluzelleTests.swift
@@ -7,6 +7,23 @@ import XCTest
 import WalletCore
 
 class BluzelleAddressTests: XCTestCase {
+
+    func testAddressPublicKey() {
+
+        let privateKeyData = Data(hexString: "1037f828ca313f4c9e120316e8e9ff25e17f07fe66ba557d5bc5e2eeb7cba8f6")!
+        let privateKey = PrivateKey(data: privateKeyData)!
+        let publicKey = privateKey.getPublicKeySecp256k1(compressed: true)
+
+        let expectedAddress = "bluzelle1jf9aaj9myrzsnmpdr7twecnaftzmku2myvn4dg"
+        let actualAddress = AnyAddress(publicKey: publicKey, coin: .bluzelle).description
+
+        let expectedPublicKeyData = "035df185566521d6a7802319ee06e1a28e97b7772dfb5fdd13ca6f0575518968e4"
+        let actualPublicKeyData = publicKey.data.hexString
+
+        XCTAssertEqual(expectedAddress, actualAddress)
+        XCTAssertEqual(expectedPublicKeyData, actualPublicKeyData)
+    }
+
     func testAddressValidation() {
         let bluzelle = CoinType.bluzelle
         for address in [

--- a/swift/Tests/Blockchains/BluzelleTests.swift
+++ b/swift/Tests/Blockchains/BluzelleTests.swift
@@ -44,80 +44,39 @@ class BluzelleSignerTests: XCTestCase {
     
     func testSigningJSON() {
         
+        // Submitted realworld tx for the following test : https://bigdipper.net.bluzelle.com/transactions/DEF394BE0DD1075CDC8B8618A7858AAA4A03A43D04476381224E316E06FD3A5B
+
         let toAddress = "bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"
         let inputJson =
         """
         {
-          "accountNumber": "8733",
-          "chainId": "bluzelle",
-          "fee": {
-            "amounts": [
-              {
-                "denom": "ubnt",
-                "amount": "5000"
-              }
-            ],
-            "gas": "200000"
-          },
-          "memo": "Testing",
-          "messages": [
-            {
-              "sendCoinsMessage": {
-                "fromAddress": "\(myAddress)",
-                "toAddress": "\(toAddress)",
-                "amounts": [
-                  {
+            "accountNumber": "590",
+            "chainId": "net-6",
+            "sequence": "3",
+            "fee": {
+                "amounts": [{
                     "denom": "ubnt",
-                    "amount": "995000"
-                  }
-                ]
-              }
-            }
-          ]
+                    "amount": "1000"
+                }],
+                "gas": "500000"
+            },
+            "memo": "Testing",
+            "messages": [{
+                "sendCoinsMessage": {
+                    "fromAddress": "\(myAddress)",
+                    "toAddress": "\(toAddress)",
+                    "amounts": [{
+                        "denom": "ubnt",
+                        "amount": "2"
+                    }]
+                }
+            }]
         }
         """
         
         let expectedSignedJson =
         """
-        {
-          "mode": "block",
-          "tx": {
-            "fee": {
-              "amount": [
-                {
-                  "amount": "5000",
-                  "denom": "ubnt"
-                }
-              ],
-              "gas": "200000"
-            },
-            "memo": "Testing",
-            "msg": [
-              {
-                "type": "cosmos-sdk/MsgSend",
-                "value": {
-                  "amount": [
-                    {
-                      "amount": "995000",
-                      "denom": "ubnt"
-                    }
-                  ],
-                  "from_address": "bluzelle1hsk6jryyqjfhp5dhc55tc9jtckygx0epzzw0fm",
-                  "to_address": "bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"
-                }
-              }
-            ],
-            "signatures": [
-              {
-                "pub_key": {
-                  "type": "tendermint/PubKeySecp256k1",
-                  "value": "AlcobsPzfTNVe7uqAAsndErJAjqplnyudaGB0f+R+p3F"
-                },
-                "signature": "gKWKk5lku9H/wosvnsD6auWUt7AGNjLEudWS+Fdv4TQr16HUBVpkq9A6gZYqZIawFukq2I/qrtyw9MKR4pVkhg=="
-              }
-            ]
-          }
-        }
+        {"mode":"block","tx":{"fee":{"amount":[{"amount":"1000","denom":"ubnt"}],"gas":"500000"},"memo":"Testing","msg":[{"type":"cosmos-sdk/MsgSend","value":{"amount":[{"amount":"2","denom":"ubnt"}],"from_address":"bluzelle1hsk6jryyqjfhp5dhc55tc9jtckygx0epzzw0fm","to_address":"bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"}}],"signatures":[{"pub_key":{"type":"tendermint/PubKeySecp256k1","value":"AlcobsPzfTNVe7uqAAsndErJAjqplnyudaGB0f+R+p3F"},"signature":"2JcfVwq9N3UAk5Lfki7+CngqcefgjfH1q/8chtJMJvEHRe6PvuYKMv5pjeN0Z5Vk2BArJT3V3EHxbpbiY2eLWw=="}]}}
         """
 
         let actualSignedJson = AnySigner.signJSON(inputJson, key: privateKeyData, coin: .bluzelle)
@@ -127,6 +86,8 @@ class BluzelleSignerTests: XCTestCase {
     }
 
     func testSigningMessage() {
+        // Submitted Realworld tx for the following test : https://bigdipper.net.bluzelle.com/transactions/B3A7F30539CCDF72D210BC995FAF65B43F9BE04FA9F8AFAE0EC969660744002F
+
         let privateKey = PrivateKey(data: privateKeyData)!
 
         let sendCoinsMessage = CosmosMessage.Send.with {
@@ -143,18 +104,18 @@ class BluzelleSignerTests: XCTestCase {
         }
 
         let fee = CosmosFee.with {
-            $0.gas = 200000
+            $0.gas = 500000
             $0.amounts = [CosmosAmount.with {
-                $0.amount = 200
+                $0.amount = 1000
                 $0.denom = "ubnt"
             }]
         }
 
         let input = CosmosSigningInput.with {
-            $0.accountNumber = 1037
-            $0.chainID = "bluzelle"
+            $0.accountNumber = 590
+            $0.chainID = "net-6"
             $0.memo = ""
-            $0.sequence = 8
+            $0.sequence = 2
             $0.messages = [message]
             $0.fee = fee
             $0.privateKey = privateKey.data
@@ -164,45 +125,7 @@ class BluzelleSignerTests: XCTestCase {
 
         let expectedJSON: String =
         """
-        {
-          "mode": "block",
-          "tx": {
-            "fee": {
-              "amount": [
-                {
-                  "amount": "200",
-                  "denom": "ubnt"
-                }
-              ],
-              "gas": "200000"
-            },
-            "memo": "",
-            "msg": [
-              {
-                "type": "cosmos-sdk/MsgSend",
-                "value": {
-                  "amount": [
-                    {
-                      "amount": "1",
-                      "denom": "ubnt"
-                    }
-                  ],
-                  "from_address": "bluzelle1hsk6jryyqjfhp5dhc55tc9jtckygx0epzzw0fm",
-                  "to_address": "bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"
-                }
-              }
-            ],
-            "signatures": [
-              {
-                "pub_key": {
-                  "type": "tendermint/PubKeySecp256k1",
-                  "value": "AlcobsPzfTNVe7uqAAsndErJAjqplnyudaGB0f+R+p3F"
-                },
-                "signature": "0StN9LHr4fIbEzCzyx5bzWJmfgiUqkwoavYGNUDm2shXKmAFogVtOviC4zMNNHKBtFTnHQ07DO1UjqEEWS/2BA=="
-              }
-            ]
-          }
-        }
+        {"mode":"block","tx":{"fee":{"amount":[{"amount":"1000","denom":"ubnt"}],"gas":"500000"},"memo":"","msg":[{"type":"cosmos-sdk/MsgSend","value":{"amount":[{"amount":"1","denom":"ubnt"}],"from_address":"bluzelle1hsk6jryyqjfhp5dhc55tc9jtckygx0epzzw0fm","to_address":"bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"}}],"signatures":[{"pub_key":{"type":"tendermint/PubKeySecp256k1","value":"AlcobsPzfTNVe7uqAAsndErJAjqplnyudaGB0f+R+p3F"},"signature":"5e3e13x1F+Y4+cPNvE1jQ/Mrz0J2RQCY69re3g4xuTY3Gw7MNGQ+8E34d9DgvcNLPM05nehdOv/0SvekY/ihIQ=="}]}}
         """
 
         XCTAssertJSONEqual(expectedJSON, output.json)

--- a/swift/Tests/CoinAddressDerivationTests.swift
+++ b/swift/Tests/CoinAddressDerivationTests.swift
@@ -209,7 +209,7 @@ class CoinAddressDerivationTests: XCTestCase {
                     let expectedResult = "thor1c8jd7ad9pcw4k3wkuqlkz4auv95mldr2kyhc65"
                     assertCoinDerivation(coin, expectedResult, derivedAddress, address)
                 case .bluzelle:
-                    let expectedResult = "bluzelle142j9u5eaduzd7faumygud6ruhdwme98q9ufmsz"
+                    let expectedResult = "bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"
                     assertCoinDerivation(coin, expectedResult, derivedAddress, address)
                 @unknown default:
                     fatalError()

--- a/swift/Tests/CoinAddressDerivationTests.swift
+++ b/swift/Tests/CoinAddressDerivationTests.swift
@@ -208,6 +208,9 @@ class CoinAddressDerivationTests: XCTestCase {
                 case .thorchain:
                     let expectedResult = "thor1c8jd7ad9pcw4k3wkuqlkz4auv95mldr2kyhc65"
                     assertCoinDerivation(coin, expectedResult, derivedAddress, address)
+                case .bluzelle:
+                    let expectedResult = "bluzelle142j9u5eaduzd7faumygud6ruhdwme98q9ufmsz"
+                    assertCoinDerivation(coin, expectedResult, derivedAddress, address)
                 @unknown default:
                     fatalError()
                 }

--- a/tests/Bluzelle/TWCoinTypeTests.cpp
+++ b/tests/Bluzelle/TWCoinTypeTests.cpp
@@ -1,0 +1,34 @@
+// Copyright © 2017-2020 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here MAY BE LOST.
+// Generated one-time (codegen/bin/cointests)
+//
+
+#include "../interface/TWTestUtilities.h"
+#include <TrustWalletCore/TWCoinTypeConfiguration.h>
+#include <gtest/gtest.h>
+
+
+TEST(TWCoinTypeBluzelle, TWCoinType) {
+    auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeBluzelle));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("AC026E0EC6E33A77D5EA6B9CEF9810699BC2AD8C5582E007E7857457C6D3B819"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeBluzelle, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("bluzelle1q9cryfal7u3jvnq6er5ufety20xtzw6ycx2te9"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeBluzelle, accId.get()));
+    auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeBluzelle));
+    auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeBluzelle));
+
+    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeBluzelle), 6);
+    ASSERT_EQ(TWBlockchainCosmos, TWCoinTypeBlockchain(TWCoinTypeBluzelle));
+    ASSERT_EQ(0x0, TWCoinTypeP2shPrefix(TWCoinTypeBluzelle));
+    ASSERT_EQ(0x0, TWCoinTypeStaticPrefix(TWCoinTypeBluzelle));
+    assertStringsEqual(symbol, "BLZ");
+    assertStringsEqual(txUrl, "https://bigdipper.net.bluzelle.com/transactions/AC026E0EC6E33A77D5EA6B9CEF9810699BC2AD8C5582E007E7857457C6D3B819");
+    assertStringsEqual(accUrl, "https://bigdipper.net.bluzelle.com/account/bluzelle1q9cryfal7u3jvnq6er5ufety20xtzw6ycx2te9");
+    assertStringsEqual(id, "bluzelle");
+    assertStringsEqual(name, "Bluzelle");
+}

--- a/tests/CoinAddressValidationTests.cpp
+++ b/tests/CoinAddressValidationTests.cpp
@@ -330,6 +330,14 @@ TEST(Coin, ValidateAddresBand) {
     EXPECT_FALSE(validateAddress(TWCoinTypeBandChain, "band1pnndgfwsrff86263xzpc5cd3t6yfvgjyqc8000"));
 }
 
+TEST(Coin, ValidateAddresBluzelle) {
+    EXPECT_TRUE(validateAddress(TWCoinTypeBluzelle, "bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"));
+    // wrong prefix
+    EXPECT_FALSE(validateAddress(TWCoinTypeBluzelle, "cosmos1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"));
+    // wrong checksum
+    EXPECT_FALSE(validateAddress(TWCoinTypeBluzelle, "bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmunx"));
+}
+
 TEST(Coin, ValidateAddresCardano) {
     // valid V3 address
     EXPECT_TRUE(validateAddress(TWCoinTypeCardano, "addr1s3hdtrqgs47l7ue5srga8wmk9dzw279x9e7lxadalt6z0fk64nnn2mgtn87mrny9r77gm09h6ecslh3gmarrvrp9n4yzmdnecfxyu59j5lempe"));

--- a/tests/CoinAddressValidationTests.cpp
+++ b/tests/CoinAddressValidationTests.cpp
@@ -330,7 +330,7 @@ TEST(Coin, ValidateAddresBand) {
     EXPECT_FALSE(validateAddress(TWCoinTypeBandChain, "band1pnndgfwsrff86263xzpc5cd3t6yfvgjyqc8000"));
 }
 
-TEST(Coin, ValidateAddresBluzelle) {
+TEST(Coin, ValidateAddressBluzelle) {
     EXPECT_TRUE(validateAddress(TWCoinTypeBluzelle, "bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"));
     // wrong prefix
     EXPECT_FALSE(validateAddress(TWCoinTypeBluzelle, "cosmos1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"));

--- a/tests/interface/TWHRPTests.cpp
+++ b/tests/interface/TWHRPTests.cpp
@@ -28,6 +28,7 @@ TEST(TWHRP, StringForHRP) {
     ASSERT_STREQ(stringForHRP(TWHRPMonacoin), "mona");
     ASSERT_STREQ(stringForHRP(TWHRPKava), "kava");
     ASSERT_STREQ(stringForHRP(TWHRPBandChain), "band");
+    ASSERT_STREQ(stringForHRP(TWHRPBluzelle), "bluzelle");
     ASSERT_STREQ(stringForHRP(TWHRPCardano), "addr");
     ASSERT_STREQ(stringForHRP(TWHRPElrond), "erd");
     ASSERT_STREQ(stringForHRP(TWHRPOasis), "oasis");
@@ -55,6 +56,7 @@ TEST(TWHRP, HRPForString) {
     ASSERT_EQ(hrpForString("erd"), TWHRPElrond);
     ASSERT_EQ(hrpForString("oasis"), TWHRPOasis);
     ASSERT_EQ(hrpForString("thor"), TWHRPTHORChain);
+    ASSERT_EQ(hrpForString("bluzelle"), TWHRPBluzelle);
 }
 
 TEST(TWHPR, HPRByCoinType) {
@@ -73,6 +75,7 @@ TEST(TWHPR, HPRByCoinType) {
     ASSERT_EQ(TWHRPMonacoin, TWCoinTypeHRP(TWCoinTypeMonacoin));
     ASSERT_EQ(TWHRPKava, TWCoinTypeHRP(TWCoinTypeKava));
     ASSERT_EQ(TWHRPBandChain, TWCoinTypeHRP(TWCoinTypeBandChain));
+    ASSERT_EQ(TWHRPBluzelle, TWCoinTypeHRP(TWCoinTypeBluzelle));
     ASSERT_EQ(TWHRPCardano, TWCoinTypeHRP(TWCoinTypeCardano));
     ASSERT_EQ(TWHRPElrond, TWCoinTypeHRP(TWCoinTypeElrond));
     ASSERT_EQ(TWHRPOasis, TWCoinTypeHRP(TWCoinTypeOasis));


### PR DESCRIPTION
## Description

Added support for the Bluzelle blockchain  This PR supports sending funds and staking.

Since bluzelle uses the Cosmos SDK, the cosmos signing logic is reused. The integration is very similar to the Terra and Kava integration.

## Testing instructions

`bootstrap.sh` passes locally. Tests pass, coverage needs met.
`tools/android-test` passes locally. Tests pass, coverage needs met.
`tools/ios-test` passes locally. Tests pass, coverage needs met.


## Types of changes

* New feature (non-breaking change which adds functionality)


## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
