### PR TITLE
[Fix] Fix ambigious reference compile error

### DIFF
--- a/src/Theta/Entry.cpp
+++ b/src/Theta/Entry.cpp
@@ -9,9 +9,10 @@
 #include "Ethereum/Address.h"
 #include "Signer.h"
 
-using namespace TW::Theta;
-using namespace std;
+namespace TW::Theta {
 
 void Entry::sign([[maybe_unused]] TWCoinType coin, const TW::Data& dataIn, TW::Data& dataOut) const {
     signTemplate<Signer, Proto::SigningInput>(dataIn, dataOut);
 }
+
+} // namespace TW::Theta


### PR DESCRIPTION
## Description

Recent CI run are failing with this error:
```
void Entry::sign([[maybe_unused]] TWCoinType coin, const TW::Data& dataIn, TW::Data& dataOut) const {
     ^
/home/runner/work/wallet-core/wallet-core/src/Tezos/Entry.h:15:7: note: candidate found by name lookup is 'TW::Tezos::Entry'
class Entry: public CoinEntry {
      ^
/home/runner/work/wallet-core/wallet-core/src/Theta/Entry.h:16:7: note: candidate found by name lookup is 'TW::Theta::Entry'
class Entry: public Ethereum::Entry {
```

This change fixes the problem.

## How to test

CI run should succeed

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] Create pull request as draft initially, unless its complete.
- [X] Add tests to cover changes as needed.
- [X] Update documentation as needed.
- [X] If there is a related Issue, mention it in the description.