### PR TITLE
[iOS] Add Authentication for curl request

### DIFF
--- a/tools/ios-release
+++ b/tools/ios-release
@@ -37,8 +37,9 @@ popd
 
 # upload to release
 download_url=$(wc_upload_asset ${release_url} ${filename})
+echo "download_url is $download_url"
 download_url=$(tr -d '"' <<< $download_url)
-echo "download_url is ${download_url}"
+echo "trimmed download_url is ${download_url}"
 
 # create podspec
 podspec_name=TrustWalletCore

--- a/tools/ios-release
+++ b/tools/ios-release
@@ -16,6 +16,10 @@ built_dir=${base_dir}/../build/ios-frameworks
 # version to release
 version=$(wc_read_version $1)
 echo "release version ${version}"
+
+# debug only
+curl https://api.github.com/repos/trustwallet/wallet-core/releases/tags/${version} | jq
+
 release_url=$(wc_release_url ${version})
 echo "release_url url is $release_url"
 

--- a/tools/ios-release
+++ b/tools/ios-release
@@ -16,10 +16,6 @@ built_dir=${base_dir}/../build/ios-frameworks
 # version to release
 version=$(wc_read_version $1)
 echo "release version ${version}"
-
-# debug only
-curl https://api.github.com/repos/trustwallet/wallet-core/releases/tags/${version} | jq
-
 release_url=$(wc_release_url ${version})
 echo "release_url url is $release_url"
 

--- a/tools/library
+++ b/tools/library
@@ -27,6 +27,6 @@ wc_upload_asset() {
     filename="$2"
 
     upload_url="${release_url}/assets?name=${filename}"
-    download_url=$(curl -u ${GITHUB_USER}:${GITHUB_TOKEN} -X POST -H "Content-Type: application/octet-stream" --data-binary @${filename} ${upload_url} | jq ".browser_download_url")
+    download_url=$(curl --progress-bar --verbose --retry 3 -u ${GITHUB_USER}:${GITHUB_TOKEN} -X POST -H "Content-Type: application/octet-stream" --data-binary @${filename} ${upload_url} | jq ".browser_download_url")
     echo ${download_url}
 }

--- a/tools/library
+++ b/tools/library
@@ -9,11 +9,9 @@ wc_read_version() {
 }
 
 wc_release_url() {
-    set -o pipefail
     tag="$1"
 
-    json=$(curl "https://api.github.com/repos/trustwallet/wallet-core/releases/tags/${tag}")
-    id=$(jq -r '.id' <<< $json)
+    id=$(curl -u ${GITHUB_USER}:${GITHUB_TOKEN} "https://api.github.com/repos/trustwallet/wallet-core/releases/tags/${tag}" | jq ".id")
     if [[ $id == "null" ]]; then
         echo "Failed to get release id for tag ${tag}"
         exit 22
@@ -23,11 +21,10 @@ wc_release_url() {
 }
 
 wc_upload_asset() {
-    set -o pipefail
     release_url="$1"
     filename="$2"
 
     upload_url="${release_url}/assets?name=${filename}"
-    download_url=$(curl --progress-bar --verbose --retry 3 -u ${GITHUB_USER}:${GITHUB_TOKEN} -X POST -H "Content-Type: application/octet-stream" --data-binary @${filename} ${upload_url} | jq ".browser_download_url")
+    download_url=$(curl --progress-bar --retry 3 -u ${GITHUB_USER}:${GITHUB_TOKEN} -X POST -H "Content-Type: application/octet-stream" --data-binary @${filename} ${upload_url} | jq ".browser_download_url")
     echo ${download_url}
 }

--- a/tools/library
+++ b/tools/library
@@ -12,10 +12,11 @@ wc_release_url() {
     set -o pipefail
     tag="$1"
 
-    id=$(curl "https://api.github.com/repos/trustwallet/wallet-core/releases/tags/${tag}" | jq ".id")
+    json=$(curl "https://api.github.com/repos/trustwallet/wallet-core/releases/tags/${tag}")
+    id=$(jq -r '.id' <<< $json)
     if [[ $id == "null" ]]; then
         echo "Failed to get release id for tag ${tag}"
-        exit -1
+        exit 22
     fi
     release_url="https://uploads.github.com/repos/trustwallet/wallet-core/releases/${id}"
     echo ${release_url}


### PR DESCRIPTION
Fix GitHub API rate limited error when release CocoaPods build

```
{
  "message": "API rate limit exceeded for 199.7.166.17. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
  "documentation_url": "https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"
}
```