### PR TITLE
Add missing `throw` for EOS transaction

### DIFF
--- a/src/EOS/Transaction.cpp
+++ b/src/EOS/Transaction.cpp
@@ -102,11 +102,9 @@ void Transaction::serialize(Data& os) const noexcept{
 json Transaction::serialize() const {
 
     // get a formatted date
-    char formattedDate[20];
     time_t time = expiration;
-    if (strftime(formattedDate, 19, "%FT%T", std::gmtime(&time)) != 19) {
-        throw std::runtime_error("Error creating a formatted string!");
-    }
+    std::stringstream buffer;
+    buffer << std::put_time(std::gmtime(&time), "%FT%T");
 
     // create a json array of signatures
     json sigs = json::array();
@@ -118,7 +116,7 @@ json Transaction::serialize() const {
     json obj;
     obj["ref_block_num"] = refBlockNumber;
     obj["ref_block_prefix"] = refBlockPrefix;
-    obj["expiration"] = std::string(formattedDate, 19);
+    obj["expiration"] = buffer.str();
     obj["max_net_usage_words"] = maxNetUsageWords;
     obj["max_cpu_usage_ms"] = maxCPUUsageInMS;
     obj["delay_sec"] = delaySeconds;

--- a/src/EOS/Transaction.cpp
+++ b/src/EOS/Transaction.cpp
@@ -12,6 +12,7 @@
 #include <TrezorCrypto/ripemd160.h>
 
 #include <ctime>
+#include <iomanip>
 #include <stdexcept>
 
 using namespace TW;

--- a/src/EOS/Transaction.cpp
+++ b/src/EOS/Transaction.cpp
@@ -101,11 +101,8 @@ void Transaction::serialize(Data& os) const noexcept{
 }
 
 json Transaction::serialize() const {
-
-    // get a formatted date
-    time_t time = expiration;
     std::stringstream buffer;
-    buffer << std::put_time(std::gmtime(&time), "%FT%T");
+    buffer << std::put_time(std::gmtime(reinterpret_cast<const time_t*>(&expiration)), "%FT%T");
     if (buffer.fail() || buffer.bad()) {
         throw std::runtime_error("Error creating a formatted string!");
     }

--- a/src/EOS/Transaction.cpp
+++ b/src/EOS/Transaction.cpp
@@ -105,7 +105,7 @@ json Transaction::serialize() const {
     char formattedDate[20];
     time_t time = expiration;
     if (strftime(formattedDate, 19, "%FT%T", std::gmtime(&time)) != 19) {
-        std::runtime_error("Error creating a formatted string!");
+        throw std::runtime_error("Error creating a formatted string!");
     }
 
     // create a json array of signatures

--- a/src/EOS/Transaction.cpp
+++ b/src/EOS/Transaction.cpp
@@ -106,6 +106,9 @@ json Transaction::serialize() const {
     time_t time = expiration;
     std::stringstream buffer;
     buffer << std::put_time(std::gmtime(&time), "%FT%T");
+    if (buffer.fail() || buffer.bad()) {
+        throw std::runtime_error("Error creating a formatted string!");
+    }
 
     // create a json array of signatures
     json sigs = json::array();


### PR DESCRIPTION
## Description

- fix missing throw according to https://cwe.mitre.org/data/definitions/390.html

