### PR TITLE
[Cardano] Plan(): extra check for missing key

### DIFF
--- a/src/Cardano/Signer.cpp
+++ b/src/Cardano/Signer.cpp
@@ -268,6 +268,11 @@ TransactionPlan Signer::doPlan() const {
         return plan;
     }
     assert(inputSum > 0);
+    if (input.private_key_size() == 0) {
+        // private key is missing, size will be smaller, treat it as error
+        plan.error = Common::Proto::Error_missing_private_key;
+        return plan;
+    }
 
     // select UTXOs
     plan.amount = input.transfer_message().amount();


### PR DESCRIPTION
## Description

Invoking plan() with no private key results in a smaller size being returned. This is incorrect, input should contain private key.  To enforce, a check has been added to return appropriate error if private key is missing from the plan input.

## Testing instructions

Cardano unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* Minor New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Prefix PR title with `[WIP]` if necessary.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain
- [x] If there is a related Issue, mention it in the description (e.g. Fixes #<issue_number> ).
