### PR TITLE
[Wasm] Implement secure random generator

### DIFF
--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -19,4 +19,8 @@ set_target_properties(${TARGET_NAME}
         CXX_STANDARD 17
         CXX_STANDARD_REQUIRED ON
 )
-set_target_properties(${TARGET_NAME} PROPERTIES COMPILE_FLAGS "-O3 -s USE_BOOST_HEADERS=1" LINK_FLAGS "--bind --no-entry --closure=1 -O3 -s ALLOW_MEMORY_GROWTH=1")
+set_target_properties(${TARGET_NAME} 
+        PROPERTIES 
+        COMPILE_FLAGS "-O3 -s USE_BOOST_HEADERS=1" 
+        LINK_FLAGS "--bind --no-entry --closure=1 -O3 -s ALLOW_MEMORY_GROWTH=1 -s ERROR_ON_UNDEFINED_SYMBOLS=1"
+)

--- a/wasm/src/Random.cpp
+++ b/wasm/src/Random.cpp
@@ -1,0 +1,25 @@
+// Copyright © 2017-2022 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+//
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <random>
+
+extern "C" {
+uint32_t random32(void) {
+    std::mt19937 rng(std::random_device{}());
+    return rng();
+}
+
+void random_buffer(uint8_t* buf, size_t len) {
+    std::mt19937 rng(std::random_device{}());
+    std::generate_n(buf, len, [&rng]() -> uint8_t { return rng() & 0x000000ff; });
+    return;
+}
+
+} // extern "C"


### PR DESCRIPTION
Fixes https://github.com/trustwallet/wallet-core/issues/2220

Emscripten already uses random API (via `getRandomDevice`) available on Browser or Node, see https://github.com/emscripten-core/emscripten/blob/main/src/library.js#L2204

What we do here is simple, we wrap `std::random_device` with `std::mt19937` and return a random uint32 value, inspired by https://github.com/emscripten-core/emscripten/pull/12240