### PR TITLE
[SPM] Upload Package.swift to GitHub release

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you want to use wallet core in your project follow these instructions.
 
 ## Android
 
-Future Android releases will be hosted on [GitHub packages](https://github.com/trustwallet/wallet-core/packages/700258), please checkout [this guide](https://docs.github.com/en/packages/guides/configuring-gradle-for-use-with-github-packages#installing-a-package) for more details.
+Android releases are hosted on [GitHub packages](https://github.com/trustwallet/wallet-core/packages/700258), please checkout [this installation guide](https://docs.github.com/en/packages/guides/configuring-gradle-for-use-with-github-packages#installing-a-package), you need to add GitHub access token to install it.
 
 Add this dependency to build.gradle and run `gradle install`
 
@@ -55,7 +55,21 @@ Replace x.y.z with latest version:
 
 ## iOS
 
-We currently support only CocoaPods. Add this line to your Podfile and run `pod install`:
+We currently support Swift Package Manager and CocoaPods.
+
+### SPM
+
+Add this line to the `dependencies` parameter in your `Package.swift`:
+
+```swift
+.package(name: "WalletCore", url: "https://github.com/trustwallet/wallet-core", .branchItem("master")),
+```
+
+Or add it to your Xcode project, `master` branch will point to latest binary release. 
+
+### CocoaPods
+
+Add this line to your Podfile and run `pod install`:
 
 ```ruby
 pod 'TrustWalletCore'

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Swift for iOS and Java for Android.
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/trustwallet/wallet-core)
 ![GitHub](https://img.shields.io/github/license/TrustWallet/wallet-core.svg)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/trustwallet/wallet-core)
+![SPM](https://img.shields.io/badge/SPM-ready-blue)
 ![Cocoapods](https://img.shields.io/cocoapods/v/TrustWalletCore.svg)
 ![Cocoapods platforms](https://img.shields.io/cocoapods/p/TrustWalletCore.svg)
 

--- a/tools/ios-xcframework-release
+++ b/tools/ios-xcframework-release
@@ -63,10 +63,10 @@ let package = Package(
 )
 EOF
 
-echo "Package.swift generated."
+echo "${package_swift} generated."
 cat $package_swift
 
-package_swift_download_url=$(wc_upload_asset ${release_url} "Package.swift")
-echo "swift protobuf url is: ${package_swift_download_url}"
+package_swift_download_url=$(wc_upload_asset ${release_url} ${package_swift})
+echo "${package_swift} url is: ${package_swift_download_url}"
 
 popd

--- a/tools/ios-xcframework-release
+++ b/tools/ios-xcframework-release
@@ -44,9 +44,8 @@ let package = Package(
     name: "WalletCore",
     platforms: [.iOS(.v13)],
     products: [
-        .library(
-            name: "WalletCore", targets: ["WalletCore", "SwiftProtobuf"]
-        )
+        .library(name: "WalletCore", targets: ["WalletCore"]),
+        .library(name: "SwiftProtobuf", targets: ["SwiftProtobuf"])
     ],
     dependencies: [],
     targets: [
@@ -65,7 +64,9 @@ let package = Package(
 EOF
 
 echo "Package.swift generated."
-
 cat $package_swift
+
+package_swift_download_url=$(wc_upload_asset ${release_url} "Package.swift")
+echo "swift protobuf url is: ${package_swift_download_url}"
 
 popd


### PR DESCRIPTION
Fixes https://github.com/trustwallet/wallet-core/issues/1804

Currently we need to update `Package.swift` on master branch each time when there is a new release, this is tedious and not pined to exact that version / tag. This improves the process: go to the release page and download it when you need to update wallet core