### PR TITLE
DoubleExt privatekeys: Access all data (Cardano fix)

### DIFF
--- a/src/Data.cpp
+++ b/src/Data.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2017-2020 Trust Wallet.
+// Copyright © 2017-2022 Trust Wallet.
 //
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
@@ -9,13 +9,18 @@
 namespace TW {
 
 Data subData(const Data& data, size_t startIndex, size_t length) {
-    size_t subLength = length;
-    if (startIndex + subLength > data.size()) { subLength = data.size() - startIndex; } // guard against over-length
+    if (startIndex >= data.size()) {
+        return Data();
+    }
+    const size_t subLength = std::min(length, data.size() - startIndex); // guard against over-length
     return TW::data(data.data() + startIndex, subLength);
 }
 
 Data subData(const Data& data, size_t startIndex) {
-    size_t subLength = data.size() - startIndex;
+    if (startIndex >= data.size()) {
+        return Data();
+    }
+    const size_t subLength = data.size() - startIndex;
     return TW::data(data.data() + startIndex, subLength);
 }
 

--- a/src/PrivateKey.cpp
+++ b/src/PrivateKey.cpp
@@ -23,6 +23,13 @@
 
 using namespace TW;
 
+
+Data PrivateKey::getSubKey(size_t index, size_t size) const {
+    index = std::min(index, bytes.size() - 1);
+    size = std::min(size, bytes.size() - index);
+    return subData(bytes, index, size);
+}
+
 bool PrivateKey::isValid(const Data& data) {
     // Check length
     if (data.size() != size && data.size() != doubleExtendedSize) {
@@ -81,34 +88,22 @@ PrivateKey::PrivateKey(const Data& data) {
     if (!isValid(data)) {
         throw std::invalid_argument("Invalid private key data");
     }
-    if (data.size() == doubleExtendedSize) {
-        // special double extended key case
-        *this = PrivateKey(
-            subData(data, 0, 32),
-            subData(data, 32, 32),
-            subData(data, 32*2, 32),
-            subData(data, 32*3, 32),
-            subData(data, 32*4, 32),
-            subData(data, 32*5, 32));
-    } else {
-        // default case
-        bytes = data;
-    }
+    bytes = data;
 }
 
 PrivateKey::PrivateKey(
-    const Data& bytes1, const Data& extension1, const Data& chainCode1,
-    const Data& bytes2, const Data& extension2, const Data& chainCode2) {
-    if (!isValid(bytes1) || !isValid(extension1) || !isValid(chainCode1) ||
-        !isValid(bytes2) || !isValid(extension2) || !isValid(chainCode2)) {
+    const Data& key1, const Data& extension1, const Data& chainCode1,
+    const Data& key2, const Data& extension2, const Data& chainCode2) {
+    if (key1.size() != size || extension1.size() != size || chainCode1.size() != size ||
+        key2.size() != size || extension2.size() != size || chainCode2.size() != size) {
         throw std::invalid_argument("Invalid private key or extended key data");
     }
-    bytes = bytes1;
-    extension = extension1;
-    chainCode = chainCode1;
-    this->second = bytes2;
-    this->secondExtension = extension2;
-    this->secondChainCode = chainCode2;
+    bytes = key1;
+    append(bytes, extension1);
+    append(bytes, chainCode1);
+    append(bytes, key2);
+    append(bytes, extension2);
+    append(bytes, chainCode2);
 }
 
 PublicKey PrivateKey::getPublicKey(TWPublicKeyType type) const {
@@ -116,46 +111,45 @@ PublicKey PrivateKey::getPublicKey(TWPublicKeyType type) const {
     switch (type) {
     case TWPublicKeyTypeSECP256k1:
         result.resize(PublicKey::secp256k1Size);
-        ecdsa_get_public_key33(&secp256k1, bytes.data(), result.data());
+        ecdsa_get_public_key33(&secp256k1, key().data(), result.data());
         break;
     case TWPublicKeyTypeSECP256k1Extended:
         result.resize(PublicKey::secp256k1ExtendedSize);
-        ecdsa_get_public_key65(&secp256k1, bytes.data(), result.data());
+        ecdsa_get_public_key65(&secp256k1, key().data(), result.data());
         break;
     case TWPublicKeyTypeNIST256p1:
         result.resize(PublicKey::secp256k1Size);
-        ecdsa_get_public_key33(&nist256p1, bytes.data(), result.data());
+        ecdsa_get_public_key33(&nist256p1, key().data(), result.data());
         break;
     case TWPublicKeyTypeNIST256p1Extended:
         result.resize(PublicKey::secp256k1ExtendedSize);
-        ecdsa_get_public_key65(&nist256p1, bytes.data(), result.data());
+        ecdsa_get_public_key65(&nist256p1, key().data(), result.data());
         break;
     case TWPublicKeyTypeED25519:
         result.resize(PublicKey::ed25519Size);
-        ed25519_publickey(bytes.data(), result.data());
+        ed25519_publickey(key().data(), result.data());
         break;
     case TWPublicKeyTypeED25519Blake2b:
         result.resize(PublicKey::ed25519Size);
-        ed25519_publickey_blake2b(bytes.data(), result.data());
+        ed25519_publickey_blake2b(key().data(), result.data());
         break;
     case TWPublicKeyTypeED25519Extended:
         {
             // must be double extended key
-            if (bytes.size() != size || extension.size() != size || chainCode.size() != size ||
-                second.size() != size || secondExtension.size() != size || secondChainCode.size() != size) {
+            if (bytes.size() != doubleExtendedSize) {
                 throw std::invalid_argument("Invalid extended key");
             }
             Data tempPub(64);
-            ed25519_publickey_ext(bytes.data(), extension.data(), tempPub.data());
+            ed25519_publickey_ext(key().data(), extension().data(), tempPub.data());
             result = Data();
             append(result, subData(tempPub, 0, 32));
             // copy chainCode
-            append(result, chainCode);
+            append(result, chainCode());
 
             // second key
-            ed25519_publickey_ext(second.data(), secondExtension.data(), tempPub.data());
+            ed25519_publickey_ext(secondKey().data(), secondExtension().data(), tempPub.data());
             append(result, subData(tempPub, 0, 32));
-            append(result, secondChainCode);
+            append(result, secondChainCode());
         }
         break;
 
@@ -174,7 +168,7 @@ Data PrivateKey::getSharedKey(const PublicKey& pubKey, TWCurve curve) const {
     }
 
     Data result(PublicKey::secp256k1ExtendedSize);
-    bool success = ecdh_multiply(&secp256k1, bytes.data(),
+    bool success = ecdh_multiply(&secp256k1, key().data(),
                                  pubKey.bytes.data(), result.data()) == 0;
 
     if (success) {
@@ -200,32 +194,32 @@ Data PrivateKey::sign(const Data& digest, TWCurve curve) const {
     switch (curve) {
     case TWCurveSECP256k1: {
         result.resize(65);
-        success = ecdsa_sign_digest_checked(&secp256k1, bytes.data(), digest.data(), digest.size(), result.data(),
+        success = ecdsa_sign_digest_checked(&secp256k1, key().data(), digest.data(), digest.size(), result.data(),
                                     result.data() + 64, nullptr) == 0;
     } break;
     case TWCurveED25519: {
         result.resize(64);
         const auto publicKey = getPublicKey(TWPublicKeyTypeED25519);
-        ed25519_sign(digest.data(), digest.size(), bytes.data(), publicKey.bytes.data(), result.data());
+        ed25519_sign(digest.data(), digest.size(), key().data(), publicKey.bytes.data(), result.data());
         success = true;
     } break;
     case TWCurveED25519Blake2bNano: {
         result.resize(64);
         const auto publicKey = getPublicKey(TWPublicKeyTypeED25519Blake2b);
-        ed25519_sign_blake2b(digest.data(), digest.size(), bytes.data(),
+        ed25519_sign_blake2b(digest.data(), digest.size(), key().data(),
                              publicKey.bytes.data(), result.data());
         success = true;
     } break;
     case TWCurveED25519Extended: {
         result.resize(64);
         const auto publicKey = getPublicKey(TWPublicKeyTypeED25519Extended);
-        ed25519_sign_ext(digest.data(), digest.size(), bytes.data(), extension.data(), publicKey.bytes.data(), result.data());
+        ed25519_sign_ext(digest.data(), digest.size(), key().data(), extension().data(), publicKey.bytes.data(), result.data());
         success = true;
     } break;
     case TWCurveCurve25519: {
         result.resize(64);
         const auto publicKey = getPublicKey(TWPublicKeyTypeED25519);
-        ed25519_sign(digest.data(), digest.size(), bytes.data(), publicKey.bytes.data(),
+        ed25519_sign(digest.data(), digest.size(), key().data(), publicKey.bytes.data(),
                      result.data());
         const auto sign_bit = publicKey.bytes[31] & 0x80;
         result[63] = result[63] & 127;
@@ -234,7 +228,7 @@ Data PrivateKey::sign(const Data& digest, TWCurve curve) const {
     } break;
     case TWCurveNIST256p1: {
         result.resize(65);
-        success = ecdsa_sign_digest_checked(&nist256p1, bytes.data(), digest.data(), digest.size(), result.data(),
+        success = ecdsa_sign_digest_checked(&nist256p1, key().data(), digest.data(), digest.size(), result.data(),
                                     result.data() + 64, nullptr) == 0;
     } break;
     case TWCurveNone:
@@ -254,7 +248,7 @@ Data PrivateKey::sign(const Data& digest, TWCurve curve, int(*canonicalChecker)(
     switch (curve) {
     case TWCurveSECP256k1: {
         result.resize(65);
-        success = ecdsa_sign_digest_checked(&secp256k1, bytes.data(), digest.data(), digest.size(), result.data() + 1,
+        success = ecdsa_sign_digest_checked(&secp256k1, key().data(), digest.data(), digest.size(), result.data() + 1,
                                     result.data(), canonicalChecker) == 0;
     } break;
     case TWCurveED25519: // not supported
@@ -264,7 +258,7 @@ Data PrivateKey::sign(const Data& digest, TWCurve curve, int(*canonicalChecker)(
         break;
     case TWCurveNIST256p1: {
         result.resize(65);
-        success = ecdsa_sign_digest_checked(&nist256p1, bytes.data(), digest.data(), digest.size(), result.data() + 1,
+        success = ecdsa_sign_digest_checked(&nist256p1, key().data(), digest.data(), digest.size(), result.data() + 1,
                                     result.data(), canonicalChecker) == 0;
     } break;
     case TWCurveNone:
@@ -284,7 +278,7 @@ Data PrivateKey::sign(const Data& digest, TWCurve curve, int(*canonicalChecker)(
 Data PrivateKey::signAsDER(const Data& digest, TWCurve curve) const {
     Data sig(64);
     bool success =
-        ecdsa_sign_digest(&secp256k1, bytes.data(), digest.data(), sig.data(), nullptr, nullptr) == 0;
+        ecdsa_sign_digest(&secp256k1, key().data(), digest.data(), sig.data(), nullptr, nullptr) == 0;
     if (!success) {
         return {};
     }
@@ -302,7 +296,7 @@ Data PrivateKey::signSchnorr(const Data& message, TWCurve curve) const {
     Data sig(64);
     switch (curve) {
     case TWCurveSECP256k1: {
-        success = zil_schnorr_sign(&secp256k1, bytes.data(), message.data(), static_cast<uint32_t>(message.size()), sig.data()) == 0;
+        success = zil_schnorr_sign(&secp256k1, key().data(), message.data(), static_cast<uint32_t>(message.size()), sig.data()) == 0;
     } break;
 
     case TWCurveNIST256p1:
@@ -324,9 +318,4 @@ Data PrivateKey::signSchnorr(const Data& message, TWCurve curve) const {
 
 void PrivateKey::cleanup() {
     std::fill(bytes.begin(), bytes.end(), 0);
-    std::fill(extension.begin(), extension.end(), 0);
-    std::fill(chainCode.begin(), chainCode.end(), 0);
-    std::fill(second.begin(), second.end(), 0);
-    std::fill(secondExtension.begin(), secondExtension.end(), 0);
-    std::fill(secondChainCode.begin(), secondChainCode.end(), 0);
 }

--- a/src/PrivateKey.cpp
+++ b/src/PrivateKey.cpp
@@ -24,12 +24,6 @@
 using namespace TW;
 
 
-Data PrivateKey::getSubKey(size_t index, size_t size) const {
-    index = std::min(index, bytes.size() - 1);
-    size = std::min(size, bytes.size() - index);
-    return subData(bytes, index, size);
-}
-
 bool PrivateKey::isValid(const Data& data) {
     // Check length
     if (data.size() != size && data.size() != doubleExtendedSize) {

--- a/src/PrivateKey.h
+++ b/src/PrivateKey.h
@@ -20,15 +20,20 @@ class PrivateKey {
     /// The number of bytes in a double extended key (used by Cardano)
     static const size_t doubleExtendedSize = 2 * 3 * 32;
 
-    /// The private key bytes.
+    /// The private key bytes:
+    /// - common case: 'size' bytes
+    /// - double extended case: 'doubleExtendedSize' bytes, key+extension+chainCode+second+secondExtension+secondChainCode
     Data bytes;
 
     /// Optional members for extended keys and second extended keys
-    Data extension;
-    Data chainCode;
-    Data second;
-    Data secondExtension;
-    Data secondChainCode;
+    Data key() const { return getSubKey(0, 32); }
+    Data extension() const { return getSubKey(32, 32); }
+    Data chainCode() const { return getSubKey(2*32, 32); }
+    Data secondKey() const { return getSubKey(3*32, 32); }
+    Data secondExtension() const { return getSubKey(4*32, 32); }
+    Data secondChainCode() const { return getSubKey(5*32, 32); }
+    // safe subdata utility
+    Data getSubKey(size_t index, size_t size) const;
 
     /// Determines if a collection of bytes makes a valid private key.
     static bool isValid(const Data& data);
@@ -39,7 +44,7 @@ class PrivateKey {
     /// Initializes a private key with an array of bytes.  Size must be exact (normally 32, or 192 for extended)
     explicit PrivateKey(const Data& data);
 
-    /// Initializes a private key from a string of bytes (convenience method).
+    /// Initializes a private key from a string of bytes.
     explicit PrivateKey(const std::string& data) : PrivateKey(TW::data(data)) {}
 
     /// Initializes a double extended private key with two extended keys

--- a/src/PrivateKey.h
+++ b/src/PrivateKey.h
@@ -26,14 +26,12 @@ class PrivateKey {
     Data bytes;
 
     /// Optional members for extended keys and second extended keys
-    Data key() const { return getSubKey(0, 32); }
-    Data extension() const { return getSubKey(32, 32); }
-    Data chainCode() const { return getSubKey(2*32, 32); }
-    Data secondKey() const { return getSubKey(3*32, 32); }
-    Data secondExtension() const { return getSubKey(4*32, 32); }
-    Data secondChainCode() const { return getSubKey(5*32, 32); }
-    // safe subdata utility
-    Data getSubKey(size_t index, size_t size) const;
+    Data key() const { return subData(bytes, 0, 32); }
+    Data extension() const { return subData(bytes, 32, 32); }
+    Data chainCode() const { return subData(bytes, 2*32, 32); }
+    Data secondKey() const { return subData(bytes, 3*32, 32); }
+    Data secondExtension() const { return subData(bytes, 4*32, 32); }
+    Data secondChainCode() const { return subData(bytes, 5*32, 32); }
 
     /// Determines if a collection of bytes makes a valid private key.
     static bool isValid(const Data& data);

--- a/swift/Tests/Blockchains/CardanoTests.swift
+++ b/swift/Tests/Blockchains/CardanoTests.swift
@@ -18,6 +18,14 @@ class CardanoTests: XCTestCase {
         XCTAssertEqual(address.description, addressFromString.description)
     }
 
+    func testDeriveAddressWallet() {
+        let wallet = HDWallet(mnemonic: "cost dash dress stove morning robust group affair stomach vacant route volume yellow salute laugh", passphrase: "")!
+        let privateKey = wallet.getKeyForCoin(coin: .cardano)
+        XCTAssertEqual(privateKey.data.hexString, "e8c8c5b2df13f3abed4e6b1609c808e08ff959d7e6fc3d849e3f2880550b574437aa559095324d78459b9bb2da069da32337e1cc5da78f48e1bd084670107f3110f3245ddf9132ecef98c670272ef39c03a232107733d4a1d28cb53318df26fae0d152bb611cb9ff34e945e4ff627e6fba81da687a601a879759cd76530b5744424db69a75edd4780a5fbc05d1a3c84ac4166ff8e424808481dd8e77627ce5f5bf2eea84515a4e16c4ff06c92381822d910b5cbf9e9c144e1fb76a6291af7276")
+        let address = CoinType.cardano.deriveAddress(privateKey: privateKey)
+        XCTAssertEqual(address, "addr1qxxe304qg9py8hyyqu8evfj4wln7dnms943wsugpdzzsxnkvvjljtzuwxvx0pnwelkcruy95ujkq3aw6rl0vvg32x35qc92xkq")
+    }
+
     func testSignTransfer1() {
         var input = CardanoSigningInput.with {
             $0.transferMessage.toAddress = "addr1q92cmkgzv9h4e5q7mnrzsuxtgayvg4qr7y3gyx97ukmz3dfx7r9fu73vqn25377ke6r0xk97zw07dqr9y5myxlgadl2s0dgke5"

--- a/tests/Cardano/AddressTests.cpp
+++ b/tests/Cardano/AddressTests.cpp
@@ -134,12 +134,12 @@ TEST(CardanoAddress, MnemonicToAddressV2) {
         }
         {
             PrivateKey privateKey = wallet.getKey(TWCoinTypeCardano, DerivationPath("m/1852'/1815'/0'/0/0"));
-            EXPECT_EQ("e8c8c5b2df13f3abed4e6b1609c808e08ff959d7e6fc3d849e3f2880550b5744", hex(privateKey.bytes));
-            EXPECT_EQ("37aa559095324d78459b9bb2da069da32337e1cc5da78f48e1bd084670107f31", hex(privateKey.extension));
-            EXPECT_EQ("10f3245ddf9132ecef98c670272ef39c03a232107733d4a1d28cb53318df26fa", hex(privateKey.chainCode));
-            EXPECT_EQ("e0d152bb611cb9ff34e945e4ff627e6fba81da687a601a879759cd76530b5744", hex(privateKey.second));
-            EXPECT_EQ("424db69a75edd4780a5fbc05d1a3c84ac4166ff8e424808481dd8e77627ce5f5", hex(privateKey.secondExtension));
-            EXPECT_EQ("bf2eea84515a4e16c4ff06c92381822d910b5cbf9e9c144e1fb76a6291af7276", hex(privateKey.secondChainCode));
+            EXPECT_EQ("e8c8c5b2df13f3abed4e6b1609c808e08ff959d7e6fc3d849e3f2880550b5744", hex(privateKey.key()));
+            EXPECT_EQ("37aa559095324d78459b9bb2da069da32337e1cc5da78f48e1bd084670107f31", hex(privateKey.extension()));
+            EXPECT_EQ("10f3245ddf9132ecef98c670272ef39c03a232107733d4a1d28cb53318df26fa", hex(privateKey.chainCode()));
+            EXPECT_EQ("e0d152bb611cb9ff34e945e4ff627e6fba81da687a601a879759cd76530b5744", hex(privateKey.secondKey()));
+            EXPECT_EQ("424db69a75edd4780a5fbc05d1a3c84ac4166ff8e424808481dd8e77627ce5f5", hex(privateKey.secondExtension()));
+            EXPECT_EQ("bf2eea84515a4e16c4ff06c92381822d910b5cbf9e9c144e1fb76a6291af7276", hex(privateKey.secondChainCode()));
             PublicKey publicKey = privateKey.getPublicKey(TWPublicKeyTypeED25519Extended);
             EXPECT_EQ("fafa7eb4146220db67156a03a5f7a79c666df83eb31abbfbe77c85e06d40da3110f3245ddf9132ecef98c670272ef39c03a232107733d4a1d28cb53318df26faf4b8d5201961e68f2e177ba594101f513ee70fe70a41324e8ea8eb787ffda6f4bf2eea84515a4e16c4ff06c92381822d910b5cbf9e9c144e1fb76a6291af7276", hex(publicKey.bytes));
             string addr = AddressV3(publicKey).string();

--- a/tests/Cardano/AddressTests.cpp
+++ b/tests/Cardano/AddressTests.cpp
@@ -85,35 +85,13 @@ TEST(CardanoAddress, FromStringV3) {
 }
 
 TEST(CardanoAddress, MnemonicToAddressV3) {
-    // Test from cardano-crypto.js; Test wallet
-    const auto mnemonic = "cost dash dress stove morning robust group affair stomach vacant route volume yellow salute laugh";
-    const auto coin = TWCoinTypeCardano;
-    const auto derivPath = derivationPath(coin);
-
-    auto wallet = HDWallet(mnemonic, "");
-
-    {
-        const auto address = wallet.deriveAddress(coin);
-        EXPECT_EQ(address, "addr1qxxe304qg9py8hyyqu8evfj4wln7dnms943wsugpdzzsxnkvvjljtzuwxvx0pnwelkcruy95ujkq3aw6rl0vvg32x35qc92xkq");
-    }
-
-    {
-        const auto privateKey = wallet.getKey(coin, derivPath);
-        const auto publicKey = privateKey.getPublicKey(TWPublicKeyTypeED25519Extended);
-
-        const auto address = AddressV3(publicKey);
-        EXPECT_EQ(address.string(), "addr1qxxe304qg9py8hyyqu8evfj4wln7dnms943wsugpdzzsxnkvvjljtzuwxvx0pnwelkcruy95ujkq3aw6rl0vvg32x35qc92xkq");
-        EXPECT_EQ(address.networkId, AddressV3::Network_Production);
-        EXPECT_EQ(address.kind, AddressV3::Kind_Base);
-        EXPECT_EQ(hex(address.bytes), "8d98bea0414243dc84070f96265577e7e6cf702d62e871016885034e" "cc64bf258b8e330cf0cdd9fdb03e10b4e4ac08f5da1fdec6222a3468");
-    }
-}
-
-TEST(CardanoAddress, MnemonicToAddressV2) {
     {
         // Test from cardano-crypto.js; Test wallet
-        auto mnemonic = "cost dash dress stove morning robust group affair stomach vacant route volume yellow salute laugh";
-        auto wallet = HDWallet(mnemonic, "");
+        const auto mnemonic = "cost dash dress stove morning robust group affair stomach vacant route volume yellow salute laugh";
+        const auto coin = TWCoinTypeCardano;
+        const auto derivPath = derivationPath(coin);
+
+        const auto wallet = HDWallet(mnemonic, "");
 
         // check entropy
         EXPECT_EQ("30a6f50aeb58ff7699b822d63e0ef27aeff17d9f", hex(wallet.getEntropy()));
@@ -131,6 +109,17 @@ TEST(CardanoAddress, MnemonicToAddressV2) {
         {
             string addr = wallet.deriveAddress(TWCoinType::TWCoinTypeCardano);
             EXPECT_EQ("addr1qxxe304qg9py8hyyqu8evfj4wln7dnms943wsugpdzzsxnkvvjljtzuwxvx0pnwelkcruy95ujkq3aw6rl0vvg32x35qc92xkq", addr);
+        }
+        {
+            const auto privateKey = wallet.getKey(coin, derivPath);
+            EXPECT_EQ(hex(privateKey.bytes), "e8c8c5b2df13f3abed4e6b1609c808e08ff959d7e6fc3d849e3f2880550b574437aa559095324d78459b9bb2da069da32337e1cc5da78f48e1bd084670107f3110f3245ddf9132ecef98c670272ef39c03a232107733d4a1d28cb53318df26fae0d152bb611cb9ff34e945e4ff627e6fba81da687a601a879759cd76530b5744424db69a75edd4780a5fbc05d1a3c84ac4166ff8e424808481dd8e77627ce5f5bf2eea84515a4e16c4ff06c92381822d910b5cbf9e9c144e1fb76a6291af7276");
+            const auto publicKey = privateKey.getPublicKey(TWPublicKeyTypeED25519Extended);
+
+            const auto address = AddressV3(publicKey);
+            EXPECT_EQ(address.string(), "addr1qxxe304qg9py8hyyqu8evfj4wln7dnms943wsugpdzzsxnkvvjljtzuwxvx0pnwelkcruy95ujkq3aw6rl0vvg32x35qc92xkq");
+            EXPECT_EQ(address.networkId, AddressV3::Network_Production);
+            EXPECT_EQ(address.kind, AddressV3::Kind_Base);
+            EXPECT_EQ(hex(address.bytes), "8d98bea0414243dc84070f96265577e7e6cf702d62e871016885034e" "cc64bf258b8e330cf0cdd9fdb03e10b4e4ac08f5da1fdec6222a3468");
         }
         {
             PrivateKey privateKey = wallet.getKey(TWCoinTypeCardano, DerivationPath("m/1852'/1815'/0'/0/0"));

--- a/tests/Cardano/TWCardanoAddressTests.cpp
+++ b/tests/Cardano/TWCardanoAddressTests.cpp
@@ -7,13 +7,15 @@
 #include <TrustWalletCore/TWAnyAddress.h>
 #include <TrustWalletCore/TWAnySigner.h>
 #include <TrustWalletCore/TWPrivateKey.h>
+#include <TrustWalletCore/TWPublicKey.h>
 #include <TrustWalletCore/TWData.h>
+#include <TrustWalletCore/TWHDWallet.h>
 #include "../interface/TWTestUtilities.h"
 #include "PrivateKey.h"
 
 #include <gtest/gtest.h>
 
-TEST(TWCardano, Address) {
+TEST(TWCardano, AddressFromPublicKey) {
     auto privateKey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(DATA(
         "b0884d248cb301edd1b34cf626ba6d880bb3ae8fd91b4696446999dc4f0b5744309941d56938e943980d11643c535e046653ca6f498c014b88f2ad9fd6e71effbf36a8fa9f5e11eb7a852c41e185e3969d518e66e6893c81d3fc7227009952d4"
         "639aadd8b6499ae39b78018b79255fbd8f585cbda9cbb9e907a72af86afb7a05d41a57c2dec9a6a19d6bf3b1fa784f334f3a0048d25ccb7b78a7b44066f9ba7bed7f28be986cbe06819165f2ee41b403678a098961013cf4a2f3e9ea61fb6c1a"
@@ -32,4 +34,22 @@ TEST(TWCardano, Address) {
     assertStringsEqual(address2String, "addr1qx4z6twzknkkux0hhp0kq6hvdfutczp56g56y5em8r8mgvxalp7nkkk25vuspleke2zltaetmlwrfxv7t049cq9jmwjswmfw6t");
 
     ASSERT_TRUE(TWAnyAddressEqual(address.get(), address2.get()));
+}
+
+TEST(TWCardano, AddressFromWallet) {
+    auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(
+        STRING("cost dash dress stove morning robust group affair stomach vacant route volume yellow salute laugh").get(),
+        STRING("").get()
+    ));
+    auto privateKey = WRAP(TWPrivateKey, TWHDWalletGetKeyForCoin(wallet.get(), TWCoinTypeCardano));
+    auto privateKeyData = WRAPD(TWPrivateKeyData(privateKey.get()));
+    EXPECT_EQ(TWDataSize(privateKeyData.get()), 192);
+    
+    auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeyEd25519Extended(privateKey.get()));
+    auto publicKeyData = WRAPD(TWPublicKeyData(publicKey.get()));
+    EXPECT_EQ(TWDataSize(publicKeyData.get()), 128);
+    assertHexEqual(publicKeyData, "fafa7eb4146220db67156a03a5f7a79c666df83eb31abbfbe77c85e06d40da3110f3245ddf9132ecef98c670272ef39c03a232107733d4a1d28cb53318df26faf4b8d5201961e68f2e177ba594101f513ee70fe70a41324e8ea8eb787ffda6f4bf2eea84515a4e16c4ff06c92381822d910b5cbf9e9c144e1fb76a6291af7276");
+
+    auto address = WRAPS(TWCoinTypeDeriveAddress(TWCoinTypeCardano, privateKey.get()));
+    assertStringsEqual(address, "addr1qxxe304qg9py8hyyqu8evfj4wln7dnms943wsugpdzzsxnkvvjljtzuwxvx0pnwelkcruy95ujkq3aw6rl0vvg32x35qc92xkq");
 }

--- a/tests/DataTests.cpp
+++ b/tests/DataTests.cpp
@@ -1,0 +1,96 @@
+// Copyright © 2017-2022 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Data.h"
+#include "HexCoding.h"
+
+#include <gtest/gtest.h>
+
+using namespace std;
+using namespace TW;
+
+TEST(DataTests, fromVector) {
+    const Data data = {1, 2, 3};
+    EXPECT_EQ(data.size(), 3);
+    EXPECT_EQ(data[1], 2);
+    EXPECT_EQ(hex(data), "010203");
+}
+
+TEST(DataTests, fromHex) {
+    const Data data = parse_hex("01020304");
+    EXPECT_EQ(data.size(), 4);
+    EXPECT_EQ(hex(data), "01020304");
+}
+
+TEST(DataTests, fromString) {
+    const Data data = TW::data(std::string("ABC"));
+    EXPECT_EQ(data.size(), 3);
+    EXPECT_EQ(hex(data), "414243");
+}
+
+TEST(DataTests, fromBytes) {
+    const std::vector<TW::byte> vec = {1, 2, 3};
+    const Data data = TW::data(vec.data(), vec.size());
+    EXPECT_EQ(data.size(), 3);
+    EXPECT_EQ(hex(data), "010203");
+}
+
+TEST(DataTests, padLeft) {
+    Data data = parse_hex("01020304");
+    pad_left(data, 10);
+    EXPECT_EQ(data.size(), 10);
+    EXPECT_EQ(hex(data), "00000000000001020304");
+}
+
+TEST(DataTests, append) {
+    Data data1 = parse_hex("01020304");
+    const Data data2 = parse_hex("aeaf");
+    append(data1, data2);
+    EXPECT_EQ(data1.size(), 6);
+    EXPECT_EQ(hex(data1), "01020304aeaf");
+}
+
+TEST(DataTests, appendByte) {
+    Data data1 = parse_hex("01020304");
+    append(data1, 5);
+    EXPECT_EQ(data1.size(), 5);
+    EXPECT_EQ(hex(data1), "0102030405");
+}
+
+TEST(DataTests, subData) {
+    const Data data = parse_hex("0102030405060708090a");
+    EXPECT_EQ(data.size(), 10);
+
+    EXPECT_EQ(hex(subData(data, 2, 3)), "030405");
+    EXPECT_EQ(hex(subData(data, 0, 10)), "0102030405060708090a");
+    EXPECT_EQ(hex(subData(data, 3, 1)), "04");
+    EXPECT_EQ(hex(subData(data, 3, 0)), "");
+    EXPECT_EQ(hex(subData(data, 200, 3)), ""); // index too big
+    EXPECT_EQ(hex(subData(data, 2, 300)), "030405060708090a"); // length too big
+    EXPECT_EQ(hex(subData(data, 200, 300)), ""); // index & length too big
+
+    EXPECT_EQ(hex(subData(data, 3)), "0405060708090a");
+    EXPECT_EQ(hex(subData(data, 0)), "0102030405060708090a");
+    EXPECT_EQ(hex(subData(data, 200)), ""); // index too big
+}
+
+TEST(DataTests, hasPrefix) {
+    const Data data = parse_hex("0102030405060708090a");
+
+    const Data prefix11 = parse_hex("010203");
+    EXPECT_TRUE(has_prefix(data, prefix11));
+    const Data prefix12 = parse_hex("01");
+    EXPECT_TRUE(has_prefix(data, prefix12));
+    const Data prefix13 = parse_hex("0102030405060708090a");
+    EXPECT_TRUE(has_prefix(data, prefix13));
+
+    const Data prefix21 = parse_hex("020304");
+    EXPECT_FALSE(has_prefix(data, prefix21));
+    const Data prefix22 = parse_hex("02");
+    EXPECT_FALSE(has_prefix(data, prefix22));
+    const Data prefix23 = parse_hex("bb");
+    EXPECT_FALSE(has_prefix(data, prefix23));
+}

--- a/tests/PrivateKeyTests.cpp
+++ b/tests/PrivateKeyTests.cpp
@@ -176,21 +176,23 @@ TEST(PrivateKey, PrivateKeyExtended) {
     auto publicKeyNonext = privateKeyNonext.getPublicKey(TWPublicKeyTypeED25519);
     EXPECT_EQ(32, publicKeyNonext.bytes.size());
 
-    // Extended keys: private key is 2x3x32 bytes, public key is 2x64 bytes
-    auto privateKeyExt = PrivateKey(parse_hex(
+    const auto fullkey = 
         "b0884d248cb301edd1b34cf626ba6d880bb3ae8fd91b4696446999dc4f0b5744"
         "309941d56938e943980d11643c535e046653ca6f498c014b88f2ad9fd6e71eff"
         "bf36a8fa9f5e11eb7a852c41e185e3969d518e66e6893c81d3fc7227009952d4"
         "639aadd8b6499ae39b78018b79255fbd8f585cbda9cbb9e907a72af86afb7a05"
         "d41a57c2dec9a6a19d6bf3b1fa784f334f3a0048d25ccb7b78a7b44066f9ba7b"
-        "ed7f28be986cbe06819165f2ee41b403678a098961013cf4a2f3e9ea61fb6c1a"
-    ));
-    EXPECT_EQ("b0884d248cb301edd1b34cf626ba6d880bb3ae8fd91b4696446999dc4f0b5744", hex(privateKeyExt.bytes));
-    EXPECT_EQ("309941d56938e943980d11643c535e046653ca6f498c014b88f2ad9fd6e71eff", hex(privateKeyExt.extension));
-    EXPECT_EQ("bf36a8fa9f5e11eb7a852c41e185e3969d518e66e6893c81d3fc7227009952d4", hex(privateKeyExt.chainCode));
-    EXPECT_EQ("639aadd8b6499ae39b78018b79255fbd8f585cbda9cbb9e907a72af86afb7a05", hex(privateKeyExt.second));
-    EXPECT_EQ("d41a57c2dec9a6a19d6bf3b1fa784f334f3a0048d25ccb7b78a7b44066f9ba7b", hex(privateKeyExt.secondExtension));
-    EXPECT_EQ("ed7f28be986cbe06819165f2ee41b403678a098961013cf4a2f3e9ea61fb6c1a", hex(privateKeyExt.secondChainCode));
+        "ed7f28be986cbe06819165f2ee41b403678a098961013cf4a2f3e9ea61fb6c1a";
+    // Extended keys: private key is 2x3x32 bytes, public key is 2x64 bytes
+    auto privateKeyExt = PrivateKey(parse_hex(fullkey));
+    EXPECT_EQ(fullkey, hex(privateKeyExt.bytes));
+    EXPECT_EQ("b0884d248cb301edd1b34cf626ba6d880bb3ae8fd91b4696446999dc4f0b5744", hex(privateKeyExt.key()));
+    EXPECT_EQ("309941d56938e943980d11643c535e046653ca6f498c014b88f2ad9fd6e71eff", hex(privateKeyExt.extension()));
+    EXPECT_EQ("bf36a8fa9f5e11eb7a852c41e185e3969d518e66e6893c81d3fc7227009952d4", hex(privateKeyExt.chainCode()));
+    EXPECT_EQ("639aadd8b6499ae39b78018b79255fbd8f585cbda9cbb9e907a72af86afb7a05", hex(privateKeyExt.secondKey()));
+    EXPECT_EQ("d41a57c2dec9a6a19d6bf3b1fa784f334f3a0048d25ccb7b78a7b44066f9ba7b", hex(privateKeyExt.secondExtension()));
+    EXPECT_EQ("ed7f28be986cbe06819165f2ee41b403678a098961013cf4a2f3e9ea61fb6c1a", hex(privateKeyExt.secondChainCode()));
+
     auto publicKeyExt = privateKeyExt.getPublicKey(TWPublicKeyTypeED25519Extended);
     EXPECT_EQ(2*64, publicKeyExt.bytes.size());
 
@@ -203,12 +205,7 @@ TEST(PrivateKey, PrivateKeyExtended) {
         parse_hex("d41a57c2dec9a6a19d6bf3b1fa784f334f3a0048d25ccb7b78a7b44066f9ba7b"),
         parse_hex("ed7f28be986cbe06819165f2ee41b403678a098961013cf4a2f3e9ea61fb6c1a")
     );
-    EXPECT_EQ("b0884d248cb301edd1b34cf626ba6d880bb3ae8fd91b4696446999dc4f0b5744", hex(privateKeyExt.bytes));
-    EXPECT_EQ("309941d56938e943980d11643c535e046653ca6f498c014b88f2ad9fd6e71eff", hex(privateKeyExt.extension));
-    EXPECT_EQ("bf36a8fa9f5e11eb7a852c41e185e3969d518e66e6893c81d3fc7227009952d4", hex(privateKeyExt.chainCode));
-    EXPECT_EQ("639aadd8b6499ae39b78018b79255fbd8f585cbda9cbb9e907a72af86afb7a05", hex(privateKeyExt.second));
-    EXPECT_EQ("d41a57c2dec9a6a19d6bf3b1fa784f334f3a0048d25ccb7b78a7b44066f9ba7b", hex(privateKeyExt.secondExtension));
-    EXPECT_EQ("ed7f28be986cbe06819165f2ee41b403678a098961013cf4a2f3e9ea61fb6c1a", hex(privateKeyExt.secondChainCode));
+    EXPECT_EQ(fullkey, hex(privateKeyExt.bytes));
 }
 
 TEST(PrivateKey, PrivateKeyExtendedError) {

--- a/tests/interface/TWHDWalletTests.cpp
+++ b/tests/interface/TWHDWalletTests.cpp
@@ -286,6 +286,17 @@ TEST(HDWallet, DeriveAvalancheCChain) {
     assertHexEqual(keyData, expectedETH);
 }
 
+TEST(HDWallet, DeriveCardano) {
+    auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), passphrase.get()));
+    auto privateKey = WRAP(TWPrivateKey, TWHDWalletGetKeyForCoin(wallet.get(), TWCoinTypeCardano));
+    auto privateKeyData = WRAPD(TWPrivateKeyData(privateKey.get()));
+    EXPECT_EQ(TWDataSize(privateKeyData.get()), 192);
+    auto address = WRAPS(TWCoinTypeDeriveAddress(TWCoinTypeCardano, privateKey.get()));
+
+    assertHexEqual(privateKeyData, "f8a3b8ad30e62c369b939336c2035aba26d1ffad135e6f346f2a370517a14952e73d20aeadf906bc8b531900fb6c3ed4a05b16973c10ae24650b68b26fae4ee5d97418ba7f3b2707fae963041ff5f174195d1578da09478ad2d17a1ecc00cad478a8ca3be214870accd41f008d70e3b4b59b5981ca933d6d3f389ad317a14952166d8fd329ae3fab4712da739efc2ded9b3eef2b1a8e225dd3dddeb4f065a729b297d9fa76b8852eef235c25aac8f0ff6209ab7251f2a84c83b3b5f1161f7c59");
+    assertStringsEqual(address, "addr1q9zz5nj4rqdvteauvdtc834f2vtzyrdrrdmnwdyp4s6huuz5fp33p9cq4xwpqtgguaxknzurmglv58yn9wrv6angpvvq9u36ya");
+}
+
 TEST(HDWallet, ExtendedKeys) {
     auto words = STRING("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about");
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(words.get(), STRING("").get()));

--- a/walletconsole/lib/Keys.cpp
+++ b/walletconsole/lib/Keys.cpp
@@ -31,14 +31,6 @@ Keys::Keys(ostream& out, const Coins& coins) : _out(out), _coins(coins) {
 void privateKeyToResult(const PrivateKey& priKey, string& res_out) {
     // take the key, but may need to take extension as well
     res_out = hex(priKey.bytes);
-    if (priKey.extension.size() > 0 || priKey.chainCode.size() > 0 ||
-        priKey.second.size() > 0 || priKey.secondExtension.size() > 0 || priKey.secondChainCode.size() > 0) {
-        res_out += hex(priKey.extension);
-        res_out += hex(priKey.chainCode);
-        res_out += hex(priKey.second);
-        res_out += hex(priKey.secondExtension);
-        res_out += hex(priKey.secondChainCode);
-    }
 }
 
 bool Keys::newKey(const string& coinid, string& res) {


### PR DESCRIPTION
## Description

Change approach to double-extended private key (used by Cardano):
instead of storing each subpart differently, store them all in the `bytes` member.
Issue was that in some places (through the C interface) only the `bytes` member was accessed, resulting in 32 bytes only (instead of 192 bytes).
Fixes #2136 .

## Testing instructions

Unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue) 

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
