### PR TITLE
Fix install dependency googletest 

### DIFF
--- a/tools/install-dependencies
+++ b/tools/install-dependencies
@@ -15,7 +15,7 @@ export LD_LIBRARY_PATH="$PREFIX/lib"
 export LD_RUN_PATH="$PREFIX/lib"
 
 # Download Google Test
-export GTEST_VERSION=1.10.0
+export GTEST_VERSION=1.11.0
 GTEST_DIR="$ROOT/build/local/src/gtest"
 mkdir -p "$GTEST_DIR"
 cd "$GTEST_DIR"


### PR DESCRIPTION
## Description
It seems that with the cache in the tests you have not realized this or g++ version is so old. When doing the build, well that. 