### PR TITLE
Replaced GRPC dependency with Protobuf

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'android.arch.core:core-testing:1.1.1'
 
-    implementation 'io.grpc:grpc-protobuf:1.43.2'
+    implementation 'com.google.protobuf:protobuf-java:3.21.2'
 }
 repositories {
     mavenCentral()

--- a/android/trustwalletcore/build.gradle
+++ b/android/trustwalletcore/build.gradle
@@ -47,7 +47,7 @@ android {
 }
 
 dependencies {
-    implementation 'io.grpc:grpc-protobuf:1.43.2'
+    implementation 'com.google.protobuf:protobuf-java:3.21.2'
 }
 
 apply from: 'maven-push.gradle'


### PR DESCRIPTION
Seems that we don't need GRPC dependency but only protobuf in Android project