### PR TITLE
[Swift sample app] Use BigInt for Eth amount serialization

### DIFF
--- a/samples/osx/cocoapods/Podfile
+++ b/samples/osx/cocoapods/Podfile
@@ -3,5 +3,6 @@ platform :osx, '10.14'
 target 'WalletCoreExample' do
   use_frameworks!
   pod 'TrustWalletCore'
+  pod 'BigInt'
 end
 

--- a/samples/osx/cocoapods/Podfile.lock
+++ b/samples/osx/cocoapods/Podfile.lock
@@ -1,4 +1,5 @@
 PODS:
+  - BigInt (5.2.0)
   - SwiftProtobuf (1.19.0)
   - TrustWalletCore (2.9.5):
     - TrustWalletCore/Core (= 2.9.5)
@@ -8,17 +9,20 @@ PODS:
     - SwiftProtobuf
 
 DEPENDENCIES:
+  - BigInt
   - TrustWalletCore
 
 SPEC REPOS:
   trunk:
+    - BigInt
     - SwiftProtobuf
     - TrustWalletCore
 
 SPEC CHECKSUMS:
+  BigInt: f668a80089607f521586bbe29513d708491ef2f7
   SwiftProtobuf: 6ef3f0e422ef90d6605ca20b21a94f6c1324d6b3
   TrustWalletCore: 52ec9b10c17c8d7443e848ff0e6adac4d39be9f0
 
-PODFILE CHECKSUM: 68848e868fc9571d319a35d139d7901079a7fe36
+PODFILE CHECKSUM: 5fb79210604aff833a8320c937ea3849c2d9ac06
 
 COCOAPODS: 1.11.3

--- a/samples/osx/cocoapods/WalletCoreExample/ViewController.swift
+++ b/samples/osx/cocoapods/WalletCoreExample/ViewController.swift
@@ -6,6 +6,7 @@
 
 import Cocoa
 import WalletCore
+import BigInt
 
 class ViewController: NSViewController {
 
@@ -27,13 +28,13 @@ class ViewController: NSViewController {
         let dummyReceiverAddress = "0xC37054b3b48C3317082E7ba872d7753D13da4986"
         let signerInput = EthereumSigningInput.with {
             $0.chainID = Data(hexString: "01")!
-            $0.gasPrice = Data(hexString: "d693a400")! // decimal 3600000000
-            $0.gasLimit = Data(hexString: "5208")! // decimal 21000
+            $0.gasPrice = BigInt(3600000000).magnitude.serialize()
+            $0.gasLimit = BigInt(21000).magnitude.serialize()
             $0.toAddress = dummyReceiverAddress
 
             $0.transaction = EthereumTransaction.with {
                 $0.transfer = EthereumTransaction.Transfer.with {
-                    $0.amount = Data(hexString: "0348bca5a16000")!
+                    $0.amount = BigInt(0.0009244*1000000000000000000).magnitude.serialize()
                 }
             }
             $0.privateKey = secretPrivateKeyEth.data


### PR DESCRIPTION
## Description

Use meaningful amount conversion in sample app (ios sample app, Eth amount), instead of hardcoded hex constant. It is more realistic this way, more educative, and easier to show best practice.

Note: BigInt is an external dependency.

See e.g. question https://github.com/trustwallet/wallet-core/discussions/2548.

## How to test

Build & execute sample app, as described in README.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [ ] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
