### PR TITLE
HDWallet: re-add mnemonic validity check

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestHDWallet.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestHDWallet.kt
@@ -38,8 +38,13 @@ class TestHDWallet {
     }
 
     @Test
-    fun testMnemonicInvalid() {
-        assertFalse(Mnemonic.isValid("THIS IS AN INVALID MNEMONIC"))
+    fun testCreateFromMnemonicInvalid() {
+        try {
+            HDWallet("THIS IS AN INVALID MNEMONIC", "")
+            fail("Missing exception")
+        } catch (ex: Exception) {
+            assertTrue(ex is InvalidParameterException)
+        }
     }
 
     @Test

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestHDWallet.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestHDWallet.kt
@@ -38,13 +38,18 @@ class TestHDWallet {
     }
 
     @Test
-    fun testCreateFromMnemonicInvalid() {
+    fun testCreateFromSpanishMnemonic() {
+        val mnemonic = "llanto radical atraer riesgo actuar masa fondo cielo dieta archivo sonrisa mamut"
         try {
-            HDWallet("THIS IS AN INVALID MNEMONIC", "")
+            HDWallet(mnemonic, "")
             fail("Missing exception")
         } catch (ex: Exception) {
             assertTrue(ex is InvalidParameterException)
         }
+        val wallet = HDWallet(mnemonic, "", false)
+        val address = wallet.getAddressForCoin(CoinType.ETHEREUM)
+
+        assertEquals(address, "0xa4531dE99E22B2166d340E7221669DF565c52024")
     }
 
     @Test

--- a/android/trustwalletcore/build.gradle
+++ b/android/trustwalletcore/build.gradle
@@ -7,9 +7,14 @@ android {
     ndkVersion '21.2.6472646'
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
+        externalNativeBuild {
+            cmake {
+                arguments "-DCMAKE_BUILD_TYPE=Release"
+            }
+        }
     }
 
     lintOptions {

--- a/include/TrustWalletCore/TWHDWallet.h
+++ b/include/TrustWalletCore/TWHDWallet.h
@@ -28,7 +28,7 @@ struct TWHDWallet;
 TW_EXPORT_STATIC_METHOD
 struct TWHDWallet *_Nullable TWHDWalletCreate(int strength, TWString *_Nonnull passphrase);
 
-/// Creates an HDWallet from a mnemonic (aka. recovery phrase).
+/// Creates an HDWallet from a BIP39 English mnemonic (aka. recovery phrase).
 /// Null is returned on invalid mnemonic.  Returned object needs to be deleted.
 TW_EXPORT_STATIC_METHOD
 struct TWHDWallet *_Nullable TWHDWalletCreateWithMnemonic(TWString *_Nonnull mnemonic, TWString *_Nonnull passphrase);

--- a/include/TrustWalletCore/TWHDWallet.h
+++ b/include/TrustWalletCore/TWHDWallet.h
@@ -24,17 +24,22 @@ struct TWHDWallet;
 /// TWHDWalletIsValid has been deprecated; use TWMnemonicIsValid().
 
 /// Creates a new HDWallet with a new random mnemonic with the provided strength in bits.
-/// Null is returned on invalid strength.  Returned object needs to be deleted.
+/// Null is returned on invalid strength. Returned object needs to be deleted.
 TW_EXPORT_STATIC_METHOD
 struct TWHDWallet *_Nullable TWHDWalletCreate(int strength, TWString *_Nonnull passphrase);
 
-/// Creates an HDWallet from a BIP39 English mnemonic (aka. recovery phrase).
-/// Null is returned on invalid mnemonic.  Returned object needs to be deleted.
+/// Creates an HDWallet from a valid BIP39 English mnemonic and a passphrase.
+/// Null is returned on invalid mnemonic. Returned object needs to be deleted.
 TW_EXPORT_STATIC_METHOD
 struct TWHDWallet *_Nullable TWHDWalletCreateWithMnemonic(TWString *_Nonnull mnemonic, TWString *_Nonnull passphrase);
 
+/// Creates an HDWallet from a BIP39 mnemonic, a passphrase and validation flag.
+/// Null is returned on invalid mnemonic. Returned object needs to be deleted.
+TW_EXPORT_STATIC_METHOD
+struct TWHDWallet *_Nullable TWHDWalletCreateWithMnemonicCheck(TWString *_Nonnull mnemonic, TWString *_Nonnull passphrase, bool check);
+
 /// Creates an HDWallet from entropy (corresponding to a mnemonic).
-/// Null is returned on invalid input.  Returned object needs to be deleted.
+/// Null is returned on invalid input. Returned object needs to be deleted.
 TW_EXPORT_STATIC_METHOD
 struct TWHDWallet *_Nullable TWHDWalletCreateWithEntropy(TWData *_Nonnull entropy, TWString *_Nonnull passphrase);
 

--- a/src/HDWallet.cpp
+++ b/src/HDWallet.cpp
@@ -48,9 +48,9 @@ HDWallet::HDWallet(int strength, const std::string& passphrase)
     updateSeedAndEntropy();
 }
 
-HDWallet::HDWallet(const std::string& mnemonic, const std::string& passphrase)
+HDWallet::HDWallet(const std::string& mnemonic, const std::string& passphrase, const bool check)
     : mnemonic(mnemonic), passphrase(passphrase) {
-    if (!Mnemonic::isValid(mnemonic)) {
+    if (check && !Mnemonic::isValid(mnemonic)) {
         throw std::invalid_argument("Invalid mnemonic");
     }
     updateSeedAndEntropy();

--- a/src/HDWallet.cpp
+++ b/src/HDWallet.cpp
@@ -45,13 +45,12 @@ HDWallet::HDWallet(int strength, const std::string& passphrase)
         throw std::invalid_argument("Invalid strength");
     }
     mnemonic = mnemonic_chars;
-    assert(Mnemonic::isValid(mnemonic));
     updateSeedAndEntropy();
 }
 
 HDWallet::HDWallet(const std::string& mnemonic, const std::string& passphrase)
     : mnemonic(mnemonic), passphrase(passphrase) {
-    if (mnemonic.size() == 0) {
+    if (!Mnemonic::isValid(mnemonic)) {
         throw std::invalid_argument("Invalid mnemonic");
     }
     updateSeedAndEntropy();
@@ -65,7 +64,6 @@ HDWallet::HDWallet(const Data& entropy, const std::string& passphrase)
         throw std::invalid_argument("Invalid mnemonic data");
     }
     mnemonic = mnemonic_chars;
-    assert(Mnemonic::isValid(mnemonic));
     updateSeedAndEntropy();
 }
 
@@ -76,15 +74,18 @@ HDWallet::~HDWallet() {
 }
 
 void HDWallet::updateSeedAndEntropy() {
+    assert(Mnemonic::isValid(mnemonic));
+
     // generate seed from mnemonic
-    // it is assumed that mnemonic is valid, enforced before calling
     mnemonic_to_seed(mnemonic.c_str(), passphrase.c_str(), seed.data(), nullptr);
 
-    // generate entropy from mnemonic
+    // generate entropy bits from mnemonic
     Data entropyRaw((Mnemonic::MaxWords * Mnemonic::BitsPerWord) / 8);
     auto entropyBytes = mnemonic_to_bits(mnemonic.c_str(), entropyRaw.data()) / 8;
     // copy to truncate
     entropy = data(entropyRaw.data(), entropyBytes);
+    assert(entropy.size() > 10);
+    assert(entropy.size() <= ((Mnemonic::MaxWords * Mnemonic::BitsPerWord) / 8 + 1) && entropy.size() >= ((Mnemonic::MinWords * Mnemonic::BitsPerWord) / 8));
 }
 
 PrivateKey HDWallet::getMasterKey(TWCurve curve) const {

--- a/src/HDWallet.h
+++ b/src/HDWallet.h
@@ -53,7 +53,7 @@ class HDWallet {
     /// Throws on invalid strength.
     HDWallet(int strength, const std::string& passphrase);
 
-    /// Initializes an HDWallet from a mnemonic.
+    /// Initializes an HDWallet from a BIP39 English mnemonic.
     /// Throws on invalid mnemonic.
     HDWallet(const std::string& mnemonic, const std::string& passphrase);
 

--- a/src/HDWallet.h
+++ b/src/HDWallet.h
@@ -55,7 +55,7 @@ class HDWallet {
 
     /// Initializes an HDWallet from a BIP39 English mnemonic.
     /// Throws on invalid mnemonic.
-    HDWallet(const std::string& mnemonic, const std::string& passphrase);
+    HDWallet(const std::string& mnemonic, const std::string& passphrase, const bool check = true);
 
     /// Initializes an HDWallet from an entropy.
     /// Throws on invalid data.

--- a/src/HDWallet.h
+++ b/src/HDWallet.h
@@ -53,7 +53,7 @@ class HDWallet {
     /// Throws on invalid strength.
     HDWallet(int strength, const std::string& passphrase);
 
-    /// Initializes an HDWallet from a BIP39 English mnemonic.
+    /// Initializes an HDWallet from a BIP39 mnemonic and a passphrase, check English dict by default.
     /// Throws on invalid mnemonic.
     HDWallet(const std::string& mnemonic, const std::string& passphrase, const bool check = true);
 
@@ -83,13 +83,13 @@ class HDWallet {
     /// Returns the extended private key.
     std::string getExtendedPrivateKey(TWPurpose purpose, TWCoinType coin, TWHDVersion version) const;
 
-    /// Returns the exteded public key.
+    /// Returns the extended public key.
     std::string getExtendedPublicKey(TWPurpose purpose, TWCoinType coin, TWHDVersion version) const;
 
-    /// Computes the public key from an exteded public key representation.
+    /// Computes the public key from an extended public key representation.
     static std::optional<PublicKey> getPublicKeyFromExtended(const std::string& extended, TWCoinType coin, const DerivationPath& path);
 
-    /// Computes the private key from an exteded private key representation.
+    /// Computes the private key from an extended private key representation.
     static std::optional<PrivateKey> getPrivateKeyFromExtended(const std::string& extended, TWCoinType coin, const DerivationPath& path);
 
   public:

--- a/src/Mnemonic.h
+++ b/src/Mnemonic.h
@@ -10,7 +10,7 @@
 
 namespace TW {
 
-/// BIP39 Mnemonic Sentence handling.
+/// BIP39 Mnemonic recovery phrase handling.
 class Mnemonic {
 public:
     static constexpr int MaxWords = 24;
@@ -18,11 +18,11 @@ public:
     static constexpr int BitsPerWord = 11; // each word encodes this many bits (there are 2^11=2048 different words)
 
 public:
-    /// Determines whether a mnemonic phrase is valid.
+    /// Determines whether a BIP39 English mnemonic phrase is valid.
     // E.g. for a valid mnemonic: "credit expect life fade cover suit response wash pear what skull force"
     static bool isValid(const std::string& mnemonic);
 
-    /// Determines whether word is a valid menemonic word.
+    /// Determines whether word is a valid BIP39 English menemonic word.
     static bool isValidWord(const std::string& word);
 
     /// Return BIP39 English words that match the given prefix.

--- a/src/interface/TWHDWallet.cpp
+++ b/src/interface/TWHDWallet.cpp
@@ -29,6 +29,14 @@ struct TWHDWallet *_Nullable TWHDWalletCreateWithMnemonic(TWString *_Nonnull mne
     }
 }
 
+struct TWHDWallet *_Nullable TWHDWalletCreateWithMnemonicCheck(TWString *_Nonnull mnemonic, TWString *_Nonnull passphrase, bool check) {
+    try {
+        return new TWHDWallet{ HDWallet(TWStringUTF8Bytes(mnemonic), TWStringUTF8Bytes(passphrase), check) };
+    } catch (...) {
+        return nullptr;
+    }
+}
+
 struct TWHDWallet *_Nullable TWHDWalletCreateWithEntropy(TWData *_Nonnull entropy, TWString *_Nonnull passphrase) {
     try {
         auto *d = reinterpret_cast<const Data*>(entropy);

--- a/swift/Tests/Blockchains/EthereumTests.swift
+++ b/swift/Tests/Blockchains/EthereumTests.swift
@@ -194,19 +194,4 @@ class EthereumTests: XCTestCase {
         let address = CoinType.ethereum.deriveAddressFromPublicKey(publicKey: pubkey2)
         XCTAssertEqual(address, "0x996891c410FB76C19DBA72C6f6cEFF2d9DD069b1")
     }
-
-    func testSpanishMnemonic() throws {
-        let wallet = HDWallet(mnemonic: "llanto radical atraer riesgo actuar masa fondo cielo dieta archivo sonrisa mamut", passphrase: "")!
-        let btcXpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .bitcoin, version: .xpub)
-        let ethXpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .ethereum, version: .xpub)
-
-        XCTAssertEqual(btcXpub, "xpub6Cq43Vqyvb2DwXzjzNeMpPuxXRCN1WnmRCmYLPaaSv2XZXM2yCwUHpWEyB3zQ3FGCQsvY21gecMaQR7b2zhhgiHnjzDYpKCE2LACueaSMuR")
-        XCTAssertEqual(ethXpub, "xpub6Bgma7boPVudhExmB97iySvatGfnXkfBxYZYNTFYJvVzigUPk1X2iE8VhJPPxVuzjH8wBuTqRBMKCbwMYQNLrFCwYzMugYw4RM5VGNeVDpp")
-
-        let ethAddress = wallet.getAddressForCoin(coin: .ethereum)
-        let btcAddress = wallet.getAddressForCoin(coin: .bitcoin)
-
-        XCTAssertEqual(ethAddress, "0xa4531dE99E22B2166d340E7221669DF565c52024")
-        XCTAssertEqual(btcAddress, "bc1q97jc0jdgsyvvhxydxxd6np8sa920c39l3qpscf")
-    }
 }

--- a/swift/Tests/Blockchains/EthereumTests.swift
+++ b/swift/Tests/Blockchains/EthereumTests.swift
@@ -194,4 +194,22 @@ class EthereumTests: XCTestCase {
         let address = CoinType.ethereum.deriveAddressFromPublicKey(publicKey: pubkey2)
         XCTAssertEqual(address, "0x996891c410FB76C19DBA72C6f6cEFF2d9DD069b1")
     }
+
+    func testSpanishMnemonic() throws {
+        let mnemonic = "llanto radical atraer riesgo actuar masa fondo cielo dieta archivo sonrisa mamut"
+        XCTAssertNil(HDWallet(mnemonic: mnemonic, passphrase: ""))
+
+        let wallet = HDWallet(mnemonic: mnemonic, passphrase: "", check: false)!
+        let btcXpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .bitcoin, version: .xpub)
+        let ethXpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .ethereum, version: .xpub)
+
+        XCTAssertEqual(btcXpub, "xpub6Cq43Vqyvb2DwXzjzNeMpPuxXRCN1WnmRCmYLPaaSv2XZXM2yCwUHpWEyB3zQ3FGCQsvY21gecMaQR7b2zhhgiHnjzDYpKCE2LACueaSMuR")
+        XCTAssertEqual(ethXpub, "xpub6Bgma7boPVudhExmB97iySvatGfnXkfBxYZYNTFYJvVzigUPk1X2iE8VhJPPxVuzjH8wBuTqRBMKCbwMYQNLrFCwYzMugYw4RM5VGNeVDpp")
+
+        let ethAddress = wallet.getAddressForCoin(coin: .ethereum)
+        let btcAddress = wallet.getAddressForCoin(coin: .bitcoin)
+
+        XCTAssertEqual(ethAddress, "0xa4531dE99E22B2166d340E7221669DF565c52024")
+        XCTAssertEqual(btcAddress, "bc1q97jc0jdgsyvvhxydxxd6np8sa920c39l3qpscf")
+    }
 }

--- a/swift/Tests/HDWalletTests.swift
+++ b/swift/Tests/HDWalletTests.swift
@@ -26,8 +26,9 @@ class HDWalletTests: XCTestCase {
         XCTAssertEqual(wallet.seed.hexString, "354c22aedb9a37407adc61f657a6f00d10ed125efa360215f36c6919abd94d6dbc193a5f9c495e21ee74118661e327e84a5f5f11fa373ec33b80897d4697557d")
     }
 
-    func testMnemonicInvalid() {
-        XCTAssertFalse(Mnemonic.isValid(mnemonic: "THIS IS AN INVALID MNEMONIC"))
+    func testCreateFromMnemonicInvalid() {
+        let wallet = HDWallet(mnemonic: "THIS IS AN INVALID MNEMONIC", passphrase: "")
+        XCTAssertNil(wallet)
     }
 
     func testGenerate() {

--- a/tests/HDWalletTests.cpp
+++ b/tests/HDWalletTests.cpp
@@ -63,14 +63,11 @@ TEST(HDWallet, createFromMnemonic) {
 }
 
 TEST(HDWallet, createFromSpanishMnemonic) {
-    {
-        HDWallet wallet = HDWallet("llanto radical atraer riesgo actuar masa fondo cielo dieta archivo sonrisa mamut", "");
-        EXPECT_EQ(hex(wallet.getSeed()), "ec8f8703432fc7d32e699ee056e9d84b1435e6a64a6a40ad63dbde11eab189a276ddcec20f3326d3c6ee39cbd018585b104fc3633b801c011063ae4c318fb9b6");
-    }
+    EXPECT_EXCEPTION(HDWallet("llanto radical atraer riesgo actuar masa fondo cielo dieta archivo sonrisa mamut", ""), "Invalid mnemonic");
 }
 
 TEST(HDWallet, createFromMnemonicInvalid) {
-    EXPECT_FALSE(Mnemonic::isValid("THIS IS AN INVALID MNEMONIC"));
+    EXPECT_EXCEPTION(HDWallet("THIS IS AN INVALID MNEMONIC", passphrase), "Invalid mnemonic");
     EXPECT_EXCEPTION(HDWallet("", passphrase), "Invalid mnemonic");
 }
 

--- a/tests/MnemonicTests.cpp
+++ b/tests/MnemonicTests.cpp
@@ -39,6 +39,8 @@ std::vector<std::string> InvalidInput = {
     "CREDIT expect life fade cover suit response wash pear what skull force",
     // back is invalid word
     "ripple scissors kick mammal hire column oak again sun offer wealth tomorrow wagon turn back",
+    // Spanish
+    "llanto radical atraer riesgo actuar masa fondo cielo dieta archivo sonrisa mamut",
 };
 
 TEST(Mnemonic, isValid) {

--- a/tests/interface/TWHDWalletTests.cpp
+++ b/tests/interface/TWHDWalletTests.cpp
@@ -80,7 +80,7 @@ TEST(HDWallet, CreateFromStrengthInvalid) {
 }
 
 TEST(HDWallet, CreateFromMnemonicInvalid) {
-    auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(STRING("").get(), STRING("").get()));
+    auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(STRING("THIS IS INVALID MNEMONIC").get(), STRING("").get()));
     ASSERT_EQ(wallet.get(), nullptr);
 }
 


### PR DESCRIPTION
## Description

Re-add mnemonic validation checks (partial revert of #1601).  Non-English mnemonics are not supported.
Fixes #1607.

The important changed line: https://github.com/trustwallet/wallet-core/pull/1616/files?file-filters%5B%5D=.cpp&file-filters%5B%5D=.h&file-filters%5B%5D=.swift#diff-70145d862894261986b9cbc1be92f3af9e7cb4aeb7bd5c6790bf8ac4e8138e75L54

## Testing instructions

Unit tests, HDWallet.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
