### PR TITLE
Various HDWallet fixes

### DIFF
--- a/include/TrustWalletCore/TWMnemonic.h
+++ b/include/TrustWalletCore/TWMnemonic.h
@@ -14,15 +14,15 @@ TW_EXTERN_C_BEGIN
 TW_EXPORT_CLASS
 struct TWMnemonic;
 
-/// Determines whether a mnemonic phrase is valid.
+/// Determines whether a BIP39 English mnemonic phrase is valid.
 TW_EXPORT_STATIC_METHOD
 bool TWMnemonicIsValid(TWString *_Nonnull mnemonic);
 
-/// Determines whether word is a valid menemonic word.
+/// Determines whether word is a valid BIP39 English menemonic word.
 TW_EXPORT_STATIC_METHOD
 bool TWMnemonicIsValidWord(TWString *_Nonnull word);
 
-/// Return BIP39 English words that match the given prefix.  A single string is returned, with space-separated list of words.
+/// Return BIP39 English words that match the given prefix. A single string is returned, with space-separated list of words.
 TW_EXPORT_STATIC_METHOD
 TWString* _Nonnull TWMnemonicSuggest(TWString *_Nonnull prefix);
 

--- a/src/Keystore/EncryptionParameters.cpp
+++ b/src/Keystore/EncryptionParameters.cpp
@@ -81,14 +81,14 @@ Data EncryptionParameters::decrypt(const Data& password) const {
     Data iv = cipherParams.iv;
     if (cipher == "aes-128-ctr") {
         aes_encrypt_ctx ctx;
-        auto result = aes_encrypt_key(derivedKey.data(), 16, &ctx);
+        auto __attribute__((unused)) result = aes_encrypt_key(derivedKey.data(), 16, &ctx);
         assert(result != EXIT_FAILURE);
 
         aes_ctr_decrypt(encrypted.data(), decrypted.data(), static_cast<int>(encrypted.size()), iv.data(),
                         aes_ctr_cbuf_inc, &ctx);
     } else if (cipher == "aes-128-cbc") {
         aes_decrypt_ctx ctx;
-        auto result = aes_decrypt_key(derivedKey.data(), 16, &ctx);
+        auto __attribute__((unused)) result = aes_decrypt_key(derivedKey.data(), 16, &ctx);
         assert(result != EXIT_FAILURE);
 
         for (auto i = 0; i < encrypted.size(); i += 16) {

--- a/swift/Tests/Blockchains/EthereumTests.swift
+++ b/swift/Tests/Blockchains/EthereumTests.swift
@@ -176,4 +176,31 @@ class EthereumTests: XCTestCase {
 
         XCTAssertEqual(result, "f86a8084d693a400825208947d8bf18c7ce84b3e175b339c4ca93aed1dd166f1870348bca5a160008025a0fe5802b49e04c6b1705088310e133605ed8b549811a18968ad409ea02ad79f21a05bf845646fb1e1b9365f63a7fd5eb5e984094e3ed35c3bed7361aebbcbf41f10")
     }
+
+    func testGetPublicKeyFromXpub() throws {
+        let wallet = HDWallet(mnemonic: "broom ramp luggage this language sketch door allow elbow wife moon impulse", passphrase: "")!
+        let path = "m/44'/60'/0'/0/1"
+        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .ethereum, version: .xpub)
+
+        XCTAssertEqual(xpub, "xpub6C7LtZJgtz1BKXG9mExKUxYvX7HSF38UMMmGbpqNQw3DfYwAw8E6sH7VSVxFipvEEm2afSqTjoRgcLmycXX4zfxCWJ4HY73a9KdgvfHEQGB")
+
+        let key = wallet.getKey(coin: .ethereum, derivationPath: path)
+        let pubkey = key.getPublicKeySecp256k1(compressed: true)
+        XCTAssertEqual(pubkey.data.hexString, "024516c4aa5352035e1bb5be132694e1389a4ac37d32e5e717d35ee4c4dfab5132")
+
+        let pubkey2 = HDWallet.getPublicKeyFromExtended(extended: xpub, coin: .ethereum, derivationPath: path)!
+        XCTAssertEqual(pubkey2.data.hexString, "044516c4aa5352035e1bb5be132694e1389a4ac37d32e5e717d35ee4c4dfab513226a9d14ea37a55962ad3644a08e2ce551b4495beabb9b09e688c7b92eba18acc")
+
+        let address = CoinType.ethereum.deriveAddressFromPublicKey(publicKey: pubkey2)
+        XCTAssertEqual(address, "0x996891c410FB76C19DBA72C6f6cEFF2d9DD069b1")
+    }
+
+    func testSpanishMnemonic() throws {
+        let wallet = HDWallet(mnemonic: "llanto radical atraer riesgo actuar masa fondo cielo dieta archivo sonrisa mamut", passphrase: "")!
+        let btcXpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .bitcoin, version: .xpub)
+        let ethXpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .ethereum, version: .xpub)
+
+        XCTAssertEqual(btcXpub, "xpub6Cq43Vqyvb2DwXzjzNeMpPuxXRCN1WnmRCmYLPaaSv2XZXM2yCwUHpWEyB3zQ3FGCQsvY21gecMaQR7b2zhhgiHnjzDYpKCE2LACueaSMuR")
+        XCTAssertEqual(ethXpub, "xpub6Bgma7boPVudhExmB97iySvatGfnXkfBxYZYNTFYJvVzigUPk1X2iE8VhJPPxVuzjH8wBuTqRBMKCbwMYQNLrFCwYzMugYw4RM5VGNeVDpp")
+    }
 }

--- a/swift/project.yml
+++ b/swift/project.yml
@@ -47,7 +47,7 @@ targets:
       INFOPLIST_FILE: 'Info.plist'
       CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION: YES_ERROR
       CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER: $(inherited) false
-      OTHER_CFLAGS: $(inherited) -Wno-comma
+      OTHER_CFLAGS: $(inherited) -Wno-comma -DNDEBUG
     postCompileScripts:
       - script: ${PODS_ROOT}/SwiftLint/swiftlint --config ../.swiftlint.yml
         name: SwiftLint

--- a/tests/HDWalletTests.cpp
+++ b/tests/HDWalletTests.cpp
@@ -62,8 +62,15 @@ TEST(HDWallet, createFromMnemonic) {
     }
 }
 
+TEST(HDWallet, createFromSpanishMnemonic) {
+    {
+        HDWallet wallet = HDWallet("llanto radical atraer riesgo actuar masa fondo cielo dieta archivo sonrisa mamut", "");
+        EXPECT_EQ(hex(wallet.getSeed()), "ec8f8703432fc7d32e699ee056e9d84b1435e6a64a6a40ad63dbde11eab189a276ddcec20f3326d3c6ee39cbd018585b104fc3633b801c011063ae4c318fb9b6");
+    }
+}
+
 TEST(HDWallet, createFromMnemonicInvalid) {
-    EXPECT_EXCEPTION(HDWallet("THIS IS AN INVALID MNEMONIC", passphrase), "Invalid mnemonic");
+    EXPECT_FALSE(Mnemonic::isValid("THIS IS AN INVALID MNEMONIC"));
     EXPECT_EXCEPTION(HDWallet("", passphrase), "Invalid mnemonic");
 }
 

--- a/tests/interface/TWHDWalletTests.cpp
+++ b/tests/interface/TWHDWalletTests.cpp
@@ -15,6 +15,7 @@
 #include <TrustWalletCore/TWPrivateKey.h>
 #include <TrustWalletCore/TWPublicKey.h>
 #include <TrustWalletCore/TWBase58.h>
+#include <TrustWalletCore/TWCoinType.h>
 #include <proto/Stellar.pb.h>
 
 #include "HexCoding.h"
@@ -79,7 +80,7 @@ TEST(HDWallet, CreateFromStrengthInvalid) {
 }
 
 TEST(HDWallet, CreateFromMnemonicInvalid) {
-    auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(STRING("THIS IS INVALID MNEMONIC").get(), STRING("").get()));
+    auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(STRING("").get(), STRING("").get()));
     ASSERT_EQ(wallet.get(), nullptr);
 }
 
@@ -352,6 +353,15 @@ TEST(HDWallet, PublicKeyFromZ) {
     assertHexEqual(data11, "0226a07edd0227fa6bc36239c0bd4db83d5e488f8fb1eeb68f89a5be916aad2d60");
 
     assertStringsEqual(address4, "bc1qm97vqzgj934vnaq9s53ynkyf9dgr05rargr04n");
+}
+
+TEST(HDWallet, PublicKeyFromExtended_Ethereum) {
+    const auto xpub = STRING("xpub6C7LtZJgtz1BKXG9mExKUxYvX7HSF38UMMmGbpqNQw3DfYwAw8E6sH7VSVxFipvEEm2afSqTjoRgcLmycXX4zfxCWJ4HY73a9KdgvfHEQGB");
+    const auto xpubAddr = WRAP(TWPublicKey, TWHDWalletGetPublicKeyFromExtended(xpub.get(), TWCoinTypeEthereum, STRING("m/44'/60'/0'/0/1").get()));
+    ASSERT_NE(xpubAddr.get(), nullptr);
+    auto data = WRAPD(TWPublicKeyData(xpubAddr.get()));
+    ASSERT_NE(data.get(), nullptr);
+    assertHexEqual(data, "044516c4aa5352035e1bb5be132694e1389a4ac37d32e5e717d35ee4c4dfab513226a9d14ea37a55962ad3644a08e2ce551b4495beabb9b09e688c7b92eba18acc");
 }
 
 TEST(HDWallet, PublicKeyFromExtended_NIST256p1) {


### PR DESCRIPTION
Fixes #1590 
Fixes #1599 
Fixes #1600 

Changes: 

* Remove English only validation inside `HDWallet(mnemonic, passphrase)`, please use `Mnemonic::isValid` before creating `HDWallet`
* Remove entropy size assert for non English phrases
* Add -DNDEBUG for iOS build
* Support getting extended public key from xpub (for Ethereum)
* Add english only comments to `TWMnemonic`