### PR TITLE
fix Solana compilation error

### DIFF
--- a/src/Solana/Signer.cpp
+++ b/src/Solana/Signer.cpp
@@ -13,6 +13,7 @@
 #include <google/protobuf/util/json_util.h>
 
 #include <algorithm>
+#include <optional>
 
 using namespace TW;
 using namespace TW::Solana;


### PR DESCRIPTION
This fixes the following compilation-error:

```
[ 18%] Building CXX object CMakeFiles/TrustWalletCore.dir/src/Solana/Signer.cpp.o
/home/felix/trustwallet-core/src/Solana/Signer.cpp:56:22: error: no member named 'optional' in namespace 'std'
                std::optional<Address> stakeAddress;
```