### PR TITLE
PublicKey.recover(): handle Eip155-style signatures with v>35

### DIFF
--- a/src/PublicKey.cpp
+++ b/src/PublicKey.cpp
@@ -187,8 +187,9 @@ PublicKey PublicKey::recover(const Data& signature, const Data& message) {
         throw std::invalid_argument("signature too short");
     }
     auto v = signature[64];
+    // handle EIP155 Eth encoding of V, of the form 27+v, or 35+chainID*2+v
     if (v >= 27) {
-        v -= 27;
+        v = !(v & 0x01);
     }
     TW::Data result(65);
     if (ecdsa_recover_pub_from_sig(&secp256k1, result.data(), signature.data(), message.data(), v) != 0) {

--- a/tests/PublicKeyTests.cpp
+++ b/tests/PublicKeyTests.cpp
@@ -231,12 +231,36 @@ TEST(PublicKeyTests, VerifySchnorrWrongType) {
 }
 
 TEST(PublicKeyTests, Recover) {
-    const auto message = parse_hex("de4e9524586d6fce45667f9ff12f661e79870c4105fa0fb58af976619bb11432");
-    const auto signature = parse_hex("00000000000000000000000000000000000000000000000000000000000000020123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef80");
-    const auto publicKey = PublicKey::recover(signature, message);
-    EXPECT_EQ(publicKey.type, TWPublicKeyTypeSECP256k1Extended);
-    EXPECT_EQ(hex(publicKey.bytes), 
-        "0456d8089137b1fd0d890f8c7d4a04d0fd4520a30b19518ee87bd168ea12ed8090329274c4c6c0d9df04515776f2741eeffc30235d596065d718c3973e19711ad0");
+    {
+        const auto message = parse_hex("de4e9524586d6fce45667f9ff12f661e79870c4105fa0fb58af976619bb11432");
+        const auto signature = parse_hex("00000000000000000000000000000000000000000000000000000000000000020123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef80");
+        const auto publicKey = PublicKey::recover(signature, message);
+        EXPECT_EQ(publicKey.type, TWPublicKeyTypeSECP256k1Extended);
+        EXPECT_EQ(hex(publicKey.bytes),
+            "0456d8089137b1fd0d890f8c7d4a04d0fd4520a30b19518ee87bd168ea12ed8090329274c4c6c0d9df04515776f2741eeffc30235d596065d718c3973e19711ad0");
+    }
+
+    const auto privateKey = PrivateKey(parse_hex("4f96ed80e9a7555a6f74b3d658afdd9c756b0a40d4ca30c42c2039eb449bb904"));
+    const auto publicKey = privateKey.getPublicKey(TWPublicKeyTypeSECP256k1Extended);
+    EXPECT_EQ(hex(publicKey.bytes), "0463ade8ebc212b85e7e4278dc3dcb4f9cc18aab912ef5d302b5d1940e772e9e1a9213522efddad487bbd5dd7907e8e776f918e9a5e4cb51893724e9fe76792a4f");
+    {
+        const auto message = parse_hex("6468eb103d51c9a683b51818fdb73390151c9973831d2cfb4e9587ad54273155");
+        const auto signature = parse_hex("92c336138f7d0231fe9422bb30ee9ef10bf222761fe9e04442e3a11e88880c646487026011dae03dc281bc21c7d7ede5c2226d197befb813a4ecad686b559e5800");
+        const auto recovered = PublicKey::recover(signature, message);
+        EXPECT_EQ(hex(recovered.bytes), hex(publicKey.bytes));
+    }
+    { // same with v=27
+        const auto message = parse_hex("6468eb103d51c9a683b51818fdb73390151c9973831d2cfb4e9587ad54273155");
+        const auto signature = parse_hex("92c336138f7d0231fe9422bb30ee9ef10bf222761fe9e04442e3a11e88880c646487026011dae03dc281bc21c7d7ede5c2226d197befb813a4ecad686b559e581b");
+        const auto recovered = PublicKey::recover(signature, message);
+        EXPECT_EQ(hex(recovered.bytes), hex(publicKey.bytes));
+    }
+    { // same with v=35+2
+        const auto message = parse_hex("6468eb103d51c9a683b51818fdb73390151c9973831d2cfb4e9587ad54273155");
+        const auto signature = parse_hex("92c336138f7d0231fe9422bb30ee9ef10bf222761fe9e04442e3a11e88880c646487026011dae03dc281bc21c7d7ede5c2226d197befb813a4ecad686b559e5825");
+        const auto recovered = PublicKey::recover(signature, message);
+        EXPECT_EQ(hex(recovered.bytes), hex(publicKey.bytes));
+    }
 }
 
 TEST(PublicKeyTests, isValidED25519) {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

PublicKey.recover(): handle Eip155-style signatures with v>35 (chainId>0).
V values of 0&1 and 27&28 (Eth Eip155) were handled, but not v>35, of the form 35+chainId*2+v.
This is a minor improvement, triggered by #1898.

## Testing instructions

Unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
