### PR TITLE
Clearing unused sensitive data from memory

### DIFF
--- a/src/HDWallet.cpp
+++ b/src/HDWallet.cpp
@@ -19,6 +19,7 @@
 #include <TrezorCrypto/bip32.h>
 #include <TrezorCrypto/bip39.h>
 #include <TrezorCrypto/curves.h>
+#include <TrezorCrypto/memzero.h>
 
 #include <array>
 #include <cstring>
@@ -46,7 +47,7 @@ HDWallet::HDWallet(int strength, const std::string& passphrase)
         throw std::invalid_argument("Invalid strength");
     }
     mnemonic = mnemonic_chars;
-    memset(buf, 0, MnemonicBufLength);
+    memzero(buf, MnemonicBufLength);
     updateSeedAndEntropy();
 }
 
@@ -67,7 +68,7 @@ HDWallet::HDWallet(const Data& entropy, const std::string& passphrase)
         throw std::invalid_argument("Invalid mnemonic data");
     }
     mnemonic = mnemonic_chars;
-    memset(buf, 0, MnemonicBufLength);
+    memzero(buf, MnemonicBufLength);
     updateSeedAndEntropy();
 }
 


### PR DESCRIPTION
A mnemonic generated in two HDWallet c-tors is not cleared properly.
Proposed change clears out the sensitive data from memory right after std::string copy-ctor.

## Description

This commit clears out sensitive data from the memory.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Prefix PR title with `[WIP]` if necessary.
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
- [ ] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [ ] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
