### PR TITLE
[Documentation] Add missing doc string for Swift classes

### DIFF
--- a/include/TrustWalletCore/TWDataVector.h
+++ b/include/TrustWalletCore/TWDataVector.h
@@ -11,7 +11,7 @@
 
 TW_EXTERN_C_BEGIN
 
-// A vector of TWData byte arrays
+/// A vector of TWData byte arrays
 TW_EXPORT_CLASS
 struct TWDataVector;
 
@@ -20,20 +20,20 @@ struct TWDataVector;
 /// \note Must be deleted with \TWDataVectorDelete
 /// \return a non-null Vector of Data.
 TW_EXPORT_STATIC_METHOD
-struct TWDataVector *_Nonnull TWDataVectorCreate();
+struct TWDataVector* _Nonnull TWDataVectorCreate();
 
 /// Creates a Vector of Data with the given element
 ///
 /// \param data A non-null valid block of data
 /// \return A Vector of data with a single given element
 TW_EXPORT_STATIC_METHOD
-struct TWDataVector *_Nonnull TWDataVectorCreateWithData(TWData *_Nonnull data);
+struct TWDataVector* _Nonnull TWDataVectorCreateWithData(TWData* _Nonnull data);
 
 /// Delete/Deallocate a Vector of Data
 ///
 /// \param dataVector A non-null Vector of data
 TW_EXPORT_METHOD
-void TWDataVectorDelete(struct TWDataVector *_Nonnull dataVector);
+void TWDataVectorDelete(struct TWDataVector* _Nonnull dataVector);
 
 /// Add an element to a Vector of Data. Element is cloned
 ///
@@ -41,14 +41,14 @@ void TWDataVectorDelete(struct TWDataVector *_Nonnull dataVector);
 /// \param data A non-null valid block of data
 /// \note data input parameter must be deleted on its own
 TW_EXPORT_METHOD
-void TWDataVectorAdd(struct TWDataVector *_Nonnull dataVector, TWData *_Nonnull data);
+void TWDataVectorAdd(struct TWDataVector* _Nonnull dataVector, TWData* _Nonnull data);
 
 /// Retrieve the number of elements
 ///
 /// \param dataVector A non-null Vector of data
 /// \return the size of the given vector.
 TW_EXPORT_PROPERTY
-size_t TWDataVectorSize(const struct TWDataVector *_Nonnull dataVector);
+size_t TWDataVectorSize(const struct TWDataVector* _Nonnull dataVector);
 
 /// Retrieve the n-th element.
 ///
@@ -57,6 +57,6 @@ size_t TWDataVectorSize(const struct TWDataVector *_Nonnull dataVector);
 /// \note Returned element must be freed with \TWDataDelete
 /// \return A non-null block of data
 TW_EXPORT_METHOD
-TWData *_Nullable TWDataVectorGet(const struct TWDataVector *_Nonnull dataVector, size_t index);
+TWData* _Nullable TWDataVectorGet(const struct TWDataVector* _Nonnull dataVector, size_t index);
 
 TW_EXTERN_C_END

--- a/swift/Sources/AnySigner.swift
+++ b/swift/Sources/AnySigner.swift
@@ -10,7 +10,15 @@ import SwiftProtobuf
 public typealias SigningInput = Message
 public typealias SigningOutput = Message
 
+/// Represents a signer to sign transactions for any blockchain.
 public final class AnySigner {
+
+    /// Signs a transaction by SigningInput message and coin type
+    ///
+    /// - Parameters:
+    /// - input: The generic SigningInput SwiftProtobuf message
+    /// - coin: CoinType
+    /// - Returns: The generic SigningOutput SwiftProtobuf message
     public static func sign<SigningOutput: Message>(input: SigningInput, coin: CoinType) -> SigningOutput {
         do {
             let outputData = nativeSign(data: try input.serializedData(), coin: coin)
@@ -20,6 +28,12 @@ public final class AnySigner {
         }
     }
 
+    /// Signs a transaction by serialized data of a SigningInput and coin type
+    ///
+    /// - Parameters:
+    /// - data: The serialized data of a SigningInput
+    /// - coin: CoinType
+    /// - Returns: The serialized data of a SigningOutput
     public static func nativeSign(data: Data, coin: CoinType) -> Data {
         let inputData = TWDataCreateWithNSData(data)
         defer {
@@ -28,10 +42,18 @@ public final class AnySigner {
         return TWDataNSData(TWAnySignerSign(inputData, TWCoinType(rawValue: coin.rawValue)))
     }
 
+    /// Check if AnySigner supports signing JSON representation of SigningInput for a given coin.
     public static func supportsJSON(coin: CoinType) -> Bool {
         return TWAnySignerSupportsJSON(TWCoinType(rawValue: coin.rawValue))
     }
 
+    /// Signs a transaction specified by the JSON representation of a SigningInput, coin type and a private key
+    ///
+    /// - Parameters:
+    /// - json: JSON representation of a SigningInput
+    /// - key: The private key data
+    /// - coin: CoinType
+    /// - Returns: The JSON representation of a SigningOutput.
     public static func signJSON(_ json: String, key: Data, coin: CoinType) -> String {
         let jsonString = TWStringCreateWithNSString(json)
         let keyData = TWDataCreateWithNSData(key)
@@ -41,6 +63,12 @@ public final class AnySigner {
         return TWStringNSString(TWAnySignerSignJSON(jsonString, keyData, TWCoinType(rawValue: coin.rawValue)))
     }
 
+    /// Plans a transaction (for UTXO chains only).
+    ///
+    /// - Parameters:
+    /// - input: The generic SigningInput SwiftProtobuf message
+    /// - coin: CoinType
+    /// - Returns: TransactionPlan SwiftProtobuf message
     public static func plan<TransactionPlan: Message>(input: SigningInput, coin: CoinType) -> TransactionPlan {
         do {
             let outputData = nativePlan(data: try input.serializedData(), coin: coin)
@@ -50,6 +78,12 @@ public final class AnySigner {
         }
     }
 
+    /// Plans a transaction (for UTXO chains only).
+    ///
+    /// - Parameters:
+    /// - input: The serialized data of a SigningInput
+    /// - coin: CoinType
+    /// - Returns: The serialized data of a TransactionPlan
     public static func nativePlan(data: Data, coin: CoinType) -> Data {
         let inputData = TWDataCreateWithNSData(data)
         defer {

--- a/swift/Sources/Extensions/AddressProtocol.swift
+++ b/swift/Sources/Extensions/AddressProtocol.swift
@@ -6,6 +6,5 @@
 
 import Foundation
 
-public protocol Address: CustomStringConvertible {}
-
-extension AnyAddress: Equatable {}
+/// Generic Address protocol for AnyAddress / SegwitAddress / SolanaAddress
+public protocol Address: Equatable, CustomStringConvertible {}

--- a/swift/Sources/Extensions/AddressProtocol.swift
+++ b/swift/Sources/Extensions/AddressProtocol.swift
@@ -7,4 +7,6 @@
 import Foundation
 
 /// Generic Address protocol for AnyAddress / SegwitAddress / SolanaAddress
-public protocol Address: Equatable, CustomStringConvertible {}
+public protocol Address: CustomStringConvertible {}
+
+extension AnyAddress: Equatable {}

--- a/tools/ios-doc
+++ b/tools/ios-doc
@@ -2,8 +2,11 @@
 
 # https://developer.apple.com/documentation/xcode/distributing-documentation-to-external-developers
 
+set -e
+set -o pipefail
+
 pushd swift
-mkdir -p build
+mkdir -p build && rm -rf build/*.doccarchive
 
 export DOCC_JSON_PRETTYPRINT="YES"
 xcodebuild -workspace TrustWalletCore.xcworkspace -derivedDataPath build/docsData -scheme WalletCore -destination 'platform=iOS Simulator,name=iPhone 13 Pro Max' -parallelizeTargets docbuild | xcbeautify


### PR DESCRIPTION
## Description

Add missing doc string for `AnySigner` (not codegen), `DataVector` and `Address` protocol

## How to test

Run `tools/ios-doc` and inspect

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

<img width="1840" alt="Screen Shot 0004-09-23 at 07 06 06" src="https://user-images.githubusercontent.com/360470/191859981-75454ab4-68b1-4ee7-9e3b-1a481d9e6f3e.png">