### PR TITLE
Expose PrivateKeyType

### DIFF
--- a/include/TrustWalletCore/TWPrivateKeyType.h
+++ b/include/TrustWalletCore/TWPrivateKeyType.h
@@ -1,0 +1,20 @@
+// Copyright © 2017-2022 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "TWBase.h"
+
+TW_EXTERN_C_BEGIN
+
+/// Private key types, the vast majority of chains use the default, 32-byte key.
+TW_EXPORT_ENUM(uint32_t)
+enum TWPrivateKeyType {
+    TWPrivateKeyTypeDefault = 0,  // 32 bytes long
+    TWPrivateKeyTypeCardano = 1,  // 2 extended keys plus chainCode, 96 bytes long, used by Cardano
+};
+
+TW_EXTERN_C_END

--- a/src/HDWallet.h
+++ b/src/HDWallet.h
@@ -122,10 +122,6 @@ class HDWallet {
     /// Computes the private key from an extended private key representation.
     static std::optional<PrivateKey> getPrivateKeyFromExtended(const std::string& extended, TWCoinType coin, const DerivationPath& path);
 
-  public:
-    // obtain privateKeyType used by the coin/curve
-    static PrivateKeyType getPrivateKeyType(TWCurve curve);
-
   private:
     void updateSeedAndEntropy(bool check = true);
 

--- a/src/PrivateKey.cpp
+++ b/src/PrivateKey.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2017-2020 Trust Wallet.
+// Copyright © 2017-2022 Trust Wallet.
 //
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
@@ -73,6 +73,15 @@ bool PrivateKey::isValid(const Data& data, TWCurve curve) {
     }
 
     return true;
+}
+
+TWPrivateKeyType PrivateKey::getType(TWCurve curve) noexcept {
+    switch (curve) {
+    case TWCurve::TWCurveED25519ExtendedCardano:
+        return TWPrivateKeyTypeCardano;
+    default:
+        return TWPrivateKeyTypeDefault;
+    }
 }
 
 PrivateKey::PrivateKey(const Data& data) {

--- a/src/PrivateKey.h
+++ b/src/PrivateKey.h
@@ -1,4 +1,4 @@
-// Copyright © 2017-2020 Trust Wallet.
+// Copyright © 2017-2022 Trust Wallet.
 //
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
@@ -9,14 +9,10 @@
 #include "Data.h"
 #include "PublicKey.h"
 
+#include <TrustWalletCore/TWPrivateKeyType.h>
 #include <TrustWalletCore/TWCurve.h>
 
 namespace TW {
-
-enum PrivateKeyType {
-    PrivateKeyTypeDefault32 = 0,      // 32 bytes private key.
-    PrivateKeyTypeCardano = 1,        // 96 bytes private key.
-};
 
 class PrivateKey {
   public:
@@ -43,6 +39,9 @@ class PrivateKey {
 
     /// Determines if a collection of bytes and curve make a valid private key.
     static bool isValid(const Data& data, TWCurve curve);
+
+    // obtain private key type used by the curve/coin
+    static TWPrivateKeyType getType(TWCurve curve) noexcept;
 
     /// Initializes a private key with an array of bytes.  Size must be exact (normally 32, or 192 for extended)
     explicit PrivateKey(const Data& data);

--- a/tests/PrivateKeyTests.cpp
+++ b/tests/PrivateKeyTests.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2017-2020 Trust Wallet.
+// Copyright © 2017-2022 Trust Wallet.
 //
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
@@ -165,6 +165,15 @@ TEST(PrivateKey, Cleanup) {
     delete privateKey;
 
     // Note: it would be good to check the memory area after deletion of the object, but this is not possible
+}
+
+TEST(PrivateKey, GetType) {
+    EXPECT_EQ(PrivateKey::getType(TWCurveSECP256k1), TWPrivateKeyTypeDefault);
+    EXPECT_EQ(PrivateKey::getType(TWCurveNIST256p1), TWPrivateKeyTypeDefault);
+    EXPECT_EQ(PrivateKey::getType(TWCurveED25519), TWPrivateKeyTypeDefault);
+    EXPECT_EQ(PrivateKey::getType(TWCurveCurve25519), TWPrivateKeyTypeDefault);
+
+    EXPECT_EQ(PrivateKey::getType(TWCurveED25519ExtendedCardano), TWPrivateKeyTypeCardano);
 }
 
 TEST(PrivateKey, PrivateKeyExtended) {


### PR DESCRIPTION
## Description

`PrivateKeyType` was internal to `PrivateKey` class.  Now this is exposed in a separate `TWPrivateKeyType` enum (available in swift/kotlin, if needed).
Also, the curve->pktype mapping is moved from `HDWallet` class to `PrivateKey`.
Note that only Cardano uses a special (96-byte) private key.

## How to test

Standard unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [ ] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
