### PR TITLE
Fix for StoredKey::privateKey() with derivation

### DIFF
--- a/src/Keystore/StoredKey.cpp
+++ b/src/Keystore/StoredKey.cpp
@@ -21,7 +21,6 @@
 
 #include <cassert>
 #include <fstream>
-#include <iostream>
 #include <sstream>
 #include <stdexcept>
 

--- a/src/Keystore/StoredKey.cpp
+++ b/src/Keystore/StoredKey.cpp
@@ -253,8 +253,8 @@ const PrivateKey StoredKey::privateKey(TWCoinType coin, const Data& password) {
 const PrivateKey StoredKey::privateKey(TWCoinType coin, TWDerivation derivation, const Data& password) {
     if (type == StoredKeyType::mnemonicPhrase) {
         const auto wallet = this->wallet(password);
-        const auto account = this->account(coin, &wallet);
-        return wallet.getKey(coin, account->derivationPath);
+        const Account& account = this->account(coin, derivation, wallet);
+        return wallet.getKey(coin, account.derivationPath);
     }
     // type == StoredKeyType::privateKey
     return PrivateKey(payload.decrypt(password));

--- a/src/Solana/Program.cpp
+++ b/src/Solana/Program.cpp
@@ -69,7 +69,7 @@ Address TokenProgram::findProgramAddress(const std::vector<TW::Data>& seeds, con
     for (std::uint8_t seed = 0; seed <= std::numeric_limits<std::uint8_t>::max(); ++seed) {
         std::vector<Data> seedsCopy = seeds;
         seedsCopy.emplace_back(bumpSeed);
-        Address address = createProgramAddress(seedsCopy, Address(ASSOCIATED_TOKEN_PROGRAM_ID_ADDRESS));
+        Address address = createProgramAddress(seedsCopy, programId);
         PublicKey publicKey = PublicKey(TW::data(address.bytes.data(), address.bytes.size()), TWPublicKeyTypeED25519);
         if (!publicKey.isValidED25519()) {
             result = address;

--- a/tests/Keystore/StoredKeyTests.cpp
+++ b/tests/Keystore/StoredKeyTests.cpp
@@ -623,4 +623,27 @@ TEST(StoredKey, CreateMultiAccounts) { // Multiple accounts for the same coin
     }
 }
 
+TEST(StoredKey, CreateWithMnemonicAlternativeDerivation) {
+    const auto coin = TWCoinTypeSolana;
+    auto key = StoredKey::createWithMnemonicAddDefaultAddress("name", password, mnemonic, coin);
+    EXPECT_EQ(key.type, StoredKeyType::mnemonicPhrase);
+
+    ASSERT_EQ(key.accounts.size(), 1);
+    EXPECT_EQ(key.accounts[0].coin, coin);
+    EXPECT_EQ(key.accounts[0].address, "HiipoCKL8hX2RVmJTz3vaLy34hS2zLhWWMkUWtw85TmZ");
+    EXPECT_EQ(key.accounts[0].publicKey, "f86b18399096c8134dd185f1e72dd7e26528772a2a998abfd81c5f8c547223d0");
+    EXPECT_EQ(hex(key.privateKey(coin, password).bytes), "d81b5c525979e487736b69cb84ed8331559de17294f38491b304555c26687e83");
+    EXPECT_EQ(hex(key.privateKey(coin, TWDerivationDefault, password).bytes), "d81b5c525979e487736b69cb84ed8331559de17294f38491b304555c26687e83");
+    ASSERT_EQ(key.accounts.size(), 1);
+
+    // alternative derivation, different keys
+    EXPECT_EQ(hex(key.privateKey(coin, TWDerivationSolanaSolana, password).bytes), "d49a5fa7f77593534c7afd2ba8dc8e9d8b007bc6ec65fe8df25ffe6fafc57151");
+
+    ASSERT_EQ(key.accounts.size(), 2);
+    EXPECT_EQ(key.accounts[1].coin, coin);
+    EXPECT_EQ(key.accounts[1].address, "CgWJeEWkiYqosy1ba7a3wn9HAQuHyK48xs3LM4SSDc1C");
+    EXPECT_EQ(key.accounts[1].publicKey, "ad8f57924dce62f9040f93b4f6ce3c3d39afde7e29bcb4013dad59db7913c4c7");
+    EXPECT_EQ(hex(key.privateKey(coin, TWDerivationSolanaSolana, password).bytes), "d49a5fa7f77593534c7afd2ba8dc8e9d8b007bc6ec65fe8df25ffe6fafc57151");
+}
+
 } // namespace TW::Keystore

--- a/tests/Solana/ProgramTests.cpp
+++ b/tests/Solana/ProgramTests.cpp
@@ -52,20 +52,30 @@ TEST(SolanaTokenProgram, findProgramAddress) {
         Base58::bitcoin.decode("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"),
         Base58::bitcoin.decode("SRMuApVNdxXokk5GT7XD5cUUgXMBCoAz2LHeuAoKWRt"),
     };
-    Address address = TokenProgram::findProgramAddress(seeds, Address("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"));
-    EXPECT_EQ(address.string(), "EDNd1ycsydWYwVmrYZvqYazFqwk1QjBgAUKFjBoz1jKP");
+    {
+        Address address = TokenProgram::findProgramAddress(seeds, Address("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"));
+        EXPECT_EQ(address.string(), "EDNd1ycsydWYwVmrYZvqYazFqwk1QjBgAUKFjBoz1jKP");
+    }
+    {
+        Address address = TokenProgram::findProgramAddress(seeds, Address("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"));
+        EXPECT_EQ(address.string(), "CuS1kE1wvGTmwGk3FYNQK85g4jU7gMySWwFRQQ9LFunp");
+    }
 }
 
 TEST(SolanaTokenProgram, createProgramAddress) {
+    std::vector<Data> seeds4 = {
+        Base58::bitcoin.decode("B1iGmDJdvmxyUiYM8UEo2Uw2D58EmUrw4KyLYMmrhf8V"),
+        Base58::bitcoin.decode("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"),
+        Base58::bitcoin.decode("SRMuApVNdxXokk5GT7XD5cUUgXMBCoAz2LHeuAoKWRt"),
+        Data{255}
+    };
     {
-        std::vector<Data> seeds = {
-            Base58::bitcoin.decode("B1iGmDJdvmxyUiYM8UEo2Uw2D58EmUrw4KyLYMmrhf8V"),
-            Base58::bitcoin.decode("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"),
-            Base58::bitcoin.decode("SRMuApVNdxXokk5GT7XD5cUUgXMBCoAz2LHeuAoKWRt"),
-            Data{255}
-        };
-        Address address = TokenProgram::createProgramAddress(seeds, Address("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"));
+        Address address = TokenProgram::createProgramAddress(seeds4, Address("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"));
         EXPECT_EQ(address.string(), "EDNd1ycsydWYwVmrYZvqYazFqwk1QjBgAUKFjBoz1jKP");
+    }
+    {
+        Address address = TokenProgram::createProgramAddress(seeds4, Address("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"));
+        EXPECT_EQ(address.string(), "CuS1kE1wvGTmwGk3FYNQK85g4jU7gMySWwFRQQ9LFunp");
     }
     // https://github.com/solana-labs/solana/blob/f25c969ad87e64e6d1fd07d2d37096ac71cf8d06/sdk/program/src/pubkey.rs#L353-L435
     {


### PR DESCRIPTION
## Description

Two minor fixes:
- StoredKey::privateKey() version with derivation disregarded the supplied derivation
- Solana TokenProgram::findProgramAddress ignored the provided `programId` parameter, but this caused no problem, as it is always invoked with the same constant value.

Found in #2397 

## How to test

Standard unit tests

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [ ] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
