### PR TITLE
Modernize Bitcoin Fee Calculator code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,7 +8,6 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: true
 IndentWidth: 4
 IndentAccessModifiers: false
 AccessModifierOffset: -4
-#AccessModifierOffset: -1
 PointerAlignment: Left
 IncludeCategories:
   - Regex:           '^"\.\./'

--- a/.clang-format
+++ b/.clang-format
@@ -6,6 +6,9 @@ BreakConstructorInitializers: BeforeComma
 ColumnLimit: 100
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 IndentWidth: 4
+IndentAccessModifiers: false
+AccessModifierOffset: -4
+#AccessModifierOffset: -1
 PointerAlignment: Left
 IncludeCategories:
   - Regex:           '^"\.\./'

--- a/src/Bitcoin/FeeCalculator.cpp
+++ b/src/Bitcoin/FeeCalculator.cpp
@@ -12,9 +12,9 @@ using namespace TW;
 
 namespace TW::Bitcoin {
 
-constexpr const double gDecredBytesPerInput{166};
-constexpr const double gDecredBytesPerOutput{38};
-constexpr const double gDecredBytesBase{12};
+constexpr double gDecredBytesPerInput{166};
+constexpr double gDecredBytesPerOutput{38};
+constexpr double gDecredBytesBase{12};
 
 int64_t LinearFeeCalculator::calculate(int64_t inputs, int64_t outputs,
                                        int64_t byteFee) const noexcept {

--- a/src/Bitcoin/FeeCalculator.cpp
+++ b/src/Bitcoin/FeeCalculator.cpp
@@ -12,24 +12,31 @@ using namespace TW;
 
 namespace TW::Bitcoin {
 
-int64_t LinearFeeCalculator::calculate(int64_t inputs, int64_t outputs, int64_t byteFee) const {
-    const auto txsize = int64_t(std::ceil(bytesPerInput * (double)inputs + bytesPerOutput * (double)outputs + bytesBase));
+constexpr const double gDecredBytesPerInput{166};
+constexpr const double gDecredBytesPerOutput{38};
+constexpr const double gDecredBytesBase{12};
+
+int64_t LinearFeeCalculator::calculate(int64_t inputs, int64_t outputs,
+                                       int64_t byteFee) const noexcept {
+    const auto txsize =
+        static_cast<int64_t>(std::ceil(bytesPerInput * static_cast<double>(inputs) +
+                                       bytesPerOutput * static_cast<double>(outputs) + bytesBase));
     return txsize * byteFee;
 }
 
-int64_t LinearFeeCalculator::calculateSingleInput(int64_t byteFee) const {
-    return int64_t(std::ceil(bytesPerInput)) * byteFee; // std::ceil(101.25) = 102
+int64_t LinearFeeCalculator::calculateSingleInput(int64_t byteFee) const noexcept {
+    return static_cast<int64_t>(std::ceil(bytesPerInput)) * byteFee; // std::ceil(101.25) = 102
 }
 
 class DecredFeeCalculator : public LinearFeeCalculator {
-public:
-    constexpr DecredFeeCalculator() noexcept: LinearFeeCalculator(166, 38, 12) {}
+  public:
+    constexpr DecredFeeCalculator() noexcept
+        : LinearFeeCalculator(gDecredBytesPerInput, gDecredBytesPerOutput, gDecredBytesBase) {}
 };
 
 constexpr DefaultFeeCalculator defaultFeeCalculator{};
 constexpr DecredFeeCalculator decredFeeCalculator{};
 constexpr SegwitFeeCalculator segwitFeeCalculator{};
-
 
 const FeeCalculator& getFeeCalculator(TWCoinType coinType) {
     switch (coinType) {

--- a/src/Bitcoin/FeeCalculator.cpp
+++ b/src/Bitcoin/FeeCalculator.cpp
@@ -23,14 +23,15 @@ int64_t LinearFeeCalculator::calculateSingleInput(int64_t byteFee) const {
 
 class DecredFeeCalculator : public LinearFeeCalculator {
 public:
-    DecredFeeCalculator(): LinearFeeCalculator(166, 38, 12) {}
+    constexpr DecredFeeCalculator() noexcept: LinearFeeCalculator(166, 38, 12) {}
 };
 
-DefaultFeeCalculator defaultFeeCalculator;
-DecredFeeCalculator decredFeeCalculator;
-SegwitFeeCalculator segwitFeeCalculator;
+constexpr DefaultFeeCalculator defaultFeeCalculator{};
+constexpr DecredFeeCalculator decredFeeCalculator{};
+constexpr SegwitFeeCalculator segwitFeeCalculator{};
 
-FeeCalculator& getFeeCalculator(TWCoinType coinType) {
+
+const FeeCalculator& getFeeCalculator(TWCoinType coinType) {
     switch (coinType) {
     case TWCoinTypeDecred:
         return decredFeeCalculator;

--- a/src/Bitcoin/FeeCalculator.cpp
+++ b/src/Bitcoin/FeeCalculator.cpp
@@ -29,7 +29,7 @@ int64_t LinearFeeCalculator::calculateSingleInput(int64_t byteFee) const noexcep
 }
 
 class DecredFeeCalculator : public LinearFeeCalculator {
-  public:
+public:
     constexpr DecredFeeCalculator() noexcept
         : LinearFeeCalculator(gDecredBytesPerInput, gDecredBytesPerOutput, gDecredBytesBase) {}
 };

--- a/src/Bitcoin/FeeCalculator.h
+++ b/src/Bitcoin/FeeCalculator.h
@@ -16,6 +16,7 @@ inline constexpr double gDefaultBytesBase{10};
 inline constexpr double gSegwitBytesPerInput{101.25};
 inline constexpr double gSegwitBytesPerOutput{31};
 inline constexpr double gSegwitBytesBase{gDefaultBytesBase};
+
 /// Interface for transaction fee calculator.
 class FeeCalculator {
   public:

--- a/src/Bitcoin/FeeCalculator.h
+++ b/src/Bitcoin/FeeCalculator.h
@@ -19,7 +19,7 @@ inline constexpr double gSegwitBytesBase{gDefaultBytesBase};
 
 /// Interface for transaction fee calculator.
 class FeeCalculator {
-  public:
+public:
     [[nodiscard]] virtual int64_t calculate(int64_t inputs, int64_t outputs,
                                             int64_t byteFee) const = 0;
     [[nodiscard]] virtual int64_t calculateSingleInput(int64_t byteFee) const = 0;
@@ -27,7 +27,7 @@ class FeeCalculator {
 
 /// Generic fee calculator with linear input and output size, and a fix size
 class LinearFeeCalculator : public FeeCalculator {
-  public:
+public:
     const double bytesPerInput;
     const double bytesPerOutput;
     const double bytesBase;
@@ -42,7 +42,7 @@ class LinearFeeCalculator : public FeeCalculator {
 
 /// Constant fee calculator
 class ConstantFeeCalculator : public FeeCalculator {
-  public:
+public:
     const int64_t fee;
     explicit constexpr ConstantFeeCalculator(int64_t fee) noexcept : fee(fee) {}
 
@@ -55,14 +55,14 @@ class ConstantFeeCalculator : public FeeCalculator {
 
 /// Default Bitcoin transaction fee calculator, non-segwit.
 class DefaultFeeCalculator : public LinearFeeCalculator {
-  public:
+public:
     constexpr DefaultFeeCalculator() noexcept
         : LinearFeeCalculator(gDefaultBytesPerInput, gDefaultBytesPerOutput, gDefaultBytesBase) {}
 };
 
 /// Bitcoin Segwit transaction fee calculator
 class SegwitFeeCalculator : public LinearFeeCalculator {
-  public:
+public:
     constexpr SegwitFeeCalculator() noexcept
         : LinearFeeCalculator(gSegwitBytesPerInput, gSegwitBytesPerOutput, gSegwitBytesBase) {}
 };

--- a/src/Bitcoin/FeeCalculator.h
+++ b/src/Bitcoin/FeeCalculator.h
@@ -10,49 +10,62 @@
 
 namespace TW::Bitcoin {
 
+inline constexpr const double gDefaultBytesPerInput{148};
+inline constexpr const double gDefaultBytesPerOutput{34};
+inline constexpr const double gDefaultBytesBase{10};
+inline constexpr const double gSegwitBytesPerInput{101.25};
+inline constexpr const double gSegwitBytesPerOutput{31};
+inline constexpr const double gSegwitBytesBase{gDefaultBytesBase};
 /// Interface for transaction fee calculator.
 class FeeCalculator {
-public:
-    virtual int64_t calculate(int64_t inputs, int64_t outputs, int64_t byteFee) const = 0;
-    virtual int64_t calculateSingleInput(int64_t byteFee) const = 0;
+  public:
+    [[nodiscard]] virtual int64_t calculate(int64_t inputs, int64_t outputs,
+                                            int64_t byteFee) const = 0;
+    [[nodiscard]] virtual int64_t calculateSingleInput(int64_t byteFee) const = 0;
 };
 
 /// Generic fee calculator with linear input and output size, and a fix size
 class LinearFeeCalculator : public FeeCalculator {
-public:
+  public:
     const double bytesPerInput;
     const double bytesPerOutput;
     const double bytesBase;
-    LinearFeeCalculator(double bytesPerInput, double bytesPerOutput, double bytesBase)
-        :bytesPerInput(bytesPerInput), bytesPerOutput(bytesPerOutput), bytesBase(bytesBase) {}
+    explicit constexpr LinearFeeCalculator(double bytesPerInput, double bytesPerOutput,
+                                           double bytesBase) noexcept
+        : bytesPerInput(bytesPerInput), bytesPerOutput(bytesPerOutput), bytesBase(bytesBase) {}
 
-    virtual int64_t calculate(int64_t inputs, int64_t outputs, int64_t byteFee) const override;
-    virtual int64_t calculateSingleInput(int64_t byteFee) const override;
+    [[nodiscard]] int64_t calculate(int64_t inputs, int64_t outputs,
+                                    int64_t byteFee) const override;
+    [[nodiscard]] int64_t calculateSingleInput(int64_t byteFee) const override;
 };
 
 /// Constant fee calculator
 class ConstantFeeCalculator : public FeeCalculator {
-public:
+  public:
     const int64_t fee;
-    ConstantFeeCalculator(int64_t fee) : fee(fee) {}
+    explicit constexpr ConstantFeeCalculator(int64_t fee) noexcept : fee(fee) {}
 
-    virtual int64_t calculate(int64_t inputs, int64_t outputs, int64_t byteFee) const override { return fee; }
-    virtual int64_t calculateSingleInput(int64_t byteFee) const override { return 0; }
+    [[nodiscard]] int64_t calculate(int64_t inputs, int64_t outputs, int64_t byteFee) const final {
+        return fee;
+    }
+    [[nodiscard]] int64_t calculateSingleInput(int64_t byteFee) const final { return 0; }
 };
 
 /// Default Bitcoin transaction fee calculator, non-segwit.
 class DefaultFeeCalculator : public LinearFeeCalculator {
-public:
-    DefaultFeeCalculator(): LinearFeeCalculator(148, 34, 10) {}
+  public:
+    constexpr DefaultFeeCalculator() noexcept
+        : LinearFeeCalculator(gDefaultBytesPerInput, gDefaultBytesPerOutput, gDefaultBytesBase) {}
 };
 
 /// Bitcoin Segwit transaction fee calculator
 class SegwitFeeCalculator : public LinearFeeCalculator {
-public:
-    SegwitFeeCalculator(): LinearFeeCalculator(101.25, 31, 10) {}
+  public:
+    constexpr SegwitFeeCalculator() noexcept
+        : LinearFeeCalculator(gSegwitBytesPerInput, gSegwitBytesPerOutput, gSegwitBytesBase) {}
 };
 
 /// Return the fee calculator for the given coin.
-FeeCalculator& getFeeCalculator(TWCoinType coinType);
+const FeeCalculator& getFeeCalculator(TWCoinType coinType);
 
 } // namespace TW::Bitcoin

--- a/src/Bitcoin/FeeCalculator.h
+++ b/src/Bitcoin/FeeCalculator.h
@@ -35,8 +35,8 @@ class LinearFeeCalculator : public FeeCalculator {
         : bytesPerInput(bytesPerInput), bytesPerOutput(bytesPerOutput), bytesBase(bytesBase) {}
 
     [[nodiscard]] int64_t calculate(int64_t inputs, int64_t outputs,
-                                    int64_t byteFee) const override;
-    [[nodiscard]] int64_t calculateSingleInput(int64_t byteFee) const override;
+                                    int64_t byteFee) const noexcept override;
+    [[nodiscard]] int64_t calculateSingleInput(int64_t byteFee) const noexcept override;
 };
 
 /// Constant fee calculator
@@ -45,10 +45,11 @@ class ConstantFeeCalculator : public FeeCalculator {
     const int64_t fee;
     explicit constexpr ConstantFeeCalculator(int64_t fee) noexcept : fee(fee) {}
 
-    [[nodiscard]] int64_t calculate(int64_t inputs, int64_t outputs, int64_t byteFee) const final {
+    [[nodiscard]] int64_t calculate(int64_t inputs, int64_t outputs,
+                                    int64_t byteFee) const noexcept final {
         return fee;
     }
-    [[nodiscard]] int64_t calculateSingleInput(int64_t byteFee) const final { return 0; }
+    [[nodiscard]] int64_t calculateSingleInput(int64_t byteFee) const noexcept final { return 0; }
 };
 
 /// Default Bitcoin transaction fee calculator, non-segwit.

--- a/src/Bitcoin/FeeCalculator.h
+++ b/src/Bitcoin/FeeCalculator.h
@@ -10,12 +10,12 @@
 
 namespace TW::Bitcoin {
 
-inline constexpr const double gDefaultBytesPerInput{148};
-inline constexpr const double gDefaultBytesPerOutput{34};
-inline constexpr const double gDefaultBytesBase{10};
-inline constexpr const double gSegwitBytesPerInput{101.25};
-inline constexpr const double gSegwitBytesPerOutput{31};
-inline constexpr const double gSegwitBytesBase{gDefaultBytesBase};
+inline constexpr double gDefaultBytesPerInput{148};
+inline constexpr double gDefaultBytesPerOutput{34};
+inline constexpr double gDefaultBytesBase{10};
+inline constexpr double gSegwitBytesPerInput{101.25};
+inline constexpr double gSegwitBytesPerOutput{31};
+inline constexpr double gSegwitBytesBase{gDefaultBytesBase};
 /// Interface for transaction fee calculator.
 class FeeCalculator {
   public:

--- a/tests/Bitcoin/FeeCalculatorTests.cpp
+++ b/tests/Bitcoin/FeeCalculatorTests.cpp
@@ -32,7 +32,7 @@ TEST(BitcoinFeeCalculator, LinearFeeCalculator) {
 }
 
 TEST(BitcoinFeeCalculator, BitcoinCalculate) {
-    FeeCalculator& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
+    const FeeCalculator& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
     EXPECT_EQ(feeCalculator.calculate(1, 2, 1), 174);
     EXPECT_EQ(feeCalculator.calculate(1, 1, 1), 143);
     EXPECT_EQ(feeCalculator.calculate(0, 2, 1), 72);
@@ -42,7 +42,7 @@ TEST(BitcoinFeeCalculator, BitcoinCalculate) {
 }
 
 TEST(BitcoinFeeCalculator, SegwitCalculate) {
-    FeeCalculator& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
+    const FeeCalculator& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
     EXPECT_EQ(feeCalculator.calculate(1, 2, 1), 174);
     EXPECT_EQ(feeCalculator.calculate(1, 1, 1), 143);
     EXPECT_EQ(feeCalculator.calculate(0, 2, 1), 72);
@@ -69,7 +69,7 @@ TEST(BitcoinFeeCalculator, DefaultCalculateSingleInput) {
 }
 
 TEST(BitcoinFeeCalculator, DecredCalculate) {
-    FeeCalculator& feeCalculator = getFeeCalculator(TWCoinTypeDecred);
+    const FeeCalculator& feeCalculator = getFeeCalculator(TWCoinTypeDecred);
     EXPECT_EQ(feeCalculator.calculate(1, 2, 1), 254);
     EXPECT_EQ(feeCalculator.calculate(0, 0, 1), 12);
     EXPECT_EQ(feeCalculator.calculate(1, 2, 10), 2540);


### PR DESCRIPTION
## Description

- Use constexpr/noexcept constructor to avoid `may throw during initialization storage`
- Make getFeeCalculator const
- Turn the default calculators constexpr
- Use C++17 inline variable for global value and give more readability
- Turn deprecated usage of virtual in an override function
- Use appropriately final when needed.
- Use noexcept when required
- Use `explicit` for single constructor
- Use `nodiscard` for non-void returning functions
- Do not use c-cast as they imply a `const_cast` by the compiler: https://en.cppreference.com/w/cpp/language/explicit_cast

## How to test

```bash
make -C build tests && build/tests/tests tests
```

## Types of changes

Modernize code (use modern c++, improve readability, more safeness)

## Checklist

- [x] Create pull request as draft initially, unless its complete.
- [x] Add/Update tests to cover changes as needed.
- [ ] Update documentation as needed.
- [ ] If there is a related Issue, mention it in the description.

ps: Regarding the format, my IDE have detected the `.clang-format` and applied format based on it

ps 2: I would like an approval status for the CI before undrafting, I've tested only the C++ tests since I've not modified any C API related files