### PR TITLE
[CI] Fix deployment target setting

### DIFF
--- a/swift/project.yml
+++ b/swift/project.yml
@@ -2,13 +2,13 @@ name: TrustWalletCore
 options:
   bundleIdPrefix: com.trustwallet
   createIntermediateGroups: true
-  deploymentTarget: 12.0
 settings:
   base:
     HEADER_SEARCH_PATHS: $(SRCROOT)/wallet-core ${SRCROOT}/trezor-crypto/crypto
     SYSTEM_HEADER_SEARCH_PATHS: ${SRCROOT}/include ${SRCROOT}/../build/local/include ${SRCROOT}/trezor-crypto/include $(SRCROOT)/protobuf /usr/local/include /opt/homebrew/include
     CLANG_CXX_LANGUAGE_STANDARD: c++17
     SWIFT_VERSION: 5.1
+    IPHONEOS_DEPLOYMENT_TARGET: 13.0
   configs:
     release:
       SWIFT_OPTIMIZATION_LEVEL: -Owholemodule


### PR DESCRIPTION
Fix #1730 , replace `deploymentTarget` with `IPHONEOS_DEPLOYMENT_TARGET`