### PR TITLE
Eth struct encoding fix, bytes type hash

### DIFF
--- a/src/Ethereum/ABI/Bytes.cpp
+++ b/src/Ethereum/ABI/Bytes.cpp
@@ -54,15 +54,7 @@ bool ParamByteArray::setValueJson(const std::string& value) {
 }
 
 Data ParamByteArray::hashStruct() const {
-    if (_bytes.size() > 32) {
-        return Hash::keccak256(_bytes);
-    }
-    Data res;
-    const auto count = _bytes.size();
-    const auto padding = ValueEncoder::padNeeded32(count);
-    res.insert(res.end(), _bytes.begin(), _bytes.begin() + count);
-    append(res, Data(padding));
-    return res;
+    return Hash::keccak256(_bytes);
 }
 
 void ParamByteArrayFix::setVal(const Data& val) {

--- a/tests/Ethereum/AbiStructTests.cpp
+++ b/tests/Ethereum/AbiStructTests.cpp
@@ -511,6 +511,19 @@ TEST(EthereumAbiStruct, hashStruct_cryptofights) {
     EXPECT_EQ(hex(store(rsv.v)), "1b");
 }
 
+TEST(EthereumAbiStruct, hashStruct_rarible) {
+    auto path = TESTS_ROOT + "/Ethereum/Data/eip712_rarible.json";
+    auto typeData = load_file(path);
+    auto hash = ParamStruct::hashStructJson(typeData);
+    EXPECT_EQ(hex(hash), "df0200de55c05eb55af2597012767ea3af653d68000be49580f8e05acd91d366");
+
+    // sign the hash
+    const auto rsv = Signer::sign(privateKeyCow, hash, true, 0);
+    EXPECT_EQ(hex(store(rsv.r)), "9e6155c62a55d3dc6034973d93821dace5a0c66bfbd8413ad29205c2fb079e84");
+    EXPECT_EQ(hex(store(rsv.s)), "3ca5906f24b82672304302a0e42e5dc090acc800060bad51fb81cc4469f69930");
+    EXPECT_EQ(hex(store(rsv.v)), "1b");
+}
+
 TEST(EthereumAbiStruct, hashStruct_snapshot) {
     auto path = TESTS_ROOT + "/Ethereum/Data/eip712_snapshot_v4.json";
     auto typeData = load_file(path);
@@ -819,11 +832,17 @@ TEST(EthereumAbiStruct, ParamHashStruct) {
     {
         auto p = std::make_shared<ParamByteArray>();
         EXPECT_TRUE(p->setValueJson("0123456789"));
-        EXPECT_EQ(hex(p->hashStruct()), "0123456789000000000000000000000000000000000000000000000000000000");
+        EXPECT_EQ(hex(p->hashStruct()), "79fad56e6cf52d0c8c2c033d568fc36856ba2b556774960968d79274b0e6b944");
         EXPECT_TRUE(p->setValueJson("0xa9059cbb0000000000000000000000002e0d94754b348d208d64d52d78bcd443afa9fa520000000000000000000000000000000000000000000000000000000000000007"));
         EXPECT_EQ(hex(p->hashStruct()), "a9485354dd9d340e02789cfc540c6c4a2ff5511beb414b64634a5e11c6a7168c");
         EXPECT_TRUE(p->setValueJson("0x0000000000000000000000000000000000000000000000000000000123456789"));
-        EXPECT_EQ(hex(p->hashStruct()), "0000000000000000000000000000000000000000000000000000000123456789");
+        EXPECT_EQ(hex(p->hashStruct()), "c8243991757dc8723e4976248127e573da4a2cbfad54b776d5a7c8d92b6e2a6b");
+        EXPECT_TRUE(p->setValueJson("0x00"));
+        EXPECT_EQ(hex(p->hashStruct()), "bc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a");
+        EXPECT_TRUE(p->setValueJson("0x"));
+        EXPECT_EQ(hex(p->hashStruct()), "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
+        EXPECT_TRUE(p->setValueJson(""));
+        EXPECT_EQ(hex(p->hashStruct()), "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
     }
     {
         auto p = std::make_shared<ParamByteArrayFix>(36);

--- a/tests/Ethereum/Data/eip712_rarible.json
+++ b/tests/Ethereum/Data/eip712_rarible.json
@@ -1,0 +1,110 @@
+{
+    "types": {
+        "EIP712Domain": [
+            {
+                "type": "string",
+                "name": "name"
+            },
+            {
+                "type": "string",
+                "name": "version"
+            },
+            {
+                "type": "uint256",
+                "name": "chainId"
+            },
+            {
+                "type": "address",
+                "name": "verifyingContract"
+            }
+        ],
+        "AssetType": [
+            {
+                "name": "assetClass",
+                "type": "bytes4"
+            },
+            {
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "Asset": [
+            {
+                "name": "assetType",
+                "type": "AssetType"
+            },
+            {
+                "name": "value",
+                "type": "uint256"
+            }
+        ],
+        "Order": [
+            {
+                "name": "maker",
+                "type": "address"
+            },
+            {
+                "name": "makeAsset",
+                "type": "Asset"
+            },
+            {
+                "name": "taker",
+                "type": "address"
+            },
+            {
+                "name": "takeAsset",
+                "type": "Asset"
+            },
+            {
+                "name": "salt",
+                "type": "uint256"
+            },
+            {
+                "name": "start",
+                "type": "uint256"
+            },
+            {
+                "name": "end",
+                "type": "uint256"
+            },
+            {
+                "name": "dataType",
+                "type": "bytes4"
+            },
+            {
+                "name": "data",
+                "type": "bytes"
+            }
+        ]
+    },
+    "domain": {
+        "chainId": 1,
+        "name": "Exchange",
+        "verifyingContract": "0x9757f2d2b135150bbeb65308d4a91804107cd8d6",
+        "version": "2"
+    },
+    "primaryType": "Order",
+    "message": {
+        "maker": "0xc182a38ae564fd05b0261cf6eec416aef02fc3fe",
+        "makeAsset": {
+            "assetType": {
+                "assetClass": "0x73ad2146",
+                "data": "0x0000000000000000000000006a5ff3ceecae9ceb96e6ac6c76b82af8b39f0eb30000000000000000000000000000000000000000000000000000000000001398"
+            },
+            "value": "1"
+        },
+        "taker": "0x0000000000000000000000000000000000000000",
+        "takeAsset": {
+            "assetType": {
+                "assetClass": "0xaaaebeba",
+                "data": "0x"
+            },
+            "value": "699000000000000000000"
+        },
+        "salt": "108946545279938080742200552539328985411221282471150769260125599178294648928102",
+        "start": 0,
+        "end": 0,
+        "dataType": "0x4c234266",
+        "data": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000001cf0df2a5a20cd61d68d4489eebbf85b8d39e18a00000000000000000000000000000000000000000000000000000000000000fa"
+    }
+}


### PR DESCRIPTION
## Description

For data of variable-length type `bytes` hash is taken if length >32, otherwise the data itself is taken, padded to even 32 bytes.  Correct is to always take the hash.
Fixes #1576 .

- Hashing of ByteArray has been changed, corresponding tests updated
- Added test with the rarible.com data
 
## Testing instructions

Unit tests

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
