### PR TITLE
[Test] Reuse global instance to remove max listener warning

### DIFF
--- a/samples/node/index.js
+++ b/samples/node/index.js
@@ -1,13 +1,26 @@
 #!/usr/bin/env node
 
-const { initWasm, TW } = require('@trustwallet/wallet-core');
+const { initWasm, TW } = require("@trustwallet/wallet-core");
 
-(async function() {
-    const start = new Date().getTime();
-    console.log(`Initializing...`);
-    const { CoinType, HexCoding } = await initWasm();
-    console.log(`Done in ${new Date().getTime() - start} ms`);
-    console.log(HexCoding.decode("0xce2fd7544e0b2cc94692d4a704debef7bcb61328"));
-    console.log(CoinType.ethereum.value);
-    console.log(TW.Ethereum);
+(async function () {
+  const start = new Date().getTime();
+  console.log(`Initializing Wasm...`);
+  const { CoinType, HexCoding, HDWallet, AnyAddress } = await initWasm();
+  console.log(`Done in ${new Date().getTime() - start} ms`);
+  
+  const wallet = HDWallet.create(256, "");
+  const key = wallet.getKeyForCoin(CoinType.ethereum);
+  const pubKey = key.getPublicKeySecp256k1(false);
+  const address = AnyAddress.createWithPublicKey(pubKey, CoinType.ethereum);
+  
+  console.log(`Create wallet: ${wallet.mnemonic()}`);
+  console.log(`Get Ethereum public key: ${HexCoding.encode(pubKey.data())}`);
+  console.log(`Get Ethereum address: ${address.description()}`);
+  console.log(`CoinType.ethereum.value = ${CoinType.ethereum.value}`);
+  console.log("Ethereum protobuf models: \n", TW.Ethereum);
+
+  wallet.delete();
+  key.delete();
+  pubKey.delete();
+  address.delete();
 })();

--- a/samples/node/package-lock.json
+++ b/samples/node/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@trustwallet/wallet-core": "^2.9.5"
+        "@trustwallet/wallet-core": "3.0.1"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -67,9 +67,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@trustwallet/wallet-core": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/@trustwallet/wallet-core/-/wallet-core-2.9.5.tgz",
-      "integrity": "sha512-pb0huJUP34DqyxWslTrTW1SX0CZzpSINVonykwVvCk2Lc1pCJvbUPvrH+tMAkBGb5ytMuceuQ/KcvJ6KzmudBw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@trustwallet/wallet-core/-/wallet-core-3.0.1.tgz",
+      "integrity": "sha512-WrZwWO85ja4SKyCftJQqj/XWqcLmrP6qJ42YuU9FSzdJp68IdOICckGj5INaW0DE+3O85bPNO+zTmBTBKRZr7g==",
       "dependencies": {
         "protobufjs": ">=6.11.3"
       }
@@ -171,9 +171,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@trustwallet/wallet-core": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/@trustwallet/wallet-core/-/wallet-core-2.9.5.tgz",
-      "integrity": "sha512-pb0huJUP34DqyxWslTrTW1SX0CZzpSINVonykwVvCk2Lc1pCJvbUPvrH+tMAkBGb5ytMuceuQ/KcvJ6KzmudBw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@trustwallet/wallet-core/-/wallet-core-3.0.1.tgz",
+      "integrity": "sha512-WrZwWO85ja4SKyCftJQqj/XWqcLmrP6qJ42YuU9FSzdJp68IdOICckGj5INaW0DE+3O85bPNO+zTmBTBKRZr7g==",
       "requires": {
         "protobufjs": ">=6.11.3"
       }

--- a/samples/node/package.json
+++ b/samples/node/package.json
@@ -4,11 +4,12 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@trustwallet/wallet-core": "^2.9.5"
+    "@trustwallet/wallet-core": "3.0.1"
   }
 }

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "mocha",
+    "test": "mocha --trace-warnings",
     "generate": "npm run codegen:js && npm run codegen:ts",
     "codegen:js": "pbjs -t static-module '../src/proto/*.proto' --no-delimited --force-long -o generated/core_proto.js",
     "codegen:js-browser": "pbjs -t static-module '../src/proto/*.proto' -w closure --no-delimited --force-long -o ../samples/wasm/core_proto.js",

--- a/wasm/tests/AES.test.ts
+++ b/wasm/tests/AES.test.ts
@@ -7,18 +7,11 @@
 import "mocha";
 import { assert } from "chai";
 import { Buffer } from "buffer";
-import { initWasm, WalletCore } from "../dist";
 
 describe("AES", () => {
 
-  let core: WalletCore;
-
-  before(async () => {
-    core = await initWasm();
-  });
-
   it("test decrypting", () => {
-    const { AES, HexCoding, AESPaddingMode } = core;
+    const { AES, HexCoding, AESPaddingMode } = globalThis.core;
 
     const key = HexCoding.decode(
       "5caa3a74154cee16bd1b570a1330be46e086474ac2f4720530662ef1a469662c"
@@ -36,7 +29,7 @@ describe("AES", () => {
   });
 
   it("test encrypting", () => {
-    const { AES, HexCoding, AESPaddingMode } = core;
+    const { AES, HexCoding, AESPaddingMode } = globalThis.core;
 
     const key = HexCoding.decode(
       "bbc82a01ebdb14698faee4a9e5038de72c995a9f6bcdb21903d62408b0c5ca96"

--- a/wasm/tests/AnyAddress.test.ts
+++ b/wasm/tests/AnyAddress.test.ts
@@ -6,11 +6,10 @@
 
 import "mocha";
 import { assert } from "chai";
-import { initWasm } from "../dist";
 
 describe("AnyAddress", () => {
-  it("test validating Solana address", async () => {
-    const { AnyAddress, HexCoding, CoinType } = await initWasm();
+  it("test validating Solana address", () => {
+    const { AnyAddress, HexCoding, CoinType } = globalThis.core;
 
     var address = AnyAddress.createWithString(
       "7v91N7iZ9mNicL8WfG6cgSCKyRXydQjLh6UYBWwm6y1Q",

--- a/wasm/tests/Base32.test.ts
+++ b/wasm/tests/Base32.test.ts
@@ -6,18 +6,11 @@
 
 import { assert } from "chai";
 import { Buffer } from "buffer";
-import { initWasm, WalletCore } from "../dist";
 
 describe("Base32", () => {
 
-  let core: WalletCore;
-
-  before(async () => {
-    core = await initWasm();
-  });
-
   it("test decrypting", () => {
-    const { Base32 } = core;
+    const { Base32 } = globalThis.core;
 
     const decoded = Base32.decode("JBSWY3DPK5XXE3DE");
 
@@ -25,7 +18,7 @@ describe("Base32", () => {
   });
 
   it("test decrypting with alphabet", () => {
-    const { Base32 } = core;
+    const { Base32 } = globalThis.core;
 
     const decoded = Base32.decodeWithAlphabet(
       "g52w64jworydimrxov5hmn3gpj2gwyttnzxdmndjo5xxiztsojuxg5dxobzhs6i",
@@ -39,7 +32,7 @@ describe("Base32", () => {
   });
 
   it("test encrypting", () => {
-    const { Base32 } = core;
+    const { Base32 } = globalThis.core;
 
     const encoded = Base32.encode(Buffer.from("HelloWorld"));
 
@@ -47,7 +40,7 @@ describe("Base32", () => {
   });
 
   it("test encrypting with alphabet", () => {
-    const { Base32 } = core;
+    const { Base32 } = globalThis.core;
 
     const encoded = Base32.encodeWithAlphabet(
       Buffer.from("7uoq6tp427uzv7fztkbsnn64iwotfrristwpryy"),

--- a/wasm/tests/Base64.test.ts
+++ b/wasm/tests/Base64.test.ts
@@ -6,17 +6,11 @@
 
 import { assert } from "chai";
 import { Buffer } from "buffer";
-import { initWasm, WalletCore } from "../dist";
 
 describe("Base64", () => {
-  let core: WalletCore;
-
-  before(async () => {
-    core = await initWasm();
-  });
 
   it("test decoding", () => {
-    const { Base64 } = core;
+    const { Base64 } = globalThis.core;
 
     const decoded = Base64.decode("SGVsbG9Xb3JsZA==");
 
@@ -24,7 +18,7 @@ describe("Base64", () => {
   });
 
   it("test encoding", () => {
-    const { Base64 } = core;
+    const { Base64 } = globalThis.core;
 
     const encoded = Base64.encode(Buffer.from("HelloWorld"));
 
@@ -32,7 +26,7 @@ describe("Base64", () => {
   });
 
   it("test encoding (URL-safe)", () => {
-    const { Base64 } = core;
+    const { Base64 } = globalThis.core;
 
     const encoded = Base64.encodeUrl(Buffer.from("==?="));
 
@@ -40,7 +34,7 @@ describe("Base64", () => {
   });
 
   it("test decoding (URL-safe)", () => {
-    const { Base64 } = core;
+    const { Base64 } = globalThis.core;
     const decoded = Base64.decodeUrl("PT0_PQ==");
 
     assert.equal(Buffer.from(decoded).toString(), "==?=");

--- a/wasm/tests/Blockchain/Ethereum.test.ts
+++ b/wasm/tests/Blockchain/Ethereum.test.ts
@@ -7,18 +7,12 @@
 import "mocha";
 import { assert } from "chai";
 import { Buffer } from "buffer";
-import { TW, initWasm, WalletCore } from "../../dist";
+import { TW } from "../../dist";
 
 describe("Ethereum", () => {
 
-  let core: WalletCore;
-
-  before(async () => {
-    core = await initWasm();
-  });
-
   it("test address", () => {
-    const { PrivateKey, HexCoding, AnyAddress, CoinType, Curve } = core;
+    const { PrivateKey, HexCoding, AnyAddress, CoinType, Curve } = globalThis.core;
 
     const data = HexCoding.decode("727f677b390c151caf9c206fd77f77918f56904b5504243db9b21e51182c4c06");
 
@@ -42,7 +36,7 @@ describe("Ethereum", () => {
   });
 
   it("test signing transfer tx", () => {
-    const { HexCoding, AnySigner, CoinType } = core;
+    const { HexCoding, AnySigner, CoinType } = globalThis.core;;
     const input = TW.Ethereum.Proto.SigningInput.create({
       toAddress: "0x3535353535353535353535353535353535353535",
       chainId: Buffer.from("01", "hex"),
@@ -74,7 +68,7 @@ describe("Ethereum", () => {
   });
 
   it("test signing eip1559 erc20 transfer tx", () => {
-    const { HexCoding, AnySigner, CoinType } = core;
+    const { HexCoding, AnySigner, CoinType } = globalThis.core;;
 
     const input = TW.Ethereum.Proto.SigningInput.create({
       toAddress: "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -105,7 +99,7 @@ describe("Ethereum", () => {
   });
 
   it("test signing personal message", () => {
-    const { EthereumAbi, HexCoding, Hash, PrivateKey, Curve } = core;
+    const { HexCoding, Hash, PrivateKey, Curve } = globalThis.core;;
     const message = Buffer.from("Some data");
     const prefix = Buffer.from("\x19Ethereum Signed Message:\n" + message.length);
     const hash = Hash.keccak256(Buffer.concat([prefix, message]));
@@ -122,7 +116,7 @@ describe("Ethereum", () => {
   });
 
   it("test signing EIP712 message", () => {
-    const { EthereumAbi, HexCoding, Hash, PrivateKey, Curve } = core;
+    const { EthereumAbi, HexCoding, Hash, PrivateKey, Curve } = globalThis.core;;
 
     const key = PrivateKey.createWithData(Hash.keccak256(Buffer.from("cow")));
     const message = {

--- a/wasm/tests/CoinType.test.ts
+++ b/wasm/tests/CoinType.test.ts
@@ -6,12 +6,10 @@
 
 import "mocha";
 import { assert } from "chai";
-import { initWasm } from "../dist";
 
 describe("CoinType", () => {
-
-  it("test raw value", async () => {
-    const { CoinType } = await initWasm();;
+  it("test raw value", () => {
+    const { CoinType } = globalThis.core;
 
     assert.equal(CoinType.bitcoin.value, 0);
     assert.equal(CoinType.litecoin.value, 2);
@@ -20,6 +18,5 @@ describe("CoinType", () => {
     assert.equal(CoinType.binance.value, 714);
     assert.equal(CoinType.cosmos.value, 118);
     assert.equal(CoinType.solana.value, 501);
-
   });
 });

--- a/wasm/tests/HDWallet.test.ts
+++ b/wasm/tests/HDWallet.test.ts
@@ -6,19 +6,11 @@
 
 import "mocha";
 import { assert } from "chai";
-import { initWasm, WalletCore } from "../dist";
-import { Buffer } from "buffer";
 
 describe("HDWallet", () => {
 
-  let core: WalletCore;
-
-  before(async () => {
-    core = await initWasm();
-  });
-
   it("test creating 24 words", () => {
-    const { HDWallet, Mnemonic } = core;
+    const { HDWallet, Mnemonic } = globalThis.core;
 
     var wallet = HDWallet.create(256, "password");
     const mnemonic = wallet.mnemonic();
@@ -30,7 +22,7 @@ describe("HDWallet", () => {
   });
 
   it("test deriving Ethereum address", () => {
-    const { HDWallet, CoinType } = core;
+    const { HDWallet, CoinType } = globalThis.core;
 
     var wallet = HDWallet.createWithMnemonic("ripple scissors kick mammal hire column oak again sun offer wealth tomorrow wagon turn fatal", "TREZOR");
     const address = wallet.getAddressForCoin(CoinType.ethereum);

--- a/wasm/tests/HRP.test.ts
+++ b/wasm/tests/HRP.test.ts
@@ -6,11 +6,10 @@
 
 import "mocha";
 import { assert } from "chai";
-import { initWasm } from "../dist";
 
 describe("HRP", () => {
-  it("test string value", async () => {
-    const { HRP, describeHRP } = await initWasm();
+  it("test string value", () => {
+    const { HRP, describeHRP } = globalThis.core;
 
     assert.equal(describeHRP(HRP.bitcoin), "bc");
     assert.equal(describeHRP(HRP.binance), "bnb");

--- a/wasm/tests/Hash.test.ts
+++ b/wasm/tests/Hash.test.ts
@@ -7,18 +7,10 @@
 import "mocha";
 import { assert } from "chai";
 import { Buffer } from "buffer";
-import { initWasm, WalletCore } from "../dist";
 
 describe("Hash", () => {
-
-  let core: WalletCore;
-
-  before(async () => {
-    core = await initWasm();
-  });
-
   it("test keccak256", () => {
-    const { Hash, HexCoding } = core;
+    const { Hash, HexCoding } = globalThis.core;
 
     const sha3Hash = Hash.keccak256(Buffer.from("Test keccak-256"));
 
@@ -29,7 +21,7 @@ describe("Hash", () => {
   });
 
   it("test sha256", () => {
-    const { Hash, HexCoding } = core;
+    const { Hash, HexCoding } = globalThis.core;
 
     const sha256Hash = Hash.sha256(Buffer.from("Test hash"));
     assert.equal(
@@ -39,7 +31,7 @@ describe("Hash", () => {
   });
 
   it("test sha512_256", () => {
-    const { Hash, HexCoding } = core;
+    const { Hash, HexCoding } = globalThis.core;
 
     const hash = Hash.sha512_256(Buffer.from("hello"));
     assert.equal(

--- a/wasm/tests/HexCoding.test.ts
+++ b/wasm/tests/HexCoding.test.ts
@@ -6,11 +6,10 @@
 
 import "mocha";
 import { assert } from "chai";
-import { initWasm } from "../dist";
 
 describe("HexCoding", () => {
-  it("test encoding / decoding hex string", async () => {
-    const { HexCoding } = await initWasm();
+  it("test encoding / decoding hex string", () => {
+    const { HexCoding } = globalThis.core;
 
     const expected = new Uint8Array([0x52, 0x8]);
     const decoded = HexCoding.decode("0x5208");

--- a/wasm/tests/Mnemonic.test.ts
+++ b/wasm/tests/Mnemonic.test.ts
@@ -6,18 +6,11 @@
 
 import "mocha";
 import { assert } from "chai";
-import { initWasm, WalletCore } from "../dist";
 
 describe("Mnemonic", () => {
 
-  let core: WalletCore;
-
-  before(async () => {
-    core = await initWasm();
-  });
-
   it("test isValid", () => {
-    const { Mnemonic } = core;
+    const { Mnemonic } = globalThis.core;
 
     assert.isTrue(
       Mnemonic.isValid(
@@ -32,7 +25,7 @@ describe("Mnemonic", () => {
   });
 
   it("test isValidWord", () => {
-    const { Mnemonic } = core;
+    const { Mnemonic } = globalThis.core;
 
     assert.isTrue(Mnemonic.isValidWord("credit"));
 
@@ -42,7 +35,7 @@ describe("Mnemonic", () => {
   });
 
   it("test suggest", () => {
-    const { Mnemonic } = core;
+    const { Mnemonic } = globalThis.core;
 
     assert.equal(Mnemonic.suggest("air"), "air airport");
     assert.equal(Mnemonic.suggest("rob"), "robot robust");

--- a/wasm/tests/PBKDF2.test.ts
+++ b/wasm/tests/PBKDF2.test.ts
@@ -7,11 +7,10 @@
 import "mocha";
 import { assert } from "chai";
 import { Buffer } from "buffer";
-import { initWasm } from "../dist";
 
 describe("PBKDF2", () => {
-  it("test sha256 hmac", async () => {
-    const { PBKDF2, HexCoding } = await initWasm();
+  it("test sha256 hmac", () => {
+    const { PBKDF2, HexCoding } = globalThis.core;
 
     const password = Buffer.from("password");
     const salt = Buffer.from("salt");

--- a/wasm/tests/StoredKey.test.ts
+++ b/wasm/tests/StoredKey.test.ts
@@ -6,12 +6,11 @@
 
 import "mocha";
 import { assert } from "chai";
-import { initWasm } from "../dist";
 import { Buffer } from "buffer";
 
 describe("StoredKey", () => {
-  it("test importing mnemonic", async () => {
-    const { StoredKey, CoinType } = await initWasm();
+  it("test importing mnemonic", () => {
+    const { StoredKey, CoinType } = globalThis.core;
 
     const mnemonic = "team engine square letter hero song dizzy scrub tornado fabric divert saddle";
     const password = Buffer.from("password");

--- a/wasm/tests/setup.test.ts
+++ b/wasm/tests/setup.test.ts
@@ -1,0 +1,6 @@
+import "mocha";
+import { initWasm } from "../dist";
+
+before(async () => {
+  globalThis.core = await initWasm();
+});


### PR DESCRIPTION
## Description

Test only, to remove warnings like
```
(node:8671) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 uncaughtException listeners added to [process]. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
```

## How to test

Run unit tests

## Types of changes

* Bug fix

## Checklist

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.
