### PR TITLE
[TestOnly] Extra HDWallet derivation tests

### DIFF
--- a/tests/HDWallet/HDWalletInternalTests.cpp
+++ b/tests/HDWallet/HDWalletInternalTests.cpp
@@ -23,13 +23,12 @@ const auto mnemonic1 = "ripple scissors kick mammal hire column oak again sun of
 
 std::string nodeToHexString(const HDNode& node) {
     std::string s;
-    s += hex(data(node.chain_code, 32));
-    s += "--";
-    s += hex(data(node.private_key, 32));
-    s += "--";
-    s += hex(data(node.private_key_extension, 32));
-    s += "--";
-    s += hex(data(node.public_key, 33));
+    s += std::to_string(node.depth);
+    s += "-" + std::to_string(node.child_num);
+    s += "--" + hex(data(node.chain_code, 32));
+    s += "--" + hex(data(node.private_key, 32));
+    s += "--" + hex(data(node.private_key_extension, 32));
+    s += "--" + hex(data(node.public_key, 33));
     return s;
 }
 
@@ -58,6 +57,7 @@ TEST(HDWalletInternal, SquareDerivationRoutes) {
     HDWallet wallet = HDWallet(mnemonic1, "");
     const auto derivationPath = DerivationPath("m/84'/0'/0'/1");
     const auto dpLastIndex = 2;
+    const auto ExpectedFinalPublicKey = "02e0b4765e9012bfbbfe8c714f99beb681acc0a92bdb5acbf2f362c0aff986ad49";
 
     // getMasterNode
     auto masterNode = HDNode();
@@ -68,17 +68,17 @@ TEST(HDWalletInternal, SquareDerivationRoutes) {
     for (auto& index : derivationPath.indices) {
         hdnode_private_ckd(&node0, index.derivationIndex());
     }
-    EXPECT_EQ(nodeToHexString(node0), "8423e869d887b6b0e7ca5f3bbed6e69234fb5d51aa02e9e8069fbffb2dc3c095--55f85b343359ec33aa3519a40673773d1f52677a044c7185529ce8f5fdb70625--0000000000000000000000000000000000000000000000000000000000000000--000000000000000000000000000000000000000000000000000000000000000000");
+    EXPECT_EQ(nodeToHexString(node0), "4-1--8423e869d887b6b0e7ca5f3bbed6e69234fb5d51aa02e9e8069fbffb2dc3c095--55f85b343359ec33aa3519a40673773d1f52677a044c7185529ce8f5fdb70625--0000000000000000000000000000000000000000000000000000000000000000--000000000000000000000000000000000000000000000000000000000000000000");
 
     {
         // Route 1 step 1: private node derivation
         auto node11 = node0;
         EXPECT_EQ(hdnode_private_ckd(&node11, dpLastIndex), 1);
-        EXPECT_EQ(nodeToHexString(node11), "53aaec7a112524bc3c8c91b278ccb0cf7e322077dac6a832563eb33149bb0051--512503395481ea0c26fe341bc342c29f4a706be003d12179ec6b65aa8a8c352d--0000000000000000000000000000000000000000000000000000000000000000--000000000000000000000000000000000000000000000000000000000000000000");
+        EXPECT_EQ(nodeToHexString(node11), "5-2--53aaec7a112524bc3c8c91b278ccb0cf7e322077dac6a832563eb33149bb0051--512503395481ea0c26fe341bc342c29f4a706be003d12179ec6b65aa8a8c352d--0000000000000000000000000000000000000000000000000000000000000000--000000000000000000000000000000000000000000000000000000000000000000");
 
         // Route 1 step 2: public key from private
         const auto publicKey = publicKeyFromPrivateKey(data(node11.private_key, 32));
-        EXPECT_EQ(hex(publicKey), "02e0b4765e9012bfbbfe8c714f99beb681acc0a92bdb5acbf2f362c0aff986ad49");
+        EXPECT_EQ(hex(publicKey), ExpectedFinalPublicKey);
     }
 
     {
@@ -86,14 +86,70 @@ TEST(HDWalletInternal, SquareDerivationRoutes) {
         auto node21 = node0;
         const auto pub21 = publicKeyFromPrivateKey(data(node21.private_key, 32));
         ::memcpy(node21.public_key, pub21.data(), 33);
-        EXPECT_EQ(nodeToHexString(node21), "8423e869d887b6b0e7ca5f3bbed6e69234fb5d51aa02e9e8069fbffb2dc3c095--55f85b343359ec33aa3519a40673773d1f52677a044c7185529ce8f5fdb70625--0000000000000000000000000000000000000000000000000000000000000000--026a940b5b683237037ecb230c402c5e351f38d41f00215e4d36006e9ff6b5cfba");
+        EXPECT_EQ(nodeToHexString(node21), "4-1--8423e869d887b6b0e7ca5f3bbed6e69234fb5d51aa02e9e8069fbffb2dc3c095--55f85b343359ec33aa3519a40673773d1f52677a044c7185529ce8f5fdb70625--0000000000000000000000000000000000000000000000000000000000000000--026a940b5b683237037ecb230c402c5e351f38d41f00215e4d36006e9ff6b5cfba");
 
         // Route 2 step 2: public node derivation
         auto node22 = node21;
         EXPECT_EQ(hdnode_public_ckd(&node22, dpLastIndex), 1);
-        EXPECT_EQ(nodeToHexString(node22), "53aaec7a112524bc3c8c91b278ccb0cf7e322077dac6a832563eb33149bb0051--0000000000000000000000000000000000000000000000000000000000000000--0000000000000000000000000000000000000000000000000000000000000000--02e0b4765e9012bfbbfe8c714f99beb681acc0a92bdb5acbf2f362c0aff986ad49");
+        EXPECT_EQ(nodeToHexString(node22), "5-2--53aaec7a112524bc3c8c91b278ccb0cf7e322077dac6a832563eb33149bb0051--0000000000000000000000000000000000000000000000000000000000000000--0000000000000000000000000000000000000000000000000000000000000000--02e0b4765e9012bfbbfe8c714f99beb681acc0a92bdb5acbf2f362c0aff986ad49");
         const auto publicKey = PublicKey(data(node22.public_key, 33), TWPublicKeyTypeSECP256k1);
-        EXPECT_EQ(hex(publicKey.bytes), "02e0b4765e9012bfbbfe8c714f99beb681acc0a92bdb5acbf2f362c0aff986ad49");
+        EXPECT_EQ(hex(publicKey.bytes), ExpectedFinalPublicKey);
+    }
+}
+
+TEST(HDWalletInternal, PrivateAndPublicCkdDerivation) {
+    /*
+
+        PrivateKey1  ---->  PrivateKey2
+
+             |                   |
+             v                   v
+
+         PublicKey1  ---->   PublicKey2
+
+    */
+
+    const auto PrivateKey1 = "55f85b343359ec33aa3519a40673773d1f52677a044c7185529ce8f5fdb70625";
+    const auto PrivateKey2 = "512503395481ea0c26fe341bc342c29f4a706be003d12179ec6b65aa8a8c352d";
+    const auto PublicKey1 = "026a940b5b683237037ecb230c402c5e351f38d41f00215e4d36006e9ff6b5cfba";
+    const auto PublicKey2 = "02e0b4765e9012bfbbfe8c714f99beb681acc0a92bdb5acbf2f362c0aff986ad49";
+    const auto ChainCode0 = "8423e869d887b6b0e7ca5f3bbed6e69234fb5d51aa02e9e8069fbffb2dc3c095";
+    const auto dpIndex = 2;
+    const auto curve = get_curve_by_name(SECP256K1_NAME);
+
+    {   // PrivateKey1 -> PublicKey1
+        EXPECT_EQ(hex(publicKeyFromPrivateKey(parse_hex(PrivateKey1))), PublicKey1);
+    }
+    {   // PrivateKey2 -> PublicKey2
+        EXPECT_EQ(hex(publicKeyFromPrivateKey(parse_hex(PrivateKey2))), PublicKey2);
+    }
+    {   // PrivateKey1 -> PrivateKey2
+        auto node = HDNode();
+        node.depth = 4;
+        node.child_num = 1;
+        node.curve = curve;
+        ::memcpy(node.chain_code, parse_hex(ChainCode0).data(), 32);
+        ::memcpy(node.private_key, parse_hex(PrivateKey1).data(), 32);
+        EXPECT_EQ(nodeToHexString(node), "4-1--8423e869d887b6b0e7ca5f3bbed6e69234fb5d51aa02e9e8069fbffb2dc3c095--55f85b343359ec33aa3519a40673773d1f52677a044c7185529ce8f5fdb70625--0000000000000000000000000000000000000000000000000000000000000000--000000000000000000000000000000000000000000000000000000000000000000");
+
+        EXPECT_EQ(hdnode_private_ckd(&node, dpIndex), 1);
+
+        EXPECT_EQ(nodeToHexString(node), "5-2--53aaec7a112524bc3c8c91b278ccb0cf7e322077dac6a832563eb33149bb0051--512503395481ea0c26fe341bc342c29f4a706be003d12179ec6b65aa8a8c352d--0000000000000000000000000000000000000000000000000000000000000000--000000000000000000000000000000000000000000000000000000000000000000");
+        EXPECT_EQ(hex(data(node.private_key, 32)), PrivateKey2);
+    }
+    {   // PublicKey1 -> PublicKey2
+        auto node = HDNode();
+        node.depth = 4;
+        node.child_num = 1;
+        node.curve = curve;
+        ::memcpy(node.chain_code, parse_hex(ChainCode0).data(), 32);
+        ::memcpy(node.public_key, parse_hex(PublicKey1).data(), 33);
+        EXPECT_EQ(nodeToHexString(node), "4-1--8423e869d887b6b0e7ca5f3bbed6e69234fb5d51aa02e9e8069fbffb2dc3c095--0000000000000000000000000000000000000000000000000000000000000000--0000000000000000000000000000000000000000000000000000000000000000--026a940b5b683237037ecb230c402c5e351f38d41f00215e4d36006e9ff6b5cfba");
+
+        EXPECT_EQ(hdnode_public_ckd(&node, dpIndex), 1);
+
+        EXPECT_EQ(nodeToHexString(node), "5-2--53aaec7a112524bc3c8c91b278ccb0cf7e322077dac6a832563eb33149bb0051--0000000000000000000000000000000000000000000000000000000000000000--0000000000000000000000000000000000000000000000000000000000000000--02e0b4765e9012bfbbfe8c714f99beb681acc0a92bdb5acbf2f362c0aff986ad49");
+        EXPECT_EQ(hex(data(node.public_key, 33)), PublicKey2);
     }
 }
 

--- a/tests/HDWallet/HDWalletInternalTests.cpp
+++ b/tests/HDWallet/HDWalletInternalTests.cpp
@@ -1,0 +1,100 @@
+// Copyright © 2017-2022 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "HDWallet.h"
+#include "Data.h"
+#include "HexCoding.h"
+#include "PrivateKey.h"
+#include "PublicKey.h"
+#include <TrezorCrypto/bip32.h>
+#include <TrezorCrypto/curves.h>
+#include "../interface/TWTestUtilities.h"
+
+#include <gtest/gtest.h>
+#include <stdlib.h>
+#include <string>
+
+namespace TW {
+
+const auto mnemonic1 = "ripple scissors kick mammal hire column oak again sun offer wealth tomorrow wagon turn fatal";
+
+std::string nodeToHexString(const HDNode& node) {
+    std::string s;
+    s += hex(data(node.chain_code, 32));
+    s += "--";
+    s += hex(data(node.private_key, 32));
+    s += "--";
+    s += hex(data(node.private_key_extension, 32));
+    s += "--";
+    s += hex(data(node.public_key, 33));
+    return s;
+}
+
+Data publicKeyFromPrivateKey(const Data& privateKey) {
+    return PrivateKey(privateKey).getPublicKey(TWPublicKeyTypeSECP256k1).bytes;
+}
+
+TEST(HDWalletInternal, SquareDerivationRoutes) {
+    /*
+       Test 'square' derivation routes, result should be the same.
+       Performing private derivation, then taking the public key yields the same as
+       taking the public key first, and performing public derivation.
+       This makes XPUB schemes possible.
+
+         priv_node  --priv_deriv.-->  priv_child_node
+
+             |                              |
+          get_pub                        get_pub
+             |                              |
+             v                              v
+
+          pub_node   ---pub_deriv.--->   pub_key
+
+    */
+
+    HDWallet wallet = HDWallet(mnemonic1, "");
+    const auto derivationPath = DerivationPath("m/84'/0'/0'/1");
+    const auto dpLastIndex = 2;
+
+    // getMasterNode
+    auto masterNode = HDNode();
+    hdnode_from_seed(wallet.getSeed().data(), HDWallet::seedSize, SECP256K1_NAME, &masterNode);
+
+    auto node0 = masterNode;
+    // getNode
+    for (auto& index : derivationPath.indices) {
+        hdnode_private_ckd(&node0, index.derivationIndex());
+    }
+    EXPECT_EQ(nodeToHexString(node0), "8423e869d887b6b0e7ca5f3bbed6e69234fb5d51aa02e9e8069fbffb2dc3c095--55f85b343359ec33aa3519a40673773d1f52677a044c7185529ce8f5fdb70625--0000000000000000000000000000000000000000000000000000000000000000--000000000000000000000000000000000000000000000000000000000000000000");
+
+    {
+        // Route 1 step 1: private node derivation
+        auto node11 = node0;
+        EXPECT_EQ(hdnode_private_ckd(&node11, dpLastIndex), 1);
+        EXPECT_EQ(nodeToHexString(node11), "53aaec7a112524bc3c8c91b278ccb0cf7e322077dac6a832563eb33149bb0051--512503395481ea0c26fe341bc342c29f4a706be003d12179ec6b65aa8a8c352d--0000000000000000000000000000000000000000000000000000000000000000--000000000000000000000000000000000000000000000000000000000000000000");
+
+        // Route 1 step 2: public key from private
+        const auto publicKey = publicKeyFromPrivateKey(data(node11.private_key, 32));
+        EXPECT_EQ(hex(publicKey), "02e0b4765e9012bfbbfe8c714f99beb681acc0a92bdb5acbf2f362c0aff986ad49");
+    }
+
+    {
+        // Route 2 step 1: public node from private (extended public key)
+        auto node21 = node0;
+        const auto pub21 = publicKeyFromPrivateKey(data(node21.private_key, 32));
+        ::memcpy(node21.public_key, pub21.data(), 33);
+        EXPECT_EQ(nodeToHexString(node21), "8423e869d887b6b0e7ca5f3bbed6e69234fb5d51aa02e9e8069fbffb2dc3c095--55f85b343359ec33aa3519a40673773d1f52677a044c7185529ce8f5fdb70625--0000000000000000000000000000000000000000000000000000000000000000--026a940b5b683237037ecb230c402c5e351f38d41f00215e4d36006e9ff6b5cfba");
+
+        // Route 2 step 2: public node derivation
+        auto node22 = node21;
+        EXPECT_EQ(hdnode_public_ckd(&node22, dpLastIndex), 1);
+        EXPECT_EQ(nodeToHexString(node22), "53aaec7a112524bc3c8c91b278ccb0cf7e322077dac6a832563eb33149bb0051--0000000000000000000000000000000000000000000000000000000000000000--0000000000000000000000000000000000000000000000000000000000000000--02e0b4765e9012bfbbfe8c714f99beb681acc0a92bdb5acbf2f362c0aff986ad49");
+        const auto publicKey = PublicKey(data(node22.public_key, 33), TWPublicKeyTypeSECP256k1);
+        EXPECT_EQ(hex(publicKey.bytes), "02e0b4765e9012bfbbfe8c714f99beb681acc0a92bdb5acbf2f362c0aff986ad49");
+    }
+}
+
+} // namespace

--- a/tests/HDWallet/HDWalletTests.cpp
+++ b/tests/HDWallet/HDWalletTests.cpp
@@ -286,4 +286,76 @@ TEST(HDWallet, Bip39Vectors) {
     }
 }
 
+TEST(HDWallet, Derive_XpubPub_vs_PrivPub) {
+    // Test 3 routes for deriving address from mnemonic, result should be the same:
+    // - Direct: mnemonic -> seed -> privateKey -> publicKey -> address
+    // - Extended Public: mnemonic -> seed -> zpub -> publicKey -> address
+    // - Extended Private: mnemonic -> seed -> zpriv -> privateKey -> publicKey -> address
+
+    HDWallet wallet = HDWallet(mnemonic1, "");
+    const auto coin = TWCoinTypeBitcoin;
+    const auto derivPath1 = DerivationPath("m/84'/0'/0'/0/0");
+    const auto derivPath2 = DerivationPath("m/84'/0'/0'/0/2");
+    const auto expectedPublicKey1 = "02df9ef2a7a5552765178b181e1e1afdefc7849985c7dfe9647706dd4fa40df6ac";
+    const auto expectedPublicKey2 = "031e1f64d2f6768dccb6814545b2e2d58e26ad5f91b7cbaffe881ed572c65060db";
+    const auto expectedAddress1 = "bc1qpsp72plnsqe6e2dvtsetxtww2cz36ztmfxghpd";
+    const auto expectedAddress2 = "bc1q7zddsunzaftf4zlsg9exhzlkvc5374a6v32jf6";
+
+    // -> privateKey -> publicKey
+    {
+        const auto privateKey1 = wallet.getKey(coin, derivPath1);
+        const auto publicKey1 = privateKey1.getPublicKey(TWPublicKeyTypeSECP256k1);
+        EXPECT_EQ(hex(publicKey1.bytes), expectedPublicKey1);
+        const auto address1 = Bitcoin::SegwitAddress(publicKey1, "bc");
+        EXPECT_EQ(address1.string(), expectedAddress1);
+    }
+    {
+        const auto privateKey2 = wallet.getKey(coin, derivPath2);
+        const auto publicKey2 = privateKey2.getPublicKey(TWPublicKeyTypeSECP256k1);
+        EXPECT_EQ(hex(publicKey2.bytes), expectedPublicKey2);
+        const auto address2 = Bitcoin::SegwitAddress(publicKey2, "bc");
+        EXPECT_EQ(address2.string(), expectedAddress2);
+    }
+
+    // zpub -> publicKey
+    const auto zpub = wallet.getExtendedPublicKey(TWPurposeBIP84, coin, TWHDVersionZPUB);
+    EXPECT_EQ(zpub, "zpub6rNUNtxSa9Gxvm4Bdxf1MPMwrvkzwDx6vP96Hkzw3jiQKdg3fhXBStxjn12YixQB8h88B3RMSRscRstf9AEVaYr3MAqVBEWBDuEJU4PGaT9");
+
+    {
+        const auto publicKey1 = wallet.getPublicKeyFromExtended(zpub, coin, derivPath1);
+        EXPECT_TRUE(publicKey1.has_value());
+        EXPECT_EQ(hex(publicKey1->bytes), expectedPublicKey1);
+        const auto address1 = Bitcoin::SegwitAddress(publicKey1.value(), "bc");
+        EXPECT_EQ(address1.string(), expectedAddress1);
+    }
+    {
+        const auto publicKey2 = wallet.getPublicKeyFromExtended(zpub, coin, derivPath2);
+        EXPECT_TRUE(publicKey2.has_value());
+        EXPECT_EQ(hex(publicKey2->bytes), expectedPublicKey2);
+        const auto address2 = Bitcoin::SegwitAddress(publicKey2.value(), "bc");
+        EXPECT_EQ(address2.string(), expectedAddress2);
+    }
+
+    // zpriv -> privateKey -> publicKey
+    const auto zpriv = wallet.getExtendedPrivateKey(TWPurposeBIP84, coin, TWHDVersionZPRV);
+    EXPECT_EQ(zpriv, "zprvAdP7yPRYjmifiGyiXw7zzFRDJtvWXmEFZADVVNbKVQBRSqLu8ACvu6eFvhrnnw4QwdTD8PUVa48MguwiPTiyfn85zWx9iA5MYy4Eufu5bas");
+
+    {
+        const auto privateKey1 = wallet.getPrivateKeyFromExtended(zpriv, coin, derivPath1);
+        EXPECT_TRUE(privateKey1.has_value());
+        const auto publicKey1 = privateKey1->getPublicKey(TWPublicKeyTypeSECP256k1);
+        EXPECT_EQ(hex(publicKey1.bytes), expectedPublicKey1);
+        const auto address1 = Bitcoin::SegwitAddress(publicKey1, "bc");
+        EXPECT_EQ(address1.string(), expectedAddress1);
+    }
+    {
+        const auto privateKey2 = wallet.getPrivateKeyFromExtended(zpriv, coin, derivPath2);
+        EXPECT_TRUE(privateKey2.has_value());
+        const auto publicKey2 = privateKey2->getPublicKey(TWPublicKeyTypeSECP256k1);
+        EXPECT_EQ(hex(publicKey2.bytes), expectedPublicKey2);
+        const auto address2 = Bitcoin::SegwitAddress(publicKey2, "bc");
+        EXPECT_EQ(address2.string(), expectedAddress2);
+    }
+}
+
 } // namespace

--- a/tests/HDWallet/HDWalletTests.cpp
+++ b/tests/HDWallet/HDWalletTests.cpp
@@ -292,7 +292,7 @@ TEST(HDWallet, Derive_XpubPub_vs_PrivPub) {
     // - Extended Public: mnemonic -> seed -> zpub -> publicKey -> address
     // - Extended Private: mnemonic -> seed -> zpriv -> privateKey -> publicKey -> address
 
-    HDWallet wallet = HDWallet(mnemonic1, "");
+    const HDWallet wallet = HDWallet(mnemonic1, "");
     const auto coin = TWCoinTypeBitcoin;
     const auto derivPath1 = DerivationPath("m/84'/0'/0'/0/0");
     const auto derivPath2 = DerivationPath("m/84'/0'/0'/0/2");

--- a/tests/HDWallet/HDWalletTests.cpp
+++ b/tests/HDWallet/HDWalletTests.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2017-2021 Trust Wallet.
+// Copyright © 2017-2022 Trust Wallet.
 //
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
@@ -287,7 +287,7 @@ TEST(HDWallet, Bip39Vectors) {
 }
 
 TEST(HDWallet, Derive_XpubPub_vs_PrivPub) {
-    // Test 3 routes for deriving address from mnemonic, result should be the same:
+    // Test different routes for deriving address from mnemonic, result should be the same:
     // - Direct: mnemonic -> seed -> privateKey -> publicKey -> address
     // - Extended Public: mnemonic -> seed -> zpub -> publicKey -> address
     // - Extended Private: mnemonic -> seed -> zpriv -> privateKey -> publicKey -> address


### PR DESCRIPTION
## Description

Add extra derivation checks to HDWallet, demonstrating how a sequence of public keys can be derived from a single XPub, giving the same result as deriving a sequence of private keys (and obtaining public keys).

## Testing instructions

Unit tests 'HDWallet'.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Extra Test only

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
