### PR TITLE
[Trezor] Fix buffer with unmatched bound warning

### DIFF
--- a/trezor-crypto/crypto/sha2.c
+++ b/trezor-crypto/crypto/sha2.c
@@ -643,7 +643,7 @@ void sha1_Final(SHA1_CTX* context, sha2_byte digest[]) {
 	usedspace = 0;
 }
 
-char *sha1_End(SHA1_CTX* context, char buffer[]) {
+char *sha1_End(SHA1_CTX* context, char buffer[SHA1_DIGEST_STRING_LENGTH]) {
 	sha2_byte	digest[SHA1_DIGEST_LENGTH] = {0}, *d = digest;
 	int		i = 0;
 
@@ -950,7 +950,7 @@ void sha256_Final(SHA256_CTX* context, sha2_byte digest[]) {
 	usedspace = 0;
 }
 
-char *sha256_End(SHA256_CTX* context, char buffer[]) {
+char *sha256_End(SHA256_CTX* context, char buffer[SHA256_DIGEST_STRING_LENGTH]) {
 	sha2_byte	digest[SHA256_DIGEST_LENGTH] = {0}, *d = digest;
 	int		i = 0;
 
@@ -1269,7 +1269,7 @@ void sha512_Final(SHA512_CTX* context, sha2_byte digest[]) {
 	memzero(context, sizeof(SHA512_CTX));
 }
 
-char *sha512_End(SHA512_CTX* context, char buffer[]) {
+char *sha512_End(SHA512_CTX* context, char buffer[SHA512_DIGEST_STRING_LENGTH]) {
 	sha2_byte	digest[SHA512_DIGEST_LENGTH] = {0}, *d = digest;
 	int		i = 0;
 


### PR DESCRIPTION
## Description

Fixed a small warning which were causing a build failure when building with some Emscripten versions.

This change is in line with the upstream version: https://github.com/trezor/trezor-firmware/blob/master/crypto/sha2.c


## How to test

Unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] Create pull request as draft initially, unless its complete.
- [X] Add tests to cover changes as needed.
- [X] Update documentation as needed.
- [X] If there is a related Issue, mention it in the description.
