### PR TITLE
Fix the enum constant generated in `coinDispatcher` when adding a new coin

### DIFF
--- a/codegen/bin/newcoin
+++ b/codegen/bin/newcoin
@@ -68,7 +68,7 @@ def insert_coin_entry(coin)
     insert_target_line(target_file, target_line, "// end_of_coin_includes_marker_do_not_modify\n")
     target_line = "#{entryName}::Entry #{entryName}DP;" + $flag_comment + "\n"
     insert_target_line(target_file, target_line, "// end_of_coin_dipatcher_declarations_marker_do_not_modify\n")
-    target_line = "        case TWCoinType#{entryName}: entry = &#{entryName}DP; break;" + $flag_comment + "\n"
+    target_line = "        case TWBlockchain#{entryName}: entry = &#{entryName}DP; break;" + $flag_comment + "\n"
     insert_target_line(target_file, target_line, "        // end_of_coin_dipatcher_switch_marker_do_not_modify\n")
 end
 


### PR DESCRIPTION
## Description

Fix incorrect enum constant generated in the `coinDispatcher` function when adding a new coin.

## How to test

Generating a new coin should now add a new `case` to the `switch` in `coinDispatcher` using the corresponding `TWBlockchain` enum constant

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Patch the `codegen/bin/newcoin` script
