### PR TITLE
Explicit selector for legacy/enveloped transactions

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/ethereum/TestEthereumTransactionSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/ethereum/TestEthereumTransactionSigner.kt
@@ -28,7 +28,7 @@ class TestEthereumTransactionSigner {
             toAddress = "0x3535353535353535353535353535353535353535"
             chainId = ByteString.copyFrom("0x1".toHexByteArray())
             nonce = ByteString.copyFrom("0x9".toHexByteArray())
-            txMode = TransactionMode.Legacy
+            // txMode not set, Legacy is the default
             gasPrice = ByteString.copyFrom("0x04a817c800".toHexByteArray())
             gasLimit = ByteString.copyFrom("0x5208".toHexByteArray())
             transaction = Ethereum.Transaction.newBuilder().apply {
@@ -51,7 +51,7 @@ class TestEthereumTransactionSigner {
             toAddress = "0x6b175474e89094c44da98b954eedeac495271d0f" // DAI
             chainId = ByteString.copyFrom("0x1".toHexByteArray())
             nonce = ByteString.copyFrom("0x0".toHexByteArray())
-            txMode = TransactionMode.Legacy
+            // txMode not set, Legacy is the default
             gasPrice = ByteString.copyFrom("0x09c7652400".toHexByteArray())
             gasLimit = ByteString.copyFrom("0x0130B9".toHexByteArray())
             transaction = Ethereum.Transaction.newBuilder().apply {
@@ -101,7 +101,7 @@ class TestEthereumTransactionSigner {
             toAddress = "0x0d8c864DA1985525e0af0acBEEF6562881827bd5"
             chainId = ByteString.copyFrom("0x1".toHexByteArray())
             nonce = ByteString.copyFrom("0x02de".toHexByteArray())
-            txMode = TransactionMode.Legacy
+            // txMode not set, Legacy is the default
             gasPrice = ByteString.copyFrom("0x22ecb25c00".toHexByteArray()) // 150 Gwei
             gasLimit = ByteString.copyFrom("0x0130b9".toHexByteArray())
             transaction = Ethereum.Transaction.newBuilder().apply {
@@ -127,7 +127,7 @@ class TestEthereumTransactionSigner {
             toAddress = "0x4e45e92ed38f885d39a733c14f1817217a89d425" // contract
             chainId = ByteString.copyFrom("0x01".toHexByteArray())
             nonce = ByteString.copyFrom("0x00".toHexByteArray())
-            txMode = TransactionMode.Legacy
+            // txMode not set, Legacy is the default
             gasPrice = ByteString.copyFrom("0x09C7652400".toHexByteArray()) // 42000000000
             gasLimit = ByteString.copyFrom("0x0130b9".toHexByteArray()) // 78009
             transaction = Ethereum.Transaction.newBuilder().apply {

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/ethereum/TestEthereumTransactionSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/ethereum/TestEthereumTransactionSigner.kt
@@ -10,6 +10,7 @@ import wallet.core.jni.CoinType
 import wallet.core.jni.CoinType.ETHEREUM
 import wallet.core.jni.proto.Ethereum
 import wallet.core.jni.proto.Ethereum.SigningOutput
+import wallet.core.jni.proto.Ethereum.TransactionMode
 import com.trustwallet.core.app.utils.Numeric
 import org.junit.Assert.assertArrayEquals
 
@@ -27,6 +28,7 @@ class TestEthereumTransactionSigner {
             toAddress = "0x3535353535353535353535353535353535353535"
             chainId = ByteString.copyFrom("0x1".toHexByteArray())
             nonce = ByteString.copyFrom("0x9".toHexByteArray())
+            txMode = TransactionMode.Legacy
             gasPrice = ByteString.copyFrom("0x04a817c800".toHexByteArray())
             gasLimit = ByteString.copyFrom("0x5208".toHexByteArray())
             transaction = Ethereum.Transaction.newBuilder().apply {
@@ -49,6 +51,7 @@ class TestEthereumTransactionSigner {
             toAddress = "0x6b175474e89094c44da98b954eedeac495271d0f" // DAI
             chainId = ByteString.copyFrom("0x1".toHexByteArray())
             nonce = ByteString.copyFrom("0x0".toHexByteArray())
+            txMode = TransactionMode.Legacy
             gasPrice = ByteString.copyFrom("0x09c7652400".toHexByteArray())
             gasLimit = ByteString.copyFrom("0x0130B9".toHexByteArray())
             transaction = Ethereum.Transaction.newBuilder().apply {
@@ -73,6 +76,7 @@ class TestEthereumTransactionSigner {
             toAddress = "0x6b175474e89094c44da98b954eedeac495271d0f" // DAI
             chainId = ByteString.copyFrom("0x1".toHexByteArray())
             nonce = ByteString.copyFrom("0x0".toHexByteArray())
+            txMode = TransactionMode.Enveloped
             maxInclusionFeePerGas = ByteString.copyFrom("0x77359400".toHexByteArray()) // 2000000000
             maxFeePerGas = ByteString.copyFrom("0xB2D05E00".toHexByteArray()) // 3000000000
             gasLimit = ByteString.copyFrom("0x0130B9".toHexByteArray())
@@ -97,6 +101,7 @@ class TestEthereumTransactionSigner {
             toAddress = "0x0d8c864DA1985525e0af0acBEEF6562881827bd5"
             chainId = ByteString.copyFrom("0x1".toHexByteArray())
             nonce = ByteString.copyFrom("0x02de".toHexByteArray())
+            txMode = TransactionMode.Legacy
             gasPrice = ByteString.copyFrom("0x22ecb25c00".toHexByteArray()) // 150 Gwei
             gasLimit = ByteString.copyFrom("0x0130b9".toHexByteArray())
             transaction = Ethereum.Transaction.newBuilder().apply {
@@ -122,6 +127,7 @@ class TestEthereumTransactionSigner {
             toAddress = "0x4e45e92ed38f885d39a733c14f1817217a89d425" // contract
             chainId = ByteString.copyFrom("0x01".toHexByteArray())
             nonce = ByteString.copyFrom("0x00".toHexByteArray())
+            txMode = TransactionMode.Legacy
             gasPrice = ByteString.copyFrom("0x09C7652400".toHexByteArray()) // 42000000000
             gasLimit = ByteString.copyFrom("0x0130b9".toHexByteArray()) // 78009
             transaction = Ethereum.Transaction.newBuilder().apply {

--- a/src/Ethereum/Signer.cpp
+++ b/src/Ethereum/Signer.cpp
@@ -93,10 +93,11 @@ std::shared_ptr<TransactionBase> Signer::build(const Proto::SigningInput& input)
     uint256_t gasLimit = load(input.gas_limit());
     uint256_t maxInclusionFeePerGas = load(input.max_inclusion_fee_per_gas());
     uint256_t maxFeePerGas = load(input.max_fee_per_gas());
+    bool isLegacy = input.tx_mode() == Proto::TransactionMode::Legacy;
     switch (input.transaction().transaction_oneof_case()) {
         case Proto::Transaction::kTransfer:
             {
-                if (gasPrice != 0) { // legacy
+                if (isLegacy) {
                     return TransactionNonTyped::buildNativeTransfer(
                         nonce, gasPrice, gasLimit,
                         /* to: */ toAddress,
@@ -114,7 +115,7 @@ std::shared_ptr<TransactionBase> Signer::build(const Proto::SigningInput& input)
         case Proto::Transaction::kErc20Transfer:
             {
                 Data tokenToAddress = addressStringToData(input.transaction().erc20_transfer().to());
-                if (gasPrice != 0) { // legacy
+                if (isLegacy) {
                     return TransactionNonTyped::buildERC20Transfer(
                         nonce, gasPrice, gasLimit,
                         /* tokenContract: */ toAddress,
@@ -132,7 +133,7 @@ std::shared_ptr<TransactionBase> Signer::build(const Proto::SigningInput& input)
         case Proto::Transaction::kErc20Approve:
             {
                 Data spenderAddress = addressStringToData(input.transaction().erc20_approve().spender());
-                if (gasPrice != 0) { // legacy
+                if (isLegacy) {
                     return TransactionNonTyped::buildERC20Approve(
                         nonce, gasPrice, gasLimit,
                         /* tokenContract: */ toAddress,
@@ -151,7 +152,7 @@ std::shared_ptr<TransactionBase> Signer::build(const Proto::SigningInput& input)
             {
                 Data tokenToAddress = addressStringToData(input.transaction().erc721_transfer().to());
                 Data tokenFromAddress = addressStringToData(input.transaction().erc721_transfer().from());
-                if (gasPrice != 0) { // legacy
+                if (isLegacy) {
                     return TransactionNonTyped::buildERC721Transfer(
                         nonce, gasPrice, gasLimit,
                         /* tokenContract: */ toAddress,
@@ -172,7 +173,7 @@ std::shared_ptr<TransactionBase> Signer::build(const Proto::SigningInput& input)
             {
                 Data tokenToAddress = addressStringToData(input.transaction().erc1155_transfer().to());
                 Data tokenFromAddress = addressStringToData(input.transaction().erc1155_transfer().from());
-                if (gasPrice != 0) { // legacy
+                if (isLegacy) {
                     return TransactionNonTyped::buildERC1155Transfer(
                         nonce, gasPrice, gasLimit,
                         /* tokenContract: */ toAddress,
@@ -197,7 +198,7 @@ std::shared_ptr<TransactionBase> Signer::build(const Proto::SigningInput& input)
         case Proto::Transaction::kContractGeneric:
         default:
             {
-                if (gasPrice != 0) { // legacy
+                if (isLegacy) {
                     return TransactionNonTyped::buildNativeTransfer(
                         nonce, gasPrice, gasLimit,
                         /* to: */ toAddress,

--- a/src/proto/Ethereum.proto
+++ b/src/proto/Ethereum.proto
@@ -89,6 +89,7 @@ message SigningInput {
     bytes nonce = 2;
 
     // Transaction version selector: Legacy or enveloped, has impact on fee structure.
+    // Default is Legacy (value 0)
     TransactionMode tx_mode = 3;
 
     // Gas price (256-bit number)

--- a/src/proto/Ethereum.proto
+++ b/src/proto/Ethereum.proto
@@ -74,10 +74,13 @@ message Transaction {
     }
 }
 
+enum TransactionMode {
+    Legacy = 0; // Legacy transaction, pre-EIP2718/EIP1559; for fee gasPrice/gasLimit is used
+    Enveloped = 1; // Enveloped transaction EIP2718 (with type 0x2), fee is according to EIP1559 (base fee, inclusion fee, ...) 
+}
+
 // Input data necessary to create a signed transaction.
-// Supported:
-// - Legacy transaction, with legacy fee (pre-EIP1559; gas price, gas limit)
-// - EIP1559 fee (transaction type: ?; max inclusion fee, max fee per gas)
+// Legacy and EIP2718/EIP1559 transactions supported, see TransactionMode.
 message SigningInput {
     // Chain identifier (256-bit number)
     bytes chain_id = 1;
@@ -85,28 +88,31 @@ message SigningInput {
     // Nonce (256-bit number)
     bytes nonce = 2;
 
+    // Transaction version selector: Legacy or enveloped, has impact on fee structure.
+    TransactionMode tx_mode = 3;
+
     // Gas price (256-bit number)
-    // If > 0, legacy fee scheme is used; if 0, EIP1559 fee scheme is used
-    bytes gas_price = 3;
+    // Relevant for legacy transactions only (disregarded for enveloped/EIP1559)
+    bytes gas_price = 4;
 
     // Gas limit (256-bit number)
-    bytes gas_limit = 4;
+    bytes gas_limit = 5;
 
     // Maxinmum optional inclusion fee (aka tip) (256-bit number)
-    // Used only for EIP1559 fee, disregarded for legacy
-    bytes max_inclusion_fee_per_gas = 8;
+    // Relevant for enveloped/EIP1559 transactions only, tx_mode=Enveloped, (disregarded for legacy)
+    bytes max_inclusion_fee_per_gas = 6;
 
     // Maxinmum fee (256-bit number)
-    // Used only for EIP1559 fee, disregarded for legacy
-    bytes max_fee_per_gas = 9;
+    // Relevant for enveloped/EIP1559 transactions only, tx_mode=Enveloped, (disregarded for legacy)
+    bytes max_fee_per_gas = 7;
 
     // Recipient's address.
-    string to_address = 5;
+    string to_address = 8;
 
     // Private key.
-    bytes private_key = 6;
+    bytes private_key = 9;
 
-    Transaction transaction = 7;
+    Transaction transaction = 10;
 }
 
 // Transaction signing output.

--- a/swift/Tests/Blockchains/EthereumTests.swift
+++ b/swift/Tests/Blockchains/EthereumTests.swift
@@ -68,7 +68,7 @@ class EthereumTests: XCTestCase {
         let input = EthereumSigningInput.with {
             $0.chainID = Data(hexString: "01")!
             $0.nonce = Data(hexString: "00")!
-            $0.txMode = EthereumTransactionMode.Enveloped
+            $0.txMode = .enveloped
             $0.gasLimit = Data(hexString: "0130B9")! // 78009
             $0.maxInclusionFeePerGas = Data(hexString: "0077359400")! // 2000000000
             $0.maxFeePerGas = Data(hexString: "00B2D05E00")! // 3000000000

--- a/swift/Tests/Blockchains/EthereumTests.swift
+++ b/swift/Tests/Blockchains/EthereumTests.swift
@@ -25,7 +25,7 @@ class EthereumTests: XCTestCase {
         let input = EthereumSigningInput.with {
             $0.chainID = Data(hexString: "01")!
             $0.nonce = Data(hexString: "09")!
-            $0.txMode = EthereumTransactionMode.Legacy
+            // txMode not set, Legacy is the default
             $0.gasPrice = Data(hexString: "04a817c800")!
             $0.gasLimit = Data(hexString: "5208")!
             $0.toAddress = "0x3535353535353535353535353535353535353535"
@@ -46,7 +46,7 @@ class EthereumTests: XCTestCase {
         let input = EthereumSigningInput.with {
             $0.chainID = Data(hexString: "01")!
             $0.nonce = Data(hexString: "00")!
-            $0.txMode = EthereumTransactionMode.Legacy
+            // txMode not set, Legacy is the default
             $0.gasPrice = Data(hexString: "09c7652400")! // 42000000000
             $0.gasLimit = Data(hexString: "0130B9")! // 78009
             $0.toAddress = "0x6b175474e89094c44da98b954eedeac495271d0f" // DAI
@@ -90,7 +90,7 @@ class EthereumTests: XCTestCase {
         let input = EthereumSigningInput.with {
             $0.chainID = Data(hexString: "01")!
             $0.nonce = Data(hexString: "00")!
-            $0.txMode = EthereumTransactionMode.Legacy
+            // txMode not set, Legacy is the default
             $0.gasPrice = Data(hexString: "09c7652400")! // 42000000000
             $0.gasLimit = Data(hexString: "0130B9")! // 78009
             $0.toAddress = "0x6b175474e89094c44da98b954eedeac495271d0f" // DAI
@@ -113,7 +113,7 @@ class EthereumTests: XCTestCase {
         let input = EthereumSigningInput.with {
             $0.chainID = Data(hexString: "01")!
             $0.nonce = Data(hexString: "02de")! // 734
-            $0.txMode = EthereumTransactionMode.Legacy
+            // txMode not set, Legacy is the default
             $0.gasPrice = Data(hexString: "22ecb25c00")! // 150000000000
             $0.gasLimit = Data(hexString: "0130b9")! // 78009
             $0.toAddress = "0x0d8c864DA1985525e0af0acBEEF6562881827bd5" // contract
@@ -136,7 +136,7 @@ class EthereumTests: XCTestCase {
         let input = EthereumSigningInput.with {
             $0.chainID = Data(hexString: "01")!
             $0.nonce = Data(hexString: "00")!
-            $0.txMode = EthereumTransactionMode.Legacy
+            // txMode not set, Legacy is the default
             $0.gasPrice = Data(hexString: "09C7652400")! // 42000000000
             $0.gasLimit = Data(hexString: "0130b9")! // 78009
             $0.toAddress = "0x4e45e92ed38f885d39a733c14f1817217a89d425" // contract

--- a/swift/Tests/Blockchains/EthereumTests.swift
+++ b/swift/Tests/Blockchains/EthereumTests.swift
@@ -25,6 +25,7 @@ class EthereumTests: XCTestCase {
         let input = EthereumSigningInput.with {
             $0.chainID = Data(hexString: "01")!
             $0.nonce = Data(hexString: "09")!
+            $0.txMode = EthereumTransactionMode.Legacy
             $0.gasPrice = Data(hexString: "04a817c800")!
             $0.gasLimit = Data(hexString: "5208")!
             $0.toAddress = "0x3535353535353535353535353535353535353535"
@@ -45,6 +46,7 @@ class EthereumTests: XCTestCase {
         let input = EthereumSigningInput.with {
             $0.chainID = Data(hexString: "01")!
             $0.nonce = Data(hexString: "00")!
+            $0.txMode = EthereumTransactionMode.Legacy
             $0.gasPrice = Data(hexString: "09c7652400")! // 42000000000
             $0.gasLimit = Data(hexString: "0130B9")! // 78009
             $0.toAddress = "0x6b175474e89094c44da98b954eedeac495271d0f" // DAI
@@ -66,6 +68,7 @@ class EthereumTests: XCTestCase {
         let input = EthereumSigningInput.with {
             $0.chainID = Data(hexString: "01")!
             $0.nonce = Data(hexString: "00")!
+            $0.txMode = EthereumTransactionMode.Enveloped
             $0.gasLimit = Data(hexString: "0130B9")! // 78009
             $0.maxInclusionFeePerGas = Data(hexString: "0077359400")! // 2000000000
             $0.maxFeePerGas = Data(hexString: "00B2D05E00")! // 3000000000
@@ -87,6 +90,7 @@ class EthereumTests: XCTestCase {
         let input = EthereumSigningInput.with {
             $0.chainID = Data(hexString: "01")!
             $0.nonce = Data(hexString: "00")!
+            $0.txMode = EthereumTransactionMode.Legacy
             $0.gasPrice = Data(hexString: "09c7652400")! // 42000000000
             $0.gasLimit = Data(hexString: "0130B9")! // 78009
             $0.toAddress = "0x6b175474e89094c44da98b954eedeac495271d0f" // DAI
@@ -109,6 +113,7 @@ class EthereumTests: XCTestCase {
         let input = EthereumSigningInput.with {
             $0.chainID = Data(hexString: "01")!
             $0.nonce = Data(hexString: "02de")! // 734
+            $0.txMode = EthereumTransactionMode.Legacy
             $0.gasPrice = Data(hexString: "22ecb25c00")! // 150000000000
             $0.gasLimit = Data(hexString: "0130b9")! // 78009
             $0.toAddress = "0x0d8c864DA1985525e0af0acBEEF6562881827bd5" // contract
@@ -131,6 +136,7 @@ class EthereumTests: XCTestCase {
         let input = EthereumSigningInput.with {
             $0.chainID = Data(hexString: "01")!
             $0.nonce = Data(hexString: "00")!
+            $0.txMode = EthereumTransactionMode.Legacy
             $0.gasPrice = Data(hexString: "09C7652400")! // 42000000000
             $0.gasLimit = Data(hexString: "0130b9")! // 78009
             $0.toAddress = "0x4e45e92ed38f885d39a733c14f1817217a89d425" // contract

--- a/tests/Ethereum/TWAnySignerTests.cpp
+++ b/tests/Ethereum/TWAnySignerTests.cpp
@@ -57,6 +57,7 @@ TEST(TWAnySignerEthereum, Sign) {
 
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
+    input.set_tx_mode(Proto::TransactionMode::Legacy);
     input.set_gas_price(gasPrice.data(), gasPrice.size());
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_private_key(key.data(), key.size());
@@ -89,6 +90,7 @@ TEST(TWAnySignerEthereum, SignERC20TransferAsERC20) {
     Proto::SigningInput input;
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
+    input.set_tx_mode(Proto::TransactionMode::Legacy);
     input.set_gas_price(gasPrice.data(), gasPrice.size());
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_to_address(token);
@@ -132,6 +134,7 @@ TEST(TWAnySignerEthereum, SignERC20TransferAsGenericContract) {
     Proto::SigningInput input;
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
+    input.set_tx_mode(Proto::TransactionMode::Legacy);
     input.set_gas_price(gasPrice.data(), gasPrice.size());
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_to_address(toAddress);
@@ -162,6 +165,7 @@ TEST(TWAnySignerEthereum, SignERC20TransferInvalidAddress) {
     Proto::SigningInput input;
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
+    input.set_tx_mode(Proto::TransactionMode::Legacy);
     input.set_gas_price(gasPrice.data(), gasPrice.size());
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_to_address(invalidAddress);
@@ -190,6 +194,7 @@ TEST(TWAnySignerEthereum, SignERC20Approve) {
     Proto::SigningInput input;
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
+    input.set_tx_mode(Proto::TransactionMode::Legacy);
     input.set_gas_price(gasPrice.data(), gasPrice.size());
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_to_address(token);
@@ -221,6 +226,7 @@ TEST(TWAnySignerEthereum, SignERC721Transfer) {
     Proto::SigningInput input;
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
+    input.set_tx_mode(Proto::TransactionMode::Legacy);
     input.set_gas_price(gasPrice.data(), gasPrice.size());
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_to_address(tokenContract);
@@ -257,6 +263,7 @@ TEST(TWAnySignerEthereum, SignERC1155Transfer) {
     Proto::SigningInput input;
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
+    input.set_tx_mode(Proto::TransactionMode::Legacy);
     input.set_gas_price(gasPrice.data(), gasPrice.size());
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_to_address(tokenContract);
@@ -324,6 +331,7 @@ TEST(TWAnySignerEthereum, SignERC1559Transfer_1442) {
     Proto::SigningInput input;
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
+    input.set_tx_mode(Proto::TransactionMode::Enveloped); // EIP1559
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_max_inclusion_fee_per_gas(maxInclusionFeePerGas.data(), maxInclusionFeePerGas.size());
     input.set_max_fee_per_gas(maxFeePerGas.data(), maxFeePerGas.size());
@@ -362,6 +370,7 @@ TEST(TWAnySignerEthereum, SignERC20Transfer_1559) {
     Proto::SigningInput input;
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
+    input.set_tx_mode(Proto::TransactionMode::Enveloped);
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_max_inclusion_fee_per_gas(maxInclusionFeePerGas.data(), maxInclusionFeePerGas.size());
     input.set_max_fee_per_gas(maxFeePerGas.data(), maxFeePerGas.size());
@@ -392,6 +401,7 @@ TEST(TWAnySignerEthereum, SignERC20Approve_1559) {
     Proto::SigningInput input;
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
+    input.set_tx_mode(Proto::TransactionMode::Enveloped);
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_max_inclusion_fee_per_gas(maxInclusionFeePerGas.data(), maxInclusionFeePerGas.size());
     input.set_max_fee_per_gas(maxFeePerGas.data(), maxFeePerGas.size());
@@ -423,6 +433,7 @@ TEST(TWAnySignerEthereum, SignERC721Transfer_1559) {
     Proto::SigningInput input;
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
+    input.set_tx_mode(Proto::TransactionMode::Enveloped);
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_max_inclusion_fee_per_gas(maxInclusionFeePerGas.data(), maxInclusionFeePerGas.size());
     input.set_max_fee_per_gas(maxFeePerGas.data(), maxFeePerGas.size());
@@ -458,6 +469,7 @@ TEST(TWAnySignerEthereum, SignERC1155Transfer_1559) {
     Proto::SigningInput input;
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
+    input.set_tx_mode(Proto::TransactionMode::Enveloped);
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_max_inclusion_fee_per_gas(maxInclusionFeePerGas.data(), maxInclusionFeePerGas.size());
     input.set_max_fee_per_gas(maxFeePerGas.data(), maxFeePerGas.size());

--- a/tests/Ethereum/TWAnySignerTests.cpp
+++ b/tests/Ethereum/TWAnySignerTests.cpp
@@ -57,7 +57,7 @@ TEST(TWAnySignerEthereum, Sign) {
 
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
-    input.set_tx_mode(Proto::TransactionMode::Legacy);
+    // tx_mode not set, Legacy is the default
     input.set_gas_price(gasPrice.data(), gasPrice.size());
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_private_key(key.data(), key.size());
@@ -90,7 +90,7 @@ TEST(TWAnySignerEthereum, SignERC20TransferAsERC20) {
     Proto::SigningInput input;
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
-    input.set_tx_mode(Proto::TransactionMode::Legacy);
+    // tx_mode not set, Legacy is the default
     input.set_gas_price(gasPrice.data(), gasPrice.size());
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_to_address(token);
@@ -134,7 +134,7 @@ TEST(TWAnySignerEthereum, SignERC20TransferAsGenericContract) {
     Proto::SigningInput input;
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
-    input.set_tx_mode(Proto::TransactionMode::Legacy);
+    // tx_mode not set, Legacy is the default
     input.set_gas_price(gasPrice.data(), gasPrice.size());
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_to_address(toAddress);
@@ -165,7 +165,7 @@ TEST(TWAnySignerEthereum, SignERC20TransferInvalidAddress) {
     Proto::SigningInput input;
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
-    input.set_tx_mode(Proto::TransactionMode::Legacy);
+    // tx_mode not set, Legacy is the default
     input.set_gas_price(gasPrice.data(), gasPrice.size());
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_to_address(invalidAddress);
@@ -194,7 +194,7 @@ TEST(TWAnySignerEthereum, SignERC20Approve) {
     Proto::SigningInput input;
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
-    input.set_tx_mode(Proto::TransactionMode::Legacy);
+    // tx_mode not set, Legacy is the default
     input.set_gas_price(gasPrice.data(), gasPrice.size());
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_to_address(token);
@@ -226,7 +226,7 @@ TEST(TWAnySignerEthereum, SignERC721Transfer) {
     Proto::SigningInput input;
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
-    input.set_tx_mode(Proto::TransactionMode::Legacy);
+    // tx_mode not set, Legacy is the default
     input.set_gas_price(gasPrice.data(), gasPrice.size());
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_to_address(tokenContract);
@@ -263,7 +263,7 @@ TEST(TWAnySignerEthereum, SignERC1155Transfer) {
     Proto::SigningInput input;
     input.set_chain_id(chainId.data(), chainId.size());
     input.set_nonce(nonce.data(), nonce.size());
-    input.set_tx_mode(Proto::TransactionMode::Legacy);
+    // tx_mode not set, Legacy is the default
     input.set_gas_price(gasPrice.data(), gasPrice.size());
     input.set_gas_limit(gasLimit.data(), gasLimit.size());
     input.set_to_address(tokenContract);


### PR DESCRIPTION
## Description

Explicit selector for legacy/enveloped transactions (legacy/Eip1559).  Fixes #1581 .

This change is BREAKING:
- Code needs to be recompiled with new wallet core version (as proto buf numbering has changed)
- Ethereum SigningInput has to be extended with:
`txMode = TransactionMode.Legacy` for legacy transactions (this can be omitted as Legacy has value 0)
`txMode = TransactionMode.Enveloped` for enveloped transactions with EIP1559 fee
 
## Testing instructions

Unit tests, esp. TWAnySignerEthereum.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

* Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
