### PR TITLE
Refactoring: prepare for supporting different CashAddress prefixes 

### DIFF
--- a/src/Bitcoin/CashAddress.cpp
+++ b/src/Bitcoin/CashAddress.cpp
@@ -33,13 +33,13 @@ bool CashAddress::isValid(const std::string& string) {
         withPrefix = cashHRP + ":" + string;
     }
 
-    std::array<char, maxHRPSize + 1> hrp = {0};
+    std::array<char, maxHRPSize + 1> decodedHRP = {0};
     std::array<uint8_t, maxDataSize> data;
     size_t dataLen;
-    if (cash_decode(hrp.data(), data.data(), &dataLen, withPrefix.c_str()) == 0 || dataLen != CashAddress::size) {
+    if (cash_decode(decodedHRP.data(), data.data(), &dataLen, withPrefix.c_str()) == 0 || dataLen != CashAddress::size) {
         return false;
     }
-    if (std::strncmp(hrp.data(), cashHRP.c_str(), std::min(cashHRP.size(), maxHRPSize)) != 0) {
+    if (std::strncmp(decodedHRP.data(), cashHRP.c_str(), std::min(cashHRP.size(), maxHRPSize)) != 0) {
         return false;
     }
     return true;
@@ -51,11 +51,11 @@ CashAddress::CashAddress(const std::string& string) {
         withPrefix = cashHRP + ":" + string;
     }
 
-    std::array<char, maxHRPSize + 1> hrp;
+    std::array<char, maxHRPSize + 1> decodedHRP;
     std::array<uint8_t, maxDataSize> data;
     size_t dataLen;
-    auto success = cash_decode(hrp.data(), data.data(), &dataLen, withPrefix.c_str()) != 0;
-    if (!success || std::strncmp(hrp.data(), cashHRP.c_str(), std::min(cashHRP.size(), maxHRPSize)) != 0 || dataLen != CashAddress::size) {
+    auto success = cash_decode(decodedHRP.data(), data.data(), &dataLen, withPrefix.c_str()) != 0;
+    if (!success || std::strncmp(decodedHRP.data(), cashHRP.c_str(), std::min(cashHRP.size(), maxHRPSize)) != 0 || dataLen != CashAddress::size) {
         throw std::invalid_argument("Invalid address string");
     }
     std::copy(data.begin(), data.begin() + dataLen, bytes.begin());

--- a/src/Bitcoin/CashAddress.cpp
+++ b/src/Bitcoin/CashAddress.cpp
@@ -24,6 +24,8 @@ static const uint8_t p2shVersion = 0x08;
 static constexpr size_t maxHRPSize = 20;
 static constexpr size_t maxDataSize = 104;
 
+const std::string BitcoinCashAddress::hrp = HRP_BITCOINCASH;
+
 bool CashAddress::isValid(const std::string& hrp, const std::string& string) {
     auto withPrefix = string;
     if (string.size() < hrp.size() || !std::equal(hrp.begin(), hrp.end(), string.begin())) {

--- a/src/Bitcoin/CashAddress.cpp
+++ b/src/Bitcoin/CashAddress.cpp
@@ -16,9 +16,6 @@
 
 using namespace TW::Bitcoin;
 
-/// Cash address human-readable part
-static const std::string cashHRP = "bitcoincash";
-
 /// From https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md
 
 static const uint8_t p2khVersion = 0x00;
@@ -27,10 +24,10 @@ static const uint8_t p2shVersion = 0x08;
 static constexpr size_t maxHRPSize = 20;
 static constexpr size_t maxDataSize = 104;
 
-bool CashAddress::isValid(const std::string& string) {
+bool CashAddress::isValid(const std::string& hrp, const std::string& string) {
     auto withPrefix = string;
-    if (string.size() < cashHRP.size() || !std::equal(cashHRP.begin(), cashHRP.end(), string.begin())) {
-        withPrefix = cashHRP + ":" + string;
+    if (string.size() < hrp.size() || !std::equal(hrp.begin(), hrp.end(), string.begin())) {
+        withPrefix = hrp + ":" + string;
     }
 
     std::array<char, maxHRPSize + 1> decodedHRP = {0};
@@ -39,36 +36,39 @@ bool CashAddress::isValid(const std::string& string) {
     if (cash_decode(decodedHRP.data(), data.data(), &dataLen, withPrefix.c_str()) == 0 || dataLen != CashAddress::size) {
         return false;
     }
-    if (std::strncmp(decodedHRP.data(), cashHRP.c_str(), std::min(cashHRP.size(), maxHRPSize)) != 0) {
+    if (std::strncmp(decodedHRP.data(), hrp.c_str(), std::min(hrp.size(), maxHRPSize)) != 0) {
         return false;
     }
     return true;
 }
 
-CashAddress::CashAddress(const std::string& string) {
+CashAddress::CashAddress(const std::string& hrp, const std::string& string)
+    : hrp(hrp) {
     auto withPrefix = string;
-    if (!std::equal(cashHRP.begin(), cashHRP.end(), string.begin())) {
-        withPrefix = cashHRP + ":" + string;
+    if (!std::equal(hrp.begin(), hrp.end(), string.begin())) {
+        withPrefix = hrp + ":" + string;
     }
 
     std::array<char, maxHRPSize + 1> decodedHRP;
     std::array<uint8_t, maxDataSize> data;
     size_t dataLen;
     auto success = cash_decode(decodedHRP.data(), data.data(), &dataLen, withPrefix.c_str()) != 0;
-    if (!success || std::strncmp(decodedHRP.data(), cashHRP.c_str(), std::min(cashHRP.size(), maxHRPSize)) != 0 || dataLen != CashAddress::size) {
+    if (!success || std::strncmp(decodedHRP.data(), hrp.c_str(), std::min(hrp.size(), maxHRPSize)) != 0 || dataLen != CashAddress::size) {
         throw std::invalid_argument("Invalid address string");
     }
     std::copy(data.begin(), data.begin() + dataLen, bytes.begin());
 }
 
-CashAddress::CashAddress(const Data& data) {
+CashAddress::CashAddress(const std::string& hrp, const Data& data)
+    : hrp(hrp) {
     if (!isValid(data)) {
         throw std::invalid_argument("Invalid address key data");
     }
     std::copy(data.begin(), data.end(), bytes.begin());
 }
 
-CashAddress::CashAddress(const PublicKey& publicKey) {
+CashAddress::CashAddress(const std::string& hrp, const PublicKey& publicKey)
+    : hrp(hrp) {
     if (publicKey.type != TWPublicKeyTypeSECP256k1) {
         throw std::invalid_argument("CashAddress needs a compressed SECP256k1 public key.");
     }
@@ -85,7 +85,7 @@ CashAddress::CashAddress(const PublicKey& publicKey) {
 
 std::string CashAddress::string() const {
     std::array<char, 129> result;
-    cash_encode(result.data(), cashHRP.c_str(), bytes.data(), CashAddress::size);
+    cash_encode(result.data(), hrp.c_str(), bytes.data(), CashAddress::size);
     return result.data();
 }
 

--- a/src/Bitcoin/CashAddress.h
+++ b/src/Bitcoin/CashAddress.h
@@ -24,6 +24,9 @@ class CashAddress {
     /// hash.
     std::array<byte, size> bytes;
 
+    /// Cash address human-readable part
+    const std::string hrp;
+
     /// Determines whether a collection of bytes makes a valid  address.
     template <typename T>
     static bool isValid(const T& data) {
@@ -31,16 +34,16 @@ class CashAddress {
     }
 
     /// Determines whether a string makes a valid  address.
-    static bool isValid(const std::string& string);
+    static bool isValid(const std::string& hrp, const std::string& string);
 
     /// Initializes a  address with a string representation.
-    explicit CashAddress(const std::string& string);
+    explicit CashAddress(const std::string& hrp, const std::string& string);
 
     /// Initializes a  address with a collection of bytes.
-    explicit CashAddress(const Data& data);
+    explicit CashAddress(const std::string& hrp, const Data& data);
 
     /// Initializes a  address with a public key.
-    explicit CashAddress(const PublicKey& publicKey);
+    explicit CashAddress(const std::string& hrp, const PublicKey& publicKey);
 
     /// Returns a string representation of the address.
     std::string string() const;
@@ -55,14 +58,21 @@ inline bool operator==(const CashAddress& lhs, const CashAddress& rhs) {
 
 class BitcoinCashAddress : public CashAddress {
   public:
-    /// Initializes a  address with a string representation.
-    explicit BitcoinCashAddress(const std::string& string) : CashAddress(string) {}
+    /// Initializes an address with a string representation.
+    explicit BitcoinCashAddress(const std::string& string)
+        : CashAddress("bitcoincash", string) {}
 
-    /// Initializes a  address with a collection of bytes.
-    explicit BitcoinCashAddress(const Data& data) : CashAddress(data) {}
+    /// Initializes an address with a collection of bytes.
+    explicit BitcoinCashAddress(const Data& data)
+        : CashAddress("bitcoincash", data) {}
 
-    /// Initializes a  address with a public key.
-    explicit BitcoinCashAddress(const PublicKey& publicKey) : CashAddress(publicKey) {}
+    /// Initializes an address with a public key.
+    explicit BitcoinCashAddress(const PublicKey& publicKey)
+        : CashAddress("bitcoincash", publicKey) {}
+
+    static bool isValid(const std::string& string) {
+        return CashAddress::isValid("bitcoincash", string);
+    }
 };
 
 } // namespace TW::Bitcoin

--- a/src/Bitcoin/CashAddress.h
+++ b/src/Bitcoin/CashAddress.h
@@ -53,4 +53,16 @@ inline bool operator==(const CashAddress& lhs, const CashAddress& rhs) {
     return lhs.bytes == rhs.bytes;
 }
 
+class BitcoinCashAddress : public CashAddress {
+  public:
+    /// Initializes a  address with a string representation.
+    explicit BitcoinCashAddress(const std::string& string) : CashAddress(string) {}
+
+    /// Initializes a  address with a collection of bytes.
+    explicit BitcoinCashAddress(const Data& data) : CashAddress(data) {}
+
+    /// Initializes a  address with a public key.
+    explicit BitcoinCashAddress(const PublicKey& publicKey) : CashAddress(publicKey) {}
+};
+
 } // namespace TW::Bitcoin

--- a/src/Bitcoin/CashAddress.h
+++ b/src/Bitcoin/CashAddress.h
@@ -58,20 +58,22 @@ inline bool operator==(const CashAddress& lhs, const CashAddress& rhs) {
 
 class BitcoinCashAddress : public CashAddress {
   public:
+    static const std::string hrp; // HRP_BITCOINCASH
+
     /// Initializes an address with a string representation.
     explicit BitcoinCashAddress(const std::string& string)
-        : CashAddress("bitcoincash", string) {}
+        : CashAddress(hrp, string) {}
 
     /// Initializes an address with a collection of bytes.
     explicit BitcoinCashAddress(const Data& data)
-        : CashAddress("bitcoincash", data) {}
+        : CashAddress(hrp, data) {}
 
     /// Initializes an address with a public key.
     explicit BitcoinCashAddress(const PublicKey& publicKey)
-        : CashAddress("bitcoincash", publicKey) {}
+        : CashAddress(hrp, publicKey) {}
 
     static bool isValid(const std::string& string) {
-        return CashAddress::isValid("bitcoincash", string);
+        return CashAddress::isValid(hrp, string);
     }
 };
 

--- a/src/Bitcoin/Entry.cpp
+++ b/src/Bitcoin/Entry.cpp
@@ -27,7 +27,7 @@ bool Entry::validateAddress(TWCoinType coin, const string& address, byte p2pkh, 
                 || Address::isValid(address, {{p2pkh}, {p2sh}});
 
         case TWCoinTypeBitcoinCash:
-            return CashAddress::isValid(address)
+            return BitcoinCashAddress::isValid(address)
                 || Address::isValid(address, {{p2pkh}, {p2sh}});
 
         case TWCoinTypeDash:
@@ -43,8 +43,8 @@ string Entry::normalizeAddress(TWCoinType coin, const string& address) const {
     switch (coin) {
         case TWCoinTypeBitcoinCash:
             // normalized with bitcoincash: prefix
-            if (CashAddress::isValid(address)) {
-                return CashAddress(address).string();
+            if (BitcoinCashAddress::isValid(address)) {
+                return BitcoinCashAddress(address).string();
             } else {
                 return std::string(address);
             }
@@ -65,7 +65,7 @@ string Entry::deriveAddress(TWCoinType coin, const PublicKey& publicKey, byte p2
             return SegwitAddress(publicKey, hrp).string();
 
         case TWCoinTypeBitcoinCash:
-            return CashAddress(publicKey).string();
+            return BitcoinCashAddress(publicKey).string();
 
         case TWCoinTypeDash:
         case TWCoinTypeDogecoin:

--- a/src/Bitcoin/Script.cpp
+++ b/src/Bitcoin/Script.cpp
@@ -310,8 +310,8 @@ Script Script::lockScriptForAddress(const std::string& string, enum TWCoinType c
         if (address.witnessVersion == 1 && address.witnessProgram.size() == 32) {
             return buildPayToV1WitnessProgram(address.witnessProgram);
         }
-    } else if (CashAddress::isValid(string)) {
-        auto address = CashAddress(string);
+    } else if (BitcoinCashAddress::isValid(string)) {
+        auto address = BitcoinCashAddress(string);
         auto bitcoinAddress = address.legacyAddress();
         return lockScriptForAddress(bitcoinAddress.string(), TWCoinTypeBitcoinCash);
     } else if (Decred::Address::isValid(string)) {

--- a/src/interface/TWAnyAddress.cpp
+++ b/src/interface/TWAnyAddress.cpp
@@ -108,7 +108,7 @@ TWData* _Nonnull TWAnyAddressData(struct TWAnyAddress* _Nonnull address) {
     }
 
     case TWCoinTypeBitcoinCash: {
-        auto addr = Bitcoin::CashAddress(string);
+        auto addr = Bitcoin::BitcoinCashAddress(string);
         data.resize(Bitcoin::Address::size);
         size_t outlen = 0;
         cash_data_to_addr(data.data(), &outlen, addr.bytes.data(), 34);

--- a/tests/BitcoinCash/TWBitcoinCashTests.cpp
+++ b/tests/BitcoinCash/TWBitcoinCashTests.cpp
@@ -27,6 +27,7 @@ using namespace TW::Bitcoin;
 
 TEST(BitcoinCash, Address) {
     EXPECT_TRUE(TWAnyAddressIsValid(STRING("pqx578nanz2h2estzmkr53zqdg6qt8xyqvwhn6qeyc").get(), TWCoinTypeBitcoinCash));
+    EXPECT_TRUE(TWAnyAddressIsValid(STRING("bitcoincash:pqx578nanz2h2estzmkr53zqdg6qt8xyqvwhn6qeyc").get(), TWCoinTypeBitcoinCash));
 }
 
 TEST(BitcoinCash, ValidAddress) {
@@ -36,6 +37,18 @@ TEST(BitcoinCash, ValidAddress) {
     
     auto script = WRAP(TWBitcoinScript, TWBitcoinScriptLockScriptForAddress(string.get(), TWCoinTypeBitcoinCash));
     ASSERT_FALSE(TWBitcoinScriptSize(script.get()) == 0);
+}
+
+TEST(BitcoinCash, InvalidAddress) {
+    // Wrong checksum
+    EXPECT_FALSE(TWAnyAddressIsValid(STRING("pqx578nanz2h2estzmkr53zqdg6qt8xyqvh683mrz0").get(), TWCoinTypeBitcoinCash));
+    EXPECT_FALSE(TWAnyAddressIsValid(STRING("bitcoincash:pqx578nanz2h2estzmkr53zqdg6qt8xyqvh683mrz0").get(), TWCoinTypeBitcoinCash));
+
+    // Wrong prefix
+    EXPECT_FALSE(TWAnyAddressIsValid(STRING("bcash:pqx578nanz2h2estzmkr53zqdg6qt8xyqvwhn6qeyc").get(), TWCoinTypeBitcoinCash));
+
+    // Wrong base 32 (characters o, i)
+    EXPECT_FALSE(TWAnyAddressIsValid(STRING("poi578nanz2h2estzmkr53zqdg6qt8xyqvwhn6qeyc").get(), TWCoinTypeBitcoinCash));
 }
 
 TEST(BitcoinCash, LegacyToCashAddr) {

--- a/tests/HDWallet/HDWalletTests.cpp
+++ b/tests/HDWallet/HDWalletTests.cpp
@@ -152,7 +152,7 @@ TEST(HDWallet, privateKeyFromXPRV) {
     auto privateKey = HDWallet::getPrivateKeyFromExtended(xprv, TWCoinTypeBitcoinCash, DerivationPath(TWPurposeBIP44, TWCoinTypeSlip44Id(TWCoinTypeBitcoinCash), 0, 0, 3));
     ASSERT_TRUE(privateKey);
     auto publicKey = privateKey->getPublicKey(TWPublicKeyTypeSECP256k1);
-    auto address = Bitcoin::CashAddress(publicKey);
+    auto address = Bitcoin::BitcoinCashAddress(publicKey);
 
     EXPECT_EQ(hex(publicKey.bytes), "025108168f7e5aad52f7381c18d8f880744dbee21dc02c15abe512da0b1cca7e2f");
     EXPECT_EQ(address.string(), "bitcoincash:qp3y0dyg6ya8nt4n3algazn073egswkytqs00z7rz4");


### PR DESCRIPTION
## Description
The current implementation of `CashAddress` has the `"bitcoincash:"` prefix hardcoded. This PR makes the code ready to support other CashAddress prefixes. This is a first necessary step for suppporting eCash.

This is achieved by refactoring the code in `cashaddresss.h/cpp`, to make `CashAddress` a base class capable of supporting different prefixes, and adding a subclass `BitcoinCashAddress` which is now used in the rest of the codebase where `CashAddress` was used before.

## Testing instructions

```
cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Debug \
    -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
make -Cbuild -j12 tests
build/tests/tests  tests

```

## Types of changes

* Refactoring without change of behavior
* Preparing for new feature (non-breaking change which adds functionality)

## Checklist

- [x] Add tests to cover changes as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
