### PR TITLE
registry.json: add bitcoin testnet; then generate it

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bitcointestnet/TestBitcoinTestnetAddress.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bitcointestnet/TestBitcoinTestnetAddress.kt
@@ -1,0 +1,33 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+package com.trustwallet.core.app.blockchains.bitcointestnet
+
+import com.trustwallet.core.app.utils.toHex
+import com.trustwallet.core.app.utils.toHexByteArray
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import wallet.core.jni.*
+
+class TestBitcoinTestnetAddress {
+
+    init {
+        System.loadLibrary("TrustWalletCore")
+    }
+
+    @Test
+    fun testAddress() {
+        // TODO: Check and finalize implementation
+
+        val key = PrivateKey("__PRIVATE_KEY_DATA__".toHexByteArray())
+        val pubkey = key.publicKeyEd25519
+        val address = AnyAddress(pubkey, CoinType.BITCOINTESTNET)
+        val expected = AnyAddress("__EXPECTED_RESULT_ADDRESS__", CoinType.BITCOINTESTNET)
+
+        assertEquals(pubkey.data().toHex(), "0x__EXPECTED_PUBKEY_DATA__")
+        assertEquals(address.description(), expected.description())
+    }
+}

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bitcointestnet/TestBitcoinTestnetSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bitcointestnet/TestBitcoinTestnetSigner.kt
@@ -1,0 +1,45 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+package com.trustwallet.core.app.blockchains.bitcointestnet
+
+import com.google.protobuf.ByteString
+import com.trustwallet.core.app.utils.Numeric
+import com.trustwallet.core.app.utils.toHexByteArray
+import com.trustwallet.core.app.utils.toHexBytes
+import com.trustwallet.core.app.utils.toHexBytesInByteString
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import wallet.core.jni.BitcoinTestnetSigner
+import wallet.core.jni.proto.BitcoinTestnet
+
+class TestBitcoinTestnetSigner {
+
+    init {
+        System.loadLibrary("TrustWalletCore")
+    }
+
+    @Test
+    fun BitcoinTestnetTransactionSigning() {
+        // TODO: Finalize implementation
+
+        //val transfer = BitcoinTestnet.TransferMessage.newBuilder()
+        //    .setTo("...")
+        //    .setAmount(...)
+        //    ...
+        //    .build()
+        //val signingInput = BitcoinTestnet.SigningInput.newBuilder()
+        //    ...
+        //    .build()
+
+        //val output: BitcoinTestnet.SigningOutput = BitcoinTestnetSigner.sign(signingInput)
+
+        //assertEquals(
+        //    "__EXPECTED_RESULT_DATA__",
+        //    Numeric.toHexString(output.encoded.toByteArray())
+        //)
+    }
+}

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -16,6 +16,7 @@ This list is generated from [./registry.json](../registry.json)
 | 60      | Ethereum         | ETH    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png" width="32" />     | <https://ethereum.org>        |
 | 61      | Ethereum Classic | ETC    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/classic/info/logo.png" width="32" />      | <https://ethereumclassic.org> |
 | 74      | ICON             | ICX    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/icon/info/logo.png" width="32" />         | <https://icon.foundation>     |
+| 90      | Bitcoin Testnet  | BTC    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/bitcointestnet/info/logo.png" width="32" /> | <https://bitcoin.org>         |
 | 118     | Cosmos           | ATOM   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/cosmos/info/logo.png" width="32" />       | <https://cosmos.network>      |
 | 133     | Zcash            | ZEC    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/zcash/info/logo.png" width="32" />        | <https://z.cash>              |
 | 136     | Zcoin            | FIRO   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/zcoin/info/logo.png" width="32" />        | <https://firo.org/>           |

--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -96,6 +96,7 @@ enum TWCoinType {
     TWCoinTypeCryptoOrg = 394,
     TWCoinTypeCelo = 52752,
     TWCoinTypeRonin = 10002020,
+    TWCoinTypeBitcoinTestnet = 90,
 };
 
 /// Returns the blockchain for a coin type.

--- a/registry.json
+++ b/registry.json
@@ -31,6 +31,37 @@
     }
   },
   {
+    "id": "bitcointestnet",
+    "name": "Bitcoin Testnet",
+    "coinId": 90,
+    "symbol": "BTC",
+    "decimals": 8,
+    "blockchain": "Bitcoin",
+    "derivationPath": "m/44'/1'/0'/0/0",
+    "curve": "secp256k1",
+    "publicKeyType": "secp256k1",
+    "p2pkhPrefix": 111,
+    "p2shPrefix": 196,
+    "hrp": "tb",
+    "publicKeyHasher": "sha256ripemd",
+    "base58Hasher": "sha256d",
+    "xpub": "zpub",
+    "xprv": "zprv",
+    "explorer": {
+      "url": "https://blockchair.com",
+      "txPath": "/bitcoin/transaction/",
+      "accountPath": "/bitcoin/address/",
+      "sampleTx": "0607f62530b68cfcc91c57a1702841dd399a899d0eecda8e31ecca3f52f01df2",
+      "sampleAccount": "17A16QmavnUfCW11DAApiJxp7ARnxN5pGX"
+    },
+    "info": {
+      "url": "https://bitcoin.org",
+      "source": "https://github.com/trezor/blockbook",
+      "rpc": "",
+      "documentation": "https://github.com/trezor/blockbook/blob/master/docs/api.md"
+    }
+  },
+  {
     "id": "litecoin",
     "name": "Litecoin",
     "coinId": 2,

--- a/src/BitcoinTestnet/Address.cpp
+++ b/src/BitcoinTestnet/Address.cpp
@@ -1,0 +1,31 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Address.h"
+
+using namespace TW::BitcoinTestnet;
+
+bool Address::isValid(const std::string& string) {
+    // TODO: Finalize implementation
+    return false;
+}
+
+Address::Address(const std::string& string) {
+    // TODO: Finalize implementation
+
+    if (!isValid(string)) {
+        throw std::invalid_argument("Invalid address string");
+    }
+}
+
+Address::Address(const PublicKey& publicKey) {
+    // TODO: Finalize implementation
+}
+
+std::string Address::string() const {
+    // TODO: Finalize implementation
+    return "TODO";
+}

--- a/src/BitcoinTestnet/Address.h
+++ b/src/BitcoinTestnet/Address.h
@@ -1,0 +1,43 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "../Data.h"
+#include "../PublicKey.h"
+
+#include <string>
+
+namespace TW::BitcoinTestnet {
+
+class Address {
+  public:
+    // TODO: Complete class definition
+
+    /// Determines whether a string makes a valid address.
+    static bool isValid(const std::string& string);
+
+    /// Initializes a BitcoinTestnet address with a string representation.
+    explicit Address(const std::string& string);
+
+    /// Initializes a BitcoinTestnet address with a public key.
+    explicit Address(const PublicKey& publicKey);
+
+    /// Returns a string representation of the address.
+    std::string string() const;
+};
+
+inline bool operator==(const Address& lhs, const Address& rhs) {
+    // TODO: Complete equality operator
+    return true;
+}
+
+} // namespace TW::BitcoinTestnet
+
+/// Wrapper for C interface.
+struct TWBitcoinTestnetAddress {
+    TW::BitcoinTestnet::Address impl;
+};

--- a/src/BitcoinTestnet/Entry.cpp
+++ b/src/BitcoinTestnet/Entry.cpp
@@ -1,0 +1,27 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Entry.h"
+
+#include "Address.h"
+#include "Signer.h"
+
+using namespace TW::BitcoinTestnet;
+using namespace std;
+
+// Note: avoid business logic from here, rather just call into classes like Address, Signer, etc.
+
+bool Entry::validateAddress(TWCoinType coin, const string& address, TW::byte, TW::byte, const char*) const {
+    return Address::isValid(address);
+}
+
+string Entry::deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+    return Address(publicKey).string();
+}
+
+void Entry::sign(TWCoinType coin, const TW::Data& dataIn, TW::Data& dataOut) const {
+    signTemplate<Signer, Proto::SigningInput>(dataIn, dataOut);
+}

--- a/src/BitcoinTestnet/Entry.h
+++ b/src/BitcoinTestnet/Entry.h
@@ -1,0 +1,25 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "../CoinEntry.h"
+
+namespace TW::BitcoinTestnet {
+
+/// Entry point for implementation of BitcoinTestnet coin.
+/// Note: do not put the implementation here (no matter how simple), to avoid having coin-specific includes in this file
+class Entry: public CoinEntry {
+public:
+    virtual const std::vector<TWCoinType> coinTypes() const { return {TWCoinTypeBitcoinTestnet}; }
+    virtual bool validateAddress(TWCoinType coin, const std::string& address, TW::byte p2pkh, TW::byte p2sh, const char* hrp) const;
+    virtual std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+    virtual void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
+    // normalizeAddress(): implement this if needed, e.g. Ethereum address is EIP55 checksummed
+    // plan(): implement this if the blockchain is UTXO based
+};
+
+} // namespace TW::BitcoinTestnet

--- a/src/BitcoinTestnet/Signer.cpp
+++ b/src/BitcoinTestnet/Signer.cpp
@@ -1,0 +1,26 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Signer.h"
+#include "Address.h"
+#include "../PublicKey.h"
+
+using namespace TW;
+using namespace TW::BitcoinTestnet;
+
+
+Proto::SigningOutput Signer::sign(const Proto::SigningInput &input) noexcept {
+    // TODO: Check and finalize implementation
+
+    auto protoOutput = Proto::SigningOutput();
+    Data encoded;
+    // auto privateKey = PrivateKey(Data(input.private_key().begin(), input.private_key().end()));
+    // auto signature = privateKey.sign(payload, TWCurveED25519);
+    // encoded = encodeSignature(signature);
+
+    protoOutput.set_encoded(encoded.data(), encoded.size());
+    return protoOutput;
+}

--- a/src/BitcoinTestnet/Signer.h
+++ b/src/BitcoinTestnet/Signer.h
@@ -1,0 +1,30 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "../Data.h"
+#include "../PrivateKey.h"
+#include "../proto/BitcoinTestnet.pb.h"
+
+namespace TW::BitcoinTestnet {
+
+/// Helper class that performs BitcoinTestnet transaction signing.
+class Signer {
+public:
+    /// Hide default constructor
+    Signer() = delete;
+
+    /// Signs a Proto::SigningInput transaction
+    static Proto::SigningOutput sign(const Proto::SigningInput& input) noexcept;
+};
+
+} // namespace TW::BitcoinTestnet
+
+/// Wrapper for C interface.
+struct TWBitcoinTestnetSigner {
+    TW::BitcoinTestnet::Signer impl;
+};

--- a/src/Coin.cpp
+++ b/src/Coin.cpp
@@ -52,6 +52,7 @@
 #include "Waves/Entry.h"
 #include "Zcash/Entry.h"
 #include "Zilliqa/Entry.h"
+#include "BitcoinTestnet/Entry.h"
 // end_of_coin_includes_marker_do_not_modify
 
 using namespace TW;
@@ -96,6 +97,7 @@ VeChain::Entry vechainDP;
 Waves::Entry wavesDP;
 Zcash::Entry zcashDP;
 Zilliqa::Entry zilliqaDP;
+BitcoinTestnet::Entry BitcoinTestnetDP;
 // end_of_coin_dipatcher_declarations_marker_do_not_modify
 
 CoinEntry* coinDispatcher(TWCoinType coinType) {
@@ -177,6 +179,7 @@ CoinEntry* coinDispatcher(TWCoinType coinType) {
         case TWCoinTypeCelo: entry = &ethereumDP; break;
         case TWCoinTypeRonin: entry = &ethereumDP; break;
         case TWCoinTypeCryptoOrg: entry = &cosmosDP; break;
+        case TWCoinTypeBitcoinTestnet: entry = &bitcoinDP; break;
         // end_of_coin_dipatcher_switch_marker_do_not_modify
 
         default: entry = nullptr; break;

--- a/src/proto/BitcoinTestnet.proto
+++ b/src/proto/BitcoinTestnet.proto
@@ -1,0 +1,32 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+syntax = "proto3";
+
+package TW.BitcoinTestnet.Proto;
+option java_package = "wallet.core.jni.proto";
+
+// TODO: typical balance transfer, add more fields needed to sign
+message TransferMessage {
+    int64 amount = 1;
+    int64 fee = 2;
+    string to = 3;
+}
+
+// TODO: Input data necessary to create a signed transaction.
+message SigningInput {
+    bytes private_key = 1;
+
+    oneof message_oneof {
+        TransferMessage transfer = 2;
+    }
+}
+
+// Transaction signing output.
+message SigningOutput {
+    // Signed and encoded transaction bytes.
+    bytes encoded = 1;
+}

--- a/swift/Tests/Blockchains/BitcoinTestnetTests.swift
+++ b/swift/Tests/Blockchains/BitcoinTestnetTests.swift
@@ -1,0 +1,28 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+import WalletCore
+import XCTest
+
+class BitcoinTestnetTests: XCTestCase {
+    // TODO: Check and finalize implementation
+
+    func testAddress() {
+        // TODO: Check and finalize implementation
+
+        let key = PrivateKey(data: Data(hexString: "__PRIVATE_KEY_DATA__")!)!
+        let pubkey = key.getPublicKeyEd25519()
+        let address = AnyAddress(publicKey: pubkey, coin: .bitcointestnet)
+        let addressFromString = AnyAddress(string: "__ADDRESS_DATA__", coin: .bitcointestnet)!
+
+        XCTAssertEqual(pubkey.data.hexString, "__EXPECTED_PUBKEY_DATA__")
+        XCTAssertEqual(address.description, addressFromString.description)
+    }
+
+    func testSign() {
+        // TODO: Create implementation
+    }
+}

--- a/tests/BitcoinTestnet/AddressTests.cpp
+++ b/tests/BitcoinTestnet/AddressTests.cpp
@@ -1,0 +1,48 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "HexCoding.h"
+#include "BitcoinTestnet/Address.h"
+#include "PublicKey.h"
+#include "PrivateKey.h"
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace TW;
+using namespace TW::BitcoinTestnet;
+
+TEST(BitcoinTestnetAddress, Valid) {
+    ASSERT_TRUE(Address::isValid("__ADD_VALID_ADDRESS_HERE__"));
+
+    // TODO: Add more tests
+}
+
+TEST(BitcoinTestnetAddress, Invalid) {
+    ASSERT_FALSE(Address::isValid("__ADD_INVALID_ADDRESS_HERE__"));
+
+    // TODO: Add more tests
+}
+
+TEST(BitcoinTestnetAddress, FromPrivateKey) {
+    // TODO: Check public key type, finalize implementation
+
+    auto privateKey = PrivateKey(parse_hex("__PRIVATE_KEY_DATA__"));
+    auto address = Address(privateKey.getPublicKey(TWPublicKeyTypeED25519));
+    ASSERT_EQ(address.string(), "__ADD_RESULTING_ADDRESS_HERE__");
+}
+
+TEST(BitcoinTestnetAddress, FromPublicKey) {
+    // TODO: Check public key type, finalize implementation
+    
+    auto publicKey = PublicKey(parse_hex("__PUBLIC_KEY_DATA__"), TWPublicKeyTypeED25519);
+    auto address = Address(publicKey);
+    ASSERT_EQ(address.string(), "__ADD_RESULTING_ADDRESS_HERE__");
+}
+
+TEST(BitcoinTestnetAddress, FromString) {
+    auto address = Address("__ADD_VALID_ADDRESS_HERE__");
+    ASSERT_EQ(address.string(), "__ADD_SAME_VALID_ADDRESS_HERE__");
+}

--- a/tests/BitcoinTestnet/SignerTests.cpp
+++ b/tests/BitcoinTestnet/SignerTests.cpp
@@ -1,0 +1,34 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "BitcoinTestnet/Signer.h"
+#include "BitcoinTestnet/Address.h"
+#include "HexCoding.h"
+#include "PrivateKey.h"
+#include "PublicKey.h"
+
+#include <gtest/gtest.h>
+
+using namespace TW;
+using namespace TW::BitcoinTestnet;
+
+// TODO: Add tests
+
+TEST(BitcoinTestnetSigner, Sign) {
+    // TODO: Finalize test implementation
+
+    //auto key = PrivateKey(parse_hex("__PRIVKEY_DATA__"));
+    //auto publicKey = key.getPublicKey(TWPublicKeyTypeED25519);
+    //auto from = Address(publicKey);
+    //auto to = Address("__TO_ADDRESS__");
+    //...
+    //auto transaction = Transaction(...)
+    //auto signature = Signer::sign(key, transaction);
+    //auto result = transaction.serialize(signature);
+
+    //ASSERT_EQ(hex(serialized), "__RESULT__");
+    //ASSERT_EQ(...)
+}

--- a/tests/BitcoinTestnet/TWAnyAddressTests.cpp
+++ b/tests/BitcoinTestnet/TWAnyAddressTests.cpp
@@ -1,0 +1,26 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include <TrustWalletCore/TWAnyAddress.h>
+#include "HexCoding.h"
+
+#include "../interface/TWTestUtilities.h"
+#include <gtest/gtest.h>
+
+using namespace TW;
+
+// TODO: Finalize tests
+
+TEST(TWBitcoinTestnet, Address) {
+    // TODO: Finalize test implementation
+
+    auto string = STRING("__ADD_VALID_ADDRESS_HERE__");
+    auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithString(string.get(), TWCoinTypeBitcoinTestnet));
+    auto string2 = WRAPS(TWAnyAddressDescription(addr.get()));
+    EXPECT_TRUE(TWStringEqual(string.get(), string2.get()));
+    auto keyHash = WRAPD(TWAnyAddressData(addr.get()));
+    assertHexEqual(keyHash, "__CORRESPONDING_ADDRESS_DATA__");
+}

--- a/tests/BitcoinTestnet/TWAnySignerTests.cpp
+++ b/tests/BitcoinTestnet/TWAnySignerTests.cpp
@@ -1,0 +1,19 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include <TrustWalletCore/TWAnySigner.h>
+#include "HexCoding.h"
+
+#include "../interface/TWTestUtilities.h"
+#include <gtest/gtest.h>
+
+using namespace TW;
+
+// TODO: Finalize tests
+
+TEST(TWAnySignerBitcoinTestnet, Sign) {
+    // TODO: Finalize test implementation
+}

--- a/tests/BitcoinTestnet/TWCoinTypeTests.cpp
+++ b/tests/BitcoinTestnet/TWCoinTypeTests.cpp
@@ -1,0 +1,34 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here MAY BE LOST.
+// Generated one-time (codegen/bin/cointests)
+//
+
+#include "../interface/TWTestUtilities.h"
+#include <TrustWalletCore/TWCoinTypeConfiguration.h>
+#include <gtest/gtest.h>
+
+
+TEST(TWBitcoinTestnetCoinType, TWCoinType) {
+    auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeBitcoinTestnet));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("0607f62530b68cfcc91c57a1702841dd399a899d0eecda8e31ecca3f52f01df2"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeBitcoinTestnet, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("17A16QmavnUfCW11DAApiJxp7ARnxN5pGX"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeBitcoinTestnet, accId.get()));
+    auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeBitcoinTestnet));
+    auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeBitcoinTestnet));
+
+    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeBitcoinTestnet), 8);
+    ASSERT_EQ(TWBlockchainBitcoin, TWCoinTypeBlockchain(TWCoinTypeBitcoinTestnet));
+    ASSERT_EQ(0xc4, TWCoinTypeP2shPrefix(TWCoinTypeBitcoinTestnet));
+    ASSERT_EQ(0x0, TWCoinTypeStaticPrefix(TWCoinTypeBitcoinTestnet));
+    assertStringsEqual(symbol, "BTC");
+    assertStringsEqual(txUrl, "https://blockchair.com/bitcoin/transaction/0607f62530b68cfcc91c57a1702841dd399a899d0eecda8e31ecca3f52f01df2");
+    assertStringsEqual(accUrl, "https://blockchair.com/bitcoin/address/17A16QmavnUfCW11DAApiJxp7ARnxN5pGX");
+    assertStringsEqual(id, "bitcointestnet");
+    assertStringsEqual(name, "Bitcoin Testnet");
+}


### PR DESCRIPTION
## Description

Add new coin: Bitcoin Testnet3
Generated wallet address will have prefix `m`
Successfully tested to send signed raw trx to testnet chain (my code is not publicly shared yet)