### PR TITLE
[Interface]: Expose TWCoinTypeDerivationPathWithDerivation to C Interface

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/TestCoinType.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/TestCoinType.kt
@@ -3,9 +3,11 @@ package com.trustwallet.core.app.blockchains
 import wallet.core.jni.CoinType
 import wallet.core.jni.Curve
 import wallet.core.jni.Purpose
+import wallet.core.jni.Derivation
+
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import wallet.core.jni.Derivation
+
 
 
 class TestCoinType {

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/TestCoinType.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/TestCoinType.kt
@@ -4,13 +4,13 @@ import wallet.core.jni.CoinType
 import wallet.core.jni.Curve
 import wallet.core.jni.Purpose
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Test
+import wallet.core.jni.Derivation
 
 
 class TestCoinType {
     init {
-        System.loadLibrary("TrustWalletCore");
+        System.loadLibrary("TrustWalletCore")
     }
 
     @Test
@@ -42,5 +42,15 @@ class TestCoinType {
     @Test
     fun testCoinCurve() {
         assertEquals(Curve.SECP256K1, CoinType.BITCOIN.curve())
+    }
+
+    @Test
+    fun testDerivationPath() {
+        var res = CoinType.createFromValue(CoinType.BITCOIN.value()).derivationPath().toString()
+        assertEquals(res, "m/84'/0'/0'/0/0")
+        res = CoinType.createFromValue(CoinType.BITCOIN.value()).derivationPathWithDerivation(Derivation.BITCOINLEGACY).toString()
+        assertEquals(res, "m/44'/0'/0'/0/0")
+        res = CoinType.createFromValue(CoinType.SOLANA.value()).derivationPathWithDerivation(Derivation.SOLANASOLANA).toString()
+        assertEquals(res, "m/44'/501'/0'/0'")
     }
 }

--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -14,6 +14,7 @@
 #include "TWPrivateKey.h"
 #include "TWPurpose.h"
 #include "TWString.h"
+#include "TWDerivation.h"
 
 TW_EXTERN_C_BEGIN
 
@@ -141,6 +142,10 @@ bool TWCoinTypeValidate(enum TWCoinType coin, TWString* _Nonnull address);
 /// Returns the default derivation path for a particular coin.
 TW_EXPORT_METHOD
 TWString* _Nonnull TWCoinTypeDerivationPath(enum TWCoinType coin);
+
+/// Returns the default derivation path for a particular coin with the explicit given derivation.
+TW_EXPORT_METHOD
+TWString* _Nonnull TWCoinTypeDerivationPathExplicit(enum TWCoinType coin, enum TWDerivation derivation);
 
 /// Derives the address for a particular coin from the private key.
 TW_EXPORT_METHOD

--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -143,9 +143,9 @@ bool TWCoinTypeValidate(enum TWCoinType coin, TWString* _Nonnull address);
 TW_EXPORT_METHOD
 TWString* _Nonnull TWCoinTypeDerivationPath(enum TWCoinType coin);
 
-/// Returns the default derivation path for a particular coin with the explicit given derivation.
+/// Returns the derivation path for a particular coin with the explicit given derivation.
 TW_EXPORT_METHOD
-TWString* _Nonnull TWCoinTypeDerivationPathExplicit(enum TWCoinType coin, enum TWDerivation derivation);
+TWString* _Nonnull TWCoinTypeDerivationPathWithDerivation(enum TWCoinType coin, enum TWDerivation derivation);
 
 /// Derives the address for a particular coin from the private key.
 TW_EXPORT_METHOD

--- a/src/interface/TWCoinType.cpp
+++ b/src/interface/TWCoinType.cpp
@@ -39,7 +39,7 @@ TWString *_Nonnull TWCoinTypeDerivationPath(enum TWCoinType coin) {
     return TWStringCreateWithUTF8Bytes(string.c_str());
 }
 
-TWString* TWCoinTypeDerivationPathExplicit(enum TWCoinType coin, enum TWDerivation derivation) {
+TWString* TWCoinTypeDerivationPathWithDerivation(enum TWCoinType coin, enum TWDerivation derivation) {
     const auto path = TW::derivationPath(coin, derivation);
     const auto string = path.string();
     return TWStringCreateWithUTF8Bytes(string.c_str());

--- a/src/interface/TWCoinType.cpp
+++ b/src/interface/TWCoinType.cpp
@@ -39,6 +39,12 @@ TWString *_Nonnull TWCoinTypeDerivationPath(enum TWCoinType coin) {
     return TWStringCreateWithUTF8Bytes(string.c_str());
 }
 
+TWString* TWCoinTypeDerivationPathExplicit(enum TWCoinType coin, enum TWDerivation derivation) {
+    const auto path = TW::derivationPath(coin, derivation);
+    const auto string = path.string();
+    return TWStringCreateWithUTF8Bytes(string.c_str());
+}
+
 TWString *_Nonnull TWCoinTypeDeriveAddress(enum TWCoinType coin, struct TWPrivateKey *_Nonnull privateKey) {
     const auto string = TW::deriveAddress(coin, privateKey->impl);
     return TWStringCreateWithUTF8Bytes(string.c_str());

--- a/swift/Tests/CoinTypeTests.swift
+++ b/swift/Tests/CoinTypeTests.swift
@@ -30,4 +30,10 @@ class CoinTypeTests: XCTestCase {
         XCTAssertEqual(CoinType.avalancheCChain.rawValue, 10009000)
         XCTAssertEqual(CoinType.xdai.rawValue, 10000100)
     }
+    
+    func testCoinDerivation() {
+        XCTAssertEqual(CoinType.bitcoin.derivationPath(), "m/84'/0'/0'/0/0")
+        XCTAssertEqual(CoinType.bitcoin.derivationPathWithDerivation(derivation: Derivation.bitcoinLegacy), "m/44'/0'/0'/0/0")
+        XCTAssertEqual(CoinType.solana.derivationPathWithDerivation(derivation: Derivation.solanaSolana), "m/44'/501'/0'/0'")
+    }
 }

--- a/tests/interface/TWCoinTypeTests.cpp
+++ b/tests/interface/TWCoinTypeTests.cpp
@@ -147,9 +147,16 @@ TEST(TWCoinType, TWCoinTypeDerivationPath) {
     TWStringDelete(res);
 }
 
-TEST(TWCoinType, TWCoinTypeDerivationPathExplicit) {
-    auto res = TWCoinTypeDerivationPathExplicit(TWCoinTypeBitcoin, TWDerivationBitcoinLegacy);
+TEST(TWCoinType, TWCoinTypeDerivationPathWithDerivation) {
+    auto res = TWCoinTypeDerivationPathWithDerivation(TWCoinTypeBitcoin, TWDerivationBitcoinLegacy);
     auto result = *reinterpret_cast<const std::string *>(res);
     ASSERT_EQ(result, "m/44'/0'/0'/0/0");
+    TWStringDelete(res);
+}
+
+TEST(TWCoinType, TWCoinTypeDerivationPathWithDerivationSolana) {
+    auto res = TWCoinTypeDerivationPathWithDerivation(TWCoinTypeSolana, TWDerivationSolanaSolana);
+    auto result = *reinterpret_cast<const std::string *>(res);
+    ASSERT_EQ(result, "m/44'/501'/0'/0'");
     TWStringDelete(res);
 }

--- a/tests/interface/TWCoinTypeTests.cpp
+++ b/tests/interface/TWCoinTypeTests.cpp
@@ -139,3 +139,17 @@ TEST(TWCoinType, TWPublicKeyType) {
     ASSERT_EQ(TWPublicKeyTypeCURVE25519, TWCoinTypePublicKeyType(TWCoinTypeWaves));
     ASSERT_EQ(TWPublicKeyTypeNIST256p1, TWCoinTypePublicKeyType(TWCoinTypeNEO));
 }
+
+TEST(TWCoinType, TWCoinTypeDerivationPath) {
+    auto res = TWCoinTypeDerivationPath(TWCoinTypeBitcoin);
+    auto result = *reinterpret_cast<const std::string *>(res);
+    ASSERT_EQ(result, "m/84'/0'/0'/0/0");
+    TWStringDelete(res);
+}
+
+TEST(TWCoinType, TWCoinTypeDerivationPathExplicit) {
+    auto res = TWCoinTypeDerivationPathExplicit(TWCoinTypeBitcoin, TWDerivationBitcoinLegacy);
+    auto result = *reinterpret_cast<const std::string *>(res);
+    ASSERT_EQ(result, "m/44'/0'/0'/0/0");
+    TWStringDelete(res);
+}


### PR DESCRIPTION
## Description

fix #2392

- [x] add TWCoinTypeDerivationPathWithDerivation method
- [x] cpp unit tests
- [x] Kotlin unit tests
- [x] Swift unit tests

## How to test

- C++ unit tests
- Kotlin unit tests
- Swift unit tests
- TypeScript unit tests

## Types of changes

* New feature (non-breaking change which adds functionality)

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.
