### PR TITLE
Ronin: normalize address to checksummed format (EIP55)

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
@@ -43,7 +43,7 @@ class CoinAddressDerivationTests {
         ETHEREUM, SMARTCHAIN, POLYGON, OPTIMISM, ARBITRUM, ECOCHAIN, AVALANCHECCHAIN, XDAI,
         FANTOM, CELO, CRONOSCHAIN, SMARTBITCOINCASH, KUCOINCOMMUNITYCHAIN, BOBA, METIS,
         AURORA, EVMOS -> assertEquals("0x8f348F300873Fd5DA36950B2aC75a26584584feE", address)
-        RONIN -> assertEquals("ronin:8f348f300873fd5da36950b2ac75a26584584fee", address)
+        RONIN -> assertEquals("ronin:8f348F300873Fd5DA36950B2aC75a26584584feE", address)
         ETHEREUMCLASSIC -> assertEquals("0x078bA3228F3E6C08bEEac9A005de0b7e7089aD1c", address)
         GOCHAIN -> assertEquals("0x5940ce4A14210d4Ccd0ac206CE92F21828016aC2", address)
         GROESTLCOIN -> assertEquals("grs1qexwmshts5pdpeqglkl39zyl6693tmfwp0cue4j", address)

--- a/src/Ronin/Address.cpp
+++ b/src/Ronin/Address.cpp
@@ -6,6 +6,7 @@
 
 #include "Address.h"
 #include "Ethereum/Address.h"
+#include "Ethereum/AddressChecksum.h"
 #include "../Hash.h"
 #include "../HexCoding.h"
 
@@ -41,6 +42,9 @@ Address::Address(const std::string& string) {
     }
 }
 
+// Normalized: with ronin prefix, checksummed hex address, no 0x prefix
 std::string Address::string() const {
-    return prefix + hex(bytes);
+    std::string address = Ethereum::checksumed(*this, Ethereum::ChecksumType::eip55);
+    if (address.size() >= 2 && address.substr(0, 2) == "0x") { address = address.substr(2); } // skip 0x
+    return prefix + address;
 }

--- a/swift/Tests/CoinAddressDerivationTests.swift
+++ b/swift/Tests/CoinAddressDerivationTests.swift
@@ -90,7 +90,7 @@ class CoinAddressDerivationTests: XCTestCase {
                     let expectedResult = "0x8f348F300873Fd5DA36950B2aC75a26584584feE"
                     assertCoinDerivation(coin, expectedResult, derivedAddress, address)
                 case .ronin:
-                    let expectedResult = "ronin:8f348f300873fd5da36950b2ac75a26584584fee"
+                    let expectedResult = "ronin:8f348F300873Fd5DA36950B2aC75a26584584feE"
                     assertCoinDerivation(coin, expectedResult, derivedAddress, address)
                 case .ethereumClassic:
                     let expectedResult = "0x078bA3228F3E6C08bEEac9A005de0b7e7089aD1c"

--- a/tests/CoinAddressDerivationTests.cpp
+++ b/tests/CoinAddressDerivationTests.cpp
@@ -80,7 +80,7 @@ TEST(Coin, DeriveAddress) {
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeAvalancheCChain, privateKey), "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F");
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeXDai, privateKey), "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F");
     EXPECT_EQ(TW::deriveAddress(TWCoinTypeCelo, privateKey), "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F");
-    EXPECT_EQ(TW::deriveAddress(TWCoinTypeRonin, privateKey), "ronin:9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f");
+    EXPECT_EQ(TW::deriveAddress(TWCoinTypeRonin, privateKey), "ronin:9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F");
 }
 
 int countThreadReady = 0;

--- a/tests/Ronin/TWAnyAddressTests.cpp
+++ b/tests/Ronin/TWAnyAddressTests.cpp
@@ -14,46 +14,45 @@
 
 #include <gtest/gtest.h>
 
-const auto normalized1 = STRING("ronin:ec49280228b0d05aa8e8b756503254e1ee7835ab");
+const auto roninPrefixChecksummed = "ronin:EC49280228b0D05Aa8e8b756503254e1eE7835ab";
 
-TEST(RoninAnyAddress, ValidateRoninNonChecksummed) {
-    EXPECT_TRUE(TWAnyAddressIsValid(normalized1.get(), TWCoinTypeRonin));
+const auto tests = {
+    roninPrefixChecksummed,
+    "ronin:ec49280228b0d05aa8e8b756503254e1ee7835ab",
+    "0xEC49280228b0D05Aa8e8b756503254e1eE7835ab",
+    "ronin:0xEC49280228b0D05Aa8e8b756503254e1eE7835ab",
+};
 
-    auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithString(normalized1.get(), TWCoinTypeRonin));
-    auto string2 = WRAPS(TWAnyAddressDescription(addr.get()));
-    EXPECT_TRUE(TWStringEqual(string2.get(), normalized1.get()));
-
-    auto keyHash = WRAPD(TWAnyAddressData(addr.get()));
-    assertHexEqual(keyHash, "ec49280228b0d05aa8e8b756503254e1ee7835ab");
+TEST(RoninAnyAddress, Validate) {
+    for (const auto& t: tests) {
+        EXPECT_TRUE(TWAnyAddressIsValid(STRING(t).get(), TWCoinTypeRonin));
+    }
 }
 
-TEST(RoninAnyAddress, ValidateRoninChecksummed) {
-    auto checksummed = STRING("ronin:EC49280228b0D05Aa8e8b756503254e1eE7835ab");
-    EXPECT_TRUE(TWAnyAddressIsValid(checksummed.get(), TWCoinTypeRonin));
+TEST(RoninAnyAddress, Normalize) {
+    for (const auto& t: tests) {
+        auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithString(STRING(t).get(), TWCoinTypeRonin));
+        auto string2 = WRAPS(TWAnyAddressDescription(addr.get()));
+        EXPECT_TRUE(TWStringEqual(string2.get(), STRING(roninPrefixChecksummed).get()));
 
-    auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithString(checksummed.get(), TWCoinTypeRonin));
-    auto string2 = WRAPS(TWAnyAddressDescription(addr.get()));
-    EXPECT_TRUE(TWStringEqual(string2.get(), normalized1.get()));
-
-    auto keyHash = WRAPD(TWAnyAddressData(addr.get()));
-    assertHexEqual(keyHash, "ec49280228b0d05aa8e8b756503254e1ee7835ab");    
-}
-
-TEST(RoninAnyAddress, ValidateEthereum) {
-    auto ethereum = STRING("0xEC49280228b0D05Aa8e8b756503254e1eE7835ab");
-    EXPECT_TRUE(TWAnyAddressIsValid(ethereum.get(), TWCoinTypeRonin));
-
-    auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithString(ethereum.get(), TWCoinTypeRonin));
-    auto string2 = WRAPS(TWAnyAddressDescription(addr.get()));
-    EXPECT_TRUE(TWStringEqual(string2.get(), normalized1.get()));
-
-    auto keyHash = WRAPD(TWAnyAddressData(addr.get()));
-    assertHexEqual(keyHash, "ec49280228b0d05aa8e8b756503254e1ee7835ab");
+        auto keyHash = WRAPD(TWAnyAddressData(addr.get()));
+        assertHexEqual(keyHash, "ec49280228b0d05aa8e8b756503254e1ee7835ab");
+    }
 }
 
 TEST(RoninAnyAddress, Invalid) {
-    EXPECT_FALSE(TWAnyAddressIsValid(STRING("EC49280228b0D05Aa8e8b756503254e1eE7835ab").get(), TWCoinTypeRonin)); // no prefix
-    EXPECT_FALSE(TWAnyAddressIsValid(STRING("EC49280228b0D05Aa8e8b756503254e1eE7835").get(), TWCoinTypeRonin)); // too short
-    EXPECT_FALSE(TWAnyAddressIsValid(STRING("ronin:EC49280228b0D05Aa8e8b756503254e1eE7835").get(), TWCoinTypeRonin)); // too short
-    EXPECT_FALSE(TWAnyAddressIsValid(STRING("ronin:ec49280228b0d05aa8e8b756503254e1ee7835").get(), TWCoinTypeRonin)); // too short
+    const auto tests = {
+        "EC49280228b0D05Aa8e8b756503254e1eE7835ab", // no prefix
+        "ec49280228b0d05aa8e8b756503254e1ee7835ab", // no prefix
+        "roni:EC49280228b0D05Aa8e8b756503254e1eE7835ab", // wrong prefix
+        "ronin=EC49280228b0D05Aa8e8b756503254e1eE7835ab", // wrong prefix
+        "0xronin:EC49280228b0D05Aa8e8b756503254e1eE7835ab", // wrong prefix
+        "EC49280228b0D05Aa8e8b756503254e1eE7835", // too short
+        "ronin:EC49280228b0D05Aa8e8b756503254e1eE7835", // too short
+        "ronin:ec49280228b0d05aa8e8b756503254e1ee7835", // too short
+    };
+
+    for (const auto& t: tests) {
+        EXPECT_FALSE(TWAnyAddressIsValid(STRING(t).get(), TWCoinTypeRonin));
+    }
 }


### PR DESCRIPTION
## Description

When normalizing a Ronin address, use the checksummed format, such as `ronin:EC49280228b0D05Aa8e8b756503254e1eE7835ab`.
Both checksummed and non checksummed versions are accepted as valid, this is not changed.

## How to test

Ronin unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

* Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [ ] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
