### PR TITLE
Cardano: Support Enterprise and Reward address types

### DIFF
--- a/src/Cardano/AddressV3.cpp
+++ b/src/Cardano/AddressV3.cpp
@@ -20,7 +20,7 @@ using namespace TW;
 using namespace TW::Cardano;
 using namespace std;
 
-bool AddressV3::checkLength([[maybe_unused]] NetworkId networkId, Kind kind, size_t length) noexcept {
+bool AddressV3::checkLength(Kind kind, size_t length) noexcept {
     switch (kind)
     {
     case Kind_Base:
@@ -50,7 +50,7 @@ bool AddressV3::parseAndCheckV3(const Data& raw, NetworkId& networkId, Kind& kin
     bytes = Data();
     std::copy(cbegin(raw) + 1, cend(raw), std::back_inserter(bytes));
 
-    return checkLength(networkId, kind, raw.size());
+    return checkLength(kind, raw.size());
 }
 
 bool AddressV3::parseAndCheckV3(const std::string& addr, NetworkId& networkId, Kind& kind, Data& bytes) noexcept {

--- a/src/Cardano/AddressV3.cpp
+++ b/src/Cardano/AddressV3.cpp
@@ -20,7 +20,7 @@ using namespace TW;
 using namespace TW::Cardano;
 using namespace std;
 
-bool AddressV3::checkLength([[maybe_unused]] NetworkId networkId, Kind kind, size_t length) {
+bool AddressV3::checkLength([[maybe_unused]] NetworkId networkId, Kind kind, size_t length) noexcept {
     switch (kind)
     {
     case Kind_Base:
@@ -36,7 +36,7 @@ bool AddressV3::checkLength([[maybe_unused]] NetworkId networkId, Kind kind, siz
     }
 }
 
-bool AddressV3::parseAndCheckV3(const Data& raw, NetworkId& networkId, Kind& kind, Data& bytes) {
+bool AddressV3::parseAndCheckV3(const Data& raw, NetworkId& networkId, Kind& kind, Data& bytes) noexcept {
     if (raw.size() < 1ul) {
         // too short, cannot extract kind and networkId
         return false;
@@ -47,17 +47,13 @@ bool AddressV3::parseAndCheckV3(const Data& raw, NetworkId& networkId, Kind& kin
         return false;
     }
 
-    bytes = Data(raw.size() - 1);
-    std::copy(raw.begin() + 1, raw.end(), bytes.begin());
+    bytes = Data();
+    std::copy(cbegin(raw) + 1, cend(raw), std::back_inserter(bytes));
 
-    if (!checkLength(networkId, kind, raw.size())) {
-        return false;
-    }
-
-    return true;
+    return checkLength(networkId, kind, raw.size());
 }
 
-bool AddressV3::parseAndCheckV3(const std::string& addr, NetworkId& networkId, Kind& kind, Data& bytes) {
+bool AddressV3::parseAndCheckV3(const std::string& addr, NetworkId& networkId, Kind& kind, Data& bytes) noexcept {
     try {
         auto bech = Bech32::decode(addr);
         if (std::get<1>(bech).size() == 0) {
@@ -76,8 +72,7 @@ bool AddressV3::parseAndCheckV3(const std::string& addr, NetworkId& networkId, K
         }
 
         // check prefix
-        const auto expectedHrp = getHrp(kind);
-        if (addr.substr(0, expectedHrp.length()) != expectedHrp) {
+        if (const auto expectedHrp = getHrp(kind); addr.substr(0, expectedHrp.length()) != expectedHrp) {
             return false;
         }
 
@@ -183,7 +178,7 @@ void AddressV3::operator=(const AddressV3& other)
     legacyAddressV2 = other.legacyAddressV2;
 }
 
-std::string AddressV3::getHrp(Kind kind) {
+std::string AddressV3::getHrp(Kind kind) noexcept {
     switch (kind) {
     case Kind_Base:
     case Kind_Enterprise:

--- a/src/Cardano/AddressV3.cpp
+++ b/src/Cardano/AddressV3.cpp
@@ -72,7 +72,7 @@ bool AddressV3::parseAndCheckV3(const std::string& addr, NetworkId& networkId, K
         }
 
         // check prefix
-        if (const auto expectedHrp = getHrp(kind); addr.substr(0, expectedHrp.length()) != expectedHrp) {
+        if (const auto expectedHrp = getHrp(kind); !addr.starts_with(expectedHrp)) {
             return false;
         }
 

--- a/src/Cardano/AddressV3.cpp
+++ b/src/Cardano/AddressV3.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2017-2020 Trust Wallet.
+// Copyright © 2017-2022 Trust Wallet.
 //
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
@@ -20,7 +20,44 @@ using namespace TW;
 using namespace TW::Cardano;
 using namespace std;
 
-bool AddressV3::parseAndCheckV3(const std::string& addr, NetworkId& networkId, Kind& kind, Data& raw) {
+bool AddressV3::checkLength([[maybe_unused]] NetworkId networkId, Kind kind, size_t length) {
+    switch (kind)
+    {
+    case Kind_Base:
+        return (length == EncodedSize2);
+
+    case Kind_Enterprise:
+    case Kind_Reward:
+        return (length == EncodedSize1);
+
+    default:
+        // accept other types as well
+        return true;
+    }
+}
+
+bool AddressV3::parseAndCheckV3(const Data& raw, NetworkId& networkId, Kind& kind, Data& bytes) {
+    if (raw.size() < 1ul) {
+        // too short, cannot extract kind and networkId
+        return false;
+    }
+    kind = kindFromFirstByte(raw[0]);
+    networkId = networkIdFromFirstByte(raw[0]);
+    if (networkId != Network_Production) {
+        return false;
+    }
+
+    bytes = Data(raw.size() - 1);
+    std::copy(raw.begin() + 1, raw.end(), bytes.begin());
+
+    if (!checkLength(networkId, kind, raw.size())) {
+        return false;
+    }
+
+    return true;
+}
+
+bool AddressV3::parseAndCheckV3(const std::string& addr, NetworkId& networkId, Kind& kind, Data& bytes) {
     try {
         auto bech = Bech32::decode(addr);
         if (std::get<1>(bech).size() == 0) {
@@ -33,14 +70,17 @@ bool AddressV3::parseAndCheckV3(const std::string& addr, NetworkId& networkId, K
         if (!success) {
             return false;
         }
-        if (conv.size() != EncodedSize) {
+
+        if (!parseAndCheckV3(conv, networkId, kind, bytes)) {
             return false;
         }
-        kind = kindFromFirstByte(conv[0]);
-        networkId = networkIdFromFirstByte(conv[0]);
 
-        raw = Data(conv.size() - 1);
-        std::copy(conv.begin() + 1, conv.end(), raw.begin());
+        // check prefix
+        const auto expectedHrp = getHrp(kind);
+        if (addr.substr(0, expectedHrp.length()) != expectedHrp) {
+            return false;
+        }
+
         return true;
     } catch (...) {
         return false;
@@ -100,7 +140,7 @@ AddressV3 AddressV3::createBase(NetworkId networkId, const PublicKey& spendingKe
 
 AddressV3::AddressV3(const std::string& addr) {
     if (parseAndCheckV3(addr, networkId, kind, bytes)) {
-    // values stored
+        // values stored
         return;
     }
     // try legacy
@@ -113,18 +153,11 @@ AddressV3::AddressV3(const PublicKey& publicKey) {
     if (publicKey.type != TWPublicKeyTypeED25519Cardano || publicKey.bytes.size() != PublicKey::cardanoKeySize) {
         throw std::invalid_argument("Invalid public key type");
     }
-    kind = Kind_Base;
-
     *this = createBase(Network_Production, PublicKey(subData(publicKey.bytes, 0, 32), TWPublicKeyTypeED25519), PublicKey(subData(publicKey.bytes, 64, 32), TWPublicKeyTypeED25519));
 }
 
 AddressV3::AddressV3(const Data& data) {
-    if (data.size() != EncodedSize) {
-        throw std::invalid_argument("Address data too short");
-    }
-    networkId = networkIdFromFirstByte(data[0]);
-    kind = kindFromFirstByte(data[0]);
-    bytes = subData(data, 1);
+    parseAndCheckV3(data, networkId, kind, bytes);
 }
 
 AddressV3::AddressV3(const AddressV3& other) = default;
@@ -150,14 +183,19 @@ void AddressV3::operator=(const AddressV3& other)
     legacyAddressV2 = other.legacyAddressV2;
 }
 
-string AddressV3::string() const {
-    std::string hrp;
+std::string AddressV3::getHrp(Kind kind) {
     switch (kind) {
-        case Kind_Base:
-            hrp = stringForHRP(TWHRPCardano); break;
-        default:
-            hrp = ""; break;
+    case Kind_Base:
+    case Kind_Enterprise:
+    default:
+        return stringForHRP(TWHRPCardano);
+    case Kind_Reward:
+        return "stake";
     }
+}
+
+string AddressV3::string() const {
+    const auto hrp = getHrp(kind);
     return string(hrp);
 }
 

--- a/src/Cardano/AddressV3.h
+++ b/src/Cardano/AddressV3.h
@@ -85,13 +85,13 @@ class AddressV3 {
     std::string string(const std::string& hrp) const;
 
     /// Hrp of kind
-    static std::string getHrp(const Kind kind); 
+    static std::string getHrp(const Kind kind) noexcept; 
     /// Check whether data length is correct
-    static bool checkLength([[maybe_unused]] NetworkId networkId, Kind kind, size_t length);
+    static bool checkLength([[maybe_unused]] NetworkId networkId, Kind kind, size_t length) noexcept;
     /// Check validity of binary address.
-    static bool parseAndCheckV3(const TW::Data& raw, NetworkId& networkId, Kind& kind, TW::Data& bytes);
+    static bool parseAndCheckV3(const TW::Data& raw, NetworkId& networkId, Kind& kind, TW::Data& bytes) noexcept;
     /// Check validity and parse elements of a string address.  Used internally by isValid and ctor.
-    static bool parseAndCheckV3(const std::string& addr, NetworkId& networkId, Kind& kind, TW::Data& bytes);
+    static bool parseAndCheckV3(const std::string& addr, NetworkId& networkId, Kind& kind, TW::Data& bytes) noexcept;
 
     /// Return the binary data representation (keys appended, internal format)
     Data data() const;

--- a/src/Cardano/AddressV3.h
+++ b/src/Cardano/AddressV3.h
@@ -1,4 +1,4 @@
-// Copyright © 2017-2020 Trust Wallet.
+// Copyright © 2017-2022 Trust Wallet.
 //
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
@@ -24,13 +24,24 @@ class AddressV3 {
     };
 
     enum Kind: uint8_t {
-        Kind_Base = 0,
+        Kind_Base = 0, // spending + staking key
+        //Kind_Base_Script_Key = 1,
+        //Kind_Base_Key_Script_Key = 2,
+        //Kind_Base_Script_Script_Key = 3,
+        //Kind_Pointer = 4,
+        //Kind_Pointer_Script = 5,
+        Kind_Enterprise = 6, // spending key
+        //Kind_Enterprise_Script = 7,
+        //Kind_Bootstrap = 8, // Byron
+        Kind_Reward = 14, // // staking key
+        //Kind_Reward_Script = 15,
     };
 
     static const uint8_t HashSize = 28;
 
     // First byte header (kind, netowrkId) and 2 hashes
-    static const uint8_t EncodedSize = 1 + 2 * HashSize;
+    static const uint8_t EncodedSize1 = 1 + HashSize;
+    static const uint8_t EncodedSize2 = 1 + 2 * HashSize;
 
     NetworkId networkId = Network_Production;
 
@@ -73,8 +84,14 @@ class AddressV3 {
     /// Returns the Bech string representation of the address, with given HRP.
     std::string string(const std::string& hrp) const;
 
+    /// Hrp of kind
+    static std::string getHrp(const Kind kind); 
+    /// Check whether data length is correct
+    static bool checkLength([[maybe_unused]] NetworkId networkId, Kind kind, size_t length);
+    /// Check validity of binary address.
+    static bool parseAndCheckV3(const TW::Data& raw, NetworkId& networkId, Kind& kind, TW::Data& bytes);
     /// Check validity and parse elements of a string address.  Used internally by isValid and ctor.
-    static bool parseAndCheckV3(const std::string& addr, NetworkId& networkId, Kind& kind, TW::Data& raw);
+    static bool parseAndCheckV3(const std::string& addr, NetworkId& networkId, Kind& kind, TW::Data& bytes);
 
     /// Return the binary data representation (keys appended, internal format)
     Data data() const;

--- a/src/Cardano/AddressV3.h
+++ b/src/Cardano/AddressV3.h
@@ -87,7 +87,7 @@ class AddressV3 {
     /// Hrp of kind
     static std::string getHrp(const Kind kind) noexcept; 
     /// Check whether data length is correct
-    static bool checkLength([[maybe_unused]] NetworkId networkId, Kind kind, size_t length) noexcept;
+    static bool checkLength(Kind kind, size_t length) noexcept;
     /// Check validity of binary address.
     static bool parseAndCheckV3(const TW::Data& raw, NetworkId& networkId, Kind& kind, TW::Data& bytes) noexcept;
     /// Check validity and parse elements of a string address.  Used internally by isValid and ctor.

--- a/tests/Cardano/AddressTests.cpp
+++ b/tests/Cardano/AddressTests.cpp
@@ -36,18 +36,29 @@ TEST(CardanoAddress, V3NetworkIdKind) {
 TEST(CardanoAddress, Validation) {
     // valid V3 address
     ASSERT_TRUE(AddressV3::isValidLegacy("addr1q8043m5heeaydnvtmmkyuhe6qv5havvhsf0d26q3jygsspxlyfpyk6yqkw0yhtyvtr0flekj84u64az82cufmqn65zdsylzk23"));
-    ASSERT_TRUE(AddressV3::isValidLegacy("addr1q92cmkgzv9h4e5q7mnrzsuxtgayvg4qr7y3gyx97ukmz3dfx7r9fu73vqn25377ke6r0xk97zw07dqr9y5myxlgadl2s0dgke5"));
+
+    ASSERT_TRUE(AddressV3::isValid("addr1q8043m5heeaydnvtmmkyuhe6qv5havvhsf0d26q3jygsspxlyfpyk6yqkw0yhtyvtr0flekj84u64az82cufmqn65zdsylzk23"));
+    ASSERT_TRUE(AddressV3::isValid("addr1q92cmkgzv9h4e5q7mnrzsuxtgayvg4qr7y3gyx97ukmz3dfx7r9fu73vqn25377ke6r0xk97zw07dqr9y5myxlgadl2s0dgke5"));
+    ASSERT_TRUE(AddressV3::isValid("addr1vyuca7esanpgs4ke0um3ft6f4yaeuz3ftpfqx9nxpct2uyqu7dvlp")); // enterprise
+    ASSERT_TRUE(AddressV3::isValid("stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65geks")); // reward
+    ASSERT_TRUE(AddressV3::isValid("addr1sxxe304qg9py8hyyqu8evfj4wln7dnms943wsugpdzzsxnkvvjljtzuwxvx0pnwelkcruy95ujkq3aw6rl0vvg32x35qmxapsy")); // kind 8
 
     // valid V2 address
     ASSERT_TRUE(AddressV3::isValidLegacy("Ae2tdPwUPEZ18ZjTLnLVr9CEvUEUX4eW1LBHbxxxJgxdAYHrDeSCSbCxrvx"));
     ASSERT_TRUE(AddressV3::isValidLegacy("Ae2tdPwUPEZ6RUCnjGHFqi59k5WZLiv3HoCCNGCW8SYc5H9srdTzn1bec4W"));
 
+    ASSERT_FALSE(AddressV3::isValid("Ae2tdPwUPEZ18ZjTLnLVr9CEvUEUX4eW1LBHbxxxJgxdAYHrDeSCSbCxrvx"));
+
     // valid V1 address
     ASSERT_TRUE(AddressV3::isValidLegacy("DdzFFzCqrhssmYoG5Eca1bKZFdGS8d6iag1mU4wbLeYcSPVvBNF2wRG8yhjzQqErbg63N6KJA4DHqha113tjKDpGEwS5x1dT2KfLSbSJ"));
     ASSERT_TRUE(AddressV3::isValidLegacy("DdzFFzCqrht7HGoJ87gznLktJGywK1LbAJT2sbd4txmgS7FcYLMQFhawb18ojS9Hx55mrbsHPr7PTraKh14TSQbGBPJHbDZ9QVh6Z6Di"));
 
-    // invalid V3, length (cardano-crypto.js)
+    // invalid V3, invalid network
     ASSERT_FALSE(AddressV3::isValidLegacy("addr1sna05l45z33zpkm8z44q8f0h57wxvm0c86e34wlmua7gtcrdgrdrzy8ny3walyfjanhe33nsyuh088qr5gepqaen6jsa9r94xvvd7fh6jc3e6x"));
+    // invalid V3, invalid prefix
+    ASSERT_FALSE(AddressV3::isValidLegacy("prefix1qxxe304qg9py8hyyqu8evfj4wln7dnms943wsugpdzzsxnkvvjljtzuwxvx0pnwelkcruy95ujkq3aw6rl0vvg32x35q3hm7lv"));
+    // invalid V3, length
+    ASSERT_FALSE(AddressV3::isValidLegacy("addr1qxxe304qg9py8hyyqu8evfj4wln7dnms943wsugpdzzsxnkvvjljtzuwxvx0pnwelkcruy95ujkq3aw6rl0vvg32xsmpqws7"));
     // invalid checksum V3
     ASSERT_FALSE(AddressV3::isValidLegacy("PREFIX1qvqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0jqxuzx4s"));
     // invalid checksum V2
@@ -70,15 +81,34 @@ TEST(CardanoAddress, FromStringV2) {
     }
 }
 
-TEST(CardanoAddress, FromStringV3) {
+TEST(CardanoAddress, FromStringV3_Base) {
     {
-        // single addr
         auto address = AddressV3("addr1qxxe304qg9py8hyyqu8evfj4wln7dnms943wsugpdzzsxnkvvjljtzuwxvx0pnwelkcruy95ujkq3aw6rl0vvg32x35qc92xkq");
         EXPECT_EQ(address.string(), "addr1qxxe304qg9py8hyyqu8evfj4wln7dnms943wsugpdzzsxnkvvjljtzuwxvx0pnwelkcruy95ujkq3aw6rl0vvg32x35qc92xkq");
         EXPECT_EQ(address.string("addr"), "addr1qxxe304qg9py8hyyqu8evfj4wln7dnms943wsugpdzzsxnkvvjljtzuwxvx0pnwelkcruy95ujkq3aw6rl0vvg32x35qc92xkq");
         EXPECT_EQ(AddressV3::Network_Production, address.networkId);
         EXPECT_EQ(AddressV3::Kind_Base, address.kind);
         EXPECT_EQ("8d98bea0414243dc84070f96265577e7e6cf702d62e871016885034ecc64bf258b8e330cf0cdd9fdb03e10b4e4ac08f5da1fdec6222a3468", hex(address.bytes));
+    }
+}
+
+TEST(CardanoAddress, FromStringV3_Enterprise) {
+    {
+        auto address = AddressV3("addr1vyuca7esanpgs4ke0um3ft6f4yaeuz3ftpfqx9nxpct2uyqu7dvlp");
+        EXPECT_EQ(address.string(), "addr1vyuca7esanpgs4ke0um3ft6f4yaeuz3ftpfqx9nxpct2uyqu7dvlp");
+        EXPECT_EQ(AddressV3::Network_Production, address.networkId);
+        EXPECT_EQ(AddressV3::Kind_Enterprise, address.kind);
+        EXPECT_EQ("398efb30ecc28856d97f3714af49a93b9e0a2958520316660e16ae10", hex(address.bytes));
+    }
+}
+
+TEST(CardanoAddress, FromStringV3_Reward) {
+    {
+        auto address = AddressV3("stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65geks");
+        EXPECT_EQ(address.string(), "stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65geks");
+        EXPECT_EQ(AddressV3::Network_Production, address.networkId);
+        EXPECT_EQ(AddressV3::Kind_Reward, address.kind);
+        EXPECT_EQ("0a84430507e150f0a06109dc3a7b1956b7a0586ae9078a55ef0e0b03", hex(address.bytes));
     }
 }
 
@@ -223,7 +253,7 @@ TEST(CardanoAddress, KeyHashV2) {
     ASSERT_EQ("a1eda96a9952a56c983d9f49117f935af325e8a6c9d38496e945faa8", hex(hash));
 }
 
-TEST(CardanoAddress, FromDataV3) {
+TEST(CardanoAddress, FromDataV3_Base) {
     auto address0 = AddressV3("addr1qxxe304qg9py8hyyqu8evfj4wln7dnms943wsugpdzzsxnkvvjljtzuwxvx0pnwelkcruy95ujkq3aw6rl0vvg32x35qc92xkq");
     EXPECT_EQ(address0.string(), "addr1qxxe304qg9py8hyyqu8evfj4wln7dnms943wsugpdzzsxnkvvjljtzuwxvx0pnwelkcruy95ujkq3aw6rl0vvg32x35qc92xkq");
     EXPECT_EQ(hex(address0.data()), "018d98bea0414243dc84070f96265577e7e6cf702d62e871016885034ecc64bf258b8e330cf0cdd9fdb03e10b4e4ac08f5da1fdec6222a3468");
@@ -239,6 +269,39 @@ TEST(CardanoAddress, FromDataV3) {
             PublicKey(parse_hex("fafa7eb4146220db67156a03a5f7a79c666df83eb31abbfbe77c85e06d40da31"), TWPublicKeyTypeED25519),
             PublicKey(parse_hex("f4b8d5201961e68f2e177ba594101f513ee70fe70a41324e8ea8eb787ffda6f4"), TWPublicKeyTypeED25519));
         EXPECT_EQ(address.string(), "addr1qxxe304qg9py8hyyqu8evfj4wln7dnms943wsugpdzzsxnkvvjljtzuwxvx0pnwelkcruy95ujkq3aw6rl0vvg32x35qc92xkq");
+    }
+}
+
+TEST(CardanoAddress, FromDataV3_Enterprise) {
+    auto address = AddressV3(parse_hex("61398efb30ecc28856d97f3714af49a93b9e0a2958520316660e16ae10"));
+    EXPECT_EQ(address.string(), "addr1vyuca7esanpgs4ke0um3ft6f4yaeuz3ftpfqx9nxpct2uyqu7dvlp");
+    EXPECT_EQ(address.kind, AddressV3::Kind_Enterprise);
+    EXPECT_EQ(address.networkId, AddressV3::Network_Production);
+    EXPECT_EQ(hex(address.bytes), "398efb30ecc28856d97f3714af49a93b9e0a2958520316660e16ae10");
+}
+
+TEST(CardanoAddress, FromDataV3_Reward) {
+    auto address = AddressV3(parse_hex("e10a84430507e150f0a06109dc3a7b1956b7a0586ae9078a55ef0e0b03"));
+    EXPECT_EQ(address.string(), "stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65geks");
+    EXPECT_EQ(address.kind, AddressV3::Kind_Reward);
+    EXPECT_EQ(address.networkId, AddressV3::Network_Production);
+    EXPECT_EQ(hex(address.bytes), "0a84430507e150f0a06109dc3a7b1956b7a0586ae9078a55ef0e0b03");
+}
+
+TEST(CardanoAddress, FromDataV3_Invalid) {
+    {   // base, invalid length
+        auto address = AddressV3(parse_hex("018d98bea0414243dc84070f96265577e7e6cf702d62e871016885034ecc64bf258b8e330cf0cdd9fdb03e10b4e4ac08f5da1fdec6222a34"));
+        EXPECT_EQ(address.string(), "addr1qxxe304qg9py8hyyqu8evfj4wln7dnms943wsugpdzzsxnkvvjljtzuwxvx0pnwelkcruy95ujkq3aw6rl0vvg32xsmpqws7");
+        EXPECT_EQ(address.kind, AddressV3::Kind_Base);
+        EXPECT_EQ(address.networkId, AddressV3::Network_Production);
+        EXPECT_EQ(hex(address.bytes), "8d98bea0414243dc84070f96265577e7e6cf702d62e871016885034ecc64bf258b8e330cf0cdd9fdb03e10b4e4ac08f5da1fdec6222a34");
+    }
+    {   // kind = 8
+        auto address = AddressV3(parse_hex("818d98bea0414243dc84070f96265577e7e6cf702d62e871016885034ecc64bf258b8e330cf0cdd9fdb03e10b4e4ac08f5da1fdec6222a3468"));
+        EXPECT_EQ(address.string(), "addr1sxxe304qg9py8hyyqu8evfj4wln7dnms943wsugpdzzsxnkvvjljtzuwxvx0pnwelkcruy95ujkq3aw6rl0vvg32x35qmxapsy");
+        EXPECT_EQ(address.kind, static_cast<AddressV3::Kind>(8));
+        EXPECT_EQ(address.networkId, AddressV3::Network_Production);
+        EXPECT_EQ(hex(address.bytes), "8d98bea0414243dc84070f96265577e7e6cf702d62e871016885034ecc64bf258b8e330cf0cdd9fdb03e10b4e4ac08f5da1fdec6222a3468");
     }
 }
 


### PR DESCRIPTION
## Description

So far only the Base address type was supported (with spending and staking keys).
Support also Enterprise type (kind = 6, spending key only) and Reward type (kind = 14, staking key only).
Fixes  #2337

## How to test

Cardano unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [ ] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
