### PR TITLE
HDWallet creation thread-safe

### DIFF
--- a/include/TrustWalletCore/TWHDWallet.h
+++ b/include/TrustWalletCore/TWHDWallet.h
@@ -24,17 +24,17 @@ struct TWHDWallet;
 /// TWHDWalletIsValid has been deprecated; use TWMnemonicIsValid().
 
 /// Creates a new HDWallet with a new random mnemonic with the provided strength in bits.
-/// Null is returned on invalid strength.  Method not thread safe!  Returned object needs to be deleted.
+/// Null is returned on invalid strength.  Returned object needs to be deleted.
 TW_EXPORT_STATIC_METHOD
 struct TWHDWallet *_Nullable TWHDWalletCreate(int strength, TWString *_Nonnull passphrase);
 
 /// Creates an HDWallet from a mnemonic (aka. recovery phrase).
-/// Null is returned on invalid mnemonic.  Method not thread safe!  Returned object needs to be deleted.
+/// Null is returned on invalid mnemonic.  Returned object needs to be deleted.
 TW_EXPORT_STATIC_METHOD
 struct TWHDWallet *_Nullable TWHDWalletCreateWithMnemonic(TWString *_Nonnull mnemonic, TWString *_Nonnull passphrase);
 
 /// Creates an HDWallet from entropy (corresponding to a mnemonic).
-/// Null is returned on invalid input.  Method not thread safe!  Returned object needs to be deleted.
+/// Null is returned on invalid input.  Returned object needs to be deleted.
 TW_EXPORT_STATIC_METHOD
 struct TWHDWallet *_Nullable TWHDWalletCreateWithEntropy(TWData *_Nonnull entropy, TWString *_Nonnull passphrase);
 

--- a/src/HDWallet.cpp
+++ b/src/HDWallet.cpp
@@ -33,9 +33,12 @@ HDNode getMasterNode(const HDWallet& wallet, TWCurve curve);
 const char* curveName(TWCurve curve);
 } // namespace
 
+const size_t MnemonicBufLength = Mnemonic::MaxWords * (Mnemonic::MaxWordLength + 3) + 20; // some extra slack
+
 HDWallet::HDWallet(int strength, const std::string& passphrase)
     : passphrase(passphrase) {
-    const char* mnemonic_chars = mnemonic_generate(strength);
+    char buf[MnemonicBufLength];
+    const char* mnemonic_chars = mnemonic_generate(strength, buf, MnemonicBufLength);
     if (mnemonic_chars == nullptr) {
         throw std::invalid_argument("Invalid strength");
     }
@@ -55,7 +58,8 @@ HDWallet::HDWallet(const std::string& mnemonic, const std::string& passphrase)
 
 HDWallet::HDWallet(const Data& entropy, const std::string& passphrase)
     : passphrase(passphrase) {
-    const char* mnemonic_chars = mnemonic_from_data(entropy.data(), static_cast<int>(entropy.size()));
+    char buf[MnemonicBufLength];
+    const char* mnemonic_chars = mnemonic_from_data(entropy.data(), static_cast<int>(entropy.size()), buf, MnemonicBufLength);
     if (mnemonic_chars == nullptr) {
         throw std::invalid_argument("Invalid mnemonic data");
     }

--- a/src/HDWallet.cpp
+++ b/src/HDWallet.cpp
@@ -33,7 +33,7 @@ HDNode getMasterNode(const HDWallet& wallet, TWCurve curve);
 const char* curveName(TWCurve curve);
 } // namespace
 
-const size_t MnemonicBufLength = Mnemonic::MaxWords * (Mnemonic::MaxWordLength + 3) + 20; // some extra slack
+const int MnemonicBufLength = Mnemonic::MaxWords * (BIP39_MAX_WORD_LENGTH + 3) + 20; // some extra slack
 
 HDWallet::HDWallet(int strength, const std::string& passphrase)
     : passphrase(passphrase) {

--- a/src/HDWallet.h
+++ b/src/HDWallet.h
@@ -50,15 +50,15 @@ class HDWallet {
 
   public:
     /// Initializes a new random HDWallet with the provided strength in bits.  
-    /// Throws on invalid strength.  Not thread safe!
+    /// Throws on invalid strength.
     HDWallet(int strength, const std::string& passphrase);
 
     /// Initializes an HDWallet from a mnemonic.
-    /// Throws on invalid mnemonic.  Not thread safe!
+    /// Throws on invalid mnemonic.
     HDWallet(const std::string& mnemonic, const std::string& passphrase);
 
     /// Initializes an HDWallet from an entropy.
-    /// Throws on invalid data.  Not thread safe!
+    /// Throws on invalid data.
     HDWallet(const Data& entropy, const std::string& passphrase);
 
     HDWallet(const HDWallet& other) = default;

--- a/src/Mnemonic.h
+++ b/src/Mnemonic.h
@@ -16,6 +16,7 @@ public:
     static constexpr size_t MaxWords = 24;
     static constexpr size_t MinWords = 12;
     static constexpr size_t BitsPerWord = 11; // each word encodes this many bits (there are 2^11=2048 different words)
+    static constexpr size_t MaxWordLength = 9; // Length of longest mnemonic word
 
 public:
     /// Determines whether a mnemonic phrase is valid.

--- a/src/Mnemonic.h
+++ b/src/Mnemonic.h
@@ -13,10 +13,9 @@ namespace TW {
 /// BIP39 Mnemonic Sentence handling.
 class Mnemonic {
 public:
-    static constexpr size_t MaxWords = 24;
-    static constexpr size_t MinWords = 12;
-    static constexpr size_t BitsPerWord = 11; // each word encodes this many bits (there are 2^11=2048 different words)
-    static constexpr size_t MaxWordLength = 9; // Length of longest mnemonic word
+    static constexpr int MaxWords = 24;
+    static constexpr int MinWords = 12;
+    static constexpr int BitsPerWord = 11; // each word encodes this many bits (there are 2^11=2048 different words)
 
 public:
     /// Determines whether a mnemonic phrase is valid.

--- a/swift/Tests/HDWalletTests.swift
+++ b/swift/Tests/HDWalletTests.swift
@@ -438,4 +438,24 @@ class HDWalletTests: XCTestCase {
 
         XCTAssertEqual(address, "band1pe8xm2r46rmctsukuqu7gl900vzprfsp4sguc3")
     }
+
+    func testCreateMultiThreaded() throws {
+        let generated = HDWallet(strength: 256, passphrase: "")
+        XCTAssertNotNil(generated)
+
+        let mnemonic = generated?.mnemonic ?? ""
+        let group = DispatchGroup()
+        for _ in 0..<50 {
+            group.enter()
+
+            Thread.init {
+                let wallet = HDWallet(mnemonic: mnemonic, passphrase: "")
+                XCTAssertEqual(wallet?.mnemonic, mnemonic)
+
+                group.leave()
+            }.start()
+        }
+
+        XCTAssertEqual(group.wait(timeout: .now() + .seconds(5)), .success)
+    }
 }

--- a/swift/Tests/HDWalletTests.swift
+++ b/swift/Tests/HDWalletTests.swift
@@ -439,23 +439,23 @@ class HDWalletTests: XCTestCase {
         XCTAssertEqual(address, "band1pe8xm2r46rmctsukuqu7gl900vzprfsp4sguc3")
     }
 
-    func testCreateMultiThreaded() throws {
-        let generated = HDWallet(strength: 256, passphrase: "")
-        XCTAssertNotNil(generated)
-
-        let mnemonic = generated?.mnemonic ?? ""
+    func testGenerateMultiThreaded() throws {
         let group = DispatchGroup()
-        for _ in 0..<50 {
+        for _ in 0..<5 {
             group.enter()
 
             Thread.init {
-                let wallet = HDWallet(mnemonic: mnemonic, passphrase: "")
-                XCTAssertEqual(wallet?.mnemonic, mnemonic)
+                // multiple steps in one thread
+                for _ in 0..<20 {
+                    let wallet = HDWallet(strength: 128, passphrase: "")
+                    XCTAssertNotNil(wallet)
+                    XCTAssertTrue(Mnemonic.isValid(mnemonic: wallet?.mnemonic  ?? ""))
+                }
 
                 group.leave()
             }.start()
         }
 
-        XCTAssertEqual(group.wait(timeout: .now() + .seconds(5)), .success)
+        XCTAssertEqual(group.wait(timeout: .now() + .seconds(10)), .success)
     }
 }

--- a/swift/Tests/HDWalletTests.swift
+++ b/swift/Tests/HDWalletTests.swift
@@ -455,7 +455,7 @@ class HDWalletTests: XCTestCase {
                     // also try mnemonic-based generation
                     let mnemonic = wallet?.mnemonic ?? ""
                     let wallet2 = HDWallet(mnemonic: mnemonic, passphrase: "")
-                    XCTAssertEqual(wallet?.mnemonic, mnemonic)
+                    XCTAssertEqual(wallet2?.mnemonic, mnemonic)
                 }
 
                 group.leave()

--- a/swift/Tests/HDWalletTests.swift
+++ b/swift/Tests/HDWalletTests.swift
@@ -446,10 +446,16 @@ class HDWalletTests: XCTestCase {
 
             Thread.init {
                 // multiple steps in one thread
-                for _ in 0..<20 {
+                for _ in 0..<10 {
+                    // random wallet generation
                     let wallet = HDWallet(strength: 128, passphrase: "")
                     XCTAssertNotNil(wallet)
                     XCTAssertTrue(Mnemonic.isValid(mnemonic: wallet?.mnemonic  ?? ""))
+
+                    // also try mnemonic-based generation
+                    let mnemonic = wallet?.mnemonic ?? ""
+                    let wallet2 = HDWallet(mnemonic: mnemonic, passphrase: "")
+                    XCTAssertEqual(wallet?.mnemonic, mnemonic)
                 }
 
                 group.leave()

--- a/tests/interface/TWHDWalletTests.cpp
+++ b/tests/interface/TWHDWalletTests.cpp
@@ -372,7 +372,6 @@ TEST(HDWallet, PublicKeyFromExtended_Negative) {
     }
 }
 
-/* Test disabled temporarily, as HDWallet creation is not thread safe, can produce invalid result which is checked now.
 TEST(HDWallet, MultipleThreads) {
     auto passphrase = STRING("");
 
@@ -398,7 +397,6 @@ TEST(HDWallet, MultipleThreads) {
     th2.join();
     th3.join();
 }
-*/
 
 TEST(HDWallet, GetDerivedKey) {
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), passphrase.get()));

--- a/trezor-crypto/crypto/bip39.c
+++ b/trezor-crypto/crypto/bip39.c
@@ -66,6 +66,7 @@ const char *mnemonic_from_data(const uint8_t *data, int len, char *buf, int bufl
   if (len % 4 || len < 16 || len > 32) {
     return 0;
   }
+  // [wallet-core] Check provided buffer validity, size
   if (!buf || buflen < 24 * 10) {
     return 0;
   }

--- a/trezor-crypto/crypto/bip39.c
+++ b/trezor-crypto/crypto/bip39.c
@@ -67,7 +67,7 @@ const char *mnemonic_from_data(const uint8_t *data, int len, char *buf, int bufl
     return 0;
   }
   // [wallet-core] Check provided buffer validity, size
-  if (!buf || buflen < 24 * 10) {
+  if (!buf || buflen < (BIP39_MAX_WORDS * (BIP39_MAX_WORD_LENGTH + 1))) {
     return 0;
   }
 

--- a/trezor-crypto/crypto/bip39.c
+++ b/trezor-crypto/crypto/bip39.c
@@ -46,21 +46,27 @@ CONFIDENTIAL struct {
 
 #endif
 
-const char *mnemonic_generate(int strength) {
+// [wallet-core] Added output buffer
+const char *mnemonic_generate(int strength, char *buf, int buflen) {
   if (strength % 32 || strength < 128 || strength > 256) {
     return 0;
   }
   uint8_t data[32] = {0};
   random_buffer(data, 32);
-  const char *r = mnemonic_from_data(data, strength / 8);
+  const char *r = mnemonic_from_data(data, strength / 8, buf, buflen);
   memzero(data, sizeof(data));
   return r;
 }
 
-CONFIDENTIAL char mnemo[24 * 10];
+// [wallet-core] Global buffer no longer used
+//CONFIDENTIAL char mnemo[24 * 10];
 
-const char *mnemonic_from_data(const uint8_t *data, int len) {
+// [wallet-core] Added output buffer
+const char *mnemonic_from_data(const uint8_t *data, int len, char *buf, int buflen) {
   if (len % 4 || len < 16 || len > 32) {
+    return 0;
+  }
+  if (!buf || buflen < 24 * 10) {
     return 0;
   }
 
@@ -75,7 +81,7 @@ const char *mnemonic_from_data(const uint8_t *data, int len) {
   int mlen = len * 3 / 4;
 
   int i = 0, j = 0, idx = 0;
-  char *p = mnemo;
+  char *p = buf; // [wallet-core]
   for (i = 0; i < mlen; i++) {
     idx = 0;
     for (j = 0; j < 11; j++) {
@@ -89,10 +95,11 @@ const char *mnemonic_from_data(const uint8_t *data, int len) {
   }
   memzero(bits, sizeof(bits));
 
-  return mnemo;
+  return buf; // [wallet-core]
 }
 
-void mnemonic_clear(void) { memzero(mnemo, sizeof(mnemo)); }
+// [wallet-core] No longer used
+//void mnemonic_clear(void) { memzero(mnemo, sizeof(mnemo)); }
 
 int mnemonic_to_bits(const char *mnemonic, uint8_t *bits) {
   if (!mnemonic) {

--- a/trezor-crypto/crypto/tests/test_check.c
+++ b/trezor-crypto/crypto/tests/test_check.c
@@ -4990,8 +4990,10 @@ START_TEST(test_mnemonic) {
   a = vectors;
   b = vectors + 1;
   c = vectors + 2;
+  const size_t bufSize = 300; // large enough to hold 24 long words
+  char buf[bufSize];
   while (*a && *b && *c) {
-    m = mnemonic_from_data(fromhex(*a), strlen(*a) / 2);
+    m = mnemonic_from_data(fromhex(*a), strlen(*a) / 2, buf, bufSize);
     ck_assert_str_eq(m, *b);
     mnemonic_to_seed(m, "TREZOR", seed, 0);
     ck_assert_mem_eq(seed, fromhex(*c), strlen(*c) / 2);
@@ -5004,6 +5006,11 @@ START_TEST(test_mnemonic) {
     b += 3;
     c += 3;
   }
+
+  // [wallet-core] negative test: provided buffer invalid (too small or null)
+  ck_assert_int_eq((int)(mnemonic_from_data(fromhex(vectors[0]), strlen(vectors[0]) / 2, buf, 200)), 0);
+  ck_assert_int_eq((int)(mnemonic_from_data(fromhex(vectors[0]), strlen(vectors[0]) / 2, buf, 0)), 0);
+  ck_assert_int_eq((int)(mnemonic_from_data(fromhex(vectors[0]), strlen(vectors[0]) / 2, NULL, 240)), 0);
 }
 END_TEST
 

--- a/trezor-crypto/include/TrezorCrypto/bip39.h
+++ b/trezor-crypto/include/TrezorCrypto/bip39.h
@@ -34,6 +34,9 @@ extern "C" {
 #define BIP39_WORDS 2048
 #define BIP39_PBKDF2_ROUNDS 2048
 
+#define BIP39_MAX_WORDS 24  // [wallet-core]
+#define BIP39_MAX_WORD_LENGTH 9  // [wallet-core]
+
 // [wallet-core] Added output buffer
 const char *mnemonic_generate(int strength, char *buf, int buflen);  // strength in bits
 // [wallet-core] Added output buffer

--- a/trezor-crypto/include/TrezorCrypto/bip39.h
+++ b/trezor-crypto/include/TrezorCrypto/bip39.h
@@ -34,11 +34,12 @@ extern "C" {
 #define BIP39_WORDS 2048
 #define BIP39_PBKDF2_ROUNDS 2048
 
-// [wallet-core] Note: not thread safe!
-const char *mnemonic_generate(int strength);  // strength in bits
-// [wallet-core] Note: not thread safe!
-const char *mnemonic_from_data(const uint8_t *data, int len);
-void mnemonic_clear(void);
+// [wallet-core] Added output buffer
+const char *mnemonic_generate(int strength, char *buf, int buflen);  // strength in bits
+// [wallet-core] Added output buffer
+const char *mnemonic_from_data(const uint8_t *data, int datalen, char *buf, int buflen);
+// [wallet-core] No longer used
+//void mnemonic_clear(void);
 
 int mnemonic_check(const char *mnemonic);
 


### PR DESCRIPTION
## Description

HDWallet creation is not thread-safe, calling simultaneously from multiple threads may result in invalid recovery phrases, and thus error.
Fix this by making the underlying Trezor lib methods -- mnemonic_generate() and mnemonic_from_data() -- thread safe, by using user-supplied output buffer instead of a common global variable.

Note that this PR is based on #1527 ar/hdwallet-error-fix, it should come after it; diff should be looked relative to that.

(Continuation of #1505 )

## Testing instructions

Unit tests, esp.`HDWallet.MultipleThreads`.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
