### PR TITLE
Bump Package.swift on master

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,27 +1,24 @@
 // swift-tools-version:5.3
-
 import PackageDescription
 
 let package = Package(
     name: "WalletCore",
     platforms: [.iOS(.v13)],
     products: [
-        .library(
-            name: "WalletCore", targets: ["WalletCore", "SwiftProtobuf"]
-        )
+        .library(name: "WalletCore", targets: ["WalletCore"]),
+        .library(name: "SwiftProtobuf", targets: ["SwiftProtobuf"])
     ],
-    dependencies: [
-    ],
+    dependencies: [],
     targets: [
         .binaryTarget(
             name: "WalletCore",
-            url: "https://github.com/trustwallet/wallet-core/releases/download/2.6.34/WalletCore.xcframework.zip",
-            checksum: "1595ed7e1efb85e939dbbc8e7b763a8d4a4285d209f622aa960701b0cc054f0d"
+            url: "https://github.com/trustwallet/wallet-core/releases/download/2.6.36/WalletCore.xcframework.zip",
+            checksum: "f8bad789644651f7153e5cf46bb3509fb457a14d35301f97863677235c2e602c"
         ),
         .binaryTarget(
             name: "SwiftProtobuf",
-            url: "https://github.com/trustwallet/wallet-core/releases/download/2.6.34/SwiftProtobuf.xcframework.zip",
-            checksum: "c7839954f10427df3f47629880f1ed76c39201500c8e5efcba808e37893995b9"
+            url: "https://github.com/trustwallet/wallet-core/releases/download/2.6.36/SwiftProtobuf.xcframework.zip",
+            checksum: "40518a795e841bbd2c7e1f7019357b8e09b321a9c1ea264b0819f85575ac04c2"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -60,13 +60,26 @@ We currently support Swift Package Manager and CocoaPods.
 
 ### SPM
 
+Download latest `Package.swift` from [GitHub Releases](https://github.com/trustwallet/wallet-core/releases) and put it in a local `WalletCore` folder.
+
 Add this line to the `dependencies` parameter in your `Package.swift`:
+
+```swift
+.package(name: "WalletCore", path: "../WalletCore"),
+```
+
+Or add remote url + `master` branch, it points to recent (not always latest) binary release.
 
 ```swift
 .package(name: "WalletCore", url: "https://github.com/trustwallet/wallet-core", .branchItem("master")),
 ```
 
-Or add it to your Xcode project, `master` branch will point to latest binary release. 
+Then add libraries to target's `dependencies`: 
+
+```swift
+.product(name: "WalletCore", package: "WalletCore"),
+.product(name: "SwiftProtobuf", package: "WalletCore"),
+```
 
 ### CocoaPods
 


### PR DESCRIPTION
Update SPM usage guide, we will only bump master `Package.swift` periodically