### PR TITLE
StoreKey: Introduce 3rd encryption level 16k, default

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestKeyStore.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestKeyStore.kt
@@ -53,8 +53,8 @@ class TestKeyStore {
                 "kdf": "scrypt",
                 "kdfparams": {
                     "dklen": 32,
-                    "n": 16384,
-                    "p": 4,
+                    "n": 4096,
+                    "p": 6,
                     "r": 8,
                     "salt": "24c72d92bf88a4f7c7b3f5e3cb3620714d71fceabbb0bc6099f50c6d5d898e7c"
                 },

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestKeyStore.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestKeyStore.kt
@@ -53,8 +53,8 @@ class TestKeyStore {
                 "kdf": "scrypt",
                 "kdfparams": {
                     "dklen": 32,
-                    "n": 4096,
-                    "p": 6,
+                    "n": 16384,
+                    "p": 4,
                     "r": 8,
                     "salt": "24c72d92bf88a4f7c7b3f5e3cb3620714d71fceabbb0bc6099f50c6d5d898e7c"
                 },

--- a/include/TrustWalletCore/TWStoredKeyEncryptionLevel.h
+++ b/include/TrustWalletCore/TWStoredKeyEncryptionLevel.h
@@ -16,9 +16,11 @@ enum TWStoredKeyEncryptionLevel {
     /// Default, which is one of the below values, determined by the implementation.
     TWStoredKeyEncryptionLevelDefault = 0,
     /// Minimal sufficient level of encryption strength (scrypt 4096)
-    TWStoredKeyEncryptionLevelWeak = 1,
+    TWStoredKeyEncryptionLevelMinimal = 1,
+    /// Weak encryption strength (scrypt 16k)
+    TWStoredKeyEncryptionLevelWeak = 2,
     /// Standard level of encryption strength (scrypt 262k)
-    TWStoredKeyEncryptionLevelStandard = 2,
+    TWStoredKeyEncryptionLevelStandard = 3,
 };
 
 TW_EXTERN_C_END

--- a/src/Keystore/EncryptionParameters.h
+++ b/src/Keystore/EncryptionParameters.h
@@ -22,10 +22,12 @@ namespace TW::Keystore {
 struct EncryptionParameters {
     static EncryptionParameters getPreset(enum TWStoredKeyEncryptionLevel preset) {
         switch (preset) {
+            case TWStoredKeyEncryptionLevelMinimal:
+                return EncryptionParameters(AESParameters(), ScryptParameters::Minimal);
             case TWStoredKeyEncryptionLevelWeak:
             case TWStoredKeyEncryptionLevelDefault:
             default:
-                return EncryptionParameters(AESParameters(), ScryptParameters::Light);
+                return EncryptionParameters(AESParameters(), ScryptParameters::Weak);
             case TWStoredKeyEncryptionLevelStandard:
                 return EncryptionParameters(AESParameters(), ScryptParameters::Standard);
         }

--- a/src/Keystore/ScryptParameters.cpp
+++ b/src/Keystore/ScryptParameters.cpp
@@ -12,8 +12,8 @@
 using namespace TW;
 using namespace TW::Keystore;
 
-ScryptParameters ScryptParameters::Light = ScryptParameters(Data(), lightN, defaultR, lightP, defaultDesiredKeyLength);
-
+ScryptParameters ScryptParameters::Minimal = ScryptParameters(Data(), minimalN, defaultR, minimalP, defaultDesiredKeyLength);
+ScryptParameters ScryptParameters::Weak = ScryptParameters(Data(), weakN, defaultR, weakP, defaultDesiredKeyLength);
 ScryptParameters ScryptParameters::Standard = ScryptParameters(Data(), standardN, defaultR, standardP, defaultDesiredKeyLength);
 
 ScryptParameters::ScryptParameters() : salt(32) {

--- a/src/Keystore/ScryptParameters.h
+++ b/src/Keystore/ScryptParameters.h
@@ -23,25 +23,22 @@ enum class ScryptValidationError {
 
 /// Scrypt function parameters.
 struct ScryptParameters {
-    static ScryptParameters Light;
-
+    static ScryptParameters Minimal;
+    static ScryptParameters Weak;
     static ScryptParameters Standard;
 
-    /// The N parameter of Scrypt encryption algorithm, using 256MB memory and
+    /// The N and P parameters of Scrypt encryption algorithm, using 256MB memory and
     /// taking approximately 1s CPU time on a modern processor.
     static const uint32_t standardN = 1 << 18;
-
-    /// The P parameter of Scrypt encryption algorithm, using 256MB memory and
-    /// taking approximately 1s CPU time on a modern processor.
     static const uint32_t standardP = 1;
 
-    /// The N parameter of Scrypt encryption algorithm, using 4MB memory and
-    /// taking approximately 100ms CPU time on a modern processor.
-    static const uint32_t lightN = 1 << 12;
+    static const uint32_t weakN = 1 << 14;
+    static const uint32_t weakP = 4;
 
-    /// The P parameter of Scrypt encryption algorithm, using 4MB memory and
+    /// The N and P parameters of Scrypt encryption algorithm, using 4MB memory and
     /// taking approximately 100ms CPU time on a modern processor.
-    static const uint32_t lightP = 6;
+    static const uint32_t minimalN = 1 << 12;
+    static const uint32_t minimalP = 6;
 
     /// Default `R` parameter of Scrypt encryption algorithm.
     static const uint32_t defaultR = 8;
@@ -56,10 +53,10 @@ struct ScryptParameters {
     std::size_t desiredKeyLength = defaultDesiredKeyLength;
 
     /// CPU/Memory cost factor.
-    uint32_t n = lightN;
+    uint32_t n = minimalN;
 
     /// Parallelization factor (1..232-1 * hLen/MFlen).
-    uint32_t p = lightP;
+    uint32_t p = minimalP;
 
     /// Block size factor.
     uint32_t r = defaultR;

--- a/tests/Keystore/StoredKeyTests.cpp
+++ b/tests/Keystore/StoredKeyTests.cpp
@@ -383,6 +383,24 @@ TEST(StoredKey, EtherWalletAddressNo0x) {
     EXPECT_EQ(key.account(TWCoinTypeEthereum, nullptr)->address, "0xAc1ec44E4f0ca7D172B7803f6836De87Fb72b309");
 }
 
+TEST(StoredKey, CreateMinimalEncryptionParameters) {
+    const auto key = StoredKey::createWithMnemonic("name", password, mnemonic, TWStoredKeyEncryptionLevelMinimal);
+    EXPECT_EQ(key.type, StoredKeyType::mnemonicPhrase);
+    const Data& mnemo2Data = key.payload.decrypt(password);
+    EXPECT_EQ(string(mnemo2Data.begin(), mnemo2Data.end()), string(mnemonic));
+    EXPECT_EQ(key.accounts.size(), 0);
+    EXPECT_EQ(key.wallet(password).getMnemonic(), string(mnemonic));
+
+    const auto json = key.json();
+
+    EXPECT_EQ(json["crypto"]["kdf"], "scrypt");
+    EXPECT_EQ(json["crypto"]["kdfparams"]["n"], 4096);
+
+    // load it back
+    const auto key2 = StoredKey::createWithJson(json);
+    EXPECT_EQ(key2.wallet(password).getMnemonic(), string(mnemonic));
+}
+
 TEST(StoredKey, CreateWeakEncryptionParameters) {
     const auto key = StoredKey::createWithMnemonic("name", password, mnemonic, TWStoredKeyEncryptionLevelWeak);
     EXPECT_EQ(key.type, StoredKeyType::mnemonicPhrase);
@@ -394,7 +412,7 @@ TEST(StoredKey, CreateWeakEncryptionParameters) {
     const auto json = key.json();
 
     EXPECT_EQ(json["crypto"]["kdf"], "scrypt");
-    EXPECT_EQ(json["crypto"]["kdfparams"]["n"], 4096);
+    EXPECT_EQ(json["crypto"]["kdfparams"]["n"], 16384);
 
     // load it back
     const auto key2 = StoredKey::createWithJson(json);

--- a/tests/interface/TWStoredKeyTests.cpp
+++ b/tests/interface/TWStoredKeyTests.cpp
@@ -234,7 +234,7 @@ TEST(TWStoredKey, encryptionParameters) {
     nlohmann::json jsonParams = nlohmann::json::parse(string(TWStringUTF8Bytes(params.get())));
 
     // compare some specific parameters
-    EXPECT_EQ(jsonParams["kdfparams"]["n"], 4096);
+    EXPECT_EQ(jsonParams["kdfparams"]["n"], 16384);
     EXPECT_EQ(std::string(jsonParams["cipherparams"]["iv"]).length(), 32);
 
     // compare all keys, except dynamic ones (like cipherparams/iv)
@@ -251,8 +251,8 @@ TEST(TWStoredKey, encryptionParameters) {
             "kdf": "scrypt",
             "kdfparams": {
                 "dklen": 32,
-                "n": 4096,
-                "p": 6,
+                "n": 16384,
+                "p": 4,
                 "r": 8,
                 "salt": "<salt>"
             },


### PR DESCRIPTION
## Description

BREAKING: in case for new wallet encryption level is not specified explicitly, encryption parameters are changed, from 4k to 16k.

StoreKey: Introduce 3rd, in-between encryption level (16k), and make that default .
Levels are now:
- Minimal -- 4k
- Weak -- 16k <-- new, this is also new Default
- Standard -- 262k

Follow up on #1766 .

## Testing instructions

Unit tests. New wallet creation.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality) 

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
