### PR TITLE
Optimization for input selection in case of huge number of UTXOs

### DIFF
--- a/src/Bitcoin/InputSelector.h
+++ b/src/Bitcoin/InputSelector.h
@@ -17,11 +17,16 @@ namespace TW::Bitcoin {
 template <typename TypeWithAmount> // TypeWithAmount has to have a uint64_t amount
 class InputSelector {
   public:
-    /// Selects unspent transactions to use given a target transaction value.
+    /// Selects unspent transactions to use given a target transaction value, using complete logic.
     ///
-    /// \returns the list of indices of selected inputs, or an empty list if there are
-    /// insufficient funds.
+    /// \returns the list of indices of selected inputs, or an empty list if there are insufficient funds.
     std::vector<TypeWithAmount> select(int64_t targetValue, int64_t byteFee, int64_t numOutputs = 2);
+
+    /// Selects unspent transactions to use given a target transaction value;
+    /// Simplified version suitable for large number of inputs
+    ///
+    /// \returns the list of indices of selected inputs, or an empty list if there are insufficient funds.
+    std::vector<TypeWithAmount> selectSimple(int64_t targetValue, int64_t byteFee, int64_t numOutputs = 2);
 
     /// Selects UTXOs for max amount; select all except those which would reduce output (dust). Return indIces.
     /// One output and no change is assumed.

--- a/src/Bitcoin/SignatureBuilder.h
+++ b/src/Bitcoin/SignatureBuilder.h
@@ -32,8 +32,8 @@ private:
     /// Transaction being signed.
     Transaction transaction;
 
-    /// List of signed inputs.
-    TransactionInputs<TransactionInput> signedInputs;
+    /// Transaction being signed, with list of signed inputs
+    Transaction transactionToSign;
 
     bool estimationMode = false;
 

--- a/src/Bitcoin/TransactionBuilder.cpp
+++ b/src/Bitcoin/TransactionBuilder.cpp
@@ -140,9 +140,7 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
                 plan.fee = 0;
                 plan.change = 0;
             }
-            
             plan.fee = estimateSegwitFee(feeCalculator, plan, output_size, input);
-
             // If fee is larger then availableAmount (can happen in special maxAmount case), we reduce it (and hope it will go through)
             plan.fee = std::min(plan.availableAmount, plan.fee);
             assert(plan.fee >= 0 && plan.fee <= plan.availableAmount);
@@ -160,11 +158,11 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
             // compute change
             plan.change = plan.availableAmount - plan.amount - plan.fee;
         }
-        assert(plan.change >= 0 && plan.change <= plan.availableAmount);
-        assert(!maxAmount || plan.change == 0); // change is 0 in max amount case
-
-        assert(plan.amount + plan.change + plan.fee == plan.availableAmount);
     }
+    assert(plan.change >= 0 && plan.change <= plan.availableAmount);
+    assert(!maxAmount || plan.change == 0); // change is 0 in max amount case
+
+    assert(plan.amount + plan.change + plan.fee == plan.availableAmount);
 
     return plan;
 }

--- a/src/Bitcoin/TransactionBuilder.cpp
+++ b/src/Bitcoin/TransactionBuilder.cpp
@@ -80,6 +80,7 @@ int64_t estimateSegwitFee(const FeeCalculator& feeCalculator, const TransactionP
 TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
     TransactionPlan plan;
 
+    bool maxAmount = input.useMaxAmount;
     if (input.amount == 0 && !maxAmount) {
         plan.error = Common::Proto::Error_zero_amount_requested;
     } else if (input.utxos.empty()) {
@@ -98,7 +99,6 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
         const auto& feeCalculator = getFeeCalculator(static_cast<TWCoinType>(input.coinType));
         auto inputSelector = InputSelector<UTXO>(inputUtxos, feeCalculator);
         auto inputSum = InputSelector<UTXO>::sum(inputUtxos);
-        bool maxAmount = input.useMaxAmount;
 
         // select UTXOs
         plan.amount = input.amount;

--- a/src/Bitcoin/TransactionBuilder.h
+++ b/src/Bitcoin/TransactionBuilder.h
@@ -41,12 +41,9 @@ public:
         }
 
         const auto emptyScript = Script();
-        // prepare inputs (truncate if needed)
+        // prepare inputs
         for (auto& utxo : plan.utxos) {
             tx.inputs.emplace_back(utxo.outPoint, emptyScript, utxo.outPoint.sequence);
-            if (tx.inputs.size() >= MaxUtxosHardLimit) {
-                break;
-            }
         }
 
         return tx;

--- a/src/Bitcoin/TransactionBuilder.h
+++ b/src/Bitcoin/TransactionBuilder.h
@@ -41,7 +41,6 @@ public:
         }
 
         const auto emptyScript = Script();
-        // prepare inputs
         for (auto& utxo : plan.utxos) {
             tx.inputs.emplace_back(utxo.outPoint, emptyScript, utxo.outPoint.sequence);
         }

--- a/src/Bitcoin/TransactionBuilder.h
+++ b/src/Bitcoin/TransactionBuilder.h
@@ -41,8 +41,12 @@ public:
         }
 
         const auto emptyScript = Script();
+        // prepare inputs (truncate if needed)
         for (auto& utxo : plan.utxos) {
             tx.inputs.emplace_back(utxo.outPoint, emptyScript, utxo.outPoint.sequence);
+            if (tx.inputs.size() >= MaxUtxosHardLimit) {
+                break;
+            }
         }
 
         return tx;
@@ -50,6 +54,9 @@ public:
 
     /// Prepares a TransactionOutput with given address and amount, prepares script for it
     static std::optional<TransactionOutput> prepareOutputWithScript(std::string address, Amount amount, enum TWCoinType coin);
+
+    /// The maximum number of UTXOs to consider.  UTXOs above this limit are cut off because it cak take very long.
+    static const size_t MaxUtxosHardLimit;
 };
 
 } // namespace TW::Bitcoin

--- a/tests/Bitcoin/InputSelectorTests.cpp
+++ b/tests/Bitcoin/InputSelectorTests.cpp
@@ -420,3 +420,63 @@ TEST(BitcoinInputSelector, SelectZcashMaxUnspents2) {
 
     EXPECT_TRUE(verifySelectedUTXOs(selected, {}));
 }
+
+TEST(BitcoinInputSelector, ManyUtxos_900) {
+    const auto n = 900;
+    const auto byteFee = 10;
+    std::vector<int64_t> values;
+    uint64_t valueSum = 0;
+    for (int i = 0; i < n; ++i) {
+        const uint64_t val = (i + 1) * 100;
+        values.push_back(val);
+        valueSum += val;
+    }
+    const uint64_t requestedAmount = valueSum / 8;
+    EXPECT_EQ(requestedAmount, 5'068'125);
+    auto utxos = buildTestUTXOs(values);
+
+    auto selector = InputSelector<UTXO>(utxos);
+    auto selected = selector.select(requestedAmount, byteFee);
+
+    // expected result: 59 utxos, with the largest amounts
+    std::vector<int64_t> subset;
+    uint64_t subsetSum = 0;
+    for (int i = n - 59; i < n; ++i) {
+        const uint64_t val = (i + 1) * 100;
+        subset.push_back(val);
+        subsetSum += val;
+    }
+    EXPECT_EQ(subset.size(), 59);
+    EXPECT_EQ(subsetSum, 5'138'900);
+    EXPECT_TRUE(verifySelectedUTXOs(selected, subset));
+}
+
+TEST(BitcoinInputSelector, ManyUtxos_4000_simple) {
+    const auto n = 4000;
+    const auto byteFee = 10;
+    std::vector<int64_t> values;
+    uint64_t valueSum = 0;
+    for (int i = 0; i < n; ++i) {
+        const uint64_t val = (i + 1) * 100;
+        values.push_back(val);
+        valueSum += val;
+    }
+    const uint64_t requestedAmount = valueSum / 8;
+    EXPECT_EQ(requestedAmount, 100'025'000);
+    auto utxos = buildTestUTXOs(values);
+
+    auto selector = InputSelector<UTXO>(utxos);
+    auto selected = selector.selectSimple(requestedAmount, byteFee);
+
+    // expected result: 1501 utxos, with the smaller amounts (except the very small dust ones)
+    std::vector<int64_t> subset;
+    uint64_t subsetSum = 0;
+    for (int i = 10; i < 1501+10; ++i) {
+        const uint64_t val = (i + 1) * 100;
+        subset.push_back(val);
+        subsetSum += val;
+    }
+    EXPECT_EQ(subset.size(), 1501);
+    EXPECT_EQ(subsetSum, 114'226'100);
+    EXPECT_TRUE(verifySelectedUTXOs(selected, subset));
+}

--- a/tests/Bitcoin/InputSelectorTests.cpp
+++ b/tests/Bitcoin/InputSelectorTests.cpp
@@ -480,3 +480,31 @@ TEST(BitcoinInputSelector, ManyUtxos_5000_simple) {
     EXPECT_EQ(subsetSum, 73'866'500);
     EXPECT_TRUE(verifySelectedUTXOs(selected, subset));
 }
+
+TEST(BitcoinInputSelector, ManyUtxos_MaxAmount_5000) {
+    const auto n = 5000;
+    const auto byteFee = 10;
+    std::vector<int64_t> values;
+    uint64_t valueSum = 0;
+    for (int i = 0; i < n; ++i) {
+        const uint64_t val = (i + 1) * 100;
+        values.push_back(val);
+        valueSum += val;
+    }
+    auto utxos = buildTestUTXOs(values);
+
+    auto selector = InputSelector<UTXO>(utxos);
+    auto selected = selector.selectMaxAmount(byteFee);
+
+    // expected result: 4990 utxos (none of which is dust)
+    std::vector<int64_t> subset;
+    uint64_t subsetSum = 0;
+    for (int i = 10; i < 4990+10; ++i) {
+        const uint64_t val = (i + 1) * 100;
+        subset.push_back(val);
+        subsetSum += val;
+    }
+    EXPECT_EQ(subset.size(), 4990);
+    EXPECT_EQ(subsetSum, 1'250'244'500);
+    EXPECT_TRUE(verifySelectedUTXOs(selected, subset));
+}

--- a/tests/Bitcoin/InputSelectorTests.cpp
+++ b/tests/Bitcoin/InputSelectorTests.cpp
@@ -451,8 +451,8 @@ TEST(BitcoinInputSelector, ManyUtxos_900) {
     EXPECT_TRUE(verifySelectedUTXOs(selected, subset));
 }
 
-TEST(BitcoinInputSelector, ManyUtxos_4000_simple) {
-    const auto n = 4000;
+TEST(BitcoinInputSelector, ManyUtxos_5000_simple) {
+    const auto n = 5000;
     const auto byteFee = 10;
     std::vector<int64_t> values;
     uint64_t valueSum = 0;
@@ -461,22 +461,22 @@ TEST(BitcoinInputSelector, ManyUtxos_4000_simple) {
         values.push_back(val);
         valueSum += val;
     }
-    const uint64_t requestedAmount = valueSum / 8;
-    EXPECT_EQ(requestedAmount, 100'025'000);
+    const uint64_t requestedAmount = valueSum / 20;
+    EXPECT_EQ(requestedAmount, 62'512'500);
     auto utxos = buildTestUTXOs(values);
 
     auto selector = InputSelector<UTXO>(utxos);
     auto selected = selector.selectSimple(requestedAmount, byteFee);
 
-    // expected result: 1501 utxos, with the smaller amounts (except the very small dust ones)
+    // expected result: 1205 utxos, with the smaller amounts (except the very small dust ones)
     std::vector<int64_t> subset;
     uint64_t subsetSum = 0;
-    for (int i = 10; i < 1501+10; ++i) {
+    for (int i = 10; i < 1205+10; ++i) {
         const uint64_t val = (i + 1) * 100;
         subset.push_back(val);
         subsetSum += val;
     }
-    EXPECT_EQ(subset.size(), 1501);
-    EXPECT_EQ(subsetSum, 114'226'100);
+    EXPECT_EQ(subset.size(), 1205);
+    EXPECT_EQ(subsetSum, 73'866'500);
     EXPECT_TRUE(verifySelectedUTXOs(selected, subset));
 }

--- a/tests/Bitcoin/InputSelectorTests.cpp
+++ b/tests/Bitcoin/InputSelectorTests.cpp
@@ -64,6 +64,15 @@ TEST(BitcoinInputSelector, SelectUnspents5) {
     EXPECT_TRUE(verifySelectedUTXOs(selected, {6000, 7000, 8000, 9000}));
 }
 
+TEST(BitcoinInputSelector, SelectUnspents5_simple) {
+    auto utxos = buildTestUTXOs({1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000});
+
+    auto selector = InputSelector<UTXO>(utxos);
+    auto selected = selector.selectSimple(28000, 1);
+
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000}));
+}
+
 TEST(BitcoinInputSelector, SelectUnspentsInsufficient) {
     auto utxos = buildTestUTXOs({4000, 4000, 4000});
 
@@ -234,7 +243,7 @@ TEST(BitcoinInputSelector, SelectTwoFirstEnoughButSecond) {
 }
 
 TEST(BitcoinInputSelector, SelectTenThree) {
-    auto utxos = buildTestUTXOs({1'000, 2'000, 100'000, 3'000, 4'000, 5,000, 125'000, 6'000, 150'000, 7'000});
+    auto utxos = buildTestUTXOs({1'000, 2'000, 100'000, 3'000, 4'000, 5'000, 125'000, 6'000, 150'000, 7'000});
 
     auto selector = InputSelector<UTXO>(utxos);
     auto selected = selector.select(300'000, 1);
@@ -242,8 +251,35 @@ TEST(BitcoinInputSelector, SelectTenThree) {
     EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000, 125'000, 150'000}));
 }
 
+TEST(BitcoinInputSelector, SelectTenThree_simple1) {
+    auto utxos = buildTestUTXOs({1'000, 2'000, 100'000, 3'000, 4'000, 5'000, 125'000, 6'000, 150'000, 7'000});
+
+    auto selector = InputSelector<UTXO>(utxos);
+    auto selected = selector.selectSimple(300'000, 1);
+
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {1'000, 2'000, 100'000, 3'000, 4'000, 5'000, 125'000, 6'000, 150'000}));
+}
+
+TEST(BitcoinInputSelector, SelectTenThree_simple2) {
+    auto utxos = buildTestUTXOs({150'000, 125'000, 100'000, 7'000, 6'000, 5'000, 4'000, 3'000, 2'000, 1'000});
+
+    auto selector = InputSelector<UTXO>(utxos);
+    auto selected = selector.selectSimple(300'000, 1);
+
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {150'000, 125'000, 100'000}));
+}
+
+TEST(BitcoinInputSelector, SelectTenThree_simple3) {
+    auto utxos = buildTestUTXOs({1'000, 2'000, 3'000, 4'000, 5'000, 6'000, 7'000, 100'000, 125'000, 150'000});
+
+    auto selector = InputSelector<UTXO>(utxos);
+    auto selected = selector.selectSimple(300'000, 1);
+
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {1'000, 2'000, 3'000, 4'000, 5'000, 6'000, 7'000, 100'000, 125'000, 150'000}));
+}
+
 TEST(BitcoinInputSelector, SelectTenThreeExact) {
-    auto utxos = buildTestUTXOs({1'000, 2'000, 100'000, 3'000, 4'000, 5,000, 125'000, 6'000, 150'000, 7'000});
+    auto utxos = buildTestUTXOs({1'000, 2'000, 100'000, 3'000, 4'000, 5'000, 125'000, 6'000, 150'000, 7'000});
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
     auto selector = InputSelector<UTXO>(utxos, feeCalculator);

--- a/tests/Bitcoin/TWBitcoinSigningTests.cpp
+++ b/tests/Bitcoin/TWBitcoinSigningTests.cpp
@@ -1268,14 +1268,14 @@ TEST(BitcoinSigning, PlanAndSign_LitecoinReal_8435) {
     );
 }
 
-TEST(BitcoinSigning, Sign_ManyUtxos_800) {
+TEST(BitcoinSigning, Sign_ManyUtxos_400) {
     auto ownAddress = "bc1q0yy3juscd3zfavw76g4h3eqdqzda7qyf58rj4m";
     auto ownPrivateKey = "eb696a065ef48a2192da5b28b694f87544b30fae8327c4510137a922f32c6dcf";
 
     // Setup input
     SigningInput input;
 
-    const auto n = 800;
+    const auto n = 400;
     uint64_t utxoSum = 0;
     for (int i = 0; i < n; ++i) {
         auto utxoScript = Script::lockScriptForAddress(ownAddress, TWCoinTypeBitcoin);
@@ -1295,12 +1295,12 @@ TEST(BitcoinSigning, Sign_ManyUtxos_800) {
         input.utxos.push_back(utxo);
         utxoSum += utxo.amount;
     }
-    EXPECT_EQ(utxoSum, 4'004'000);
+    EXPECT_EQ(utxoSum, 1'202'000);
 
     input.coinType = TWCoinTypeBitcoin;
     input.hashType = hashTypeForCoin(TWCoinTypeBitcoin);
     input.useMaxAmount = false;
-    input.amount = 400'000;
+    input.amount = 300'000;
     input.byteFee = 1;
     input.toAddress = "bc1qauwlpmzamwlf9tah6z4w0t8sunh6pnyyjgk0ne";
     input.changeAddress = ownAddress;
@@ -1308,17 +1308,17 @@ TEST(BitcoinSigning, Sign_ManyUtxos_800) {
     // Plan
     auto plan = TransactionBuilder::plan(input);
 
-    // expected result: 47 utxos, with the largest amounts
+    // expected result: 66 utxos, with the largest amounts
     std::vector<int64_t> subset;
     uint64_t subsetSum = 0;
-    for (int i = n - 47; i < n; ++i) {
+    for (int i = n - 66; i < n; ++i) {
         const uint64_t val = 1000 + (i + 1) * 10;
         subset.push_back(val);
         subsetSum += val;
     }
-    EXPECT_EQ(subset.size(), 47);
-    EXPECT_EQ(subsetSum, 412'190);
-    EXPECT_TRUE(verifyPlan(plan, subset, 400'000, 3'269));
+    EXPECT_EQ(subset.size(), 66);
+    EXPECT_EQ(subsetSum, 308'550);
+    EXPECT_TRUE(verifyPlan(plan, subset, 300'000, 4'561));
 
     // Extend input with keys, reuse plan, Sign
     auto privKey = PrivateKey(parse_hex(ownPrivateKey));
@@ -1334,7 +1334,7 @@ TEST(BitcoinSigning, Sign_ManyUtxos_800) {
     Data serialized;
     signedTx.encode(serialized);
 
-    EXPECT_EQ(serialized.size(), 7050);
+    EXPECT_EQ(serialized.size(), 9871);
 }
 
 TEST(BitcoinSigning, EncodeThreeOutput) {

--- a/tests/Bitcoin/TWBitcoinSigningTests.cpp
+++ b/tests/Bitcoin/TWBitcoinSigningTests.cpp
@@ -1268,6 +1268,75 @@ TEST(BitcoinSigning, PlanAndSign_LitecoinReal_8435) {
     );
 }
 
+TEST(BitcoinSigning, Sign_ManyUtxos_800) {
+    auto ownAddress = "bc1q0yy3juscd3zfavw76g4h3eqdqzda7qyf58rj4m";
+    auto ownPrivateKey = "eb696a065ef48a2192da5b28b694f87544b30fae8327c4510137a922f32c6dcf";
+
+    // Setup input
+    SigningInput input;
+
+    const auto n = 800;
+    uint64_t utxoSum = 0;
+    for (int i = 0; i < n; ++i) {
+        auto utxoScript = Script::lockScriptForAddress(ownAddress, TWCoinTypeBitcoin);
+        Data keyHash;
+        EXPECT_TRUE(utxoScript.matchPayToWitnessPublicKeyHash(keyHash));
+        EXPECT_EQ(hex(keyHash), "79091972186c449eb1ded22b78e40d009bdf0089");
+
+        auto redeemScript = Script::buildPayToPublicKeyHash(keyHash);
+        input.scripts[std::string(keyHash.begin(), keyHash.end())] = redeemScript;
+
+        UTXO utxo;
+        utxo.script = utxoScript;
+        utxo.amount = 1000 + (i + 1) * 10;
+        auto hash = parse_hex("a85fd6a9a7f2f54cacb57e83dfd408e51c0a5fc82885e3fa06be8692962bc407");
+        std::reverse(hash.begin(), hash.end());
+        utxo.outPoint = OutPoint(hash, 0, UINT32_MAX);
+        input.utxos.push_back(utxo);
+        utxoSum += utxo.amount;
+    }
+    EXPECT_EQ(utxoSum, 4'004'000);
+
+    input.coinType = TWCoinTypeBitcoin;
+    input.hashType = hashTypeForCoin(TWCoinTypeBitcoin);
+    input.useMaxAmount = false;
+    input.amount = 400'000;
+    input.byteFee = 1;
+    input.toAddress = "bc1qauwlpmzamwlf9tah6z4w0t8sunh6pnyyjgk0ne";
+    input.changeAddress = ownAddress;
+
+    // Plan
+    auto plan = TransactionBuilder::plan(input);
+
+    // expected result: 47 utxos, with the largest amounts
+    std::vector<int64_t> subset;
+    uint64_t subsetSum = 0;
+    for (int i = n - 47; i < n; ++i) {
+        const uint64_t val = 1000 + (i + 1) * 10;
+        subset.push_back(val);
+        subsetSum += val;
+    }
+    EXPECT_EQ(subset.size(), 47);
+    EXPECT_EQ(subsetSum, 412'190);
+    EXPECT_TRUE(verifyPlan(plan, subset, 400'000, 3'269));
+
+    // Extend input with keys, reuse plan, Sign
+    auto privKey = PrivateKey(parse_hex(ownPrivateKey));
+    input.privateKeys.push_back(privKey);
+    input.plan = plan;
+
+    // Sign
+    auto result = TransactionSigner<Transaction, TransactionBuilder>::sign(input);
+
+    ASSERT_TRUE(result) << std::to_string(result.error());
+    auto signedTx = result.payload();
+
+    Data serialized;
+    signedTx.encode(serialized);
+
+    EXPECT_EQ(serialized.size(), 7050);
+}
+
 TEST(BitcoinSigning, EncodeThreeOutput) {
     auto coin = TWCoinTypeLitecoin;
     auto ownAddress = "ltc1qt36tu30tgk35tyzsve6jjq3dnhu2rm8l8v5q00";

--- a/tests/Bitcoin/TWBitcoinSigningTests.cpp
+++ b/tests/Bitcoin/TWBitcoinSigningTests.cpp
@@ -1337,6 +1337,75 @@ TEST(BitcoinSigning, Sign_ManyUtxos_400) {
     EXPECT_EQ(serialized.size(), 9871);
 }
 
+TEST(BitcoinSigning, Sign_ManyUtxos_2000) {
+    auto ownAddress = "bc1q0yy3juscd3zfavw76g4h3eqdqzda7qyf58rj4m";
+    auto ownPrivateKey = "eb696a065ef48a2192da5b28b694f87544b30fae8327c4510137a922f32c6dcf";
+
+    // Setup input
+    SigningInput input;
+
+    const auto n = 2000;
+    uint64_t utxoSum = 0;
+    for (int i = 0; i < n; ++i) {
+        auto utxoScript = Script::lockScriptForAddress(ownAddress, TWCoinTypeBitcoin);
+        Data keyHash;
+        EXPECT_TRUE(utxoScript.matchPayToWitnessPublicKeyHash(keyHash));
+        EXPECT_EQ(hex(keyHash), "79091972186c449eb1ded22b78e40d009bdf0089");
+
+        auto redeemScript = Script::buildPayToPublicKeyHash(keyHash);
+        input.scripts[std::string(keyHash.begin(), keyHash.end())] = redeemScript;
+
+        UTXO utxo;
+        utxo.script = utxoScript;
+        utxo.amount = 1000 + (i + 1) * 10;
+        auto hash = parse_hex("a85fd6a9a7f2f54cacb57e83dfd408e51c0a5fc82885e3fa06be8692962bc407");
+        std::reverse(hash.begin(), hash.end());
+        utxo.outPoint = OutPoint(hash, 0, UINT32_MAX);
+        input.utxos.push_back(utxo);
+        utxoSum += utxo.amount;
+    }
+    EXPECT_EQ(utxoSum, 22'010'000);
+
+    input.coinType = TWCoinTypeBitcoin;
+    input.hashType = hashTypeForCoin(TWCoinTypeBitcoin);
+    input.useMaxAmount = false;
+    input.amount = 2'000'000;
+    input.byteFee = 1;
+    input.toAddress = "bc1qauwlpmzamwlf9tah6z4w0t8sunh6pnyyjgk0ne";
+    input.changeAddress = ownAddress;
+
+    // Plan
+    auto plan = TransactionBuilder::plan(input);
+
+    // expected result: 601 utxos (smaller ones)
+    std::vector<int64_t> subset;
+    uint64_t subsetSum = 0;
+    for (int i = 0; i < 601; ++i) {
+        const uint64_t val = 1000 + (i + 1) * 10;
+        subset.push_back(val);
+        subsetSum += val;
+    }
+    EXPECT_EQ(subset.size(), 601);
+    EXPECT_EQ(subsetSum, 2'410'010);
+    EXPECT_TRUE(verifyPlan(plan, subset, 2'000'000, 40'943));
+
+    // Extend input with keys, reuse plan, Sign
+    auto privKey = PrivateKey(parse_hex(ownPrivateKey));
+    input.privateKeys.push_back(privKey);
+    input.plan = plan;
+
+    // Sign
+    auto result = TransactionSigner<Transaction, TransactionBuilder>::sign(input);
+
+    ASSERT_TRUE(result) << std::to_string(result.error());
+    auto signedTx = result.payload();
+
+    Data serialized;
+    signedTx.encode(serialized);
+
+    EXPECT_EQ(serialized.size(), 89'339);
+}
+
 TEST(BitcoinSigning, EncodeThreeOutput) {
     auto coin = TWCoinTypeLitecoin;
     auto ownAddress = "ltc1qt36tu30tgk35tyzsve6jjq3dnhu2rm8l8v5q00";

--- a/tests/Bitcoin/TransactionPlanTests.cpp
+++ b/tests/Bitcoin/TransactionPlanTests.cpp
@@ -507,65 +507,133 @@ TEST(TransactionPlan, AmountDecred) {
     EXPECT_TRUE(verifyPlan(txPlan, {39900000}, 10000000, 2540));
 }
 
-TEST(TransactionPlan, LotsofUtxosNonmax) {
-    const auto n = 1000;
+TEST(TransactionPlan, LotsofUtxosNonmax_900) {
+    const auto n = 900;
     const auto byteFee = 10;
     std::vector<int64_t> values;
     uint64_t valueSum = 0;
     for (int i = 0; i < n; ++i) {
-        const auto val = (i + 1) * 100;
+        const uint64_t val = (i + 1) * 100;
         values.push_back(val);
         valueSum += val;
     }
-    const auto requestedAmount = valueSum / 2 + 123;
+    const uint64_t requestedAmount = valueSum / 8;
+    EXPECT_EQ(requestedAmount, 5'068'125);
 
     auto utxos = buildTestUTXOs(values);
     auto sigingInput = buildSigningInput(requestedAmount, byteFee, utxos, false, TWCoinTypeBitcoin);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    // expected result: 298 utxos, with amounts 70300,70400,70500,...,100000. 
+    // expected result: 59 utxos, with the largest amounts
     std::vector<int64_t> subset;
     uint64_t subsetSum = 0;
-    for (int i = n - 298; i < n; ++i) {
-        const auto val = (i + 1) * 100;
+    for (int i = n - 59; i < n; ++i) {
+        const uint64_t val = (i + 1) * 100;
         subset.push_back(val);
         subsetSum += val;
     }
-    EXPECT_TRUE(verifyPlan(txPlan, subset, requestedAmount, 203'450));
+    EXPECT_EQ(subset.size(), 59);
+    EXPECT_EQ(subsetSum, 5'138'900);
+    EXPECT_TRUE(verifyPlan(txPlan, subset, requestedAmount, 40'910));
 }
 
-TEST(TransactionPlan, LotsofUtxosMax) {
-    const auto n = 1000;
+TEST(TransactionPlan, LotsofUtxosNonmax_4000_simple) {
+    const auto n = 4000;
     const auto byteFee = 10;
     std::vector<int64_t> values;
     uint64_t valueSum = 0;
     for (int i = 0; i < n; ++i) {
-        const auto val = (i + 1) * 100;
+        const uint64_t val = (i + 1) * 100;
+        values.push_back(val);
+        valueSum += val;
+    }
+    const uint64_t requestedAmount = valueSum / 8;
+    EXPECT_EQ(requestedAmount, 100'025'000);
+
+    auto utxos = buildTestUTXOs(values);
+    auto sigingInput = buildSigningInput(requestedAmount, byteFee, utxos, false, TWCoinTypeBitcoin);
+
+    auto txPlan = TransactionBuilder::plan(sigingInput);
+
+    // expected result: 1501 utxos, with the smaller amounts (except the very small dust ones)
+    std::vector<int64_t> subset;
+    uint64_t subsetSum = 0;
+    for (int i = 10; i < 1501+10; ++i) {
+        const uint64_t val = (i + 1) * 100;
+        subset.push_back(val);
+        subsetSum += val;
+    }
+    EXPECT_EQ(subset.size(), 1501);
+    EXPECT_EQ(subsetSum, 114'226'100);
+    EXPECT_TRUE(verifyPlan(txPlan, subset, requestedAmount, 1'520'490));
+}
+
+TEST(TransactionPlan, LotsofUtxosMax_900) {
+    const auto n = 900;
+    const auto byteFee = 10;
+    std::vector<int64_t> values;
+    uint64_t valueSum = 0;
+    for (int i = 0; i < n; ++i) {
+        const uint64_t val = (i + 1) * 100;
         values.push_back(val);
         valueSum += val;
     }
 
-    // Use Ravencoin, because of faster non-segwit estimation, and one original issues was with this coin.
+    // Use Ravencoin, because of faster non-segwit estimation, and one of the original issues was with this coin.
     auto utxos = buildTestUTXOs(values);
     auto sigingInput = buildSigningInput(valueSum, byteFee, utxos, true, TWCoinTypeRavencoin);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    // a few smallest UTXOs are filtered out
-    const auto dustLimit = byteFee * 148;
+    // all are selected, except a few smallest UTXOs are filtered out
+    const uint64_t dustLimit = byteFee * 148;
     std::vector<int64_t> filteredValues;
     uint64_t filteredValueSum = 0;
     for (int i = 0; i < n; ++i) {
-        const auto val = (i + 1) * 100;
+        const uint64_t val = (i + 1) * 100;
         if (val > dustLimit) {
             filteredValues.push_back(val);
             filteredValueSum += val;
         }
     }
-    EXPECT_EQ(valueSum, 50'050'000);
+    EXPECT_EQ(valueSum, 40'545'000);
     EXPECT_EQ(dustLimit, 1480);
-    EXPECT_EQ(filteredValues.size(), 986);
-    EXPECT_EQ(filteredValueSum, 50'039'500);
-    EXPECT_TRUE(verifyPlan(txPlan, filteredValues, 48'579'780, 1'459'720));
+    EXPECT_EQ(filteredValues.size(), 886);
+    EXPECT_EQ(filteredValueSum, 40'534'500);
+    EXPECT_TRUE(verifyPlan(txPlan, filteredValues, 39'222'780, 1'311'720));
+}
+
+TEST(TransactionPlan, LotsofUtxosMax_4000_simple) {
+    const auto n = 4000;
+    const auto byteFee = 10;
+    std::vector<int64_t> values;
+    uint64_t valueSum = 0;
+    for (int i = 0; i < n; ++i) {
+        const uint64_t val = (i + 1) * 100;
+        values.push_back(val);
+        valueSum += val;
+    }
+
+    auto utxos = buildTestUTXOs(values);
+    auto sigingInput = buildSigningInput(valueSum, byteFee, utxos, true);
+
+    auto txPlan = TransactionBuilder::plan(sigingInput);
+
+    // all are selected, except a few smallest UTXOs are filtered out
+    const uint64_t dustLimit = byteFee * 110;
+    std::vector<int64_t> filteredValues;
+    uint64_t filteredValueSum = 0;
+    for (int i = 0; i < n; ++i) {
+        const uint64_t val = (i + 1) * 100;
+        if (val >= dustLimit) {
+            filteredValues.push_back(val);
+            filteredValueSum += val;
+        }
+    }
+    EXPECT_EQ(valueSum, 800'200'000);
+    EXPECT_EQ(dustLimit, 1100);
+    EXPECT_EQ(filteredValues.size(), 3990);
+    EXPECT_EQ(filteredValueSum, 800'194'500);
+    EXPECT_TRUE(verifyPlan(txPlan, filteredValues, 796'154'210, 4'040'290));
 }

--- a/tests/Bitcoin/TransactionPlanTests.cpp
+++ b/tests/Bitcoin/TransactionPlanTests.cpp
@@ -507,8 +507,8 @@ TEST(TransactionPlan, AmountDecred) {
     EXPECT_TRUE(verifyPlan(txPlan, {39900000}, 10000000, 2540));
 }
 
-TEST(TransactionPlan, ManyUtxosNonmax_900) {
-    const auto n = 900;
+TEST(TransactionPlan, ManyUtxosNonmax_400) {
+    const auto n = 400;
     const auto byteFee = 10;
     std::vector<int64_t> values;
     uint64_t valueSum = 0;
@@ -518,28 +518,28 @@ TEST(TransactionPlan, ManyUtxosNonmax_900) {
         valueSum += val;
     }
     const uint64_t requestedAmount = valueSum / 8;
-    EXPECT_EQ(requestedAmount, 5'068'125);
+    EXPECT_EQ(requestedAmount, 1'002'500);
 
     auto utxos = buildTestUTXOs(values);
     auto sigingInput = buildSigningInput(requestedAmount, byteFee, utxos, false, TWCoinTypeBitcoin);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    // expected result: 59 utxos, with the largest amounts
+    // expected result: 27 utxos, with the largest amounts
     std::vector<int64_t> subset;
     uint64_t subsetSum = 0;
-    for (int i = n - 59; i < n; ++i) {
+    for (int i = n - 27; i < n; ++i) {
         const uint64_t val = (i + 1) * 100;
         subset.push_back(val);
         subsetSum += val;
     }
-    EXPECT_EQ(subset.size(), 59);
-    EXPECT_EQ(subsetSum, 5'138'900);
-    EXPECT_TRUE(verifyPlan(txPlan, subset, requestedAmount, 40'910));
+    EXPECT_EQ(subset.size(), 27);
+    EXPECT_EQ(subsetSum, 1'044'900);
+    EXPECT_TRUE(verifyPlan(txPlan, subset, requestedAmount, 19'150));
 }
 
-TEST(TransactionPlan, ManyUtxosNonmax_4000_simple) {
-    const auto n = 4000;
+TEST(TransactionPlan, ManyUtxosNonmax_5000_simple) {
+    const auto n = 5000;
     const auto byteFee = 10;
     std::vector<int64_t> values;
     uint64_t valueSum = 0;
@@ -548,25 +548,25 @@ TEST(TransactionPlan, ManyUtxosNonmax_4000_simple) {
         values.push_back(val);
         valueSum += val;
     }
-    const uint64_t requestedAmount = valueSum / 8;
-    EXPECT_EQ(requestedAmount, 100'025'000);
+    const uint64_t requestedAmount = valueSum / 20;
+    EXPECT_EQ(requestedAmount, 62'512'500);
 
     auto utxos = buildTestUTXOs(values);
     auto sigingInput = buildSigningInput(requestedAmount, byteFee, utxos, false, TWCoinTypeBitcoin);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    // expected result: 1501 utxos, with the smaller amounts (except the very small dust ones)
+    // expected result: 1188 utxos, with the smaller amounts (except the very small dust ones)
     std::vector<int64_t> subset;
     uint64_t subsetSum = 0;
-    for (int i = 10; i < 1501+10; ++i) {
+    for (int i = 10; i < 1188 + 10; ++i) {
         const uint64_t val = (i + 1) * 100;
         subset.push_back(val);
         subsetSum += val;
     }
-    EXPECT_EQ(subset.size(), 1501);
-    EXPECT_EQ(subsetSum, 114'226'100);
-    EXPECT_TRUE(verifyPlan(txPlan, subset, requestedAmount, 1'520'490));
+    EXPECT_EQ(subset.size(), 1188);
+    EXPECT_EQ(subsetSum, 71'814'600);
+    EXPECT_TRUE(verifyPlan(txPlan, subset, requestedAmount, 808'650));
 }
 
 TEST(TransactionPlan, ManyUtxosMax_900) {
@@ -604,8 +604,8 @@ TEST(TransactionPlan, ManyUtxosMax_900) {
     EXPECT_TRUE(verifyPlan(txPlan, filteredValues, 39'222'780, 1'311'720));
 }
 
-TEST(TransactionPlan, ManyUtxosMax_4000_simple) {
-    const auto n = 4000;
+TEST(TransactionPlan, ManyUtxosMax_5000_simple) {
+    const auto n = 5000;
     const auto byteFee = 10;
     std::vector<int64_t> values;
     uint64_t valueSum = 0;
@@ -620,20 +620,20 @@ TEST(TransactionPlan, ManyUtxosMax_4000_simple) {
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    // all are selected, except a few smallest UTXOs are filtered out
+    // only the first 3000 are selected, minus a few small dust UTXOs
     const uint64_t dustLimit = byteFee * 110;
     std::vector<int64_t> filteredValues;
     uint64_t filteredValueSum = 0;
-    for (int i = 0; i < n; ++i) {
+    for (int i = 0; i < 3000; ++i) {
         const uint64_t val = (i + 1) * 100;
         if (val >= dustLimit) {
             filteredValues.push_back(val);
             filteredValueSum += val;
         }
     }
-    EXPECT_EQ(valueSum, 800'200'000);
+    EXPECT_EQ(valueSum, 1'250'250'000);
     EXPECT_EQ(dustLimit, 1100);
-    EXPECT_EQ(filteredValues.size(), 3990);
-    EXPECT_EQ(filteredValueSum, 800'194'500);
-    EXPECT_TRUE(verifyPlan(txPlan, filteredValues, 796'154'210, 4'040'290));
+    EXPECT_EQ(filteredValues.size(), 2990);
+    EXPECT_EQ(filteredValueSum, 450'144'500);
+    EXPECT_TRUE(verifyPlan(txPlan, filteredValues, 448'110'830, 2'033'670));
 }

--- a/tests/Bitcoin/TransactionPlanTests.cpp
+++ b/tests/Bitcoin/TransactionPlanTests.cpp
@@ -557,17 +557,17 @@ TEST(TransactionPlan, ManyUtxosNonmax_5000_simple) {
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    // expected result: 1196 utxos, with the smaller amounts (except the very small dust ones)
+    // expected result: 1220 utxos, with the smaller amounts (except the very small dust ones)
     std::vector<int64_t> subset;
     uint64_t subsetSum = 0;
-    for (int i = 14; i < 1196 + 14; ++i) {
+    for (int i = 14; i < 1220 + 14; ++i) {
         const uint64_t val = (i + 1) * 100;
         subset.push_back(val);
         subsetSum += val;
     }
-    EXPECT_EQ(subset.size(), 1196);
-    EXPECT_EQ(subsetSum, 73'255'000);
-    EXPECT_TRUE(verifyPlan(txPlan, subset, requestedAmount, 1'770'860));
+    EXPECT_EQ(subset.size(), 1220);
+    EXPECT_EQ(subsetSum, 76'189'000);
+    EXPECT_TRUE(verifyPlan(txPlan, subset, requestedAmount, 1'806'380));
 }
 
 TEST(TransactionPlan, ManyUtxosMax_400) {
@@ -622,11 +622,11 @@ TEST(TransactionPlan, ManyUtxosMax_5000_simple) {
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    // only the first 3000 are selected, minus a few small dust UTXOs
+    // only 3000 are selected, the first ones minus a few small dust ones
     const uint64_t dustLimit = byteFee * 150;
     std::vector<int64_t> filteredValues;
     uint64_t filteredValueSum = 0;
-    for (int i = 0; i < 3000; ++i) {
+    for (int i = 0; i < 3000 + 14; ++i) {
         const uint64_t val = (i + 1) * 100;
         if (val >= dustLimit) {
             filteredValues.push_back(val);
@@ -635,7 +635,7 @@ TEST(TransactionPlan, ManyUtxosMax_5000_simple) {
     }
     EXPECT_EQ(valueSum, 1'250'250'000);
     EXPECT_EQ(dustLimit, 1500);
-    EXPECT_EQ(filteredValues.size(), 2986);
-    EXPECT_EQ(filteredValueSum, 450'139'500);
-    EXPECT_TRUE(verifyPlan(txPlan, filteredValues, 445'719'780, 4'419'720));
+    EXPECT_EQ(filteredValues.size(), 3000);
+    EXPECT_EQ(filteredValueSum, 454'350'000);
+    EXPECT_TRUE(verifyPlan(txPlan, filteredValues, 449'909'560, 4'440'440));
 }

--- a/tests/Bitcoin/TransactionPlanTests.cpp
+++ b/tests/Bitcoin/TransactionPlanTests.cpp
@@ -507,7 +507,7 @@ TEST(TransactionPlan, AmountDecred) {
     EXPECT_TRUE(verifyPlan(txPlan, {39900000}, 10000000, 2540));
 }
 
-TEST(TransactionPlan, LotsofUtxosNonmax_900) {
+TEST(TransactionPlan, ManyUtxosNonmax_900) {
     const auto n = 900;
     const auto byteFee = 10;
     std::vector<int64_t> values;
@@ -538,7 +538,7 @@ TEST(TransactionPlan, LotsofUtxosNonmax_900) {
     EXPECT_TRUE(verifyPlan(txPlan, subset, requestedAmount, 40'910));
 }
 
-TEST(TransactionPlan, LotsofUtxosNonmax_4000_simple) {
+TEST(TransactionPlan, ManyUtxosNonmax_4000_simple) {
     const auto n = 4000;
     const auto byteFee = 10;
     std::vector<int64_t> values;
@@ -569,7 +569,7 @@ TEST(TransactionPlan, LotsofUtxosNonmax_4000_simple) {
     EXPECT_TRUE(verifyPlan(txPlan, subset, requestedAmount, 1'520'490));
 }
 
-TEST(TransactionPlan, LotsofUtxosMax_900) {
+TEST(TransactionPlan, ManyUtxosMax_900) {
     const auto n = 900;
     const auto byteFee = 10;
     std::vector<int64_t> values;
@@ -604,7 +604,7 @@ TEST(TransactionPlan, LotsofUtxosMax_900) {
     EXPECT_TRUE(verifyPlan(txPlan, filteredValues, 39'222'780, 1'311'720));
 }
 
-TEST(TransactionPlan, LotsofUtxosMax_4000_simple) {
+TEST(TransactionPlan, ManyUtxosMax_4000_simple) {
     const auto n = 4000;
     const auto byteFee = 10;
     std::vector<int64_t> values;

--- a/tests/Bitcoin/TransactionPlanTests.cpp
+++ b/tests/Bitcoin/TransactionPlanTests.cpp
@@ -551,26 +551,27 @@ TEST(TransactionPlan, ManyUtxosNonmax_5000_simple) {
     const uint64_t requestedAmount = valueSum / 20;
     EXPECT_EQ(requestedAmount, 62'512'500);
 
+    // Use Ravencoin, because of faster non-segwit estimation, and one of the original issues was with this coin.
     auto utxos = buildTestUTXOs(values);
-    auto sigingInput = buildSigningInput(requestedAmount, byteFee, utxos, false, TWCoinTypeBitcoin);
+    auto sigingInput = buildSigningInput(requestedAmount, byteFee, utxos, false, TWCoinTypeRavencoin);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    // expected result: 1188 utxos, with the smaller amounts (except the very small dust ones)
+    // expected result: 1196 utxos, with the smaller amounts (except the very small dust ones)
     std::vector<int64_t> subset;
     uint64_t subsetSum = 0;
-    for (int i = 10; i < 1188 + 10; ++i) {
+    for (int i = 14; i < 1196 + 14; ++i) {
         const uint64_t val = (i + 1) * 100;
         subset.push_back(val);
         subsetSum += val;
     }
-    EXPECT_EQ(subset.size(), 1188);
-    EXPECT_EQ(subsetSum, 71'814'600);
-    EXPECT_TRUE(verifyPlan(txPlan, subset, requestedAmount, 808'650));
+    EXPECT_EQ(subset.size(), 1196);
+    EXPECT_EQ(subsetSum, 73'255'000);
+    EXPECT_TRUE(verifyPlan(txPlan, subset, requestedAmount, 1'770'860));
 }
 
-TEST(TransactionPlan, ManyUtxosMax_900) {
-    const auto n = 900;
+TEST(TransactionPlan, ManyUtxosMax_400) {
+    const auto n = 400;
     const auto byteFee = 10;
     std::vector<int64_t> values;
     uint64_t valueSum = 0;
@@ -597,11 +598,11 @@ TEST(TransactionPlan, ManyUtxosMax_900) {
             filteredValueSum += val;
         }
     }
-    EXPECT_EQ(valueSum, 40'545'000);
+    EXPECT_EQ(valueSum, 8'020'000);
     EXPECT_EQ(dustLimit, 1480);
-    EXPECT_EQ(filteredValues.size(), 886);
-    EXPECT_EQ(filteredValueSum, 40'534'500);
-    EXPECT_TRUE(verifyPlan(txPlan, filteredValues, 39'222'780, 1'311'720));
+    EXPECT_EQ(filteredValues.size(), 386);
+    EXPECT_EQ(filteredValueSum, 80'09'500);
+    EXPECT_TRUE(verifyPlan(txPlan, filteredValues, 7'437'780, 571'720));
 }
 
 TEST(TransactionPlan, ManyUtxosMax_5000_simple) {
@@ -615,13 +616,14 @@ TEST(TransactionPlan, ManyUtxosMax_5000_simple) {
         valueSum += val;
     }
 
+    // Use Ravencoin, because of faster non-segwit estimation, and one of the original issues was with this coin.
     auto utxos = buildTestUTXOs(values);
-    auto sigingInput = buildSigningInput(valueSum, byteFee, utxos, true);
+    auto sigingInput = buildSigningInput(valueSum, byteFee, utxos, true, TWCoinTypeRavencoin);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
     // only the first 3000 are selected, minus a few small dust UTXOs
-    const uint64_t dustLimit = byteFee * 110;
+    const uint64_t dustLimit = byteFee * 150;
     std::vector<int64_t> filteredValues;
     uint64_t filteredValueSum = 0;
     for (int i = 0; i < 3000; ++i) {
@@ -632,8 +634,8 @@ TEST(TransactionPlan, ManyUtxosMax_5000_simple) {
         }
     }
     EXPECT_EQ(valueSum, 1'250'250'000);
-    EXPECT_EQ(dustLimit, 1100);
-    EXPECT_EQ(filteredValues.size(), 2990);
-    EXPECT_EQ(filteredValueSum, 450'144'500);
-    EXPECT_TRUE(verifyPlan(txPlan, filteredValues, 448'110'830, 2'033'670));
+    EXPECT_EQ(dustLimit, 1500);
+    EXPECT_EQ(filteredValues.size(), 2986);
+    EXPECT_EQ(filteredValueSum, 450'139'500);
+    EXPECT_TRUE(verifyPlan(txPlan, filteredValues, 445'719'780, 4'419'720));
 }

--- a/tests/Bitcoin/TxComparisonHelper.cpp
+++ b/tests/Bitcoin/TxComparisonHelper.cpp
@@ -75,10 +75,14 @@ bool verifySelectedUTXOs(const UTXOs& selected, const std::vector<int64_t>& expe
         ret = false;
         std::cerr << "Wrong number of selected UTXOs, " << selected.size() << " vs. " << expectedAmounts.size() << std::endl;
     }
+    int errorCount = 0;
     for (auto i = 0; i < selected.size() && i < expectedAmounts.size(); ++i) {
         if (expectedAmounts[i] != selected[i].amount) {
             ret = false;
-            std::cerr << "Wrong UTXOs amount, pos " << i << " amount " << selected[i].amount << " expected " << expectedAmounts[i] << std::endl;
+            ++errorCount;
+            if (errorCount < 10) {
+                std::cerr << "Wrong UTXOs amount, pos " << i << " amount " << selected[i].amount << " expected " << expectedAmounts[i] << std::endl;
+            }
         }
     }
     return ret;


### PR DESCRIPTION
## Description

Optimizations for cases with large number of UTXOs:
- In cases with over 1000 UTXOs, use simplified selection strategy -- uisng a single pass over UTXOs (O(N) instead of O(N log N)).
- Always limit to max. 3000 the number of UTXOs used, potentially resulting in a lower transfer amount (even in maxAmount case).

Fixes #1639.

Some benchmarks:
- 2000 utxos, 601 selected:   master:  7.18s   PR: 4.63s  35% speedup
- 5000 utxos, maxamount:    master: 234.0s   PR: 42.9s  81% speedup

(wc part, on dev laptop, median of 5 measurements).

## Testing instructions

Relevant unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* Optimization (non-breaking change which does not affect functionality, but improves performance) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
