### PR TITLE
Bitcoin proto: Expose LockTime field

### DIFF
--- a/src/Bitcoin/Transaction.h
+++ b/src/Bitcoin/Transaction.h
@@ -49,7 +49,7 @@ public:
 public:
     Transaction() = default;
 
-    Transaction(int32_t version, uint32_t lockTime, TW::Hash::Hasher hasher = TW::Hash::sha256d)
+    Transaction(int32_t version, uint32_t lockTime = 0, TW::Hash::Hasher hasher = TW::Hash::sha256d)
         : version(version), lockTime(lockTime), inputs(), outputs(), hasher(hasher) {}
 
     /// Whether the transaction is empty.

--- a/src/Bitcoin/TransactionBuilder.h
+++ b/src/Bitcoin/TransactionBuilder.h
@@ -24,13 +24,14 @@ public:
     /// Builds a transaction by selecting UTXOs and calculating fees.
     template <typename Transaction>
     static Transaction build(const TransactionPlan& plan, const std::string& toAddress,
-                             const std::string& changeAddress, enum TWCoinType coin) {
+                             const std::string& changeAddress, enum TWCoinType coin, uint32_t lockTime) {
         auto lockingScriptTo = Script::lockScriptForAddress(toAddress, coin);
         if (lockingScriptTo.empty()) {
             return {};
         }
 
         Transaction tx;
+        tx.lockTime = lockTime;
         tx.outputs.push_back(TransactionOutput(plan.amount, lockingScriptTo));
 
         if (plan.change > 0) {

--- a/src/Bitcoin/TransactionSigner.h
+++ b/src/Bitcoin/TransactionSigner.h
@@ -58,7 +58,7 @@ class TransactionSigner {
         plan = TransactionBuilder::plan(input);
       }
       transaction = TransactionBuilder::template build<Transaction>(
-        plan, input.to_address(), input.change_address(), TWCoinType(input.coin_type())
+        plan, input.to_address(), input.change_address(), TWCoinType(input.coin_type()), input.lock_time()
       );
     }
 

--- a/src/Groestlcoin/Transaction.h
+++ b/src/Groestlcoin/Transaction.h
@@ -12,7 +12,7 @@ namespace TW::Groestlcoin {
 
 struct Transaction : public Bitcoin::Transaction {
     Transaction() : Bitcoin::Transaction(1, 0, static_cast<Hash::HasherSimpleType>(Hash::sha256)) {}
-    Transaction(int32_t version, uint32_t lockTime) :
+    Transaction(int32_t version, uint32_t lockTime = 0) :
         Bitcoin::Transaction(version, lockTime, static_cast<Hash::HasherSimpleType>(Hash::sha256)) {}
 };
 

--- a/src/Zcash/TransactionBuilder.h
+++ b/src/Zcash/TransactionBuilder.h
@@ -26,10 +26,10 @@ struct TransactionBuilder {
     /// Builds a transaction by selecting UTXOs and calculating fees.
     template <typename Transaction>
     static Transaction build(const Bitcoin::TransactionPlan& plan, const std::string& toAddress,
-                             const std::string& changeAddress, enum TWCoinType coin) {
+                             const std::string& changeAddress, enum TWCoinType coin, uint32_t lockTime) {
         coin = TWCoinTypeZcash;
         Transaction tx =
-            Bitcoin::TransactionBuilder::build<Transaction>(plan, toAddress, changeAddress, coin);
+            Bitcoin::TransactionBuilder::build<Transaction>(plan, toAddress, changeAddress, coin, lockTime);
         // if not set, always use latest consensus branch id
         if (plan.branchId.empty()) {
             std::copy(BlossomBranchID.begin(), BlossomBranchID.end(), tx.branchId.begin());

--- a/src/proto/Bitcoin.proto
+++ b/src/proto/Bitcoin.proto
@@ -100,6 +100,13 @@ message SigningInput {
 
     // Optional transaction plan
     TransactionPlan plan = 11;
+
+    // Optional lockTime, default value 0 means no time locking.
+    // If all inputs have final (`0xffffffff`) sequence numbers then `lockTime` is irrelevant.
+    // Otherwise, the transaction may not be added to a block until after `lockTime`.
+    //  value  < 500000000 : Block number at which this transaction is unlocked
+    //  value >= 500000000 : UNIX timestamp at which this transaction is unlocked
+    uint32 lock_time = 12;
 }
 
 // Describes a preliminary transaction plan.

--- a/tests/Bitcoin/TWBitcoinSigningTests.cpp
+++ b/tests/Bitcoin/TWBitcoinSigningTests.cpp
@@ -929,7 +929,7 @@ TEST(BitcoinSigning, EncodeP2SH_P2WSH) {
 
 TEST(BitcoinSigning, SignP2SH_P2WSH) {
     auto emptyScript = Script();
-    auto unsignedTx = Transaction(1, 0);
+    auto unsignedTx = Transaction(1);
 
     auto outpoint0 = OutPoint(parse_hex("36641869ca081e70f394c6948e8af409e18b619df2ed74aa106c1ca29787b96e"), 1);
     unsignedTx.inputs.emplace_back(outpoint0, emptyScript, 0xffffffff);
@@ -1319,7 +1319,7 @@ TEST(BitcoinSigning, EncodeThreeOutput) {
     auto toAmount0 = 1'000'000;
     auto toAmount1 = 2'000'000;
 
-    auto unsignedTx = Transaction(1, 0);
+    auto unsignedTx = Transaction(1);
 
     auto hash0 = parse_hex("bbe736ada63c4678025dff0ff24d5f38970a3e4d7a2f77808689ed68004f55fe");
     std::reverse(hash0.begin(), hash0.end());

--- a/tests/Bitcoin/TWBitcoinSigningTests.cpp
+++ b/tests/Bitcoin/TWBitcoinSigningTests.cpp
@@ -196,6 +196,7 @@ TEST(BitcoinSigning, SignP2WPKH_Bip143) {
     const auto utxoPubkeyHash1 = Hash::ripemd(Hash::sha256(pubKey1.bytes));
     EXPECT_EQ(hex(utxoPubkeyHash1), "1d0f172a0ecb48aee1be1f2687d2963ae33f71a1");
     input.add_private_key(utxoKey1.bytes.data(), utxoKey1.bytes.size());
+    input.set_lock_time(0x11);
 
     auto utxo0 = input.add_utxo();
     utxo0->set_script(utxo0Script.bytes.data(), utxo0Script.bytes.size());
@@ -224,7 +225,6 @@ TEST(BitcoinSigning, SignP2WPKH_Bip143) {
 
     // Sign
     auto signer = TransactionSigner<Transaction, TransactionBuilder>(std::move(input));
-    signer.transaction.lockTime = 0x11; // there is no way to set locktime through SigningInput
     auto result = signer.sign();
 
     ASSERT_TRUE(result) << std::to_string(result.error());

--- a/tests/BitcoinGold/TWBitcoinGoldTests.cpp
+++ b/tests/BitcoinGold/TWBitcoinGoldTests.cpp
@@ -78,7 +78,8 @@ TEST(TWBitcoinGoldTxGeneration, TxGeneration) {
 
     auto utxoKey0 = parse_hex("cbe13a79b82ec7f8871b336a64fd8d531f598e7c9022e29c67e824cfd54af57f");
     input.add_private_key(utxoKey0.data(), utxoKey0.size());
-
+    input.set_lock_time(0x00098971);
+    
 
     auto scriptPub1 = Script(parse_hex("0014db746a75d9aae8995d135b1e19a04d7765242a8f"));
     auto scriptHash = std::vector<uint8_t>();
@@ -101,7 +102,6 @@ TEST(TWBitcoinGoldTxGeneration, TxGeneration) {
 
     // Sign
     auto txSigner = TransactionSigner<Transaction, TransactionBuilder>(std::move(input));
-    txSigner.transaction.lockTime = 0x00098971;
     auto result = txSigner.sign();
 
     ASSERT_TRUE(result) << std::to_string(result.error());

--- a/tests/BitcoinGold/TWSignerTests.cpp
+++ b/tests/BitcoinGold/TWSignerTests.cpp
@@ -58,6 +58,7 @@ TEST(TWBitcoinGoldSigner, SignTransaction) {
     utxo0->mutable_out_point()->set_hash(hash0.data(), hash0.size());
     utxo0->mutable_out_point()->set_index(1);
     utxo0->mutable_out_point()->set_sequence(0xfffffffd);
+    input.set_lock_time(0x00098971);
 
 
     Proto::TransactionPlan plan;
@@ -74,7 +75,6 @@ TEST(TWBitcoinGoldSigner, SignTransaction) {
 
     // Sign
     auto txSigner = TransactionSigner<Transaction, TransactionBuilder>(std::move(input));
-    txSigner.transaction.lockTime = 0x00098971;
     auto result = txSigner.sign();
 
     ASSERT_TRUE(result) << std::to_string(result.error());


### PR DESCRIPTION
## Description

The lockTime field was not exposed through the SigningInput interface.
Although it is not used in Trust Wallet use cases, it is added for completeness and testability.
Some reference Bitcoin tests use non-zero lockTime.
The Proto change is backwards compatible, but breaking on binary level.

## Testing instructions

Unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
