### PR TITLE
[Wasm] Revert module type and add README for NPM

### DIFF
--- a/wasm/README.md
+++ b/wasm/README.md
@@ -1,0 +1,9 @@
+Trust Wallet Core is an open source, cross platform and cross blockchain library, it adds beta support for WebAssembly recently.
+
+You can try it out now:
+
+```js
+npm install @trustwallet/wallet-core
+```
+
+Documentation will be added to [developer.trustwallet.com](https://developer.trustwallet.com/wallet-core), later please check out the [tests](https://github.com/trustwallet/wallet-core/tree/master/wasm/tests) for API usages.

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -1,9 +1,7 @@
-Trust Wallet Core is an open source, cross platform and cross blockchain library, it adds beta support for WebAssembly recently.
-
-You can try it out now:
+Trust Wallet Core is an open source, cross platform and cross blockchain library, it adds beta support for WebAssembly recently, You can try it out now:
 
 ```js
 npm install @trustwallet/wallet-core
 ```
 
-Documentation will be added to [developer.trustwallet.com](https://developer.trustwallet.com/wallet-core), later please check out the [tests](https://github.com/trustwallet/wallet-core/tree/master/wasm/tests) for API usages.
+Documentation will be added to [developer.trustwallet.com](https://developer.trustwallet.com/wallet-core) later, please check out [tests](https://github.com/trustwallet/wallet-core/tree/master/wasm/tests) here for API usages.

--- a/wasm/index.ts
+++ b/wasm/index.ts
@@ -4,6 +4,5 @@
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
 
-import { TW } from "./generated/core_proto";
-import * as WalletCore from "./lib/wallet-core";
-export { TW, WalletCore };
+export { TW } from "./generated/core_proto";
+export * as WalletCore from "./lib/wallet-core";

--- a/wasm/index.ts
+++ b/wasm/index.ts
@@ -4,5 +4,6 @@
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
 
-export { TW } from "./generated/core_proto";
-export * as WalletCore from "./lib/wallet-core";
+import { TW } from "./generated/core_proto";
+import * as WalletCore from "./lib/wallet-core";
+export { TW, WalletCore };

--- a/wasm/tsconfig.json
+++ b/wasm/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "es5",
-        "module": "umd",
+        "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,
         "outDir": "./dist",


### PR DESCRIPTION
## Description

Fixes https://github.com/trustwallet/wallet-core/issues/2417. This was introduced in https://github.com/trustwallet/wallet-core/pull/2332, it breaks wallet core react sample, revert back to old module type

## How to test

Build and test locally (overwrite built js under `node_modules`

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.
