### PR TITLE
Scripts: separate out full build script from bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,28 +1,12 @@
 #!/usr/bin/env bash
+#
+# Initializes the workspace with dependencies, then performs full build
 
 # Fail if any commands fails
 set -e
 
-echo "#### Initializing... ####"
+echo "#### Initializing workspace ... ####"
 tools/install-dependencies
 
-echo "#### Generating files... ####"
-tools/generate-files
-
-echo "#### Building... ####"
-cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Debug \
-    -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
-make -Cbuild -j12 tests TrezorCryptoTests
-
-if [ -x "$(command -v clang-tidy)" ]; then
-    echo "#### Linting... ####"
-    tools/lint
-fi
-
-echo "#### Testing... ####"
-export CK_TIMEOUT_MULTIPLIER=4
-build/trezor-crypto/crypto/tests/TrezorCryptoTests
-
-ROOT="`dirname \"$0\"`"
-TESTS_ROOT="`(cd \"$ROOT/tests\" && pwd)`"
-build/tests/tests "$TESTS_ROOT"
+echo "#### Building and running ... ####"
+tools/build-and-test

--- a/tools/build-and-test
+++ b/tools/build-and-test
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Perform full build and runs the tests.
+# Prerequisite: workspace with dependencies installed, see bootstrap.sh
+
+# Fail if any commands fails
+set -e
+
+echo "#### Generating files... ####"
+tools/generate-files
+
+echo "#### Building... ####"
+cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+make -Cbuild -j12 tests TrezorCryptoTests
+
+if [ -x "$(command -v clang-tidy)" ]; then
+    echo "#### Linting... ####"
+    tools/lint
+fi
+
+echo "#### Testing... ####"
+export CK_TIMEOUT_MULTIPLIER=4
+build/trezor-crypto/crypto/tests/TrezorCryptoTests
+
+ROOT="`dirname \"$0\"`"
+TESTS_ROOT="`(cd \"$ROOT/tests\" && pwd)`"
+build/tests/tests "$TESTS_ROOT"


### PR DESCRIPTION
## Description

The script `bootstrap.sh` install dependencies, builds the library, and runs the tests.
But dependencies are needed to be installed only once for a workspace.
It would be good to have a command that performs the full build + tests, without the long dependency install. This could be used in the examples/instructions on https://developer.trustwallet.com

The build and tests steps are simply moved out to a new file `tools/build-and-test`.

## How to test

Perform `tools/build-and-test`
Perform `bootstrap.sh`

## Types of changes

* Build infrastructure refactoring

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [ ] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
