### PR TITLE
[Kotlin] generate protobuf models

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -13,10 +13,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-java@v2
-      with:
-        distribution: 'zulu' # See 'Supported distributions' for available options
-        java-version: '11'
     - name: Install system dependencies
       run: brew install boost ninja
     - name: Install Android Dependencies

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -13,6 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-java@v2
+      with:
+        distribution: 'zulu' # See 'Supported distributions' for available options
+        java-version: '11'
     - name: Install system dependencies
       run: brew install boost ninja
     - name: Install Android Dependencies

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'android.arch.core:core-testing:1.1.1'
 
-    implementation 'io.grpc:grpc-protobuf:1.34.0'
+    implementation 'io.grpc:grpc-protobuf:1.43.2'
 }
 repositories {
     mavenCentral()

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/aeternity/TestAeternitySigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/aeternity/TestAeternitySigner.kt
@@ -7,8 +7,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.java.AnySigner
 import wallet.core.jni.CoinType.AETERNITY
-import wallet.core.jni.proto.Aeternity
-import wallet.core.jni.proto.Aeternity.SigningOutput
+import wallet.core.proto.Aeternity.signingInput
+import wallet.core.proto.Aeternity.SigningOutput
 
 class TestAeternitySigner {
 
@@ -18,18 +18,18 @@ class TestAeternitySigner {
 
     @Test
     fun aeternityTransactionSigning() {
-        val signingInput = Aeternity.SigningInput.newBuilder()
-            .setFromAddress("ak_2p5878zbFhxnrm7meL7TmqwtvBaqcBddyp5eGzZbovZ5FeVfcw")
-            .setToAddress("ak_Egp9yVdpxmvAfQ7vsXGvpnyfNq71msbdUpkMNYGTeTe8kPL3v")
-            .setAmount(ByteString.copyFrom("0a".toHexByteArray()))
-            .setFee(ByteString.copyFrom("12309ce54000".toHexByteArray()))
-            .setPayload("Hello World")
-            .setTtl(82757)
-            .setNonce(49)
-            .setPrivateKey("4646464646464646464646464646464646464646464646464646464646464646".toHexBytesInByteString())
-            .build()
+        val input = signingInput {
+            fromAddress = "ak_2p5878zbFhxnrm7meL7TmqwtvBaqcBddyp5eGzZbovZ5FeVfcw"
+            toAddress = "ak_Egp9yVdpxmvAfQ7vsXGvpnyfNq71msbdUpkMNYGTeTe8kPL3v"
+            amount = ByteString.copyFrom("0a".toHexByteArray())
+            fee = ByteString.copyFrom("12309ce54000".toHexByteArray())
+            payload = "Hello World"
+            ttl = 82757
+            nonce = 49
+            privateKey = "4646464646464646464646464646464646464646464646464646464646464646".toHexBytesInByteString()
+        }
 
-        val output = AnySigner.sign(signingInput, AETERNITY, SigningOutput.parser())
+        val output = AnySigner.sign(input, AETERNITY, SigningOutput.parser())
 
         assertEquals(
             output.encoded,

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/aion/TestAion.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/aion/TestAion.kt
@@ -11,8 +11,8 @@ import wallet.core.jni.AnyAddress
 import wallet.core.jni.CoinType
 import wallet.core.jni.CoinType.AION
 import wallet.core.jni.PrivateKey
-import wallet.core.jni.proto.Aion
-import wallet.core.jni.proto.Aion.SigningOutput
+import wallet.core.proto.Aion.SigningInput
+import wallet.core.proto.Aion.SigningOutput
 
 class TestAionAddress {
 
@@ -38,7 +38,7 @@ class TestAionAddress {
 
     @Test
     fun aeternityTransactionSigning() {
-        val signingInput = Aion.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
             .setNonce("09".toHexBytesInByteString())
             .setGasPrice("04a817c800".toHexBytesInByteString())
             .setGasLimit("5208".toHexBytesInByteString())

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/algorand/TestAlgorandSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/algorand/TestAlgorandSigner.kt
@@ -8,8 +8,7 @@ import org.junit.Assert.*
 import org.junit.Test
 import wallet.core.java.AnySigner
 import wallet.core.jni.CoinType.ALGORAND
-import wallet.core.jni.proto.Algorand
-import wallet.core.jni.proto.Algorand.SigningOutput
+import wallet.core.proto.Algorand.*
 
 class TestAlgorandSigner {
 
@@ -19,11 +18,11 @@ class TestAlgorandSigner {
 
     @Test
     fun AlgorandTransactionSigning() {
-        val transaction = Algorand.Transfer.newBuilder()
+        val transaction = Transfer.newBuilder()
             .setToAddress("CRLADAHJZEW2GFY2UPEHENLOGCUOU74WYSTUXQLVLJUJFHEUZOHYZNWYR4")
             .setAmount(1000000000000)
             .build()
-        val signingInput = Algorand.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
             .setGenesisId("mainnet-v1.0")
             .setGenesisHash(ByteString.copyFrom("c061c4d8fc1dbdded2d7604be4568e3f6d041987ac37bde4b620b5ab39248adf".toHexByteArray()))
             .setNote(ByteString.copyFrom("68656c6c6f".toHexByteArray()))

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bandchain/TestBandChainSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bandchain/TestBandChainSigner.kt
@@ -14,8 +14,7 @@ import wallet.core.java.AnySigner
 import wallet.core.jni.AnyAddress
 import wallet.core.jni.CoinType.BANDCHAIN
 import wallet.core.jni.PrivateKey
-import wallet.core.jni.proto.Cosmos
-import wallet.core.jni.proto.Cosmos.SigningOutput
+import wallet.core.proto.Cosmos.*
 
 class TestBandChainSigner {
 
@@ -30,32 +29,32 @@ class TestBandChainSigner {
         val publicKey = key.getPublicKeySecp256k1(true)
         val from = AnyAddress(publicKey, BANDCHAIN).description()
 
-        val txAmount = Cosmos.Amount.newBuilder().apply {
+        val txAmount = Amount.newBuilder().apply {
             amount = 1
             denom = "uband"
         }.build()
 
-        val sendCoinsMsg = Cosmos.Message.Send.newBuilder().apply {
+        val sendCoinsMsg = Message.Send.newBuilder().apply {
             fromAddress = from
             toAddress = "band1jf9aaj9myrzsnmpdr7twecnaftzmku2mgms4n3"
             addAllAmounts(listOf(txAmount))
         }.build()
 
-        val message = Cosmos.Message.newBuilder().apply {
+        val message = Message.newBuilder().apply {
             sendCoinsMessage = sendCoinsMsg
         }.build()
 
-        val feeAmount = Cosmos.Amount.newBuilder().apply {
+        val feeAmount = Amount.newBuilder().apply {
             amount = 200
             denom = "uband"
         }.build()
 
-        val cosmosFee = Cosmos.Fee.newBuilder().apply {
+        val cosmosFee = Fee.newBuilder().apply {
             gas = 200000
             addAllAmounts(listOf(feeAmount))
         }.build()
 
-        val signingInput = Cosmos.SigningInput.newBuilder().apply {
+        val signingInput = SigningInput.newBuilder().apply {
             accountNumber = 1037
             chainId = "band-wenchang-testnet2"
             memo = ""

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/binance/TestBinanceTransactionSigning.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/binance/TestBinanceTransactionSigning.kt
@@ -4,8 +4,7 @@ import com.google.protobuf.ByteString
 import com.trustwallet.core.app.utils.toHexBytes
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import wallet.core.jni.proto.Binance
-import wallet.core.jni.proto.Binance.SigningOutput
+import wallet.core.proto.Binance.*
 import wallet.core.jni.*
 import com.trustwallet.core.app.utils.toHex
 import wallet.core.jni.CoinType.BINANCE
@@ -24,32 +23,32 @@ class TestBinanceTransactionSigning {
         val privateKey = PrivateKey("95949f757db1f57ca94a5dff23314accbe7abee89597bf6a3c7382c84d7eb832".toHexBytes())
         val publicKey = privateKey.getPublicKeySecp256k1(true)
 
-        val signingInput = Binance.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.chainId = "Binance-Chain-Nile"
         signingInput.accountNumber = 0
         signingInput.sequence = 0
 
         signingInput.privateKey = ByteString.copyFrom(privateKey.data())
 
-        val token = Binance.SendOrder.Token.newBuilder()
+        val token = SendOrder.Token.newBuilder()
         token.denom = "BNB"
         token.amount = 1
 
-        val input = Binance.SendOrder.Input.newBuilder()
+        val input = SendOrder.Input.newBuilder()
         input.address = ByteString.copyFrom(AnyAddress(publicKey, BINANCE).data())
         input.addAllCoins(listOf(token.build()))
 
-        val output =  Binance.SendOrder.Output.newBuilder()
+        val output =  SendOrder.Output.newBuilder()
         output.address = ByteString.copyFrom(AnyAddress("bnb1hlly02l6ahjsgxw9wlcswnlwdhg4xhx38yxpd5", BINANCE).data())
         output.addAllCoins(listOf(token.build()))
 
-        val sendOrder = Binance.SendOrder.newBuilder()
+        val sendOrder = SendOrder.newBuilder()
         sendOrder.addAllInputs(listOf(input.build()))
         sendOrder.addAllOutputs(listOf(output.build()))
 
         signingInput.sendOrder = sendOrder.build()
 
-        val sign: Binance.SigningOutput = AnySigner.sign(signingInput.build(), BINANCE, SigningOutput.parser())
+        val sign: SigningOutput = AnySigner.sign(signingInput.build(), BINANCE, SigningOutput.parser())
         val signBytes = sign.encoded.toByteArray()
         assertEquals(signBytes.toHex(), "0xb801f0625dee0a462a2c87fa0a1f0a1440c2979694bbc961023d1d27be6fc4d21a9febe612070a03424e421001121f0a14bffe47abfaede50419c577f1074fee6dd1535cd112070a03424e421001126a0a26eb5ae98721026a35920088d98c3888ca68c53dfc93f4564602606cbb87f0fe5ee533db38e50212401b1181faec30b60a2ddaa2804c253cf264c69180ec31814929b5de62088c0c5a45e8a816d1208fc5366bb8b041781a6771248550d04094c3d7a504f9e8310679")
     }
@@ -58,17 +57,17 @@ class TestBinanceTransactionSigning {
     fun testSignTransferOutOrder() {
         val key = testKey
         val pubkey = key.getPublicKeySecp256k1(true)
-        val input = Binance.SigningInput.newBuilder()
+        val input = SigningInput.newBuilder()
         input.chainId = "test-chain"
         input.accountNumber = 15
         input.sequence = 1
         input.privateKey = ByteString.copyFrom(key.data())
 
-        val amount = Binance.SendOrder.Token.newBuilder()
+        val amount = SendOrder.Token.newBuilder()
         amount.denom = "BNB"
         amount.amount = 100000000
 
-        val order = Binance.TransferOut.newBuilder()
+        val order = TransferOut.newBuilder()
         order.from = ByteString.copyFrom(AnyAddress(pubkey, CoinType.BINANCE).data())
         order.to = ByteString.copyFrom(AnyAddress("0x35552c16704d214347f29Fa77f77DA6d75d7C752", CoinType.ETHEREUM).data())
         order.amount = amount.build()
@@ -76,7 +75,7 @@ class TestBinanceTransactionSigning {
 
         input.transferOutOrder = order.build()
 
-        val output: Binance.SigningOutput = AnySigner.sign(input.build(), CoinType.BINANCE, SigningOutput.parser())
+        val output: SigningOutput = AnySigner.sign(input.build(), CoinType.BINANCE, SigningOutput.parser())
 
         assertEquals("0xb701f0625dee0a41800819c00a1408c7c918f6b72c3c0c21b7d08eb6fc66509998e1121435552c16704d214347f29fa77f77da6d75d7c7521a0a0a03424e421080c2d72f20cec2f105126e0a26eb5ae9872103a9a55c040c8eb8120f3d1b32193250841c08af44ea561aac993dbe0f6b6a8fc712407eda148e1167b1be1271a788ccf4e3eade1c7e1773e9d2093982d7f802f8f85f35ef550049011728206e4eda1a272f9e96fd95ef3983cad85a29cd14262c22e0180f2001",
             output.encoded.toByteArray().toHex())

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bitcoin/TestBitcoinSigning.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bitcoin/TestBitcoinSigning.kt
@@ -10,9 +10,8 @@ import wallet.core.jni.BitcoinScript
 import wallet.core.jni.BitcoinSigHashType
 import wallet.core.jni.CoinType
 import wallet.core.jni.CoinType.BITCOIN
-import wallet.core.jni.proto.Bitcoin
-import wallet.core.jni.proto.Bitcoin.SigningOutput
-import wallet.core.jni.proto.Common.SigningError
+import wallet.core.proto.Bitcoin.*
+import wallet.core.proto.Common.SigningError
 
 class TestBitcoinSigning {
 
@@ -22,7 +21,7 @@ class TestBitcoinSigning {
 
     @Test
     fun testSignP2WPKH() {
-        val input = Bitcoin.SigningInput.newBuilder()
+        val input = SigningInput.newBuilder()
             .setAmount(335_790_000)
             .setHashType(BitcoinScript.hashTypeForCoin(CoinType.BITCOIN))
             .setToAddress("1Bp9U1ogV3A14FMvKbRJms7ctyso4Z4Tcx")
@@ -41,13 +40,13 @@ class TestBitcoinSigning {
 
         // Redeem scripts
 
-        val outpoint0 = Bitcoin.OutPoint.newBuilder()
+        val outpoint0 = OutPoint.newBuilder()
             .setHash(ByteString.copyFrom(Numeric.hexStringToByteArray("fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f")))
             .setIndex(0)
             .setSequence(Long.MAX_VALUE.toInt())
             .build()
 
-        val utxo0 = Bitcoin.UnspentTransaction.newBuilder()
+        val utxo0 = UnspentTransaction.newBuilder()
             .setAmount(625_000_000)
             .setOutPoint(outpoint0)
             .setScript(ByteString.copyFrom("2103c9f4836b9a4f77fc0d81f7bcb01b7f1b35916864b9476c241ce9fc198bd25432ac".toHexBytes()))
@@ -56,13 +55,13 @@ class TestBitcoinSigning {
         input.addUtxo(utxo0)
 
 
-        val outpoint1 = Bitcoin.OutPoint.newBuilder()
+        val outpoint1 = OutPoint.newBuilder()
             .setHash(ByteString.copyFrom("ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a".toHexBytes()))
             .setIndex(1)
             .setSequence(Long.MAX_VALUE.toInt())
             .build()
 
-        val utxo1 = Bitcoin.UnspentTransaction.newBuilder()
+        val utxo1 = UnspentTransaction.newBuilder()
             .setAmount(600_000_000)
             .setOutPoint(outpoint1)
             .setScript(ByteString.copyFrom(Numeric.hexStringToByteArray("00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1")))
@@ -86,7 +85,7 @@ class TestBitcoinSigning {
 
     @Test
     fun testSignP2PKH() {
-        val input = Bitcoin.SigningInput.newBuilder()
+        val input = SigningInput.newBuilder()
             .setAmount(55_000)
             .setHashType(BitcoinScript.hashTypeForCoin(CoinType.BITCOIN))
             .setToAddress("1GDCMHsTLBkawQXP8dqcZtr8zGgb4XpCug")
@@ -105,13 +104,13 @@ class TestBitcoinSigning {
 
         // Redeem scripts
 
-        val outpoint0 = Bitcoin.OutPoint.newBuilder()
+        val outpoint0 = OutPoint.newBuilder()
             .setHash(ByteString.copyFrom(Numeric.hexStringToByteArray("fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f")))
             .setIndex(0)
             .setSequence(Long.MAX_VALUE.toInt())
             .build()
 
-        val utxo0 = Bitcoin.UnspentTransaction.newBuilder()
+        val utxo0 = UnspentTransaction.newBuilder()
             .setAmount(30_000)
             .setOutPoint(outpoint0)
             .setScript(ByteString.copyFrom("2103c9f4836b9a4f77fc0d81f7bcb01b7f1b35916864b9476c241ce9fc198bd25432ac".toHexBytes()))
@@ -119,13 +118,13 @@ class TestBitcoinSigning {
 
         input.addUtxo(utxo0)
 
-        val outpoint1 = Bitcoin.OutPoint.newBuilder()
+        val outpoint1 = OutPoint.newBuilder()
             .setHash(ByteString.copyFrom("ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a".toHexBytes()))
             .setIndex(1)
             .setSequence(Long.MAX_VALUE.toInt())
             .build()
 
-        val utxo1 = Bitcoin.UnspentTransaction.newBuilder()
+        val utxo1 = UnspentTransaction.newBuilder()
             .setAmount(45_000)
             .setOutPoint(outpoint1)
             .setScript(ByteString.copyFrom(Numeric.hexStringToByteArray("00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1")))
@@ -134,7 +133,7 @@ class TestBitcoinSigning {
         input.addUtxo(utxo1)
 
         // Calculate fee (plan a transaction)
-        val plan = AnySigner.plan(input.build(), BITCOIN, Bitcoin.TransactionPlan.parser())
+        val plan = AnySigner.plan(input.build(), BITCOIN, TransactionPlan.parser())
         assertEquals(55_000, plan.amount)
         assertEquals(75_000, plan.availableAmount)
         assertEquals(2610, plan.fee)

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bluzelle/TestBluzelleSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/bluzelle/TestBluzelleSigner.kt
@@ -17,8 +17,7 @@ import wallet.core.java.AnySigner
 import wallet.core.jni.AnyAddress
 import wallet.core.jni.CoinType.BLUZELLE
 import wallet.core.jni.PrivateKey
-import wallet.core.jni.proto.Cosmos
-import wallet.core.jni.proto.Cosmos.SigningOutput
+import wallet.core.proto.Cosmos.*
 
 class TestBluzelleSigner {
 
@@ -35,32 +34,32 @@ class TestBluzelleSigner {
         val publicKey = key.getPublicKeySecp256k1(true)
         val from = AnyAddress(publicKey, BLUZELLE).description()
 
-        val txAmount = Cosmos.Amount.newBuilder().apply {
+        val txAmount = Amount.newBuilder().apply {
             amount = 1
             denom = "ubnt"
         }.build()
 
-        val sendCoinsMsg = Cosmos.Message.Send.newBuilder().apply {
+        val sendCoinsMsg = Message.Send.newBuilder().apply {
             fromAddress = from
             toAddress = "bluzelle1xccvees6ev4wm2r49rc6ptulsdxa8x8jfpmund"
             addAllAmounts(listOf(txAmount))
         }.build()
 
-        val message = Cosmos.Message.newBuilder().apply {
+        val message = Message.newBuilder().apply {
             sendCoinsMessage = sendCoinsMsg
         }.build()
 
-        val feeAmount = Cosmos.Amount.newBuilder().apply {
+        val feeAmount = Amount.newBuilder().apply {
             amount = 1000
             denom = "ubnt"
         }.build()
 
-        val cosmosFee = Cosmos.Fee.newBuilder().apply {
+        val cosmosFee = Fee.newBuilder().apply {
             gas = 500000
             addAllAmounts(listOf(feeAmount))
         }.build()
 
-        val signingInput = Cosmos.SigningInput.newBuilder().apply {
+        val signingInput = SigningInput.newBuilder().apply {
             accountNumber = 590
             chainId = "net-6"
             memo = ""

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/cosmos/TestCosmosTransactions.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/cosmos/TestCosmosTransactions.kt
@@ -8,9 +8,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.jni.*
 import wallet.core.jni.CoinType.COSMOS
-import wallet.core.jni.proto.Cosmos
-import wallet.core.jni.proto.Cosmos.SigningOutput
-import wallet.core.jni.proto.Cosmos.SigningMode
+import wallet.core.proto.Cosmos.*
 import wallet.core.java.AnySigner
 
 class TestCosmosTransactions {
@@ -26,32 +24,32 @@ class TestCosmosTransactions {
         val publicKey = key.getPublicKeySecp256k1(true)
         val from = AnyAddress(publicKey, COSMOS).description()
 
-        val txAmount = Cosmos.Amount.newBuilder().apply {
+        val txAmount = Amount.newBuilder().apply {
             amount = 1
             denom = "muon"
         }.build()
 
-        val sendCoinsMsg = Cosmos.Message.Send.newBuilder().apply {
+        val sendCoinsMsg = Message.Send.newBuilder().apply {
             fromAddress = from
             toAddress = "cosmos1zt50azupanqlfam5afhv3hexwyutnukeh4c573"
             addAllAmounts(listOf(txAmount))
         }.build()
 
-        val message = Cosmos.Message.newBuilder().apply {
+        val message = Message.newBuilder().apply {
             sendCoinsMessage = sendCoinsMsg
         }.build()
 
-        val feeAmount = Cosmos.Amount.newBuilder().apply {
+        val feeAmount = Amount.newBuilder().apply {
             amount = 200
             denom = "muon"
         }.build()
 
-        val cosmosFee = Cosmos.Fee.newBuilder().apply {
+        val cosmosFee = Fee.newBuilder().apply {
             gas = 200000
             addAllAmounts(listOf(feeAmount))
         }.build()
 
-        val signingInput = Cosmos.SigningInput.newBuilder().apply {
+        val signingInput = SigningInput.newBuilder().apply {
             signingMode = SigningMode.Protobuf
             accountNumber = 1037
             chainId = "gaia-13003"

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/cryptoorg/TestCryptoorgSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/cryptoorg/TestCryptoorgSigner.kt
@@ -7,18 +7,12 @@
 package com.trustwallet.core.app.blockchains.cryptoorg
 
 import com.google.protobuf.ByteString
-import com.trustwallet.core.app.utils.Numeric
 import com.trustwallet.core.app.utils.toHexByteArray
-import com.trustwallet.core.app.utils.toHexBytes
-import com.trustwallet.core.app.utils.toHex
-import com.trustwallet.core.app.utils.toHexBytesInByteString
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.java.AnySigner
 import wallet.core.jni.CoinType.CRYPTOORG
-import wallet.core.jni.proto.Cosmos
-import wallet.core.jni.proto.Cosmos.SigningOutput
-import wallet.core.jni.proto.Cosmos.SigningMode
+import wallet.core.proto.Cosmos.*
 import wallet.core.jni.*
 
 class TestCryptoorgSigner {
@@ -33,32 +27,32 @@ class TestCryptoorgSigner {
         val publicKey = key.getPublicKeySecp256k1(true)
         val from = AnyAddress(publicKey, CRYPTOORG).description()
 
-        val txAmount = Cosmos.Amount.newBuilder().apply {
+        val txAmount = Amount.newBuilder().apply {
             amount = 50000000
             denom = "basecro"
         }.build()
 
-        val sendCoinsMsg = Cosmos.Message.Send.newBuilder().apply {
+        val sendCoinsMsg = Message.Send.newBuilder().apply {
             fromAddress = from
             toAddress = "cro1xpahy6c7wldxacv6ld99h435mhvfnsup24vcus"
             addAllAmounts(listOf(txAmount))
         }.build()
 
-        val message = Cosmos.Message.newBuilder().apply {
+        val message = Message.newBuilder().apply {
             sendCoinsMessage = sendCoinsMsg
         }.build()
 
-        val feeAmount = Cosmos.Amount.newBuilder().apply {
+        val feeAmount = Amount.newBuilder().apply {
             amount = 5000
             denom = "basecro"
         }.build()
 
-        val cosmosFee = Cosmos.Fee.newBuilder().apply {
+        val cosmosFee = Fee.newBuilder().apply {
             gas = 200000
             addAllAmounts(listOf(feeAmount))
         }.build()
 
-        val signingInput = Cosmos.SigningInput.newBuilder().apply {
+        val signingInput = SigningInput.newBuilder().apply {
             signingMode = SigningMode.Protobuf
             accountNumber = 125798
             chainId = "crypto-org-chain-mainnet-1"

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/elrond/TestElrondSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/elrond/TestElrondSigner.kt
@@ -13,7 +13,7 @@ import org.junit.Test
 import wallet.core.java.AnySigner
 import wallet.core.jni.CoinType
 import wallet.core.jni.PrivateKey
-import wallet.core.jni.proto.Elrond
+import wallet.core.proto.Elrond.*
 
 class TestElrondSigner {
 
@@ -31,7 +31,7 @@ class TestElrondSigner {
 
     @Test
     fun signTransaction() {
-        val transaction = Elrond.TransactionMessage.newBuilder()
+        val transaction = TransactionMessage.newBuilder()
             .setNonce(0)
             .setValue("0")
             .setSender(aliceBech32)
@@ -45,12 +45,12 @@ class TestElrondSigner {
         
         val privateKey = ByteString.copyFrom(PrivateKey(aliceSeedHex.toHexByteArray()).data())
 
-        val signingInput = Elrond.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
             .setPrivateKey(privateKey)
             .setTransaction(transaction)
             .build()
 
-        val output = AnySigner.sign(signingInput, CoinType.ELROND, Elrond.SigningOutput.parser())
+        val output = AnySigner.sign(signingInput, CoinType.ELROND, SigningOutput.parser())
         val expectedSignature = "b5fddb8c16fa7f6123cb32edc854f1e760a3eb62c6dc420b5a4c0473c58befd45b621b31a448c5b59e21428f2bc128c80d0ee1caa4f2bf05a12be857ad451b00"
 
         assertEquals(expectedSignature, output.signature)

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/eos/TestEOSSigning.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/eos/TestEOSSigning.kt
@@ -6,9 +6,8 @@ import org.junit.Assert.*
 import org.junit.Test
 import org.json.JSONObject
 import wallet.core.jni.*
-import wallet.core.jni.proto.EOS
-import wallet.core.jni.proto.EOS.SigningOutput
-import wallet.core.jni.proto.Common.SigningError
+import wallet.core.proto.EOS.*
+import wallet.core.proto.Common.SigningError
 import wallet.core.java.AnySigner
 
 
@@ -39,8 +38,8 @@ class TestEOSSigning {
         }
     }
 
-    fun getAssetBuilder(amt: Long, decimal: Int, sym: String): EOS.Asset.Builder {
-        var asset: EOS.Asset.Builder = EOS.Asset.newBuilder();
+    fun getAssetBuilder(amt: Long, decimal: Int, sym: String): Asset.Builder {
+        var asset: Asset.Builder = Asset.newBuilder();
         asset.apply {
             amount = amt
             decimals = decimal
@@ -53,7 +52,7 @@ class TestEOSSigning {
     // ensure valid input is signed
     @Test
     fun eosTransactionSigning() {
-        val signingInput: EOS.SigningInput.Builder = EOS.SigningInput.newBuilder()
+        val signingInput: SigningInput.Builder = SigningInput.newBuilder()
 
         signingInput.apply {
             chainId =
@@ -67,7 +66,7 @@ class TestEOSSigning {
             memo = "my second transfer"
             asset = getAssetBuilder(300000, 4, "TKN").build()
             privateKey = ByteString.copyFrom(Hash.sha256("A".toByteArray()))
-            privateKeyType = EOS.KeyType.MODERNK1
+            privateKeyType = KeyType.MODERNK1
         }
 
         val output = AnySigner.sign(signingInput.build(), CoinType.EOS, SigningOutput.parser())
@@ -91,7 +90,7 @@ class TestEOSSigning {
     // ensure invalid inputs are not signed
     @Test
     fun testFailures() {
-        val signingInput: EOS.SigningInput.Builder = EOS.SigningInput.newBuilder()
+        val signingInput: SigningInput.Builder = SigningInput.newBuilder()
         val goodInput = signingInput.apply {
             chainId =ByteString.copyFrom("cf057bbfb72640471fd910bcb67639c22df9f92470936cddc1ade0e2f2e7dc4f".toHexByteArray())
             referenceBlockId =ByteString.copyFrom("000067d6f6a7e7799a1f3d487439a679f8cf95f1c986f35c0d2fa320f51a7144".toHexByteArray())
@@ -102,7 +101,7 @@ class TestEOSSigning {
             memo = "my second transfer"
             asset = getAssetBuilder(300000, 4, "TKN").build()
             privateKey = ByteString.copyFrom(Hash.sha256("A".toByteArray()))
-            privateKeyType = EOS.KeyType.MODERNK1
+            privateKeyType = KeyType.MODERNK1
         }
 
 

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/ethereum/TestEthereumTransactionSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/ethereum/TestEthereumTransactionSigner.kt
@@ -8,9 +8,7 @@ import wallet.core.jni.PrivateKey
 import wallet.core.java.AnySigner
 import wallet.core.jni.CoinType
 import wallet.core.jni.CoinType.ETHEREUM
-import wallet.core.jni.proto.Ethereum
-import wallet.core.jni.proto.Ethereum.SigningOutput
-import wallet.core.jni.proto.Ethereum.TransactionMode
+import wallet.core.proto.Ethereum.*
 import com.trustwallet.core.app.utils.Numeric
 import org.junit.Assert.assertArrayEquals
 
@@ -22,7 +20,7 @@ class TestEthereumTransactionSigner {
 
     @Test
     fun testEthereumTransactionSigning() {
-        val signingInput = Ethereum.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             privateKey = ByteString.copyFrom(PrivateKey("0x4646464646464646464646464646464646464646464646464646464646464646".toHexByteArray()).data())
             toAddress = "0x3535353535353535353535353535353535353535"
@@ -31,8 +29,8 @@ class TestEthereumTransactionSigner {
             // txMode not set, Legacy is the default
             gasPrice = ByteString.copyFrom("0x04a817c800".toHexByteArray())
             gasLimit = ByteString.copyFrom("0x5208".toHexByteArray())
-            transaction = Ethereum.Transaction.newBuilder().apply {
-                transfer = Ethereum.Transaction.Transfer.newBuilder().apply {
+            transaction = Transaction.newBuilder().apply {
+                transfer = Transaction.Transfer.newBuilder().apply {
                     amount = ByteString.copyFrom("0x0de0b6b3a7640000".toHexByteArray())
                 }.build()
             }.build()
@@ -45,7 +43,7 @@ class TestEthereumTransactionSigner {
 
     @Test
     fun testEthereumERC20Signing() {
-        val signingInput = Ethereum.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             privateKey = ByteString.copyFrom(PrivateKey("0x608dcb1742bb3fb7aec002074e3420e4fab7d00cced79ccdac53ed5b27138151".toHexByteArray()).data())
             toAddress = "0x6b175474e89094c44da98b954eedeac495271d0f" // DAI
@@ -54,8 +52,8 @@ class TestEthereumTransactionSigner {
             // txMode not set, Legacy is the default
             gasPrice = ByteString.copyFrom("0x09c7652400".toHexByteArray())
             gasLimit = ByteString.copyFrom("0x0130B9".toHexByteArray())
-            transaction = Ethereum.Transaction.newBuilder().apply {
-                erc20Transfer = Ethereum.Transaction.ERC20Transfer.newBuilder().apply {
+            transaction = Transaction.newBuilder().apply {
+                erc20Transfer = Transaction.ERC20Transfer.newBuilder().apply {
                     to = "0x5322b34c88ed0691971bf52a7047448f0f4efc84"
                     amount = ByteString.copyFrom("0x1bc16d674ec80000".toHexByteArray())       
                 }.build()
@@ -70,7 +68,7 @@ class TestEthereumTransactionSigner {
 
     @Test
     fun testEthereumERC20_1559_Signing() {
-        val signingInput = Ethereum.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             privateKey = ByteString.copyFrom(PrivateKey("0x608dcb1742bb3fb7aec002074e3420e4fab7d00cced79ccdac53ed5b27138151".toHexByteArray()).data())
             toAddress = "0x6b175474e89094c44da98b954eedeac495271d0f" // DAI
@@ -80,8 +78,8 @@ class TestEthereumTransactionSigner {
             maxInclusionFeePerGas = ByteString.copyFrom("0x77359400".toHexByteArray()) // 2000000000
             maxFeePerGas = ByteString.copyFrom("0xB2D05E00".toHexByteArray()) // 3000000000
             gasLimit = ByteString.copyFrom("0x0130B9".toHexByteArray())
-            transaction = Ethereum.Transaction.newBuilder().apply {
-                erc20Transfer = Ethereum.Transaction.ERC20Transfer.newBuilder().apply {
+            transaction = Transaction.newBuilder().apply {
+                erc20Transfer = Transaction.ERC20Transfer.newBuilder().apply {
                     to = "0x5322b34c88ed0691971bf52a7047448f0f4efc84"
                     amount = ByteString.copyFrom("0x1bc16d674ec80000".toHexByteArray())       
                 }.build()
@@ -95,7 +93,7 @@ class TestEthereumTransactionSigner {
 
     @Test
     fun testEthereumERC721Signing() {
-        val signingInput = Ethereum.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             privateKey = ByteString.copyFrom(PrivateKey("0x608dcb1742bb3fb7aec002074e3420e4fab7d00cced79ccdac53ed5b27138151".toHexByteArray()).data())
             toAddress = "0x0d8c864DA1985525e0af0acBEEF6562881827bd5"
@@ -104,8 +102,8 @@ class TestEthereumTransactionSigner {
             // txMode not set, Legacy is the default
             gasPrice = ByteString.copyFrom("0x22ecb25c00".toHexByteArray()) // 150 Gwei
             gasLimit = ByteString.copyFrom("0x0130b9".toHexByteArray())
-            transaction = Ethereum.Transaction.newBuilder().apply {
-                erc721Transfer = Ethereum.Transaction.ERC721Transfer.newBuilder().apply {
+            transaction = Transaction.newBuilder().apply {
+                erc721Transfer = Transaction.ERC721Transfer.newBuilder().apply {
                     from = "0x7d8bf18C7cE84b3E175b339c4Ca93aEd1dD166F1"
                     to = "0x47331175b23C2f067204B506CA1501c26731C990"
                     tokenId = ByteString.copyFrom("0x0fd8".toHexByteArray())
@@ -121,7 +119,7 @@ class TestEthereumTransactionSigner {
 
     @Test
     fun testEthereumERC1155Signing() {
-        val signingInput = Ethereum.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             privateKey = ByteString.copyFrom(PrivateKey("0x608dcb1742bb3fb7aec002074e3420e4fab7d00cced79ccdac53ed5b27138151".toHexByteArray()).data())
             toAddress = "0x4e45e92ed38f885d39a733c14f1817217a89d425" // contract
@@ -130,8 +128,8 @@ class TestEthereumTransactionSigner {
             // txMode not set, Legacy is the default
             gasPrice = ByteString.copyFrom("0x09C7652400".toHexByteArray()) // 42000000000
             gasLimit = ByteString.copyFrom("0x0130b9".toHexByteArray()) // 78009
-            transaction = Ethereum.Transaction.newBuilder().apply {
-                erc1155Transfer = Ethereum.Transaction.ERC1155Transfer.newBuilder().apply {
+            transaction = Transaction.newBuilder().apply {
+                erc1155Transfer = Transaction.ERC1155Transfer.newBuilder().apply {
                     from = "0x718046867b5b1782379a14eA4fc0c9b724DA94Fc"
                     to = "0x5322b34c88ed0691971bf52a7047448f0f4efc84"
                     tokenId = ByteString.copyFrom("0x23c47ee5".toHexByteArray())

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/filecoin/TestFilecoin.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/filecoin/TestFilecoin.kt
@@ -7,11 +7,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.java.AnySigner
 import wallet.core.jni.AnyAddress
-import wallet.core.jni.CoinType
 import wallet.core.jni.CoinType.FILECOIN
 import wallet.core.jni.PrivateKey
-import wallet.core.jni.proto.Filecoin
-import wallet.core.jni.proto.Filecoin.SigningOutput
+import wallet.core.proto.Filecoin.*
 
 class TestFilecoin {
 
@@ -23,13 +21,13 @@ class TestFilecoin {
     fun testAddress() {
         val privateKey = PrivateKey("1d969865e189957b9824bd34f26d5cbf357fda1a6d844cbf0c9ab1ed93fa7dbe".toHexByteArray())
         val publicKey = privateKey.getPublicKeySecp256k1(false)
-        val address = AnyAddress(publicKey, CoinType.FILECOIN)
+        val address = AnyAddress(publicKey, FILECOIN)
         assertEquals("f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq", address.description())
     }
 
     @Test
     fun testSigner() {
-        val input = Filecoin.SigningInput.newBuilder()
+        val input = SigningInput.newBuilder()
             .setPrivateKey("1d969865e189957b9824bd34f26d5cbf357fda1a6d844cbf0c9ab1ed93fa7dbe".toHexBytesInByteString())
             .setTo("f3um6uo3qt5of54xjbx3hsxbw5mbsc6auxzrvfxekn5bv3duewqyn2tg5rhrlx73qahzzpkhuj7a34iq7oifsq")
             .setNonce(2)
@@ -40,7 +38,7 @@ class TestFilecoin {
             .setGasPremium(ByteString.copyFrom("2b5e3af16b18800000".toHexByteArray()))
             .build()
 
-        val output = AnySigner.sign(input, CoinType.FILECOIN, SigningOutput.parser())
+        val output = AnySigner.sign(input, FILECOIN, SigningOutput.parser())
         val expted = """{"Message":{"From":"f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq","GasFeeCap":"700000000000000000000","GasLimit":1000,"GasPremium":"800000000000000000000","Nonce":2,"To":"f3um6uo3qt5of54xjbx3hsxbw5mbsc6auxzrvfxekn5bv3duewqyn2tg5rhrlx73qahzzpkhuj7a34iq7oifsq","Value":"600000000000000000000"},"Signature":{"Data":"jMRu+OZ/lfppgmqSfGsntFrRLWZnUg3ZYmJTTRLsVt4V1310vR3VKGJpaE6S4sNvDOE6sEgmN9YmfTkPVK2qMgE=","Type":1}}"""
         assertEquals(expted, output.json)
     }

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/fio/TestFIOSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/fio/TestFIOSigner.kt
@@ -15,9 +15,8 @@ import wallet.core.java.AnySigner
 import wallet.core.jni.AnyAddress
 import wallet.core.jni.CoinType
 import wallet.core.jni.PrivateKey
-import wallet.core.jni.proto.FIO
-import wallet.core.jni.proto.FIO.SigningOutput
-import wallet.core.jni.proto.Common.SigningError
+import wallet.core.proto.FIO.*
+import wallet.core.proto.Common.SigningError
 
 class TestFIOSigner {
 
@@ -32,17 +31,17 @@ class TestFIOSigner {
         val publicKey = privateKey.getPublicKeySecp256k1(false)
         val address = AnyAddress(publicKey, CoinType.FIO)
 
-        val chainParams = FIO.ChainParams.newBuilder()
+        val chainParams = ChainParams.newBuilder()
             .setChainId(chainId)
             .setHeadBlockNumber(39881)
             .setRefBlockPrefix(4279583376)
-        val regAddrAction = FIO.Action.RegisterFioAddress.newBuilder()
+        val regAddrAction = Action.RegisterFioAddress.newBuilder()
             .setFioAddress("adam@fiotestnet")
             .setOwnerFioPublicKey(address.description())
             .setFee(5000000000)
-        val action = FIO.Action.newBuilder()
+        val action = Action.newBuilder()
             .setRegisterFioAddressMessage(regAddrAction)
-        val input = FIO.SigningInput.newBuilder()
+        val input = SigningInput.newBuilder()
             .setExpiry(1579784511)
             .setChainParams(chainParams)
             .setPrivateKey(ByteString.copyFrom(privateKey.data()))
@@ -61,19 +60,19 @@ class TestFIOSigner {
         val chainId = ByteString.copyFrom("4e46572250454b796d7296eec9e8896327ea82dd40f2cd74cf1b1d8ba90bcd77".toHexBytes())
         val privateKey = PrivateKey("ba0828d5734b65e3bcc2c51c93dfc26dd71bd666cc0273adee77d73d9a322035".toHexByteArray())
 
-        val chainParams = FIO.ChainParams.newBuilder()
+        val chainParams = ChainParams.newBuilder()
             .setChainId(chainId)
             .setHeadBlockNumber(11565)
             .setRefBlockPrefix(4281229859)
-        val addAddrAction = FIO.Action.AddPubAddress.newBuilder()
+        val addAddrAction = Action.AddPubAddress.newBuilder()
             .setFioAddress("adam@fiotestnet")
-            .addPublicAddresses(FIO.PublicAddress.newBuilder().setCoinSymbol("BTC").setAddress("bc1qvy4074rggkdr2pzw5vpnn62eg0smzlxwp70d7v"))
-            .addPublicAddresses(FIO.PublicAddress.newBuilder().setCoinSymbol("ETH").setAddress("0xce5cB6c92Da37bbBa91Bd40D4C9D4D724A3a8F51"))
-            .addPublicAddresses(FIO.PublicAddress.newBuilder().setCoinSymbol("BNB").setAddress("bnb1ts3dg54apwlvr9hupv2n0j6e46q54znnusjk9s"))
+            .addPublicAddresses(PublicAddress.newBuilder().setCoinSymbol("BTC").setAddress("bc1qvy4074rggkdr2pzw5vpnn62eg0smzlxwp70d7v"))
+            .addPublicAddresses(PublicAddress.newBuilder().setCoinSymbol("ETH").setAddress("0xce5cB6c92Da37bbBa91Bd40D4C9D4D724A3a8F51"))
+            .addPublicAddresses(PublicAddress.newBuilder().setCoinSymbol("BNB").setAddress("bnb1ts3dg54apwlvr9hupv2n0j6e46q54znnusjk9s"))
             .setFee(0)
-        val action = FIO.Action.newBuilder()
+        val action = Action.newBuilder()
             .setAddPubAddressMessage(addAddrAction)
-        val input = FIO.SigningInput.newBuilder()
+        val input = SigningInput.newBuilder()
             .setExpiry(1579729429)
             .setChainParams(chainParams)
             .setPrivateKey(ByteString.copyFrom(privateKey.data()))
@@ -92,17 +91,17 @@ class TestFIOSigner {
         val chainId = ByteString.copyFrom("4e46572250454b796d7296eec9e8896327ea82dd40f2cd74cf1b1d8ba90bcd77".toHexBytes())
         val privateKey = PrivateKey("ba0828d5734b65e3bcc2c51c93dfc26dd71bd666cc0273adee77d73d9a322035".toHexByteArray())
 
-        val chainParams = FIO.ChainParams.newBuilder()
+        val chainParams = ChainParams.newBuilder()
             .setChainId(chainId)
             .setHeadBlockNumber(50000)
             .setRefBlockPrefix(4000123456)
-        val transferAction = FIO.Action.Transfer.newBuilder()
+        val transferAction = Action.Transfer.newBuilder()
             .setPayeePublicKey("FIO7uMZoeei5HtXAD24C4yCkpWWbf24bjYtrRNjWdmGCXHZccwuiE")
             .setAmount(1000000000)
             .setFee(250000000)
-        val action = FIO.Action.newBuilder()
+        val action = Action.newBuilder()
             .setTransferMessage(transferAction)
-        val input = FIO.SigningInput.newBuilder()
+        val input = SigningInput.newBuilder()
             .setExpiry(1579790000)
             .setChainParams(chainParams)
             .setPrivateKey(ByteString.copyFrom(privateKey.data()))

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/harmony/TestHarmonyStakingDelegateSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/harmony/TestHarmonyStakingDelegateSigner.kt
@@ -7,8 +7,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.java.AnySigner
 import wallet.core.jni.PrivateKey
-import wallet.core.jni.proto.Harmony
-import wallet.core.jni.proto.Harmony.SigningOutput
+import wallet.core.proto.Harmony.*
 import wallet.core.jni.CoinType.HARMONY
 
 class TestHarmonyStakingDelegateSigner {
@@ -22,31 +21,31 @@ class TestHarmonyStakingDelegateSigner {
         System.loadLibrary("TrustWalletCore")
     }
 
-    fun createValidator(): Harmony.DirectiveCreateValidator.Builder {
-        val desc = Harmony.Description.newBuilder()
+    fun createValidator(): DirectiveCreateValidator.Builder {
+        val desc = Description.newBuilder()
         desc.apply {
             name = "Alice"
             identity = "alice"
-            website = "alice.harmony.one"
+            website = "alice.one"
             securityContact = "Bob"
             details = "Don't mess with me!!!"
         }
-        val r = Harmony.Decimal.newBuilder()
+        val r = Decimal.newBuilder()
         r.apply {
             value = ByteString.copyFrom("0x1".toHexByteArray())
             precision = ByteString.copyFrom("0x1".toHexByteArray())
         }
-        val mr = Harmony.Decimal.newBuilder()
+        val mr = Decimal.newBuilder()
         mr.apply {
             value = ByteString.copyFrom("0x9".toHexByteArray())
             precision = ByteString.copyFrom("0x1".toHexByteArray())
         }
-        val mcr = Harmony.Decimal.newBuilder()
+        val mcr = Decimal.newBuilder()
         mcr.apply {
             value = ByteString.copyFrom("0x5".toHexByteArray())
             precision = ByteString.copyFrom("0x2".toHexByteArray())
         }
-        val cRate = Harmony.CommissionRate.newBuilder()
+        val cRate = CommissionRate.newBuilder()
         cRate.apply {
             rate = r.build()
             maxRate = mr.build()
@@ -54,7 +53,7 @@ class TestHarmonyStakingDelegateSigner {
         }
         val pubKey = pubKeyData
         val blsSig = blsSigData
-        val createValidator = Harmony.DirectiveCreateValidator.newBuilder()
+        val createValidator = DirectiveCreateValidator.newBuilder()
         createValidator.apply {
             validatorAddress = oneAddress
             description = desc.build()
@@ -71,14 +70,14 @@ class TestHarmonyStakingDelegateSigner {
     @Test
     fun testHarmonyStakingTransactionCreateValidatorSigning() {
         val createValidator = createValidator();
-        val staking = Harmony.StakingMessage.newBuilder()
+        val staking = StakingMessage.newBuilder()
         staking.apply {
             nonce = ByteString.copyFrom("0x2".toHexByteArray())
             gasPrice = ByteString.copyFrom("0x0".toHexByteArray())
             gasLimit = ByteString.copyFrom("0x64".toHexByteArray())
             createValidatorMessage = createValidator.build()
         }
-        val signingInput = Harmony.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             privateKey = privateKeyData
             chainId = ByteString.copyFrom("0x02".toHexByteArray())
@@ -96,20 +95,20 @@ class TestHarmonyStakingDelegateSigner {
 
     @Test
     fun testHarmonyStakingTransactionEditValidatorSigning() {
-        val desc = Harmony.Description.newBuilder()
+        val desc = Description.newBuilder()
         desc.apply {
             name = "Alice"
             identity = "alice"
-            website = "alice.harmony.one"
+            website = "alice.one"
             securityContact = "Bob"
             details = "Don't mess with me!!!"
         }
-        val rate = Harmony.Decimal.newBuilder()
+        val rate = Decimal.newBuilder()
         rate.apply {
             value = ByteString.copyFrom("0x1".toHexByteArray())
             precision = ByteString.copyFrom("0x1".toHexByteArray())
         }
-        val editValidator = Harmony.DirectiveEditValidator.newBuilder()
+        val editValidator = DirectiveEditValidator.newBuilder()
         editValidator.apply {
             validatorAddress = oneAddress
             description = desc.build()
@@ -121,14 +120,14 @@ class TestHarmonyStakingDelegateSigner {
             slotKeyToAddSig = blsSigData
             active = ByteString.copyFrom("0x1".toHexByteArray())
         }
-        val staking = Harmony.StakingMessage.newBuilder()
+        val staking = StakingMessage.newBuilder()
         staking.apply {
             nonce = ByteString.copyFrom("0x2".toHexByteArray())
             gasPrice = ByteString.copyFrom("0x0".toHexByteArray())
             gasLimit = ByteString.copyFrom("0x64".toHexByteArray())
             editValidatorMessage = editValidator.build()
         }
-        val signingInput = Harmony.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             privateKey = privateKeyData
             chainId = ByteString.copyFrom("0x02".toHexByteArray())
@@ -146,20 +145,20 @@ class TestHarmonyStakingDelegateSigner {
 
     @Test
     fun testHarmonyStakingTransactionEditValidatorSigning2() {
-        val desc = Harmony.Description.newBuilder()
+        val desc = Description.newBuilder()
         desc.apply {
             name = "Alice"
             identity = "alice"
-            website = "alice.harmony.one"
+            website = "alice.one"
             securityContact = "Bob"
             details = "Don't mess with me!!!"
         }
-        val rate = Harmony.Decimal.newBuilder()
+        val rate = Decimal.newBuilder()
         rate.apply {
             value = ByteString.copyFrom("0x1".toHexByteArray())
             precision = ByteString.copyFrom("0x1".toHexByteArray())
         }
-        val editValidator = Harmony.DirectiveEditValidator.newBuilder()
+        val editValidator = DirectiveEditValidator.newBuilder()
         editValidator.apply {
             validatorAddress = oneAddress
             description = desc.build()
@@ -171,14 +170,14 @@ class TestHarmonyStakingDelegateSigner {
             slotKeyToAddSig = blsSigData
             active = ByteString.copyFrom("0x2".toHexByteArray())
         }
-        val staking = Harmony.StakingMessage.newBuilder()
+        val staking = StakingMessage.newBuilder()
         staking.apply {
             nonce = ByteString.copyFrom("0x2".toHexByteArray())
             gasPrice = ByteString.copyFrom("0x0".toHexByteArray())
             gasLimit = ByteString.copyFrom("0x64".toHexByteArray())
             editValidatorMessage = editValidator.build()
         }
-        val signingInput = Harmony.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             privateKey = privateKeyData
             chainId = ByteString.copyFrom("0x02".toHexByteArray())
@@ -196,20 +195,20 @@ class TestHarmonyStakingDelegateSigner {
 
     @Test
     fun testHarmonyStakingTransactionEditValidatorSigning3() {
-        val desc = Harmony.Description.newBuilder()
+        val desc = Description.newBuilder()
         desc.apply {
             name = "Alice"
             identity = "alice"
-            website = "alice.harmony.one"
+            website = "alice.one"
             securityContact = "Bob"
             details = "Don't mess with me!!!"
         }
-        val rate = Harmony.Decimal.newBuilder()
+        val rate = Decimal.newBuilder()
         rate.apply {
             value = ByteString.copyFrom("0x1".toHexByteArray())
             precision = ByteString.copyFrom("0x1".toHexByteArray())
         }
-        val editValidator = Harmony.DirectiveEditValidator.newBuilder()
+        val editValidator = DirectiveEditValidator.newBuilder()
         editValidator.apply {
             validatorAddress = oneAddress
             description = desc.build()
@@ -221,14 +220,14 @@ class TestHarmonyStakingDelegateSigner {
             slotKeyToAddSig = blsSigData
             active = ByteString.copyFrom("0x0".toHexByteArray())
         }
-        val staking = Harmony.StakingMessage.newBuilder()
+        val staking = StakingMessage.newBuilder()
         staking.apply {
             nonce = ByteString.copyFrom("0x2".toHexByteArray())
             gasPrice = ByteString.copyFrom("0x0".toHexByteArray())
             gasLimit = ByteString.copyFrom("0x64".toHexByteArray())
             editValidatorMessage = editValidator.build()
         }
-        val signingInput = Harmony.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             privateKey = privateKeyData
             chainId = ByteString.copyFrom("0x02".toHexByteArray())
@@ -246,20 +245,20 @@ class TestHarmonyStakingDelegateSigner {
 
     @Test
     fun testHarmonyStakingTransactionDelegateSigning() {
-        val delegate = Harmony.DirectiveDelegate.newBuilder()
+        val delegate = DirectiveDelegate.newBuilder()
         delegate.apply {
             delegatorAddress = oneAddress
             validatorAddress = oneAddress
             amount = ByteString.copyFrom("0xa".toHexByteArray())
         }
-        val staking = Harmony.StakingMessage.newBuilder()
+        val staking = StakingMessage.newBuilder()
         staking.apply {
             nonce = ByteString.copyFrom("0x2".toHexByteArray())
             gasPrice = ByteString.copyFrom("0x0".toHexByteArray())
             gasLimit = ByteString.copyFrom("0x64".toHexByteArray())
             delegateMessage = delegate.build()
         }
-        val signingInput = Harmony.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             privateKey = privateKeyData
             chainId = ByteString.copyFrom("0x02".toHexByteArray())
@@ -276,20 +275,20 @@ class TestHarmonyStakingDelegateSigner {
 
     @Test
     fun testHarmonyStakingTransactionUndelegateSigning() {
-        val undelegate = Harmony.DirectiveUndelegate.newBuilder()
+        val undelegate = DirectiveUndelegate.newBuilder()
         undelegate.apply {
             delegatorAddress = oneAddress
             validatorAddress = oneAddress
             amount = ByteString.copyFrom("0xa".toHexByteArray())
         }
-        val staking = Harmony.StakingMessage.newBuilder()
+        val staking = StakingMessage.newBuilder()
         staking.apply {
             nonce = ByteString.copyFrom("0x2".toHexByteArray())
             gasPrice = ByteString.copyFrom("0x0".toHexByteArray())
             gasLimit = ByteString.copyFrom("0x64".toHexByteArray())
             undelegateMessage = undelegate.build()
         }
-        val signingInput = Harmony.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             privateKey = privateKeyData
             chainId = ByteString.copyFrom("0x02".toHexByteArray())
@@ -306,18 +305,18 @@ class TestHarmonyStakingDelegateSigner {
 
     @Test
     fun testHarmonyStakingTransactionCollectRewardsSigning() {
-        val cRewards = Harmony.DirectiveCollectRewards.newBuilder()
+        val cRewards = DirectiveCollectRewards.newBuilder()
         cRewards.apply {
             delegatorAddress = oneAddress
         }
-        val staking = Harmony.StakingMessage.newBuilder()
+        val staking = StakingMessage.newBuilder()
         staking.apply {
             nonce = ByteString.copyFrom("0x2".toHexByteArray())
             gasPrice = ByteString.copyFrom("0x0".toHexByteArray())
             gasLimit = ByteString.copyFrom("0x64".toHexByteArray())
             collectRewards = cRewards.build()
         }
-        val signingInput = Harmony.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             privateKey = privateKeyData
             chainId = ByteString.copyFrom("0x02".toHexByteArray())

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/harmony/TestHarmonyTransactionSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/harmony/TestHarmonyTransactionSigner.kt
@@ -6,8 +6,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.jni.PrivateKey
 import wallet.core.java.AnySigner
-import wallet.core.jni.proto.Harmony
-import wallet.core.jni.proto.Harmony.SigningOutput
+import wallet.core.proto.Harmony.*
 import com.trustwallet.core.app.utils.Numeric
 import wallet.core.jni.CoinType.HARMONY
 
@@ -19,7 +18,7 @@ class TestHarmonyTransactionSigner {
 
     @Test
     fun testHarmonyTransactionSigning() {
-        val transaction = Harmony.TransactionMessage.newBuilder()
+        val transaction = TransactionMessage.newBuilder()
         transaction.apply {
             nonce = ByteString.copyFrom("0x9".toHexByteArray())
             gasPrice = ByteString.copyFrom("0x0".toHexByteArray())
@@ -29,7 +28,7 @@ class TestHarmonyTransactionSigner {
             toShardId = ByteString.copyFrom("0x0".toHexByteArray())
             amount = ByteString.copyFrom("0x4c53ecdc18a60000".toHexByteArray())
         }
-        val signingInput = Harmony.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             privateKey = ByteString.copyFrom(PrivateKey("0xb578822c5c718e510f67a9e291e9c6efdaf753f406020f55223b940e1ddb282e".toHexByteArray()).data())
             chainId = ByteString.copyFrom("0x02".toHexByteArray())

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/iotex/TestIotexSigning.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/iotex/TestIotexSigning.kt
@@ -3,13 +3,11 @@ package com.trustwallet.core.app.blockchains.IoTeX
 import com.google.protobuf.ByteString
 import com.trustwallet.core.app.utils.toHex
 import com.trustwallet.core.app.utils.Numeric
-import com.trustwallet.core.app.utils.toHexBytes
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.java.AnySigner
 import wallet.core.jni.CoinType.IOTEX
-import wallet.core.jni.proto.IoTeX
-import wallet.core.jni.proto.IoTeX.SigningOutput
+import wallet.core.proto.IoTex.*
 
 class TestIotexSigning {
 
@@ -19,14 +17,14 @@ class TestIotexSigning {
     
     @Test
     fun testIotexSigningCreate() {   
-        val input = IoTeX.SigningInput.newBuilder()
+        val input = SigningInput.newBuilder()
             .setVersion(1)
             .setNonce(0)
             .setGasLimit(1000000)
             .setGasPrice("10")
             .setPrivateKey(ByteString.copyFrom(Numeric.hexStringToByteArray("cfa6ef757dee2e50351620dca002d32b9c090cfda55fb81f37f1d26b273743f1")))
         // test sign Create
-        val create = IoTeX.Staking.Create.newBuilder().apply {
+        val create = Staking.Create.newBuilder().apply {
             candidateName = "io19d0p3ah4g8ww9d7kcxfq87yxe7fnr8rpth5shj"
             stakedAmount = "100"
             stakedDuration = 10000
@@ -43,14 +41,14 @@ class TestIotexSigning {
         assertEquals(signBytes.toByteArray().toHex(), "0x0a4b080118c0843d22023130c2023e0a29696f313964307033616834673877773964376b63786671383779786537666e7238727074683573686a120331303018904e20012a077061796c6f6164124104755ce6d8903f6b3793bddb4ea5d3589d637de2d209ae0ea930815c82db564ee8cc448886f639e8a0c7e94e99a5c1335b583c0bc76ef30dd6a1038ed9da8daf331a412e8bac421bab88dcd99c26ac8ffbf27f11ee57a41e7d2537891bfed5aed8e2e026d46e55d1b856787bc1cd7c1216a6e2534c5b5d1097c3afe8e657aa27cbbb0801")
     }
     fun testIotexSigningAddDeposit() {   
-            val input = IoTeX.SigningInput.newBuilder()
+            val input = SigningInput.newBuilder()
                 .setVersion(1)
                 .setNonce(0)
                 .setGasLimit(1000000)
                 .setGasPrice("10")
                 .setPrivateKey(ByteString.copyFrom(Numeric.hexStringToByteArray("cfa6ef757dee2e50351620dca002d32b9c090cfda55fb81f37f1d26b273743f1")))
         // test sign AddDeposit
-        val adddeposit = IoTeX.Staking.AddDeposit.newBuilder().apply {
+        val adddeposit = Staking.AddDeposit.newBuilder().apply {
             bucketIndex = 10
             amount = "10"
             payload = ByteString.copyFrom("payload".toByteArray())
@@ -65,14 +63,14 @@ class TestIotexSigning {
         assertEquals(signBytesAddDeposit.toByteArray().toHex(), "0x0a1c080118c0843d22023130da020f080a120231301a077061796c6f6164124104755ce6d8903f6b3793bddb4ea5d3589d637de2d209ae0ea930815c82db564ee8cc448886f639e8a0c7e94e99a5c1335b583c0bc76ef30dd6a1038ed9da8daf331a41a48ab1feba8181d760de946aefed7d815a89fd9b1ab503d2392bb55e1bb75eec42dddc8bd642f89accc3a37b3cf15a103a95d66695fdf0647b202869fdd66bcb01")
     }
     fun testIotexSigningUnstake() {   
-            val input = IoTeX.SigningInput.newBuilder()
+            val input = SigningInput.newBuilder()
                 .setVersion(1)
                 .setNonce(0)
                 .setGasLimit(1000000)
                 .setGasPrice("10")
                 .setPrivateKey(ByteString.copyFrom(Numeric.hexStringToByteArray("cfa6ef757dee2e50351620dca002d32b9c090cfda55fb81f37f1d26b273743f1")))
         // test sign Unstake
-        val unstake = IoTeX.Staking.Reclaim.newBuilder().apply {
+        val unstake = Staking.Reclaim.newBuilder().apply {
             bucketIndex = 10
             payload = ByteString.copyFrom("payload".toByteArray())
             }.build()
@@ -86,14 +84,14 @@ class TestIotexSigning {
         assertEquals(signBytesUnstake.toByteArray().toHex(), "0x0a18080118c0843d22023130ca020b080a12077061796c6f6164124104755ce6d8903f6b3793bddb4ea5d3589d637de2d209ae0ea930815c82db564ee8cc448886f639e8a0c7e94e99a5c1335b583c0bc76ef30dd6a1038ed9da8daf331a4100adee39b48e1d3dbbd65298a57c7889709fc4df39987130da306f6997374a184b7e7c232a42f21e89b06e6e7ceab81303c6b7483152d08d19ac829b22eb81e601")
     }
     fun testIotexSigningWithdraw() {   
-            val input = IoTeX.SigningInput.newBuilder()
+            val input = SigningInput.newBuilder()
                 .setVersion(1)
                 .setNonce(0)
                 .setGasLimit(1000000)
                 .setGasPrice("10")
                 .setPrivateKey(ByteString.copyFrom(Numeric.hexStringToByteArray("cfa6ef757dee2e50351620dca002d32b9c090cfda55fb81f37f1d26b273743f1")))
         // test sign Withdraw
-        val withdraw = IoTeX.Staking.Reclaim.newBuilder().apply {
+        val withdraw = Staking.Reclaim.newBuilder().apply {
             bucketIndex = 10
             payload = ByteString.copyFrom("payload".toByteArray())
             }.build()
@@ -107,14 +105,14 @@ class TestIotexSigning {
         assertEquals(signBytesWithdraw.toByteArray().toHex(), "0x0a18080118c0843d22023130d2020b080a12077061796c6f6164124104755ce6d8903f6b3793bddb4ea5d3589d637de2d209ae0ea930815c82db564ee8cc448886f639e8a0c7e94e99a5c1335b583c0bc76ef30dd6a1038ed9da8daf331a4152644d102186be6640d46b517331f3402e24424b0d85129595421d28503d75340b2922f5a0d4f667bbd6f576d9816770286b2ce032ba22eaec3952e24da4756b00")
     }
     fun testIotexSigningRestake() {   
-            val input = IoTeX.SigningInput.newBuilder()
+            val input = SigningInput.newBuilder()
                 .setVersion(1)
                 .setNonce(0)
                 .setGasLimit(1000000)
                 .setGasPrice("10")
                 .setPrivateKey(ByteString.copyFrom(Numeric.hexStringToByteArray("cfa6ef757dee2e50351620dca002d32b9c090cfda55fb81f37f1d26b273743f1")))
          // test sign Restake
-         val restake = IoTeX.Staking.Restake.newBuilder().apply {
+         val restake = Staking.Restake.newBuilder().apply {
             bucketIndex = 10
             stakedDuration = 1000
             autoStake = true
@@ -130,14 +128,14 @@ class TestIotexSigning {
         assertEquals(signBytesRestake.toByteArray().toHex(), "0x0a1d080118c0843d22023130e20210080a10e807180122077061796c6f6164124104755ce6d8903f6b3793bddb4ea5d3589d637de2d209ae0ea930815c82db564ee8cc448886f639e8a0c7e94e99a5c1335b583c0bc76ef30dd6a1038ed9da8daf331a41e2e763aed5b1fd1a8601de0f0ae34eb05162e34b0389ae3418eedbf762f64959634a968313a6516dba3a97b34efba4753bbed3a33d409ecbd45ac75007cd8e9101")
     }
     fun testIotexSigningChangeCandidate() {   
-            val input = IoTeX.SigningInput.newBuilder()
+            val input = SigningInput.newBuilder()
                 .setVersion(1)
                 .setNonce(0)
                 .setGasLimit(1000000)
                 .setGasPrice("10")
                 .setPrivateKey(ByteString.copyFrom(Numeric.hexStringToByteArray("cfa6ef757dee2e50351620dca002d32b9c090cfda55fb81f37f1d26b273743f1")))
         // test sign ChangeCandidate
-        val changecandidate = IoTeX.Staking.ChangeCandidate.newBuilder().apply {
+        val changecandidate = Staking.ChangeCandidate.newBuilder().apply {
             bucketIndex = 10
             candidateName = "io1xpq62aw85uqzrccg9y5hnryv8ld2nkpycc3gza"
             payload = ByteString.copyFrom("payload".toByteArray())
@@ -152,14 +150,14 @@ class TestIotexSigning {
         assertEquals(signBytesChangeCandidate.toByteArray().toHex(), "0x0a43080118c0843d22023130ea0236080a1229696f3178707136326177383575717a72636367397935686e727976386c64326e6b7079636333677a611a077061796c6f6164124104755ce6d8903f6b3793bddb4ea5d3589d637de2d209ae0ea930815c82db564ee8cc448886f639e8a0c7e94e99a5c1335b583c0bc76ef30dd6a1038ed9da8daf331a41d519eb3747163b945b862989b7e82a7f8468001e9683757cb88d5ddd95f81895047429e858bd48f7d59a88bfec92de231d216293aeba1e4fbe11461d9c9fc99801")
     }
     fun testIotexSigningTransferOwnership() {   
-            val input = IoTeX.SigningInput.newBuilder()
+            val input = SigningInput.newBuilder()
                 .setVersion(1)
                 .setNonce(0)
                 .setGasLimit(1000000)
                 .setGasPrice("10")
                 .setPrivateKey(ByteString.copyFrom(Numeric.hexStringToByteArray("cfa6ef757dee2e50351620dca002d32b9c090cfda55fb81f37f1d26b273743f1")))
         // test sign TransferOwnership
-        val transfer = IoTeX.Staking.TransferOwnership.newBuilder().apply {
+        val transfer = Staking.TransferOwnership.newBuilder().apply {
             bucketIndex = 10
             voterAddress = "io1xpq62aw85uqzrccg9y5hnryv8ld2nkpycc3gza"
             payload = ByteString.copyFrom("payload".toByteArray())
@@ -174,14 +172,14 @@ class TestIotexSigning {
         assertEquals(signBytesTransferOwnership.toByteArray().toHex(), "0x0a43080118c0843d22023130f20236080a1229696f3178707136326177383575717a72636367397935686e727976386c64326e6b7079636333677a611a077061796c6f6164124104755ce6d8903f6b3793bddb4ea5d3589d637de2d209ae0ea930815c82db564ee8cc448886f639e8a0c7e94e99a5c1335b583c0bc76ef30dd6a1038ed9da8daf331a41fa26db427ab87a56a129196c1604f2e22c4dd2a1f99b2217bc916260757d00093d9e6dccdf53e3b0b64e41a69d71c238fbf9281625164694a74dfbeba075d0ce01")
     }
     fun testIotexSigningCandidateBasicInfo() {   
-            val input = IoTeX.SigningInput.newBuilder()
+            val input = SigningInput.newBuilder()
                 .setVersion(1)
                 .setNonce(0)
                 .setGasLimit(1000000)
                 .setGasPrice("10")
                 .setPrivateKey(ByteString.copyFrom(Numeric.hexStringToByteArray("cfa6ef757dee2e50351620dca002d32b9c090cfda55fb81f37f1d26b273743f1")))
         // test sign CandidateBasicInfo
-        val cbi = IoTeX.Staking.CandidateBasicInfo.newBuilder().apply {
+        val cbi = Staking.CandidateBasicInfo.newBuilder().apply {
             name = "test"
             operatorAddress = "io1cl6rl2ev5dfa988qmgzg2x4hfazmp9vn2g66ng"
             rewardAddress = "io1juvx5g063eu4ts832nukp4vgcwk2gnc5cu9ayd"
@@ -196,19 +194,19 @@ class TestIotexSigning {
         assertEquals(signBytesCandidateBasicInfo.toByteArray().toHex(), "0x0a69080118c0843d2202313082035c0a04746573741229696f31636c36726c32657635646661393838716d677a673278346866617a6d7039766e326736366e671a29696f316a757678356730363365753474733833326e756b7034766763776b32676e6335637539617964124104755ce6d8903f6b3793bddb4ea5d3589d637de2d209ae0ea930815c82db564ee8cc448886f639e8a0c7e94e99a5c1335b583c0bc76ef30dd6a1038ed9da8daf331a4101885c9c6684a4a8f2f5bf11f8326f27be48658f292e8f55ec8a11a604bb0c563a11ebf12d995ca1c152e00f8e0f0edf288db711aa10dbdfd5b7d73b4a28e1f701")
     }
     fun testIotexSigningCandidateRegister() {   
-            val input = IoTeX.SigningInput.newBuilder()
+            val input = SigningInput.newBuilder()
                 .setVersion(1)
                 .setNonce(0)
                 .setGasLimit(1000000)
                 .setGasPrice("1000")
                 .setPrivateKey(ByteString.copyFrom(Numeric.hexStringToByteArray("cfa6ef757dee2e50351620dca002d32b9c090cfda55fb81f37f1d26b273743f1")))
         // test sign CandidateBasicInfo
-        val cbi = IoTeX.Staking.CandidateBasicInfo.newBuilder().apply {
+        val cbi = Staking.CandidateBasicInfo.newBuilder().apply {
             name = "test"
             operatorAddress = "io10a298zmzvrt4guq79a9f4x7qedj59y7ery84he"
             rewardAddress = "io13sj9mzpewn25ymheukte4v39hvjdtrfp00mlyv"
             }.build()
-        val cr = IoTeX.Staking.CandidateRegister.newBuilder().apply {
+        val cr = Staking.CandidateRegister.newBuilder().apply {
             candidate = cbi
             stakedAmount = "100"
             stakedDuration = 10000

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/kava/TestKavaTransactions.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/kava/TestKavaTransactions.kt
@@ -7,8 +7,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.jni.*
 import wallet.core.jni.CoinType.KAVA
-import wallet.core.jni.proto.Cosmos
-import wallet.core.jni.proto.Cosmos.SigningOutput
+import wallet.core.proto.Cosmos.*
 import wallet.core.java.AnySigner
 
 class TestKavaTransactions {
@@ -23,7 +22,7 @@ class TestKavaTransactions {
         val publicKey = key.getPublicKeySecp256k1(true)
         val from = AnyAddress(publicKey, KAVA).description()
 
-        val rawJSON = Cosmos.Message.RawJSON.newBuilder().apply {
+        val rawJSON = Message.RawJSON.newBuilder().apply {
             type = "withdraw_cdp"
             value = """
                 {
@@ -39,21 +38,21 @@ class TestKavaTransactions {
                 """.trimIndent()
         }.build()
 
-        val feeAmount = Cosmos.Amount.newBuilder().apply {
+        val feeAmount = Amount.newBuilder().apply {
             amount = 100
             denom = "ukava"
         }.build()
 
-        val kavaFee = Cosmos.Fee.newBuilder().apply {
+        val kavaFee = Fee.newBuilder().apply {
             gas = 200000
             addAllAmounts(listOf(feeAmount))
         }.build()
 
-        val message = Cosmos.Message.newBuilder().apply {
+        val message = Message.newBuilder().apply {
             rawJsonMessage = rawJSON
         }.build()
 
-        val signingInput = Cosmos.SigningInput.newBuilder().apply {
+        val signingInput = SigningInput.newBuilder().apply {
             accountNumber = 204
             chainId = "kava-2"
             sequence = 4

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/kusama/TestKusamaSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/kusama/TestKusamaSigner.kt
@@ -12,8 +12,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.java.AnySigner
 import wallet.core.jni.CoinType.KUSAMA
-import wallet.core.jni.proto.Polkadot
-import wallet.core.jni.proto.Polkadot.SigningOutput
+import wallet.core.proto.Polkadot.*
 
 class TestKusamaSigner {
 
@@ -26,20 +25,20 @@ class TestKusamaSigner {
         val key = "0x8cdc538e96f460da9d639afc5c226f477ce98684d77fb31e88db74c1f1dd86b2".toHexBytesInByteString()
         val hash = "0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe".toHexBytesInByteString()
 
-        val call = Polkadot.Balance.Transfer.newBuilder().apply {
+        val call = Balance.Transfer.newBuilder().apply {
             toAddress = "CtwdfrhECFs3FpvCGoiE4hwRC4UsSiM8WL899HjRdQbfYZY"
             value = "0x02540be400".toHexBytesInByteString()
         }
 
-        val input = Polkadot.SigningInput.newBuilder().apply {
+        val input = SigningInput.newBuilder().apply {
             genesisHash = hash
             blockHash = hash
             nonce = 1
             specVersion = 2019
-            network = Polkadot.Network.KUSAMA
+            network = Network.KUSAMA
             transactionVersion = 2
             privateKey = key
-            balanceCall = Polkadot.Balance.newBuilder().apply {
+            balanceCall = Balance.newBuilder().apply {
                 transfer = call.build()
             }.build()
         }

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/nano/TestNanoSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/nano/TestNanoSigner.kt
@@ -7,8 +7,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.jni.CoinType.NANO
 import wallet.core.java.AnySigner
-import wallet.core.jni.proto.Nano
-import wallet.core.jni.proto.Nano.SigningOutput
+import wallet.core.proto.Nano.*
 
 class TestNanoSigner {
 
@@ -18,7 +17,7 @@ class TestNanoSigner {
 
     @Test
     fun testSign() {
-        val signingInput = Nano.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             privateKey = ByteString.copyFrom("173c40e97fe2afcd24187e74f6b603cb949a5365e72fbdd065a6b165e2189e34".toHexByteArray())
             linkBlock = ByteString.copyFrom("491fca2c69a84607d374aaf1f6acd3ce70744c5be0721b5ed394653e85233507".toHexByteArray())

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/near/TestNEARSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/near/TestNEARSigner.kt
@@ -8,8 +8,7 @@ import org.junit.Test
 import wallet.core.jni.Base58
 import wallet.core.java.AnySigner
 import wallet.core.jni.CoinType
-import wallet.core.jni.proto.NEAR
-import wallet.core.jni.proto.NEAR.SigningOutput
+import wallet.core.proto.NEAR.*
 
 class TestNEARSigner {
 
@@ -19,10 +18,10 @@ class TestNEARSigner {
 
     @Test
     fun testTransferSign() {
-        val transferAction = NEAR.Transfer.newBuilder().apply {
+        val transferAction = Transfer.newBuilder().apply {
             deposit = ByteString.copyFrom("01000000000000000000000000000000".toHexByteArray())
         }.build()
-        val signingInput = NEAR.SigningInput.newBuilder().apply {
+        val signingInput = SigningInput.newBuilder().apply {
             signerId = "test.near"
             nonce = 1
             receiverId = "whatever.near"

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/nebulas/TestNebulasSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/nebulas/TestNebulasSigner.kt
@@ -8,8 +8,7 @@ import org.junit.Test
 import wallet.core.jni.CoinType.NEBULAS
 import wallet.core.jni.PrivateKey
 import wallet.core.java.AnySigner
-import wallet.core.jni.proto.Nebulas
-import wallet.core.jni.proto.Nebulas.SigningOutput
+import wallet.core.proto.Nebulas.*
 
 class TestNebulasSigner {
 
@@ -19,7 +18,7 @@ class TestNebulasSigner {
 
     @Test
     fun testNebulasSigner() {
-        val signingInput = Nebulas.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             fromAddress = "n1V5bB2tbaM3FUiL4eRwpBLgEredS5C2wLY"
             toAddress = "n1SAeQRVn33bamxN4ehWUT7JGdxipwn8b17"

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/neo/TestsNEOSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/neo/TestsNEOSigner.kt
@@ -9,7 +9,7 @@ package com.trustwallet.core.app.blockchains.neo
 import com.trustwallet.core.app.utils.Numeric
 import org.junit.Test
 import wallet.core.java.AnySigner
-import wallet.core.jni.proto.NEO
+import wallet.core.proto.NEO.*
 import com.trustwallet.core.app.utils.toHexBytesInByteString
 import org.junit.Assert.assertEquals
 import wallet.core.jni.CoinType
@@ -20,8 +20,8 @@ class TestNEOSigner {
         System.loadLibrary("TrustWalletCore")
     }
 
-    fun addInput(builder: NEO.SigningInput.Builder, hash: String, index: Int, assetID: String, value: Long) {
-        builder.addInputs(NEO.TransactionInput.newBuilder()
+    fun addInput(builder: SigningInput.Builder, hash: String, index: Int, assetID: String, value: Long) {
+        builder.addInputs(TransactionInput.newBuilder()
                 .setPrevHash(hash.toHexBytesInByteString())
                 .setPrevIndex(index)
                 .setAssetId(assetID)
@@ -29,7 +29,7 @@ class TestNEOSigner {
                 .build())
     }
 
-    fun prepareInputs(builder: NEO.SigningInput.Builder) {
+    fun prepareInputs(builder: SigningInput.Builder) {
         val NEO_ASSET_ID = "9b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc5"
         val GAS_ASSET_ID = "e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c60"
 
@@ -75,14 +75,14 @@ class TestNEOSigner {
         val NEO_ASSET_ID = "9b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc5"
         val GAS_ASSET_ID = "e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c60"
 
-        val input = NEO.SigningInput.newBuilder().apply {
+        val input = SigningInput.newBuilder().apply {
             privateKey = "F18B2F726000E86B4950EBEA7BFF151F69635951BC4A31C44F28EE6AF7AEC128".toHexBytesInByteString()
             fee = 12345
             gasAssetId = GAS_ASSET_ID
             gasChangeAddress = "AdtSLMBqACP4jv8tRWwyweXGpyGG46eMXV"
         }
         prepareInputs(input)
-        val output = NEO.TransactionOutput.newBuilder()
+        val output = TransactionOutput.newBuilder()
                 .setAssetId(NEO_ASSET_ID)
                 .setAmount(25000000000)
                 .setToAddress("Ad9A1xPbuA5YBFr1XPznDwBwQzdckAjCev")
@@ -90,9 +90,9 @@ class TestNEOSigner {
                 .build()
         input.addOutputs(output)
 
-        val plan = AnySigner.plan(input.build(), CoinType.NEO,NEO.TransactionPlan.parser())
+        val plan = AnySigner.plan(input.build(), CoinType.NEO,TransactionPlan.parser())
         input.setPlan(plan)
-        val result = AnySigner.sign(input.build(), CoinType.NEO, NEO.SigningOutput.parser()).encoded.toByteArray()
+        val result = AnySigner.sign(input.build(), CoinType.NEO, SigningOutput.parser()).encoded.toByteArray()
         val hex = Numeric.toHexString(result, 0, result.size, false)
 
         //  https://testnet-explorer.o3.network/transactions/0x7b138c753c24f474d0f70af30a9d79756e0ee9c1f38c12ed07fbdf6fc5132eaf

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/nuls/TestNULSSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/nuls/TestNULSSigner.kt
@@ -7,8 +7,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.jni.CoinType
 import wallet.core.java.AnySigner
-import wallet.core.jni.proto.NULS
-import wallet.core.jni.proto.NULS.SigningOutput
+import wallet.core.proto.NULS.*
 
 class TestNULSSigner {
 
@@ -18,7 +17,7 @@ class TestNULSSigner {
 
     @Test
     fun NULSTransactionSigning() { 
-        val signingInput = NULS.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
             .setPrivateKey(ByteString.copyFrom(Numeric.hexStringToByteArray("9ce21dad67e0f0af2599b41b515a7f7018059418bab892a7b68f283d489abc4b")))
             .setFrom("NULSd6Hgj7ZoVgsPN9ybB4C1N2TbvkgLc8Z9H")
             .setTo("NULSd6Hgied7ym6qMEfVzZanMaa9qeqA6TZSe")

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/oasis/TestOasisSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/oasis/TestOasisSigner.kt
@@ -8,15 +8,11 @@ package com.trustwallet.core.app.blockchains.oasis
 
 import com.google.protobuf.ByteString
 import com.trustwallet.core.app.utils.Numeric
-import com.trustwallet.core.app.utils.toHexByteArray
-import com.trustwallet.core.app.utils.toHexBytes
-import com.trustwallet.core.app.utils.toHexBytesInByteString
 import junit.framework.Assert.assertEquals
 import org.junit.Test
 import wallet.core.java.AnySigner
 import wallet.core.jni.CoinType.OASIS
-import wallet.core.jni.proto.Oasis
-import wallet.core.jni.proto.Oasis.SigningOutput
+import wallet.core.proto.Oasis.*
 import java.math.BigInteger
 
 class TestOasisSigner {
@@ -27,7 +23,7 @@ class TestOasisSigner {
 
     @Test
     fun OasisTransactionSigning() {
-        val transferMsg = Oasis.TransferMessage.newBuilder()
+        val transferMsg = TransferMessage.newBuilder()
 
         transferMsg.apply {
             to = "oasis1qrrnesqpgc6rfy2m50eew5d7klqfqk69avhv4ak5"
@@ -41,7 +37,7 @@ class TestOasisSigner {
             context = "oasis-core/consensus: tx for chain a245619497e580dd3bc1aa3256c07f68b8dcc13f92da115eadc3b231b083d3c4"
         }
 
-        val signingInput = Oasis.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             privateKey = (ByteString.copyFrom(Numeric.hexStringToByteArray("4f8b5676990b00e23d9904a92deb8d8f428ff289c8939926358f1d20537c21a0")))
             transfer = transferMsg.build()

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/ontology/TestOntologySigning.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/ontology/TestOntologySigning.kt
@@ -6,8 +6,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.java.AnySigner
 import wallet.core.jni.CoinType.ONTOLOGY
-import wallet.core.jni.proto.Ontology
-import wallet.core.jni.proto.Ontology.SigningOutput
+import wallet.core.proto.Ontology.*
 
 class TestOntologySigning {
     init {
@@ -16,7 +15,7 @@ class TestOntologySigning {
 
     @Test
     fun testSignOngBalanceOf() {
-        val signerBuilder = Ontology.SigningInput.newBuilder()
+        val signerBuilder = SigningInput.newBuilder()
         val input = signerBuilder.apply {
             contract = "ONG"
             method = "balanceOf"
@@ -36,7 +35,7 @@ class TestOntologySigning {
 
     @Test
     fun testSignOntBalanceOf() {
-        val signerBuilder = Ontology.SigningInput.newBuilder()
+        val signerBuilder = SigningInput.newBuilder()
         val input = signerBuilder.apply {
             contract = "ONT"
             method = "balanceOf"
@@ -56,7 +55,7 @@ class TestOntologySigning {
 
     @Test
     fun testSignOntTransfer() {
-        val signerBuilder = Ontology.SigningInput.newBuilder()
+        val signerBuilder = SigningInput.newBuilder()
         val input = signerBuilder.apply {
             contract = "ONT"
             method = "transfer"
@@ -80,7 +79,7 @@ class TestOntologySigning {
 
     @Test
     fun testSignOngTransfer() {
-        val signerBuilder = Ontology.SigningInput.newBuilder()
+        val signerBuilder = SigningInput.newBuilder()
         val input = signerBuilder.apply {
             contract = "ONG"
             method = "transfer"

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/osmosis/TestOsmosisSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/osmosis/TestOsmosisSigner.kt
@@ -17,9 +17,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.jni.*
 import wallet.core.jni.CoinType.OSMOSIS
-import wallet.core.jni.proto.Cosmos
-import wallet.core.jni.proto.Cosmos.SigningOutput
-import wallet.core.jni.proto.Cosmos.SigningMode
+import wallet.core.proto.Cosmos.*
 import wallet.core.java.AnySigner
 
 class TestOsmosisSigner {
@@ -34,32 +32,32 @@ class TestOsmosisSigner {
         val publicKey = key.getPublicKeySecp256k1(true)
         val from = AnyAddress(publicKey, OSMOSIS).description()
 
-        val txAmount = Cosmos.Amount.newBuilder().apply {
+        val txAmount = Amount.newBuilder().apply {
             amount = 100000 - 200
             denom = "uosmo"
         }.build()
 
-        val sendCoinsMsg = Cosmos.Message.Send.newBuilder().apply {
+        val sendCoinsMsg = Message.Send.newBuilder().apply {
             fromAddress = from
             toAddress = "osmo18s0hdnsllgcclweu9aymw4ngktr2k0rkvn7jmn"
             addAllAmounts(listOf(txAmount))
         }.build()
 
-        val message = Cosmos.Message.newBuilder().apply {
+        val message = Message.newBuilder().apply {
             sendCoinsMessage = sendCoinsMsg
         }.build()
 
-        val feeAmount = Cosmos.Amount.newBuilder().apply {
+        val feeAmount = Amount.newBuilder().apply {
             amount = 200
             denom = "uosmo"
         }.build()
 
-        val osmosisFee = Cosmos.Fee.newBuilder().apply {
+        val osmosisFee = Fee.newBuilder().apply {
             gas = 200000
             addAllAmounts(listOf(feeAmount))
         }.build()
 
-        val signingInput = Cosmos.SigningInput.newBuilder().apply {
+        val signingInput = SigningInput.newBuilder().apply {
             signingMode = SigningMode.Protobuf
             accountNumber = 124703
             chainId = "osmosis-1"

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/polkadot/TestPolkadotSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/polkadot/TestPolkadotSigner.kt
@@ -12,8 +12,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.java.AnySigner
 import wallet.core.jni.CoinType.POLKADOT
-import wallet.core.jni.proto.Polkadot
-import wallet.core.jni.proto.Polkadot.SigningOutput
+import wallet.core.proto.Polkadot.*
 
 class TestPolkadotSigner {
 
@@ -28,21 +27,21 @@ class TestPolkadotSigner {
     fun PolkadotTransactionSigning() {
         val key = "0x37932b086586a6675e66e562fe68bd3eeea4177d066619c602fe3efc290ada62".toHexBytesInByteString()
 
-        val call = Polkadot.Staking.Bond.newBuilder().apply {
+        val call = Staking.Bond.newBuilder().apply {
             controller = "14CeRumfZBNBVux9GgaiR5qw9E8RndNsiFWvhcHs76HEPjbP"
             value = "0x02540be400".toHexBytesInByteString()
-            rewardDestination = Polkadot.RewardDestination.STAKED
+            rewardDestination = RewardDestination.STAKED
         }
 
-        val input = Polkadot.SigningInput.newBuilder().apply {
+        val input = SigningInput.newBuilder().apply {
             genesisHash = genesisHashStr
             blockHash = genesisHashStr
             nonce = 0
             specVersion = 17
-            network = Polkadot.Network.POLKADOT
+            network = Network.POLKADOT
             transactionVersion = 3
             privateKey = key
-            stakingCall = Polkadot.Staking.newBuilder().apply {
+            stakingCall = Staking.newBuilder().apply {
                 bond = call.build()
             }.build()
         }
@@ -56,23 +55,23 @@ class TestPolkadotSigner {
 
     @Test
     fun PolkadotTransactionSignBondAndNominate() {
-        val call = Polkadot.Staking.BondAndNominate.newBuilder().apply {
+        val call = Staking.BondAndNominate.newBuilder().apply {
             controller = "13ZLCqJNPsRZYEbwjtZZFpWt9GyFzg5WahXCVWKpWdUJqrQ5"
             value = "0x02540be400".toHexBytesInByteString() // 1 DOT
-            rewardDestination = Polkadot.RewardDestination.STASH
+            rewardDestination = RewardDestination.STASH
             addNominators("1zugcavYA9yCuYwiEYeMHNJm9gXznYjNfXQjZsZukF1Mpow")
             addNominators("15oKi7HoBQbwwdQc47k71q4sJJWnu5opn1pqoGx4NAEYZSHs")
         }
 
-        val input = Polkadot.SigningInput.newBuilder().apply {
+        val input = SigningInput.newBuilder().apply {
             genesisHash = genesisHashStr
             blockHash = genesisHashStr
             nonce = 4
             specVersion = 30
-            network = Polkadot.Network.POLKADOT
+            network = Network.POLKADOT
             transactionVersion = 7
             privateKey = iOSTestKey
-            stakingCall = Polkadot.Staking.newBuilder().apply {
+            stakingCall = Staking.newBuilder().apply {
                 bondAndNominate = call.build()
             }.build()
         }

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/ripple/TestRippleTransactionSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/ripple/TestRippleTransactionSigner.kt
@@ -8,8 +8,8 @@ import org.junit.Test
 import wallet.core.jni.PrivateKey
 import wallet.core.java.AnySigner
 import wallet.core.jni.CoinType.XRP
-import wallet.core.jni.proto.Ripple
-import wallet.core.jni.proto.Ripple.SigningOutput
+import wallet.core.proto.Ripple.signingInput
+import wallet.core.proto.Ripple.SigningOutput
 
 class TestRippleTransactionSigner {
 
@@ -19,8 +19,7 @@ class TestRippleTransactionSigner {
 
     @Test
     fun testRippleTransactionSigning() {
-        val signingInput = Ripple.SigningInput.newBuilder()
-        signingInput.apply {
+        val input = signingInput {
             account = "rDpysuumkweqeC7XdNgYNtzL5GxbdsmrtF"
             amount = 29_000_000
             destination = "rU893viamSnsfP3zjzM2KPxjqZjXSXK6VF"
@@ -29,10 +28,9 @@ class TestRippleTransactionSigner {
             privateKey = ByteString.copyFrom(PrivateKey("ba005cd605d8a02e3d5dfd04234cef3a3ee4f76bfbad2722d1fb5af8e12e6764".toHexByteArray()).data())
         }
 
-        val sign = AnySigner.sign(signingInput.build(), XRP, SigningOutput.parser())
+        val sign = AnySigner.sign(input, XRP, SigningOutput.parser())
         val signBytes = sign.encoded.toByteArray()
 
         assertEquals(signBytes.toHex(), "0x12000022800000002400000001614000000001ba8140684000000000030d407321026cc34b92cefb3a4537b3edb0b6044c04af27c01583c577823ecc69a9a21119b6744630440220067f20b3eebfc7107dd0bcc72337a236ac3be042c0469f2341d76694a17d4bb9022048393d7ee7dcb729783b33f5038939ddce1bb8337e66d752974626854556bbb681148400b6b6d08d5d495653d73eda6804c249a5148883148132e4e20aecf29090ac428a9c43f230a829220d")
     }
-
 }

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/solana/TestSolanaSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/solana/TestSolanaSigner.kt
@@ -1,15 +1,13 @@
 package com.trustwallet.core.app.blockchains.solana
 
 import com.google.protobuf.ByteString
-import com.trustwallet.core.app.utils.toHex
 import com.trustwallet.core.app.utils.toHexByteArray
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.jni.Base58
 import wallet.core.java.AnySigner
 import wallet.core.jni.CoinType.SOLANA
-import wallet.core.jni.proto.Solana
-import wallet.core.jni.proto.Solana.SigningOutput
+import wallet.core.proto.Solana.*
 
 class TestSolanaSigner {
 
@@ -23,11 +21,11 @@ class TestSolanaSigner {
 
     @Test
     fun testTransferSign() {
-        val transferMessage = Solana.Transfer.newBuilder().apply {
+        val transferMessage = Transfer.newBuilder().apply {
             recipient = "EN2sCsJ1WDV8UFqsiTXHcUPUxQ4juE71eCknHYYMifkd"
             value = 42
         }.build()
-        val signingInput = Solana.SigningInput.newBuilder().apply {
+        val signingInput = SigningInput.newBuilder().apply {
             transferTransaction = transferMessage
             recentBlockhash = blockhash
             privateKey = ByteString.copyFrom(Base58.decodeNoCheck("A7psj2GW7ZMdY4E5hJq14KMeYg7HFjULSsWSrTXZLvYr"))
@@ -41,12 +39,12 @@ class TestSolanaSigner {
 
     @Test
     fun testDelegateStakeSign() {
-        val delegateStakeMessage = Solana.DelegateStake.newBuilder().apply {
+        val delegateStakeMessage = DelegateStake.newBuilder().apply {
             validatorPubkey = commonValidatorPubkey
             value = 42
             stakeAccount = ""
         }.build()
-        val signingInput = Solana.SigningInput.newBuilder().apply {
+        val signingInput = SigningInput.newBuilder().apply {
             delegateStakeTransaction = delegateStakeMessage
             recentBlockhash = blockhash
             privateKey = ByteString.copyFrom(Base58.decodeNoCheck(commonPrivateKey))
@@ -60,10 +58,10 @@ class TestSolanaSigner {
 
     @Test
     fun testDeactivateStakeSign() {
-        val deactivateStakeMessage = Solana.DeactivateStake.newBuilder().apply {
+        val deactivateStakeMessage = DeactivateStake.newBuilder().apply {
             stakeAccount = "6u9vJH9pRj66N5oJFCBADEbpMTrLxQATcL6q5p5MXwYv"
         }.build()
-        val signingInput = Solana.SigningInput.newBuilder().apply {
+        val signingInput = SigningInput.newBuilder().apply {
             deactivateStakeTransaction = deactivateStakeMessage
             recentBlockhash = blockhash
             privateKey = ByteString.copyFrom(Base58.decodeNoCheck(commonPrivateKey))
@@ -77,11 +75,11 @@ class TestSolanaSigner {
 
     @Test
     fun testWithdrawStakeSign() {
-        val withdrawStakeMessage = Solana.WithdrawStake.newBuilder().apply {
+        val withdrawStakeMessage = WithdrawStake.newBuilder().apply {
             stakeAccount = "6u9vJH9pRj66N5oJFCBADEbpMTrLxQATcL6q5p5MXwYv"
             value = 42
         }.build()
-        val signingInput = Solana.SigningInput.newBuilder().apply {
+        val signingInput = SigningInput.newBuilder().apply {
             withdrawTransaction = withdrawStakeMessage
             recentBlockhash = blockhash
             privateKey = ByteString.copyFrom(Base58.decodeNoCheck(commonPrivateKey))
@@ -95,12 +93,12 @@ class TestSolanaSigner {
 
     @Test
     fun testCreateTokenAccountSign() {
-        val createAccountMessage = Solana.CreateTokenAccount.newBuilder().apply {
+        val createAccountMessage = CreateTokenAccount.newBuilder().apply {
             mainAddress = "B1iGmDJdvmxyUiYM8UEo2Uw2D58EmUrw4KyLYMmrhf8V"
             tokenMintAddress = "SRMuApVNdxXokk5GT7XD5cUUgXMBCoAz2LHeuAoKWRt"
             tokenAddress = "EDNd1ycsydWYwVmrYZvqYazFqwk1QjBgAUKFjBoz1jKP"
         }.build()
-        val signingInput = Solana.SigningInput.newBuilder().apply {
+        val signingInput = SigningInput.newBuilder().apply {
             createTokenAccountTransaction = createAccountMessage
             recentBlockhash = "9ipJh5xfyoyDaiq8trtrdqQeAhQbQkWy2eANizKvx75K"
             privateKey = ByteString.copyFrom(Base58.decodeNoCheck("9YtuoD4sH4h88CVM8DSnkfoAaLY7YeGC2TarDJ8eyMS5"))
@@ -114,14 +112,14 @@ class TestSolanaSigner {
 
     @Test
     fun testTokenTransferSign() {
-        val tokenTransferMessage = Solana.TokenTransfer.newBuilder().apply {
+        val tokenTransferMessage = TokenTransfer.newBuilder().apply {
             tokenMintAddress = "SRMuApVNdxXokk5GT7XD5cUUgXMBCoAz2LHeuAoKWRt"
             senderTokenAddress = "EDNd1ycsydWYwVmrYZvqYazFqwk1QjBgAUKFjBoz1jKP"
             recipientTokenAddress = "3WUX9wASxyScbA7brDipioKfXS1XEYkQ4vo3Kej9bKei"
             amount = 4000  // 0.004
             decimals = 6
         }.build()
-        val signingInput = Solana.SigningInput.newBuilder().apply {
+        val signingInput = SigningInput.newBuilder().apply {
             tokenTransferTransaction = tokenTransferMessage
             recentBlockhash = "CNaHfvqePgGYMvtYi9RuUdVxDYttr1zs4TWrTXYabxZi"
             privateKey = ByteString.copyFrom(Base58.decodeNoCheck("9YtuoD4sH4h88CVM8DSnkfoAaLY7YeGC2TarDJ8eyMS5"))
@@ -135,7 +133,7 @@ class TestSolanaSigner {
 
     @Test
     fun testCreateAndTransferTokenSign() {
-        val createAndTransferTokenMessage = Solana.CreateAndTransferToken.newBuilder().apply {
+        val createAndTransferTokenMessage = CreateAndTransferToken.newBuilder().apply {
             recipientMainAddress = "71e8mDsh3PR6gN64zL1HjwuxyKpgRXrPDUJT7XXojsVd"
             tokenMintAddress = "SRMuApVNdxXokk5GT7XD5cUUgXMBCoAz2LHeuAoKWRt"
             recipientTokenAddress = "EF6L8yJT1SoRoDCkAZfSVmaweqMzfhxZiptKi7Tgj5XY"
@@ -143,7 +141,7 @@ class TestSolanaSigner {
             amount = 2900
             decimals = 6
         }.build()
-        val signingInput = Solana.SigningInput.newBuilder().apply {
+        val signingInput = SigningInput.newBuilder().apply {
             createAndTransferTokenTransaction = createAndTransferTokenMessage
             recentBlockhash = "DMmDdJP41M9mw8Z4586VSvxqGCrqPy5uciF6HsKUVDja"
             privateKey = ByteString.copyFrom(Base58.decodeNoCheck("66ApBuKpo2uSzpjGBraHq7HP8UZMUJzp3um8FdEjkC9c"))

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/stellar/TestStellarSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/stellar/TestStellarSigner.kt
@@ -8,8 +8,7 @@ import wallet.core.jni.PrivateKey
 import wallet.core.jni.StellarPassphrase
 import wallet.core.java.AnySigner
 import wallet.core.jni.CoinType.STELLAR
-import wallet.core.jni.proto.Stellar
-import wallet.core.jni.proto.Stellar.SigningOutput
+import wallet.core.proto.Stellar.*
 
 class TestStellarTransactionSigner {
 
@@ -19,12 +18,12 @@ class TestStellarTransactionSigner {
 
     @Test
     fun testStellarTransactionSigning() {
-        val operation = Stellar.OperationPayment.newBuilder()
+        val operation = OperationPayment.newBuilder()
         operation.apply {
             destination = "GDCYBNRRPIHLHG7X7TKPUPAZ7WVUXCN3VO7WCCK64RIFV5XM5V5K4A52"
             amount = 10_000_000
         }
-        val signingInput = Stellar.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             account = "GAE2SZV4VLGBAPRYRFV2VY7YYLYGYIP5I7OU7BSP6DJT7GAZ35OKFDYI"
             fee = 1000
@@ -43,19 +42,19 @@ class TestStellarTransactionSigner {
 
     @Test
     fun testStellarTransactionSigningMemoHash() {
-        val operation = Stellar.OperationPayment.newBuilder()
+        val operation = OperationPayment.newBuilder()
         operation.apply {
             destination = "GDCYBNRRPIHLHG7X7TKPUPAZ7WVUXCN3VO7WCCK64RIFV5XM5V5K4A52"
             amount = 10_000_000
         }
-        val signingInput = Stellar.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             account = "GAE2SZV4VLGBAPRYRFV2VY7YYLYGYIP5I7OU7BSP6DJT7GAZ35OKFDYI"
             fee = 1000
             sequence = 2
             passphrase = StellarPassphrase.STELLAR.toString()
             opPayment = operation.build()
-            memoHash = Stellar.MemoHash.newBuilder().setHash(ByteString.copyFrom("315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3".toHexByteArray())).build()
+            memoHash = MemoHash.newBuilder().setHash(ByteString.copyFrom("315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3".toHexByteArray())).build()
             privateKey = ByteString.copyFrom(PrivateKey("59a313f46ef1c23a9e4f71cea10fc0c56a2a6bb8a4b9ea3d5348823e5a478722".toHexByteArray()).data())
         }
 
@@ -67,19 +66,19 @@ class TestStellarTransactionSigner {
 
     @Test
     fun testStellarTransactionSigningMemoReturn() {
-        val operation = Stellar.OperationPayment.newBuilder()
+        val operation = OperationPayment.newBuilder()
         operation.apply {
             destination = "GDCYBNRRPIHLHG7X7TKPUPAZ7WVUXCN3VO7WCCK64RIFV5XM5V5K4A52"
             amount = 10_000_000
         }
-        val signingInput = Stellar.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             account = "GAE2SZV4VLGBAPRYRFV2VY7YYLYGYIP5I7OU7BSP6DJT7GAZ35OKFDYI"
             fee = 1000
             sequence = 2
             passphrase = StellarPassphrase.STELLAR.toString()
             opPayment = operation.build()
-            memoReturnHash = Stellar.MemoHash.newBuilder().setHash(ByteString.copyFrom("315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3".toHexByteArray())).build()
+            memoReturnHash = MemoHash.newBuilder().setHash(ByteString.copyFrom("315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3".toHexByteArray())).build()
             privateKey = ByteString.copyFrom(PrivateKey("59a313f46ef1c23a9e4f71cea10fc0c56a2a6bb8a4b9ea3d5348823e5a478722".toHexByteArray()).data())
         }
 
@@ -91,19 +90,19 @@ class TestStellarTransactionSigner {
 
     @Test
     fun testStellarTransactionSigningMemoId() {
-        val operation = Stellar.OperationPayment.newBuilder()
+        val operation = OperationPayment.newBuilder()
         operation.apply {
             destination = "GDCYBNRRPIHLHG7X7TKPUPAZ7WVUXCN3VO7WCCK64RIFV5XM5V5K4A52"
             amount = 10_000_000
         }
-        val signingInput = Stellar.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             account = "GAE2SZV4VLGBAPRYRFV2VY7YYLYGYIP5I7OU7BSP6DJT7GAZ35OKFDYI"
             fee = 1000
             sequence = 2
             passphrase = StellarPassphrase.STELLAR.toString()
             opPayment = operation.build()
-            memoId = Stellar.MemoId.newBuilder().setId(1234567890).build()
+            memoId = MemoId.newBuilder().setId(1234567890).build()
             privateKey = ByteString.copyFrom(PrivateKey("59a313f46ef1c23a9e4f71cea10fc0c56a2a6bb8a4b9ea3d5348823e5a478722".toHexByteArray()).data())
         }
 
@@ -115,19 +114,19 @@ class TestStellarTransactionSigner {
 
     @Test
     fun testStellarTransactionSigningCreateAccount() {
-        val operation = Stellar.OperationCreateAccount.newBuilder()
+        val operation = OperationCreateAccount.newBuilder()
         operation.apply {
             destination = "GDCYBNRRPIHLHG7X7TKPUPAZ7WVUXCN3VO7WCCK64RIFV5XM5V5K4A52"
             amount = 10_000_000
         }
-        val signingInput = Stellar.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             account = "GAE2SZV4VLGBAPRYRFV2VY7YYLYGYIP5I7OU7BSP6DJT7GAZ35OKFDYI"
             fee = 1000
             sequence = 2
             passphrase = StellarPassphrase.STELLAR.toString()
             opCreateAccount = operation.build()
-            memoId = Stellar.MemoId.newBuilder().setId(1234567890).build()
+            memoId = MemoId.newBuilder().setId(1234567890).build()
             privateKey = ByteString.copyFrom(PrivateKey("59a313f46ef1c23a9e4f71cea10fc0c56a2a6bb8a4b9ea3d5348823e5a478722".toHexByteArray()).data())
         }
 
@@ -139,17 +138,17 @@ class TestStellarTransactionSigner {
 
     @Test
     fun testStellarTransactionSigningChangeTrust() {
-        val assetMobi = Stellar.Asset.newBuilder()
+        val assetMobi = Asset.newBuilder()
         assetMobi.apply {
             issuer = "GA6HCMBLTZS5VYYBCATRBRZ3BZJMAFUDKYYF6AH6MVCMGWMRDNSWJPIH"
             alphanum4 = "MOBI"
         }
-        val operation = Stellar.OperationChangeTrust.newBuilder()
+        val operation = OperationChangeTrust.newBuilder()
         operation.apply {
             asset = assetMobi.build()
             validBefore = 1613336576
         }
-        val signingInput = Stellar.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
         signingInput.apply {
             account = "GDFEKJIFKUZP26SESUHZONAUJZMBSODVN2XBYN4KAGNHB7LX2OIXLPUL"
             fee = 10000

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/terra/TestTerraTransactions.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/terra/TestTerraTransactions.kt
@@ -8,8 +8,7 @@ import org.junit.Test
 import wallet.core.java.AnySigner
 import wallet.core.jni.*
 import wallet.core.jni.CoinType.TERRA
-import wallet.core.jni.proto.Cosmos
-import wallet.core.jni.proto.Cosmos.SigningOutput
+import wallet.core.proto.Cosmos.*
 
 class TestTerraTransactions {
 
@@ -24,33 +23,33 @@ class TestTerraTransactions {
         val publicKey = key.getPublicKeySecp256k1(true)
         val from = AnyAddress(publicKey, TERRA).description()
 
-        val txAmount = Cosmos.Amount.newBuilder().apply {
+        val txAmount = Amount.newBuilder().apply {
             amount = 1000000
             denom = "uluna"
         }.build()
 
-        val sendCoinsMsg = Cosmos.Message.Send.newBuilder().apply {
+        val sendCoinsMsg = Message.Send.newBuilder().apply {
             fromAddress = from
             toAddress = "terra1hdp298kaz0eezpgl6scsykxljrje3667d233ms"
             addAllAmounts(listOf(txAmount))
             typePrefix = "bank/MsgSend"
         }.build()
 
-        val message = Cosmos.Message.newBuilder().apply {
+        val message = Message.newBuilder().apply {
             sendCoinsMessage = sendCoinsMsg
         }.build()
 
-        val feeAmount = Cosmos.Amount.newBuilder().apply {
+        val feeAmount = Amount.newBuilder().apply {
             amount = 3000
             denom = "uluna"
         }.build()
 
-        val cosmosFee = Cosmos.Fee.newBuilder().apply {
+        val cosmosFee = Fee.newBuilder().apply {
             gas = 200000
             addAllAmounts(listOf(feeAmount))
         }.build()
 
-        val signingInput = Cosmos.SigningInput.newBuilder().apply {
+        val signingInput = SigningInput.newBuilder().apply {
             accountNumber = 158
             chainId = "soju-0013"
             memo = ""

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/thorchain/TestTHORChainSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/thorchain/TestTHORChainSigner.kt
@@ -16,8 +16,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.java.AnySigner
 import wallet.core.jni.CoinType.THORCHAIN
-import wallet.core.jni.proto.Cosmos
-import wallet.core.jni.proto.Cosmos.SigningOutput
+import wallet.core.proto.Cosmos.*
 import wallet.core.jni.*
 
 class TestTHORChainSigner {
@@ -33,32 +32,32 @@ class TestTHORChainSigner {
         val publicKey = key.getPublicKeySecp256k1(true)
         val from = AnyAddress(publicKey, THORCHAIN).description()
 
-        val txAmount = Cosmos.Amount.newBuilder().apply {
+        val txAmount = Amount.newBuilder().apply {
             amount = 2000000
             denom = "rune"
         }.build()
 
-        val sendCoinsMsg = Cosmos.Message.Send.newBuilder().apply {
+        val sendCoinsMsg = Message.Send.newBuilder().apply {
             fromAddress = from
             toAddress = "thor1e2ryt8asq4gu0h6z2sx9u7rfrykgxwkmr9upxn"
             addAllAmounts(listOf(txAmount))
         }.build()
 
-        val message = Cosmos.Message.newBuilder().apply {
+        val message = Message.newBuilder().apply {
             sendCoinsMessage = sendCoinsMsg
         }.build()
 
-        val feeAmount = Cosmos.Amount.newBuilder().apply {
+        val feeAmount = Amount.newBuilder().apply {
             amount = 2000000
             denom = "rune"
         }.build()
 
-        val cosmosFee = Cosmos.Fee.newBuilder().apply {
+        val cosmosFee = Fee.newBuilder().apply {
             gas = 200000
             addAllAmounts(listOf(feeAmount))
         }.build()
 
-        val signingInput = Cosmos.SigningInput.newBuilder().apply {
+        val signingInput = SigningInput.newBuilder().apply {
             accountNumber = 593
             chainId = "thorchain"
             memo = ""

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/thorchain/TestTHORSwapSigning.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/thorchain/TestTHORSwapSigning.kt
@@ -8,8 +8,8 @@ import org.junit.Test
 import wallet.core.jni.PrivateKey
 import wallet.core.java.AnySigner
 import wallet.core.jni.CoinType.ETHEREUM
-import wallet.core.jni.proto.Ethereum.SigningOutput
-import wallet.core.jni.proto.THORChainSwap
+import wallet.core.proto.Ethereum.SigningOutput
+import wallet.core.proto.THORChainSwap.*
 import wallet.core.jni.THORChainSwap.buildSwap
 import com.trustwallet.core.app.utils.Numeric
 
@@ -22,12 +22,12 @@ class TestTHORChainSwap {
     @Test
     fun testSwapEthBnb() {
         // prepare swap input
-        val input = THORChainSwap.SwapInput.newBuilder()
+        val input = SwapInput.newBuilder()
         input.apply {
-            fromChain = THORChainSwap.Chain.ETH
+            fromChain = Chain.ETH
             fromAddress = "0xb9f5771c27664bf2282d98e09d7f50cec7cb01a7"
-            toAsset = THORChainSwap.Asset.newBuilder().apply {
-                chain = THORChainSwap.Chain.BNB
+            toAsset = Asset.newBuilder().apply {
+                chain = Chain.BNB
                 symbol = "BNB"
                 tokenId = ""
             }.build()
@@ -47,10 +47,10 @@ class TestTHORChainSwap {
         assertEquals(outputData.count(), 311)
 
         // parse result in proto
-        val outputProto = THORChainSwap.SwapOutput.newBuilder().mergeFrom(outputData)
-        assertEquals(outputProto.fromChain, THORChainSwap.Chain.ETH)
-        assertEquals(outputProto.toChain, THORChainSwap.Chain.BNB)
-        assertEquals(outputProto.error.code, THORChainSwap.ErrorCode.OK)
+        val outputProto = SwapOutput.newBuilder().mergeFrom(outputData)
+        assertEquals(outputProto.fromChain, Chain.ETH)
+        assertEquals(outputProto.toChain, Chain.BNB)
+        assertEquals(outputProto.error.code, ErrorCode.OK)
         assertTrue(outputProto.hasEthereum())
         val txInput = outputProto.ethereum
 

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/tron/TestTronTransactionSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/tron/TestTronTransactionSigner.kt
@@ -5,10 +5,8 @@ import com.trustwallet.core.app.utils.toHexByteArray
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.java.AnySigner
-import wallet.core.jni.proto.Tron
-import wallet.core.jni.proto.Tron.SigningOutput
+import wallet.core.proto.Tron.*
 import com.trustwallet.core.app.utils.Numeric
-import org.junit.Assert.assertArrayEquals
 import wallet.core.jni.CoinType.TRON
 
 class TestTronTransactionSigner {
@@ -19,14 +17,14 @@ class TestTronTransactionSigner {
 
     @Test
     fun testSignTransferTrc20Contract() {
-        val trc20Contract = Tron.TransferTRC20Contract.newBuilder()
+        val trc20Contract = TransferTRC20Contract.newBuilder()
             .setOwnerAddress("TJRyWwFs9wTFGZg3JbrVriFbNfCug5tDeC")
             .setContractAddress("THTR75o8xXAgCTQqpiot2AFRAjvW1tSbVV")
             .setToAddress("TW1dU4L3eNm7Lw8WvieLKEHpXWAussRG9Z")
             // 1000
             .setAmount(ByteString.copyFrom("0x00000000000000000000000000000000000000000000000000000000000003e8".toHexByteArray()))
 
-        val blockHeader = Tron.BlockHeader.newBuilder()
+        val blockHeader = BlockHeader.newBuilder()
             .setTimestamp(1539295479000)
             .setTxTrieRoot(ByteString.copyFrom("0x64288c2db0641316762a99dbb02ef7c90f968b60f9f2e410835980614332f86d".toHexByteArray()))
             .setParentHash(ByteString.copyFrom("0x00000000002f7b3af4f5f8b9e23a30c530f719f165b742e7358536b280eead2d".toHexByteArray()))
@@ -35,17 +33,17 @@ class TestTronTransactionSigner {
             .setVersion(3)
             .build()
 
-        val transaction = Tron.Transaction.newBuilder()
+        val transaction = Transaction.newBuilder()
             .setTransferTrc20Contract(trc20Contract)
             .setTimestamp(1539295479000)
             .setBlockHeader(blockHeader)
             .build()
 
-        val signingInput = Tron.SigningInput.newBuilder()
+        val signingInput = SigningInput.newBuilder()
             .setTransaction(transaction)
             .setPrivateKey(ByteString.copyFrom("2d8f68944bdbfbc0769542fba8fc2d2a3de67393334471624364c7006da2aa54".toHexByteArray()))
 
-        val output = AnySigner.sign(signingInput.build(), TRON, Tron.SigningOutput.parser())
+        val output = AnySigner.sign(signingInput.build(), TRON, SigningOutput.parser())
 
         assertEquals(Numeric.toHexString(output.id.toByteArray()), "0x0d644290e3cf554f6219c7747f5287589b6e7e30e1b02793b48ba362da6a5058")
         assertEquals(Numeric.toHexString(output.signature.toByteArray()), "0xbec790877b3a008640781e3948b070740b1f6023c29ecb3f7b5835433c13fc5835e5cad3bd44360ff2ddad5ed7dc9d7dee6878f90e86a40355b7697f5954b88c01")

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/waves/TestWavesSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/waves/TestWavesSigner.kt
@@ -7,8 +7,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.jni.CoinType.WAVES
 import wallet.core.java.AnySigner
-import wallet.core.jni.proto.Waves
-import wallet.core.jni.proto.Waves.SigningOutput
+import wallet.core.proto.Waves.*
 
 class TestWavesTransactionSigner {
 
@@ -18,8 +17,8 @@ class TestWavesTransactionSigner {
 
     @Test
     fun testWavesTransactionSigning() {
-        val signingInput = Waves.SigningInput.newBuilder()
-        val transferMsg = Waves.TransferMessage.newBuilder().apply {
+        val signingInput = SigningInput.newBuilder()
+        val transferMsg = TransferMessage.newBuilder().apply {
             amount = 100_000_000
             asset = "DacnEpaUVFRCYk8Fcd1F3cqUZuT4XG7qW9mRyoZD81zq"
             fee = 100_000

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.21'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +10,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.android.tools.build:gradle:7.0.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.4.21'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +10,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:4.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/android/trustwalletcore/build.gradle
+++ b/android/trustwalletcore/build.gradle
@@ -1,15 +1,14 @@
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 apply plugin: 'maven-publish'
 group='com.github.trustwallet'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     ndkVersion '21.2.6472646'
     defaultConfig {
         minSdkVersion 23
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
         externalNativeBuild {
             cmake {
                 arguments "-DCMAKE_BUILD_TYPE=Release"
@@ -48,7 +47,13 @@ android {
 }
 
 dependencies {
-    implementation 'io.grpc:grpc-protobuf:1.43.2'
+    implementation "io.grpc:grpc-protobuf:1.43.2"
+    implementation "com.google.protobuf:protobuf-kotlin:3.19.2"
+    implementation "androidx.core:core-ktx:1.6.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 apply from: 'maven-push.gradle'
+repositories {
+    mavenCentral()
+}

--- a/src/proto/Aeternity.proto
+++ b/src/proto/Aeternity.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Aeternity.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Aeternity";
+option java_multiple_files = true;
 
 // Input data necessary to create a signed transaction.
 message SigningInput {

--- a/src/proto/Aion.proto
+++ b/src/proto/Aion.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Aion.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Aion";
+option java_multiple_files = true;
 
 // Input data necessary to create a signed transaction.
 message SigningInput {

--- a/src/proto/Algorand.proto
+++ b/src/proto/Algorand.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Algorand.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Algorand";
+option java_multiple_files = true;
 
 message Transfer {
     string to_address = 1;

--- a/src/proto/Binance.proto
+++ b/src/proto/Binance.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Binance.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Binance";
+option java_multiple_files = true;
 
 message Transaction {
     // int64 SIZE-OF-ENCODED      // varint encoded length of the structure after encoding

--- a/src/proto/Bitcoin.proto
+++ b/src/proto/Bitcoin.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Bitcoin.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Bitcoin";
+option java_multiple_files = true;
 
 import "Common.proto";
 

--- a/src/proto/Common.proto
+++ b/src/proto/Common.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Common.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Common";
+option java_multiple_files = true;
 
 enum SigningError {
     OK = 0; // OK

--- a/src/proto/Cosmos.proto
+++ b/src/proto/Cosmos.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Cosmos.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Cosmos";
+option java_multiple_files = true;
 
 message Amount {
     string denom = 1;

--- a/src/proto/Decred.proto
+++ b/src/proto/Decred.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Decred.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Decred";
+option java_multiple_files = true;
 
 import "Bitcoin.proto";
 import "Common.proto";

--- a/src/proto/EOS.proto
+++ b/src/proto/EOS.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.EOS.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.EOS";
+option java_multiple_files = true;
 
 import "Common.proto";
 

--- a/src/proto/Elrond.proto
+++ b/src/proto/Elrond.proto
@@ -7,7 +7,8 @@
 syntax = "proto3";
 
 package TW.Elrond.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Elrond";
+option java_multiple_files = true;
 
 // A transaction, typical balance transfer
 message TransactionMessage {

--- a/src/proto/Ethereum.proto
+++ b/src/proto/Ethereum.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Ethereum.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Ethereum";
+option java_multiple_files = true;
 
 // Transaction (transfer, smart contract call, ...)
 message Transaction {

--- a/src/proto/FIO.proto
+++ b/src/proto/FIO.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.FIO.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.FIO";
+option java_multiple_files = true;
 
 import "Common.proto";
 

--- a/src/proto/Filecoin.proto
+++ b/src/proto/Filecoin.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Filecoin.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Filecoin";
+option java_multiple_files = true;
 
 // Input data necessary to create a signed transaction.
 message SigningInput {

--- a/src/proto/Harmony.proto
+++ b/src/proto/Harmony.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Harmony.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Harmony";
+option java_multiple_files = true;
 
 // Input data necessary to create a signed transaction.
 message SigningInput {

--- a/src/proto/Icon.proto
+++ b/src/proto/Icon.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Icon.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Icon";
+option java_multiple_files = true;
 
 // Input data necessary to create a signed transaction.
 message SigningInput {

--- a/src/proto/IoTeX.proto
+++ b/src/proto/IoTeX.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.IoTeX.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.IoTex";
+option java_multiple_files = true;
 
 message Transfer {
     string amount  = 1;

--- a/src/proto/NEAR.proto
+++ b/src/proto/NEAR.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.NEAR.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.NEAR";
+option java_multiple_files = true;
 
 message PublicKey {
     uint32 key_type = 1;

--- a/src/proto/NEO.proto
+++ b/src/proto/NEO.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.NEO.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.NEO";
+option java_multiple_files = true;
 
 import "Common.proto";
 

--- a/src/proto/NULS.proto
+++ b/src/proto/NULS.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.NULS.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.NULS";
+option java_multiple_files = true;
 
 message TransactionCoinFrom {
     string from_address = 1;

--- a/src/proto/Nano.proto
+++ b/src/proto/Nano.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Nano.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Nano";
+option java_multiple_files = true;
 
 // Input data necessary to create a signed transaction.
 message SigningInput {

--- a/src/proto/Nebulas.proto
+++ b/src/proto/Nebulas.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Nebulas.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Nebulas";
+option java_multiple_files = true;
 
 // Input data necessary to create a signed transaction.
 message SigningInput {

--- a/src/proto/Nimiq.proto
+++ b/src/proto/Nimiq.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Nimiq.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Nimiq";
+option java_multiple_files = true;
 
 // Input data necessary to create a signed transaction.
 message SigningInput {

--- a/src/proto/Oasis.proto
+++ b/src/proto/Oasis.proto
@@ -7,7 +7,8 @@
 syntax = "proto3";
 
 package TW.Oasis.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Oasis";
+option java_multiple_files = true;
 
 message TransferMessage {
     string to = 1;

--- a/src/proto/Ontology.proto
+++ b/src/proto/Ontology.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Ontology.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Ontology";
+option java_multiple_files = true;
 
 // Input data necessary to create a signed transaction.
 message SigningInput {

--- a/src/proto/Polkadot.proto
+++ b/src/proto/Polkadot.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Polkadot.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Polkadot";
+option java_multiple_files = true;
 
 enum Network {
     POLKADOT = 0;

--- a/src/proto/Ripple.proto
+++ b/src/proto/Ripple.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Ripple.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Ripple";
+option java_multiple_files = true;
 
 import "Common.proto";
 

--- a/src/proto/Solana.proto
+++ b/src/proto/Solana.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Solana.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Solana";
+option java_multiple_files = true;
 
 message Transfer {
     string recipient = 1;

--- a/src/proto/Stellar.proto
+++ b/src/proto/Stellar.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Stellar.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Stellar";
+option java_multiple_files = true;
 
 message Asset {
     // Optional in case of non-native asset; the asset issuer address

--- a/src/proto/THORChainSwap.proto
+++ b/src/proto/THORChainSwap.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.THORChainSwap.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.THORChainSwap";
+option java_multiple_files = true;
 
 import "Bitcoin.proto";
 import "Ethereum.proto";

--- a/src/proto/Tezos.proto
+++ b/src/proto/Tezos.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Tezos.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Tezos";
+option java_multiple_files = true;
 
 // Input data necessary to create a signed Tezos transaction.
 // Next field: 3

--- a/src/proto/Theta.proto
+++ b/src/proto/Theta.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Theta.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Theta";
+option java_multiple_files = true;
 
 /// Input data necessary to create a signed transaction
 message SigningInput {

--- a/src/proto/Tron.proto
+++ b/src/proto/Tron.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Tron.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Tron";
+option java_multiple_files = true;
 
 message TransferContract {
     // Sender address.

--- a/src/proto/VeChain.proto
+++ b/src/proto/VeChain.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.VeChain.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.VeChain";
+option java_multiple_files = true;
 
 message Clause {
     /// Recipient address.

--- a/src/proto/Waves.proto
+++ b/src/proto/Waves.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Waves.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Waves";
+option java_multiple_files = true;
 
 //Transfer transaction
 message TransferMessage {

--- a/src/proto/Zilliqa.proto
+++ b/src/proto/Zilliqa.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
 
 package TW.Zilliqa.Proto;
-option java_package = "wallet.core.jni.proto";
+option java_package = "wallet.core.proto.Zilliqa";
+option java_multiple_files = true;
 
 message Transaction {
     message Transfer {

--- a/tools/generate-files
+++ b/tools/generate-files
@@ -49,11 +49,12 @@ codegen/bin/coins
 # Generate interface code
 codegen/bin/codegen
 
-# Generate Java, C++ and Swift Protobuf files
+# Generate C++ / Java / Kotlin protobuf code
+"$PROTOC" -I=$PREFIX/include -I=src/proto --cpp_out=src/proto --java_out=jni/java --kotlin_out=jni/java src/proto/*.proto
+
+# Generate Swift code
 if [ -x "$(command -v protoc-gen-swift)" ]; then
-    "$PROTOC" -I=$PREFIX/include -I=src/proto --cpp_out=src/proto --java_out=jni/java --swift_out=swift/Sources/Generated/Protobuf --swift_opt=Visibility=Public src/proto/*.proto
-else
-    "$PROTOC" -I=$PREFIX/include -I=src/proto --cpp_out=src/proto --java_out=jni/java src/proto/*.proto
+    "$PROTOC" -I=$PREFIX/include -I=src/proto --swift_out=swift/Sources/Generated/Protobuf --swift_opt=Visibility=Public src/proto/*.proto
 fi
 
 # Generate internal message protocol Protobuf files
@@ -68,10 +69,10 @@ fi
 
 # Generate Xcode project
 if [ -x "$(command -v xcodegen)" ]; then
-    pushd swift
+    pushd swift > /dev/null
     xcodegen
     pod install
-    popd
+    popd > /dev/null
 else
     echo -e "\nWARNING: Skipped generating Xcode project because the xcodegen tool is not installed."
 fi


### PR DESCRIPTION
Trying to fix https://github.com/trustwallet/wallet-core/issues/1767, testing CI

Checked with Max, It's still early to use Kotlin protobuf models: 

1. Still need to generate Java code, more like syntactic sugar at the moment (see `TestAeternitySigner.kt` diff)
2. `uint32` in .proto files still defined as `Long` type, seems not very helpful
3. `java_multiple_files=false` is not supported
