### PR TITLE
[BTC] Taproot improvements

### DIFF
--- a/include/TrustWalletCore/TWSegwitAddress.h
+++ b/include/TrustWalletCore/TWSegwitAddress.h
@@ -31,7 +31,8 @@ bool TWSegwitAddressIsValidString(TWString *_Nonnull string);
 TW_EXPORT_STATIC_METHOD
 struct TWSegwitAddress *_Nullable TWSegwitAddressCreateWithString(TWString *_Nonnull string);
 
-/// Creates an address from a public key.
+/// Creates a segwit-version-0 address from a public key and HRP prefix.
+/// Taproot (v>=1) is not supported by this method.
 TW_EXPORT_STATIC_METHOD
 struct TWSegwitAddress *_Nonnull TWSegwitAddressCreateWithPublicKey(enum TWHRP hrp, struct TWPublicKey *_Nonnull publicKey);
 
@@ -45,6 +46,10 @@ TWString *_Nonnull TWSegwitAddressDescription(struct TWSegwitAddress *_Nonnull a
 /// Returns the human-readable part.
 TW_EXPORT_PROPERTY
 enum TWHRP TWSegwitAddressHRP(struct TWSegwitAddress *_Nonnull address);
+
+/// Returns the human-readable part.
+TW_EXPORT_PROPERTY
+int TWSegwitAddressWitnessVersion(struct TWSegwitAddress *_Nonnull address);
 
 /// Returns the witness program
 TW_EXPORT_PROPERTY

--- a/src/Bitcoin/Entry.cpp
+++ b/src/Bitcoin/Entry.cpp
@@ -62,7 +62,7 @@ string Entry::deriveAddress(TWCoinType coin, const PublicKey& publicKey, byte p2
         case TWCoinTypeLitecoin:
         case TWCoinTypeViacoin:
         case TWCoinTypeBitcoinGold:
-            return SegwitAddress(publicKey, 0, hrp).string();
+            return SegwitAddress(publicKey, hrp).string();
 
         case TWCoinTypeBitcoinCash:
             return CashAddress(publicKey).string();

--- a/src/Bitcoin/SegwitAddress.cpp
+++ b/src/Bitcoin/SegwitAddress.cpp
@@ -31,8 +31,8 @@ bool SegwitAddress::isValid(const std::string& string, const std::string& hrp) {
     return true;
 }
 
-SegwitAddress::SegwitAddress(const PublicKey& publicKey, int witver, std::string hrp)
-    : hrp(std::move(hrp)), witnessVersion(witver), witnessProgram() {
+SegwitAddress::SegwitAddress(const PublicKey& publicKey, std::string hrp)
+    : hrp(std::move(hrp)), witnessVersion(0), witnessProgram() {
     if (publicKey.type != TWPublicKeyTypeSECP256k1) {
         throw std::invalid_argument("SegwitAddress needs a compressed SECP256k1 public key.");
     }
@@ -73,10 +73,10 @@ std::tuple<SegwitAddress, std::string, bool> SegwitAddress::decode(const std::st
 
 std::string SegwitAddress::string() const {
     Data enc;
-    enc.push_back(static_cast<uint8_t>(witnessVersion));
+    enc.push_back(witnessVersion);
     Bech32::convertBits<8, 5, true>(enc, witnessProgram);
     Bech32::ChecksumVariant variant = Bech32::ChecksumVariant::Bech32;
-    if (witnessVersion== 0) {
+    if (witnessVersion == 0) {
         variant = Bech32::ChecksumVariant::Bech32;
     } else if (witnessVersion >= 1) {
         variant = Bech32::ChecksumVariant::Bech32M;

--- a/src/Bitcoin/SegwitAddress.h
+++ b/src/Bitcoin/SegwitAddress.h
@@ -26,7 +26,7 @@ class SegwitAddress {
     std::string hrp;
 
     /// Witness program version.
-    int witnessVersion;
+    byte witnessVersion;
 
     /// Witness program.
     Data witnessProgram;
@@ -40,11 +40,12 @@ class SegwitAddress {
 
     /// Initializes a Bech32 address with a human-readable part, a witness
     /// version, and a witness program.
-    SegwitAddress(std::string hrp, int witver, Data witprog)
+    SegwitAddress(std::string hrp, byte witver, Data witprog)
         : hrp(std::move(hrp)), witnessVersion(witver), witnessProgram(std::move(witprog)) {}
 
-    /// Initializes a Bech32 address with a public key and a HRP prefix.
-    SegwitAddress(const PublicKey& publicKey, int witver, std::string hrp);
+    /// Initializes a segwit-version-0 Bech32 address with a public key and a HRP prefix.
+    /// Taproot (v>=1) is not supported by this method.
+    SegwitAddress(const PublicKey& publicKey, std::string hrp);
 
     /// Decodes a SegWit address.
     ///

--- a/src/Groestlcoin/Entry.cpp
+++ b/src/Groestlcoin/Entry.cpp
@@ -19,7 +19,7 @@ bool Entry::validateAddress(TWCoinType coin, const string& address, TW::byte p2p
 }
 
 string Entry::deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const {
-    return TW::Bitcoin::SegwitAddress(publicKey, 0, hrp).string();
+    return TW::Bitcoin::SegwitAddress(publicKey, hrp).string();
 }
 
 void Entry::sign(TWCoinType coin, const TW::Data& dataIn, TW::Data& dataOut) const {

--- a/src/interface/TWSegwitAddress.cpp
+++ b/src/interface/TWSegwitAddress.cpp
@@ -35,7 +35,7 @@ struct TWSegwitAddress *_Nullable TWSegwitAddressCreateWithString(TWString *_Non
 }
 
 struct TWSegwitAddress *_Nonnull TWSegwitAddressCreateWithPublicKey(enum TWHRP hrp, struct TWPublicKey *_Nonnull publicKey) {
-    const auto address = SegwitAddress(publicKey->impl, 0, stringForHRP(hrp));
+    const auto address = SegwitAddress(publicKey->impl, stringForHRP(hrp));
     return new TWSegwitAddress{ std::move(address) };
 }
 
@@ -50,6 +50,10 @@ TWString *_Nonnull TWSegwitAddressDescription(struct TWSegwitAddress *_Nonnull a
 
 enum TWHRP TWSegwitAddressHRP(struct TWSegwitAddress *_Nonnull address) {
     return hrpForString(address->impl.hrp.c_str());
+}
+
+int TWSegwitAddressWitnessVersion(struct TWSegwitAddress *_Nonnull address) {
+    return address->impl.witnessVersion;
 }
 
 TWData *_Nonnull TWSegwitAddressWitnessProgram(struct TWSegwitAddress *_Nonnull address) {

--- a/tests/Bitcoin/TWBitcoinSigningTests.cpp
+++ b/tests/Bitcoin/TWBitcoinSigningTests.cpp
@@ -1571,7 +1571,7 @@ TEST(BitcoinSigning, SignP2TR_5df51e) {
     auto utxoKey0 = PrivateKey(parse_hex(privateKey));
     auto pubKey0 = utxoKey0.getPublicKey(TWPublicKeyTypeSECP256k1);
     EXPECT_EQ(hex(pubKey0.bytes), "021e582a887bd94d648a9267143eb600449a8d59a0db0653740b1378067a6d0cee");
-    EXPECT_EQ(SegwitAddress(pubKey0, 0, "bc").string(), ownAddress);
+    EXPECT_EQ(SegwitAddress(pubKey0, "bc").string(), ownAddress);
     auto utxoPubkeyHash = Hash::ripemd(Hash::sha256(pubKey0.bytes));
     EXPECT_EQ(hex(utxoPubkeyHash), "0cb9f5c6b62c03249367bc20a90dd2425e6926af");
     input.privateKeys.push_back(utxoKey0);
@@ -1692,7 +1692,7 @@ TEST(BitcoinSigning, Build_OpReturn_THORChainSwap_eb4c) {
 TEST(BitcoinSigning, Sign_OpReturn_THORChainSwap) {
     PrivateKey privateKey = PrivateKey(parse_hex("6bd4096fa6f08bd3af2b437244ba0ca2d35045c5233b8d6796df37e61e974de5"));
     PublicKey publicKey = privateKey.getPublicKey(TWPublicKeyTypeSECP256k1);
-    auto ownAddress = SegwitAddress(publicKey, 0, "bc");
+    auto ownAddress = SegwitAddress(publicKey, "bc");
     auto ownAddressString = ownAddress.string();
     EXPECT_EQ(ownAddressString, "bc1q2gzg42w98ytatvmsgxfc8vrg6l24c25pydup9u");
     auto toAddress = "bc1qxu5a8gtnjxw3xwdlmr2gl9d76h9fysu3zl656e";

--- a/tests/Bitcoin/TWSegwitAddressTests.cpp
+++ b/tests/Bitcoin/TWSegwitAddressTests.cpp
@@ -11,8 +11,9 @@
 
 #include <gtest/gtest.h>
 
-const char *address1 = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
-const char *address2 = "bc1qr583w2swedy2acd7rung055k8t3n7udp7vyzyg";
+const char* address1 = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+const char* address2 = "bc1qr583w2swedy2acd7rung055k8t3n7udp7vyzyg";
+const char* address3Taproot = "bc1ptmsk7c2yut2xah4pgflpygh2s7fh0cpfkrza9cjj29awapv53mrslgd5cf";
 
 TEST(TWSegwitAddress, PublicKeyToAddress) {
     auto pkData = DATA("0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798");
@@ -31,6 +32,23 @@ TEST(TWSegwitAddress, InitWithAddress) {
 
     ASSERT_TRUE(address.get() != nullptr);
     ASSERT_STREQ(address1, TWStringUTF8Bytes(description.get()));
+
+    ASSERT_EQ(0, TWSegwitAddressWitnessVersion(address.get()));
+
+    ASSERT_EQ(TWHRPBitcoin, TWSegwitAddressHRP(address.get()));
+}
+
+TEST(TWSegwitAddress, TaprootString) {
+    const auto string = STRING(address3Taproot);
+    const auto address = WRAP(TWSegwitAddress, TWSegwitAddressCreateWithString(string.get()));
+    ASSERT_TRUE(address.get() != nullptr);
+
+    const auto description = WRAPS(TWSegwitAddressDescription(address.get()));
+    ASSERT_STREQ(address3Taproot, TWStringUTF8Bytes(description.get()));
+
+    ASSERT_EQ(1, TWSegwitAddressWitnessVersion(address.get())); // taproot has segwit version 1
+
+    ASSERT_EQ(TWHRPBitcoin, TWSegwitAddressHRP(address.get()));
 }
 
 TEST(TWSegwitAddress, InvalidAddress) {

--- a/tests/BitcoinGold/TWSegwitAddressTests.cpp
+++ b/tests/BitcoinGold/TWSegwitAddressTests.cpp
@@ -34,7 +34,7 @@ TEST(TWBitcoinGoldSegwitAddress, PubkeyToAddress) {
     const auto publicKey = PublicKey(parse_hex("02f74712b5d765a73b52a14c1e113f2ef3f9502d09d5987ee40f53828cfe68b9a6"), TWPublicKeyTypeSECP256k1);
 
     /// construct with public key
-    auto address = Bitcoin::SegwitAddress(publicKey, 0, "btg");
+    auto address = Bitcoin::SegwitAddress(publicKey, "btg");
 
     ASSERT_TRUE(Bitcoin::SegwitAddress::isValid(address.string()));
     ASSERT_EQ(address.string(), "btg1qtesn92ddy8m5yvypgsdtft3zj5qldj9g2u52sk");

--- a/tests/HDWallet/HDWalletTests.cpp
+++ b/tests/HDWallet/HDWalletTests.cpp
@@ -216,7 +216,7 @@ TEST(HDWallet, privateKeyFromZprv) {
     const std::string zprv = "zprvAdzGEQ44z4WPLNCRpDaup2RumWxLGgR8PQ9UVsSmJigXsHVDaHK1b6qGM2u9PmxB2Gx264ctAz4yRoN3Xwf1HZmKcn6vmjqwsawF4WqQjfd";
     auto privateKey = HDWallet::getPrivateKeyFromExtended(zprv, TWCoinTypeBitcoinCash, DerivationPath(TWPurposeBIP44, TWCoinTypeSlip44Id(TWCoinTypeBitcoin), 0, 0, 5));
     auto publicKey = privateKey->getPublicKey(TWPublicKeyTypeSECP256k1);
-    auto address = Bitcoin::SegwitAddress(publicKey, 0, "bc");
+    auto address = Bitcoin::SegwitAddress(publicKey, "bc");
 
     EXPECT_EQ(hex(publicKey.bytes), "022dc3f5a3fcfd2d1cc76d0cb386eaad0e30247ba729da0d8847a2713e444fdafa");
     EXPECT_EQ(address.string(), "bc1q5yyq60jepll68hds7exa7kpj20gsvdu0aztw5x");

--- a/tests/THORChain/SwapTests.cpp
+++ b/tests/THORChain/SwapTests.cpp
@@ -62,7 +62,7 @@ TEST(THORChainSwap, SwapBtcEth) {
 
     // set few fields before signing
     tx.set_byte_fee(20);
-    EXPECT_EQ(Bitcoin::SegwitAddress(PrivateKey(TestKey1Btc).getPublicKey(TWPublicKeyTypeSECP256k1), 0, "bc").string(), Address1Btc);
+    EXPECT_EQ(Bitcoin::SegwitAddress(PrivateKey(TestKey1Btc).getPublicKey(TWPublicKeyTypeSECP256k1), "bc").string(), Address1Btc);
     tx.add_private_key(TestKey1Btc.data(), TestKey1Btc.size());
     auto& utxo = *tx.add_utxo();
     Data utxoHash = parse_hex("1234000000000000000000000000000000000000000000000000000000005678");
@@ -115,7 +115,7 @@ TEST(THORChainSwap, SwapBtcBnb) {
 
     // set few fields before signing
     tx.set_byte_fee(80);
-    EXPECT_EQ(Bitcoin::SegwitAddress(PrivateKey(TestKey1Btc).getPublicKey(TWPublicKeyTypeSECP256k1), 0, "bc").string(), Address1Btc);
+    EXPECT_EQ(Bitcoin::SegwitAddress(PrivateKey(TestKey1Btc).getPublicKey(TWPublicKeyTypeSECP256k1), "bc").string(), Address1Btc);
     tx.add_private_key(TestKey1Btc.data(), TestKey1Btc.size());
     auto& utxo = *tx.add_utxo();
     Data utxoHash = parse_hex("8eae5c3a4c75058d4e3facd5d72f18a40672bcd3d1f35ebf3094bd6c78da48eb");

--- a/tests/THORChain/TWSwapTests.cpp
+++ b/tests/THORChain/TWSwapTests.cpp
@@ -79,7 +79,7 @@ TEST(TWTHORChainSwap, SwapBtcToEth) {
     // sign tx input for signed full tx
     // set few fields before signing
     txInput.set_byte_fee(20);
-    EXPECT_EQ(Bitcoin::SegwitAddress(PrivateKey(TestKey1Btc).getPublicKey(TWPublicKeyTypeSECP256k1), 0, "bc").string(), Address1Btc);
+    EXPECT_EQ(Bitcoin::SegwitAddress(PrivateKey(TestKey1Btc).getPublicKey(TWPublicKeyTypeSECP256k1), "bc").string(), Address1Btc);
     txInput.add_private_key(TestKey1Btc.data(), TestKey1Btc.size());
     auto& utxo = *txInput.add_utxo();
     Data utxoHash = parse_hex("1234000000000000000000000000000000000000000000000000000000005678");


### PR DESCRIPTION
## Description

Minor improvements related to Bitcoin Taproot address handling:
- `SegwitAddress()` constructor with PrivateKey does no support Taproot address, so witness version input is removed, it is always 0.  Note: C-version (`TWSegwitAddressCreateWithPublicKey`) had no witver. Note: Schnorr keys are not yet implemented.
- SegwitAddress constructor comment expanded to mention v0 and no Taproot (both C++ and C version)
- Added C accessor for segwit version `TWSegwitAddressWitnessVersion`, this was missing
- Internal witnessVersion field type changed to `byte` (from `int`).

Triggered by #1904 .

## Testing instructions

Unit tests, `*Segwit*`

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
