### PR TITLE
GetExtendedKey with custom account

### DIFF
--- a/include/TrustWalletCore/TWHDWallet.h
+++ b/include/TrustWalletCore/TWHDWallet.h
@@ -81,13 +81,21 @@ struct TWPrivateKey *_Nonnull TWHDWalletGetKey(struct TWHDWallet *_Nonnull walle
 TW_EXPORT_METHOD
 struct TWPrivateKey *_Nonnull TWHDWalletGetDerivedKey(struct TWHDWallet *_Nonnull wallet, enum TWCoinType coin, uint32_t account, uint32_t change, uint32_t address);
 
-/// Returns the extended private key.
+/// Returns the extended private key (for default 0 account).  Returned object needs to be deleted.
 TW_EXPORT_METHOD
 TWString *_Nonnull TWHDWalletGetExtendedPrivateKey(struct TWHDWallet *_Nonnull wallet, enum TWPurpose purpose, enum TWCoinType coin, enum TWHDVersion version);
 
-/// Returns the exteded public key.  Returned object needs to be deleted.
+/// Returns the exteded public key (for default 0 account).  Returned object needs to be deleted.
 TW_EXPORT_METHOD
 TWString *_Nonnull TWHDWalletGetExtendedPublicKey(struct TWHDWallet *_Nonnull wallet, enum TWPurpose purpose, enum TWCoinType coin, enum TWHDVersion version);
+
+/// Returns the extended private key, for custom account.  Returned object needs to be deleted.
+TW_EXPORT_METHOD
+TWString *_Nonnull TWHDWalletGetExtendedPrivateKeyAccount(struct TWHDWallet *_Nonnull wallet, enum TWPurpose purpose, enum TWCoinType coin, enum TWHDVersion version, uint32_t account);
+
+/// Returns the exteded public key, for custom account.  Returned object needs to be deleted.
+TW_EXPORT_METHOD
+TWString *_Nonnull TWHDWalletGetExtendedPublicKeyAccount(struct TWHDWallet *_Nonnull wallet, enum TWPurpose purpose, enum TWCoinType coin, enum TWHDVersion version, uint32_t account);
 
 /// Computes the public key from an exteded public key representation.  Returned object needs to be deleted.
 TW_EXPORT_STATIC_METHOD

--- a/src/HDWallet.cpp
+++ b/src/HDWallet.cpp
@@ -137,7 +137,7 @@ std::string HDWallet::deriveAddress(TWCoinType coin) const {
     return TW::deriveAddress(coin, getKey(coin, derivationPath));
 }
 
-std::string HDWallet::getExtendedPrivateKey(TWPurpose purpose, TWCoinType coin, TWHDVersion version) const {
+std::string HDWallet::getExtendedPrivateKey(TWPurpose purpose, TWCoinType coin, TWHDVersion version, uint32_t account) const {
     if (version == TWHDVersionNone) {
         return "";
     }
@@ -146,11 +146,11 @@ std::string HDWallet::getExtendedPrivateKey(TWPurpose purpose, TWCoinType coin, 
     auto derivationPath = TW::DerivationPath({DerivationPathIndex(purpose, true), DerivationPathIndex(coin, true)});
     auto node = getNode(*this, curve, derivationPath);
     auto fingerprintValue = fingerprint(&node, publicKeyHasher(coin));
-    hdnode_private_ckd(&node, 0x80000000);
+    hdnode_private_ckd(&node, account + 0x80000000);
     return serialize(&node, fingerprintValue, version, false, base58Hasher(coin));
 }
 
-std::string HDWallet::getExtendedPublicKey(TWPurpose purpose, TWCoinType coin, TWHDVersion version) const {
+std::string HDWallet::getExtendedPublicKey(TWPurpose purpose, TWCoinType coin, TWHDVersion version, uint32_t account) const {
     if (version == TWHDVersionNone) {
         return "";
     }
@@ -159,7 +159,7 @@ std::string HDWallet::getExtendedPublicKey(TWPurpose purpose, TWCoinType coin, T
     auto derivationPath = TW::DerivationPath({DerivationPathIndex(purpose, true), DerivationPathIndex(coin, true)});
     auto node = getNode(*this, curve, derivationPath);
     auto fingerprintValue = fingerprint(&node, publicKeyHasher(coin));
-    hdnode_private_ckd(&node, 0x80000000);
+    hdnode_private_ckd(&node, account + 0x80000000);
     hdnode_fill_public_key(&node);
     return serialize(&node, fingerprintValue, version, true, base58Hasher(coin));
 }

--- a/src/HDWallet.cpp
+++ b/src/HDWallet.cpp
@@ -137,7 +137,7 @@ std::string HDWallet::deriveAddress(TWCoinType coin) const {
     return TW::deriveAddress(coin, getKey(coin, derivationPath));
 }
 
-std::string HDWallet::getExtendedPrivateKey(TWPurpose purpose, TWCoinType coin, TWHDVersion version, uint32_t account) const {
+std::string HDWallet::getExtendedPrivateKeyAccount(TWPurpose purpose, TWCoinType coin, TWHDVersion version, uint32_t account) const {
     if (version == TWHDVersionNone) {
         return "";
     }
@@ -150,7 +150,7 @@ std::string HDWallet::getExtendedPrivateKey(TWPurpose purpose, TWCoinType coin, 
     return serialize(&node, fingerprintValue, version, false, base58Hasher(coin));
 }
 
-std::string HDWallet::getExtendedPublicKey(TWPurpose purpose, TWCoinType coin, TWHDVersion version, uint32_t account) const {
+std::string HDWallet::getExtendedPublicKeyAccount(TWPurpose purpose, TWCoinType coin, TWHDVersion version, uint32_t account) const {
     if (version == TWHDVersionNone) {
         return "";
     }

--- a/src/HDWallet.h
+++ b/src/HDWallet.h
@@ -80,11 +80,11 @@ class HDWallet {
     /// Derives the address for a coin.
     std::string deriveAddress(TWCoinType coin) const;
 
-    /// Returns the extended private key.
-    std::string getExtendedPrivateKey(TWPurpose purpose, TWCoinType coin, TWHDVersion version) const;
+    /// Returns the extended private key, derivation path used is "m/purpose'/coin'/account'".
+    std::string getExtendedPrivateKey(TWPurpose purpose, TWCoinType coin, TWHDVersion version, uint32_t account = 0) const;
 
-    /// Returns the extended public key.
-    std::string getExtendedPublicKey(TWPurpose purpose, TWCoinType coin, TWHDVersion version) const;
+    /// Returns the extended public key, derivation path used is "m/purpose'/coin'/account'".
+    std::string getExtendedPublicKey(TWPurpose purpose, TWCoinType coin, TWHDVersion version, uint32_t account = 0) const;
 
     /// Returns the BIP32 Root Key (private)
     std::string getRootKey(TWCoinType coin, TWHDVersion version) const;

--- a/src/HDWallet.h
+++ b/src/HDWallet.h
@@ -80,11 +80,17 @@ class HDWallet {
     /// Derives the address for a coin.
     std::string deriveAddress(TWCoinType coin) const;
 
-    /// Returns the extended private key, derivation path used is "m/purpose'/coin'/account'".
-    std::string getExtendedPrivateKey(TWPurpose purpose, TWCoinType coin, TWHDVersion version, uint32_t account = 0) const;
+    /// Returns the extended private key for default 0 account; derivation path used is "m/purpose'/coin'/0'".
+    std::string getExtendedPrivateKey(TWPurpose purpose, TWCoinType coin, TWHDVersion version) const { return getExtendedPrivateKeyAccount(purpose, coin, version, 0); }
 
-    /// Returns the extended public key, derivation path used is "m/purpose'/coin'/account'".
-    std::string getExtendedPublicKey(TWPurpose purpose, TWCoinType coin, TWHDVersion version, uint32_t account = 0) const;
+    /// Returns the extended public key for default 0 account; derivation path used is "m/purpose'/coin'/0'".
+    std::string getExtendedPublicKey(TWPurpose purpose, TWCoinType coin, TWHDVersion version) const { return getExtendedPublicKeyAccount(purpose, coin, version, 0); }
+
+    /// Returns the extended private key for a custom account; derivation path used is "m/purpose'/coin'/account'".
+    std::string getExtendedPrivateKeyAccount(TWPurpose purpose, TWCoinType coin, TWHDVersion version, uint32_t account) const;
+
+    /// Returns the extended public key for a custom account; derivation path used is "m/purpose'/coin'/account'".
+    std::string getExtendedPublicKeyAccount(TWPurpose purpose, TWCoinType coin, TWHDVersion version, uint32_t account) const;
 
     /// Returns the BIP32 Root Key (private)
     std::string getRootKey(TWCoinType coin, TWHDVersion version) const;

--- a/src/interface/TWHDWallet.cpp
+++ b/src/interface/TWHDWallet.cpp
@@ -98,11 +98,11 @@ TWString *_Nonnull TWHDWalletGetExtendedPublicKey(struct TWHDWallet *wallet, TWP
 }
 
 TWString *_Nonnull TWHDWalletGetExtendedPrivateKeyAccount(struct TWHDWallet *wallet, TWPurpose purpose, TWCoinType coin, TWHDVersion version, uint32_t account) {
-    return new std::string(wallet->impl.getExtendedPrivateKey(purpose, coin, version, account));
+    return new std::string(wallet->impl.getExtendedPrivateKeyAccount(purpose, coin, version, account));
 }
 
 TWString *_Nonnull TWHDWalletGetExtendedPublicKeyAccount(struct TWHDWallet *wallet, TWPurpose purpose, TWCoinType coin, TWHDVersion version, uint32_t account) {
-    return new std::string(wallet->impl.getExtendedPublicKey(purpose, coin, version, account));
+    return new std::string(wallet->impl.getExtendedPublicKeyAccount(purpose, coin, version, account));
 }
 
 TWPublicKey *TWHDWalletGetPublicKeyFromExtended(TWString *_Nonnull extended, enum TWCoinType coin, TWString *_Nonnull derivationPath) {

--- a/src/interface/TWHDWallet.cpp
+++ b/src/interface/TWHDWallet.cpp
@@ -97,6 +97,14 @@ TWString *_Nonnull TWHDWalletGetExtendedPublicKey(struct TWHDWallet *wallet, TWP
     return new std::string(wallet->impl.getExtendedPublicKey(purpose, coin, version));
 }
 
+TWString *_Nonnull TWHDWalletGetExtendedPrivateKeyAccount(struct TWHDWallet *wallet, TWPurpose purpose, TWCoinType coin, TWHDVersion version, uint32_t account) {
+    return new std::string(wallet->impl.getExtendedPrivateKey(purpose, coin, version, account));
+}
+
+TWString *_Nonnull TWHDWalletGetExtendedPublicKeyAccount(struct TWHDWallet *wallet, TWPurpose purpose, TWCoinType coin, TWHDVersion version, uint32_t account) {
+    return new std::string(wallet->impl.getExtendedPublicKey(purpose, coin, version, account));
+}
+
 TWPublicKey *TWHDWalletGetPublicKeyFromExtended(TWString *_Nonnull extended, enum TWCoinType coin, TWString *_Nonnull derivationPath) {
     const auto derivationPathObject = DerivationPath(*reinterpret_cast<const std::string*>(derivationPath));
     auto publicKey = HDWallet::getPublicKeyFromExtended(*reinterpret_cast<const std::string*>(extended), coin, derivationPathObject);

--- a/tests/HDWallet/HDWalletTests.cpp
+++ b/tests/HDWallet/HDWalletTests.cpp
@@ -297,11 +297,11 @@ TEST(HDWallet, getExtendedPrivateKey) {
     EXPECT_EQ(extPubKey1, "zprvAcwsTZNaY1f7rfwsy5GseSDStYBrxwtsBZDkb3iyuQUs4NF6n58BuH7Xj54RuaSCWtU5CiQzuYQgFgqr1HokgKcVAeGeXokhJUAJeP3VmvY");
 
     // explicitly specify default account=0
-    const auto extPubKey2 = wallet.getExtendedPrivateKey(purpose, coin, hdVersion, 0);
+    const auto extPubKey2 = wallet.getExtendedPrivateKeyAccount(purpose, coin, hdVersion, 0);
     EXPECT_EQ(extPubKey2, "zprvAcwsTZNaY1f7rfwsy5GseSDStYBrxwtsBZDkb3iyuQUs4NF6n58BuH7Xj54RuaSCWtU5CiQzuYQgFgqr1HokgKcVAeGeXokhJUAJeP3VmvY");
 
     // custom account=1
-    const auto extPubKey3 = wallet.getExtendedPrivateKey(purpose, coin, hdVersion, 1);
+    const auto extPubKey3 = wallet.getExtendedPrivateKeyAccount(purpose, coin, hdVersion, 1);
     EXPECT_EQ(extPubKey3, "zprvAcwsTZNaY1f7sifgNNgdNa4P9mPtyg3zRVgwkx2qF9Sn7F255MzP6Zyumn6bgV5xuoS8ZrDvjzE7APcFSacXdzFYpGvyybb1bnAoh5nHxpn");
 }
 
@@ -316,11 +316,11 @@ TEST(HDWallet, getExtendedPublicKey) {
     EXPECT_EQ(extPubKey1, "zpub6qwDs4uUNPDR5A2M56ot1aABSa2MNQciYn9MPS8bTk1qwAaFKcSST5S1aLidvPp9twqpaumG7vikR2vHhBXjp5oGgHyMvWK3AtUkfeEgyns");
 
     // explicitly specify default account=0
-    const auto extPubKey2 = wallet.getExtendedPublicKey(purpose, coin, hdVersion, 0);
+    const auto extPubKey2 = wallet.getExtendedPublicKeyAccount(purpose, coin, hdVersion, 0);
     EXPECT_EQ(extPubKey2, "zpub6qwDs4uUNPDR5A2M56ot1aABSa2MNQciYn9MPS8bTk1qwAaFKcSST5S1aLidvPp9twqpaumG7vikR2vHhBXjp5oGgHyMvWK3AtUkfeEgyns");
 
     // custom account=1
-    const auto extPubKey3 = wallet.getExtendedPublicKey(purpose, coin, hdVersion, 1);
+    const auto extPubKey3 = wallet.getExtendedPublicKeyAccount(purpose, coin, hdVersion, 1);
     EXPECT_EQ(extPubKey3, "zpub6qwDs4uUNPDR6Ck9UQDdji17hoEPP8mqnicYZLSSoUykz3MDcuJdeNJPd3BozqEafeLZkegWqzAvkgA4JZZ5tTN2rDpGKfk54essyfx1eZP");
 }
 

--- a/tests/HDWallet/HDWalletTests.cpp
+++ b/tests/HDWallet/HDWalletTests.cpp
@@ -286,6 +286,44 @@ TEST(HDWallet, Bip39Vectors) {
     }
 }
 
+TEST(HDWallet, getExtendedPrivateKey) {
+    const HDWallet wallet = HDWallet(mnemonic1, "");
+    const auto purpose = TWPurposeBIP44;
+    const auto coin = TWCoinTypeBitcoin;
+    const auto hdVersion = TWHDVersionZPRV;
+    
+    // default
+    const auto extPubKey1 = wallet.getExtendedPrivateKey(purpose, coin, hdVersion);
+    EXPECT_EQ(extPubKey1, "zprvAcwsTZNaY1f7rfwsy5GseSDStYBrxwtsBZDkb3iyuQUs4NF6n58BuH7Xj54RuaSCWtU5CiQzuYQgFgqr1HokgKcVAeGeXokhJUAJeP3VmvY");
+
+    // explicitly specify default account=0
+    const auto extPubKey2 = wallet.getExtendedPrivateKey(purpose, coin, hdVersion, 0);
+    EXPECT_EQ(extPubKey2, "zprvAcwsTZNaY1f7rfwsy5GseSDStYBrxwtsBZDkb3iyuQUs4NF6n58BuH7Xj54RuaSCWtU5CiQzuYQgFgqr1HokgKcVAeGeXokhJUAJeP3VmvY");
+
+    // custom account=1
+    const auto extPubKey3 = wallet.getExtendedPrivateKey(purpose, coin, hdVersion, 1);
+    EXPECT_EQ(extPubKey3, "zprvAcwsTZNaY1f7sifgNNgdNa4P9mPtyg3zRVgwkx2qF9Sn7F255MzP6Zyumn6bgV5xuoS8ZrDvjzE7APcFSacXdzFYpGvyybb1bnAoh5nHxpn");
+}
+
+TEST(HDWallet, getExtendedPublicKey) {
+    const HDWallet wallet = HDWallet(mnemonic1, "");
+    const auto purpose = TWPurposeBIP44;
+    const auto coin = TWCoinTypeBitcoin;
+    const auto hdVersion = TWHDVersionZPUB;
+    
+    // default
+    const auto extPubKey1 = wallet.getExtendedPublicKey(purpose, coin, hdVersion);
+    EXPECT_EQ(extPubKey1, "zpub6qwDs4uUNPDR5A2M56ot1aABSa2MNQciYn9MPS8bTk1qwAaFKcSST5S1aLidvPp9twqpaumG7vikR2vHhBXjp5oGgHyMvWK3AtUkfeEgyns");
+
+    // explicitly specify default account=0
+    const auto extPubKey2 = wallet.getExtendedPublicKey(purpose, coin, hdVersion, 0);
+    EXPECT_EQ(extPubKey2, "zpub6qwDs4uUNPDR5A2M56ot1aABSa2MNQciYn9MPS8bTk1qwAaFKcSST5S1aLidvPp9twqpaumG7vikR2vHhBXjp5oGgHyMvWK3AtUkfeEgyns");
+
+    // custom account=1
+    const auto extPubKey3 = wallet.getExtendedPublicKey(purpose, coin, hdVersion, 1);
+    EXPECT_EQ(extPubKey3, "zpub6qwDs4uUNPDR6Ck9UQDdji17hoEPP8mqnicYZLSSoUykz3MDcuJdeNJPd3BozqEafeLZkegWqzAvkgA4JZZ5tTN2rDpGKfk54essyfx1eZP");
+}
+
 TEST(HDWallet, Derive_XpubPub_vs_PrivPub) {
     // Test different routes for deriving address from mnemonic, result should be the same:
     // - Direct: mnemonic -> seed -> privateKey -> publicKey -> address

--- a/tests/interface/TWHDWalletTests.cpp
+++ b/tests/interface/TWHDWalletTests.cpp
@@ -312,6 +312,21 @@ TEST(HDWallet, ExtendedKeys) {
     assertStringsEqual(emptyPub, "");
 }
 
+TEST(HDWallet, ExtendedKeysCustomAccount) {
+    auto words = STRING("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about");
+    auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), STRING("").get()));
+
+    auto zprv0 = WRAPS(TWHDWalletGetExtendedPrivateKeyAccount(wallet.get(), TWPurposeBIP84, TWCoinTypeBitcoin, TWHDVersionZPRV, 0));
+    assertStringsEqual(zprv0, "zprvAdG4iTXWBoARxkkzNpNh8r6Qag3irQB8PzEMkAFeTRXxHpbF9z4QgEvBRmfvqWvGp42t42nvgGpNgYSJA9iefm1yYNZKEm7z6qUWCroSQnE");
+    auto zprv1 = WRAPS(TWHDWalletGetExtendedPrivateKeyAccount(wallet.get(), TWPurposeBIP84, TWCoinTypeBitcoin, TWHDVersionZPRV, 1));
+    assertStringsEqual(zprv1, "zprvAdG4iTXWBoAS2cCGuaGevCvH54GCunrvLJb2hoWCSuE3D9LS42XVg3c6sPm64w6VMq3w18vJf8nF3cBA2kUMkyWHsq6enWVXivzw42UrVHG");
+
+    auto zpub0 = WRAPS(TWHDWalletGetExtendedPublicKeyAccount(wallet.get(), TWPurposeBIP84, TWCoinTypeBitcoin, TWHDVersionZPUB, 0));
+    assertStringsEqual(zpub0, "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs");
+    auto zpub1 = WRAPS(TWHDWalletGetExtendedPublicKeyAccount(wallet.get(), TWPurposeBIP84, TWCoinTypeBitcoin, TWHDVersionZPUB, 1));
+    assertStringsEqual(zpub1, "zpub6rFR7y4Q2AijF6Gk1bofHLs1d66hKFamhXWdWBup1Em25wfabZqkDqvaieV63fDQFaYmaatCG7jVNUpUiM2hAMo6SAVHcrUpSnHDpNzucB7");
+}
+
 TEST(HDWallet, PublicKeyFromX) {
     auto xpub = STRING("xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj");
     auto xpubAddr2 = WRAP(TWPublicKey, TWHDWalletGetPublicKeyFromExtended(xpub.get(), TWCoinTypeBitcoinCash, STRING("m/44'/145'/0'/0/2").get()));


### PR DESCRIPTION
## Description

Add a way to obtain extended public key for non-default accounts.
Method TWHDWalletGetExtendedPublicKey derives an extended public key, but always using the default 0 account value.

Fixes #2084 .

## Testing instructions

Unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
