### PR TITLE
cmake: specify clang as the compiler

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,7 +10,8 @@ echo "#### Generating files... ####"
 tools/generate-files
 
 echo "#### Building... ####"
-cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Debug
+cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
 make -Cbuild -j12 tests TrezorCryptoTests
 
 if [ -x "$(command -v clang-tidy)" ]; then


### PR DESCRIPTION
This makes the build work on a system with both gcc and clang installed (gcc being the default)

## Description

Specifically ask for clang as the compiler when building the project.

## Testing instructions

On ubuntu 21.10 with gcc being the default compiler and clang being available, run `./boostrap.sh` and check that it does not fail with the following error: `FATAL_ERROR "You should use clang compiler"`



## Types of changes

* Bug fix (non-breaking change which fixes an issue)

