### PR TITLE
Add Smart Bitcoin Cash

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
@@ -41,7 +41,7 @@ class CoinAddressDerivationTests {
         DASH -> assertEquals("XqHiz8EXYbTAtBEYs4pWTHh7ipEDQcNQeT", address)
         DIGIBYTE -> assertEquals("dgb1qtjgmerfqwdffyf8ghcrkgy52cghsqptynmyswu", address)
         ETHEREUM, SMARTCHAIN, POLYGON, OPTIMISM, ARBITRUM, ECOCHAIN, AVALANCHECCHAIN, XDAI,
-        FANTOM, CELO, CRONOSCHAIN -> assertEquals("0x8f348F300873Fd5DA36950B2aC75a26584584feE", address)
+        FANTOM, CELO, CRONOSCHAIN, SMARTBITCOINCASH -> assertEquals("0x8f348F300873Fd5DA36950B2aC75a26584584feE", address)
         RONIN -> assertEquals("ronin:8f348f300873fd5da36950b2ac75a26584584fee", address)
         ETHEREUMCLASSIC -> assertEquals("0x078bA3228F3E6C08bEEac9A005de0b7e7089aD1c", address)
         GOCHAIN -> assertEquals("0x5940ce4A14210d4Ccd0ac206CE92F21828016aC2", address)

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/smartbitcoincash/TestSmartBitcoinCashAddress.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/smartbitcoincash/TestSmartBitcoinCashAddress.kt
@@ -1,0 +1,31 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+package com.trustwallet.core.app.blockchains.smartbitcoincash
+
+import com.trustwallet.core.app.utils.toHex
+import com.trustwallet.core.app.utils.toHexByteArray
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import wallet.core.jni.*
+
+class TestSmartBitcoinCashAddress {
+
+    init {
+        System.loadLibrary("TrustWalletCore")
+    }
+
+    @Test
+    fun testAddress() {
+        val key = PrivateKey("ab4accc9310d90a61fc354d8f353bca4a2b3c0590685d3eb82d0216af3badddc".toHexByteArray())
+        val pubkey = key.getPublicKeySecp256k1(false)
+        val address = AnyAddress(pubkey, CoinType.SMARTBITCOINCASH)
+        val expected = AnyAddress("0xA3Dcd899C0f3832DFDFed9479a9d828c6A4EB2A7", CoinType.SMARTBITCOINCASH)
+
+        assertEquals(pubkey.data().toHex(), "0x0448a9ffac8022f1c7eb5253746e24d11d9b6b2737c0aecd48335feabb95a179916b1f3a97bed6740a85a2d11c663d38566acfb08af48a47ce0c835c65c9b23d0d")
+        assertEquals(address.description(), expected.description())
+    }
+}

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -73,6 +73,7 @@ This list is generated from [./registry.json](../registry.json)
 | 10000070 | Optimistic Ethereum | OETH   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/optimism/info/logo.png" width="32" />     | <https://optimism.io/>        |
 | 10000100 | Gnosis Chain     | xDAI   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/xdai/info/logo.png" width="32" />         | <https://www.xdaichain.com>   |
 | 10000118 | Osmosis          | OSMO   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/osmosis/info/logo.png" width="32" />      | <https://osmosis.zone/>       |
+| 10000145 | Smart Bitcoin Cash | BCH    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/smartbch/info/logo.png" width="32" />     | <https://smartbch.org/>       |
 | 10000250 | Fantom           | FTM    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/fantom/info/logo.png" width="32" />       | <https://fantom.foundation>   |
 | 10000553 | Huobi ECO Chain  | HT     | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/heco/info/logo.png" width="32" />         | <https://www.hecochain.com/en-us> |
 | 10002020 | Ronin            | RON    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ronin/info/logo.png" width="32" />        | <https://whitepaper.axieinfinity.com/technology/ronin-ethereum-sidechain> |

--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -99,6 +99,7 @@ enum TWCoinType {
     TWCoinTypeOsmosis = 10000118,
     TWCoinTypeECash = 899,
     TWCoinTypeCronosChain = 10000025,
+    TWCoinTypeSmartBitcoinCash = 10000145,
 };
 
 /// Returns the blockchain for a coin type.

--- a/include/TrustWalletCore/TWEthereumChainID.h
+++ b/include/TrustWalletCore/TWEthereumChainID.h
@@ -33,6 +33,7 @@ enum TWEthereumChainID {
     TWEthereumChainIDCelo = 42220,
     TWEthereumChainIDRonin = 2020,
     TWEthereumChainIDCronos = 25,
+    TWEthereumChainIDSmartBitcoinCash = 10000,
 };
 
 TW_EXTERN_C_END

--- a/registry.json
+++ b/registry.json
@@ -1893,5 +1893,29 @@
       "clientPublic": "https://evm-cronos.crypto.org",
       "clientDocs": "https://eth.wiki/json-rpc/API"
     }
+  },
+  {
+    "id": "smartbch",
+    "name": "Smart Bitcoin Cash",
+    "coinId": 10000145,
+    "symbol": "BCH",
+    "decimals": 18,
+    "blockchain": "Ethereum",
+    "derivationPath": "m/44'/60'/0'/0/0",
+    "curve": "secp256k1",
+    "publicKeyType": "secp256k1Extended",
+    "explorer": {
+      "url": "https://www.smartscan.cash",
+      "txPath": "/tx/",
+      "accountPath": "/address/",
+      "sampleTx": "0x6413466b455b17d03c7a8ce2d7f99fec34bcd338628bdd2d0580a21e3197a4d9",
+      "sampleAccount": "0xFeEc227410E1DF9f3b4e6e2E284DC83051ae468F"
+    },
+    "info": {
+      "url": "https://smartbch.org/",
+      "source": "https://github.com/smartbch/smartbch",
+      "rpc": "https://smartbch.fountainhead.cash/mainnet",
+      "documentation": "https://github.com/smartbch/docs/blob/main/developers-guide/jsonrpc.md"
+    }
   }
 ]

--- a/src/AnyAddress.h
+++ b/src/AnyAddress.h
@@ -125,7 +125,8 @@ class AnyAddress {
         case TWCoinTypeXDai:
         case TWCoinTypeAvalancheCChain:
         case TWCoinTypeFantom:
-        case TWCoinTypeCelo: {
+        case TWCoinTypeCelo:
+        case TWCoinTypeSmartBitcoinCash: {
             const auto addr = Ethereum::Address(string);
             return {addr.bytes.begin(), addr.bytes.end()};
         }

--- a/src/Coin.cpp
+++ b/src/Coin.cpp
@@ -182,6 +182,7 @@ CoinEntry* coinDispatcher(TWCoinType coinType) {
         case TWCoinTypeCryptoOrg: entry = &cosmosDP; break;
         case TWCoinTypeOsmosis: entry = &cosmosDP; break;
         case TWCoinTypeCronosChain: entry = &ethereumDP; break;
+        case TWCoinTypeSmartBitcoinCash: entry = &ethereumDP; break;
         // end_of_coin_dipatcher_switch_marker_do_not_modify
 
         default: entry = nullptr; break;

--- a/src/Ethereum/Entry.h
+++ b/src/Ethereum/Entry.h
@@ -35,6 +35,7 @@ public:
             TWCoinTypeFantom,
             TWCoinTypeCelo,
             TWCoinTypeCronosChain,
+            TWCoinTypeSmartBitcoinCash,
         };
     }
     virtual bool validateAddress(TWCoinType coin, const std::string& address, TW::byte p2pkh, TW::byte p2sh, const char* hrp) const;

--- a/swift/Tests/Blockchains/SmartBitcoinCashTests.swift
+++ b/swift/Tests/Blockchains/SmartBitcoinCashTests.swift
@@ -1,0 +1,22 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+import WalletCore
+import XCTest
+
+class SmartBitcoinCashTests: XCTestCase {
+
+    func testAddress() {
+        let key = PrivateKey(data: Data(hexString: "ab4accc9310d90a61fc354d8f353bca4a2b3c0590685d3eb82d0216af3badddc")!)!
+        let pubkey = key.getPublicKeySecp256k1(compressed: false)
+        let address = AnyAddress(publicKey: pubkey, coin: .smartBitcoinCash)
+        let addressFromString = AnyAddress(string: "0xA3Dcd899C0f3832DFDFed9479a9d828c6A4EB2A7", coin: .smartBitcoinCash)!
+
+        XCTAssertEqual(pubkey.data.hexString, "0448a9ffac8022f1c7eb5253746e24d11d9b6b2737c0aecd48335feabb95a179916b1f3a97bed6740a85a2d11c663d38566acfb08af48a47ce0c835c65c9b23d0d")
+        XCTAssertEqual(address.description, addressFromString.description)
+    }
+
+}

--- a/swift/Tests/CoinAddressDerivationTests.swift
+++ b/swift/Tests/CoinAddressDerivationTests.swift
@@ -80,7 +80,8 @@ class CoinAddressDerivationTests: XCTestCase {
                      .xdai,
                      .fantom,
                      .celo,
-                     .cronosChain:
+                     .cronosChain,
+                     .smartBitcoinCash:
                     let expectedResult = "0x8f348F300873Fd5DA36950B2aC75a26584584feE"
                     assertCoinDerivation(coin, expectedResult, derivedAddress, address)
                 case .ronin:

--- a/tests/SmartBitcoinCash/TWCoinTypeTests.cpp
+++ b/tests/SmartBitcoinCash/TWCoinTypeTests.cpp
@@ -1,0 +1,34 @@
+// Copyright © 2017-2021 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here MAY BE LOST.
+// Generated one-time (codegen/bin/cointests)
+//
+
+#include "../interface/TWTestUtilities.h"
+#include <TrustWalletCore/TWCoinTypeConfiguration.h>
+#include <gtest/gtest.h>
+
+
+TEST(TWSmartBitcoinCashCoinType, TWCoinType) {
+    auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeSmartBitcoinCash));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("0x6413466b455b17d03c7a8ce2d7f99fec34bcd338628bdd2d0580a21e3197a4d9"));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeSmartBitcoinCash, txId.get()));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("0xFeEc227410E1DF9f3b4e6e2E284DC83051ae468F"));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeSmartBitcoinCash, accId.get()));
+    auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeSmartBitcoinCash));
+    auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeSmartBitcoinCash));
+
+    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeSmartBitcoinCash), 18);
+    ASSERT_EQ(TWBlockchainEthereum, TWCoinTypeBlockchain(TWCoinTypeSmartBitcoinCash));
+    ASSERT_EQ(0x0, TWCoinTypeP2shPrefix(TWCoinTypeSmartBitcoinCash));
+    ASSERT_EQ(0x0, TWCoinTypeStaticPrefix(TWCoinTypeSmartBitcoinCash));
+    assertStringsEqual(symbol, "BCH");
+    assertStringsEqual(txUrl, "https://www.smartscan.cash/tx/0x6413466b455b17d03c7a8ce2d7f99fec34bcd338628bdd2d0580a21e3197a4d9");
+    assertStringsEqual(accUrl, "https://www.smartscan.cash/address/0xFeEc227410E1DF9f3b4e6e2E284DC83051ae468F");
+    assertStringsEqual(id, "smartbch");
+    assertStringsEqual(name, "Smart Bitcoin Cash");
+}

--- a/tests/interface/TWAnyAddressTests.cpp
+++ b/tests/interface/TWAnyAddressTests.cpp
@@ -32,6 +32,13 @@ TEST(AnyAddress, Data) {
         auto keyHash = WRAPD(TWAnyAddressData(addr.get()));
         assertHexEqual(keyHash, "4e5b2e1dc63f6b91cb6cd759936495434c7e972f");
     }
+    // smartBCH
+    {
+        auto string = STRING("0x4E5B2e1dc63F6b91cb6Cd759936495434C7e972F");
+        auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithString(string.get(), TWCoinTypeSmartBitcoinCash));
+        auto keyHash = WRAPD(TWAnyAddressData(addr.get()));
+        assertHexEqual(keyHash, "4e5b2e1dc63f6b91cb6cd759936495434c7e972f");
+    }
     // bnb address key hash
     {
         auto string = STRING("bnb1hlly02l6ahjsgxw9wlcswnlwdhg4xhx38yxpd5");


### PR DESCRIPTION
## Description

Add Smart Bitcoin Cash (smartBCH for short). It is a sidechain for Bitcoin Cash and has an aim to explore new ideas and unlock possibilities. It is compatible with Ethereum's EVM and Web3 API and provides high throughput for DApps in a fast, secure, and decentralized manner.

## Testing instructions

Test in the same manner as BSC or Polygon was tested.

## Types of changes

* New feature (non-breaking change which adds functionality) 

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [ ] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
