### PR TITLE
[Fix]: use std::copy in implementation of to_array

### DIFF
--- a/src/Bitcoin/OutPoint.h
+++ b/src/Bitcoin/OutPoint.h
@@ -33,7 +33,7 @@ struct OutPoint {
     /// Initializes an out-point reference with hash, index.
     template <typename T>
     OutPoint(const T& h, uint32_t index, uint32_t sequence = 0) noexcept
-        : hash(to_array<32, byte>(std::begin(h))), index(index), sequence(sequence) {}
+        : hash(to_array<byte, 32>(h)), index(index), sequence(sequence) {}
 
     /// Initializes an out-point from a Protobuf out-point.
     OutPoint(const Proto::OutPoint& other) noexcept

--- a/src/algorithm/to_array.h
+++ b/src/algorithm/to_array.h
@@ -6,22 +6,16 @@
 
 #pragma once
 
-#include <array>       //< std::array
-#include <cstddef>     //< std::size_t
-#include <type_traits> //< std::is_same
+#include <algorithm> //< std::copy
+#include <array>     //< std::array
 
 namespace TW {
 
-template <typename T, typename Iter, std::size_t... Is>
-constexpr auto to_array(Iter& iter, std::index_sequence<Is...>) -> std::array<T, sizeof...(Is)> {
-    return {{((void)Is, T(*iter++))...}};
-}
-
-template <std::size_t N, typename U = void, typename Iter,
-          typename V = typename std::iterator_traits<Iter>::value_type,
-          typename T = std::conditional_t<std::is_same<U, void>{}, V, U>>
-constexpr auto to_array(Iter iter) -> std::array<T, N> {
-    return to_array<T>(iter, std::make_index_sequence<N>{});
+template <typename T, std::size_t N, typename Collection>
+constexpr std::array<T, N> to_array(Collection&& collection) {
+    std::array<T, N> out{};
+    std::copy(begin(collection), end(collection), out.begin());
+    return out;
 }
 
 } // namespace TW

--- a/tests/algorithm/to_array_tests.cpp
+++ b/tests/algorithm/to_array_tests.cpp
@@ -12,12 +12,12 @@ using namespace TW;
 
 TEST(Algorithms, ToArray) {
     std::string str{"foo"};
-    auto value = TW::to_array<4, std::uint8_t>(begin(str));
+    auto value = TW::to_array<std::uint8_t, 4>(str);
     auto expected = std::array<std::uint8_t, 4>{"foo"};
     ASSERT_EQ(value, expected);
 
     std::vector<std::uint8_t> ints{0, 1, 2};
-    auto another_value = TW::to_array<3, std::uint8_t>(begin(ints));
+    auto another_value = TW::to_array<std::uint8_t, 3>(ints);
     auto expected_ints = std::array<std::uint8_t, 3>{0, 1, 2};
     ASSERT_EQ(another_value, expected_ints);
 }


### PR DESCRIPTION
## Summary:

- some input collections may have a different size than the size of the array
- Got confused with the `assert(other.hash.size())` (was assuming every input will be of the size of std::array)
- make to_array take the type of the array
- use std::copy inside instead of index_sequences to avoid buffer overflow reading

## How to test

run unit tests with ASAN enabled

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
