### PR TITLE
[Fio] Fix `signatureToBase58` typo

### DIFF
--- a/src/FIO/Signer.cpp
+++ b/src/FIO/Signer.cpp
@@ -40,7 +40,7 @@ Data Signer::signData(const PrivateKey& privKey, const Data& data) {
     return signature;
 }
 
-std::string Signer::signatureToBsase58(const Data& sig) {
+std::string Signer::signatureToBase58(const Data& sig) {
     Data sigWithSuffix(sig);
     append(sigWithSuffix, TW::data(SignatureSuffix));
     // take hash, ripemd, first 4 bytes 

--- a/src/FIO/Signer.h
+++ b/src/FIO/Signer.h
@@ -30,7 +30,7 @@ class Signer {
     static Data signData(const PrivateKey& privKey, const Data& data);
 
     /// Used internally, encode signature to base58 with prefix. Ex.: "SIG_K1_K54CA1jmhgWrSdvrNrkokPyvqh7dwsSoQHNU9xgD3Ezf6cJySzhKeUubVRqmpYdnjoP1DM6SorroVAgrCu3qqvJ9coAQ6u"
-    static std::string signatureToBsase58(const Data& sig);
+    static std::string signatureToBase58(const Data& sig);
 
     /// Verify a signature, used in testing
     static bool verify(const PublicKey& pubKey, const Data& data, const Data& signature);

--- a/src/FIO/TransactionBuilder.cpp
+++ b/src/FIO/TransactionBuilder.cpp
@@ -240,7 +240,7 @@ string TransactionBuilder::signAdnBuildTx(const Data& chainId, const Data& packe
     Data sigBuf(chainId);
     append(sigBuf, packedTx);
     append(sigBuf, TW::Data(32)); // context_free
-    string signature = Signer::signatureToBsase58(Signer::signData(privateKey, sigBuf));
+    string signature = Signer::signatureToBase58(Signer::signData(privateKey, sigBuf));
 
     // Build json
     json tx = {

--- a/tests/FIO/SignerTests.cpp
+++ b/tests/FIO/SignerTests.cpp
@@ -18,7 +18,7 @@ namespace TW::FIO::tests {
 using namespace std;
 
 TEST(FIOSigner, SignEncode) {
-    string sig1 = Signer::signatureToBsase58(parse_hex("1f4fccc30bcba876963aef6de584daf7258306c02f4528fe25b116b517de8b349968bdc080cd6bef36f5a46d31a7c01ed0806ad215bb66a94f61e27a895d610983"));
+    string sig1 = Signer::signatureToBase58(parse_hex("1f4fccc30bcba876963aef6de584daf7258306c02f4528fe25b116b517de8b349968bdc080cd6bef36f5a46d31a7c01ed0806ad215bb66a94f61e27a895d610983"));
 
     EXPECT_EQ("SIG_K1_K5hJTPeiV4bDkNR13mf66N2DY5AtVL4NU1iWE4G4dsczY2q68oCcUVxhzFdxjgV2eAeb2jNV1biqtCJ3SaNL8kkNgoZ43H", sig1);
 }
@@ -37,7 +37,7 @@ TEST(FIOSigner, SignInternals) {
     Data sign2 = Signer::signData(pk, rawData);
     EXPECT_EQ("1f4ae8d1b993f94d0de4b249d5185481770de0711863ad640b3aac21de598fcc02761c6e5395106bafb7b09aab1c7aa5ac0573dbd821c2d255725391a5105d30d1", hex(sign2));
 
-    string sigStr = Signer::signatureToBsase58(sign2);
+    string sigStr = Signer::signatureToBase58(sign2);
     EXPECT_EQ("SIG_K1_K54CA1jmhgWrSdvrNrkokPyvqh7dwsSoQHNU9xgD3Ezf6cJySzhKeUubVRqmpYdnjoP1DM6SorroVAgrCu3qqvJ9coAQ6u", sigStr);
     EXPECT_TRUE(Signer::verify(pk.getPublicKey(TWPublicKeyTypeSECP256k1), hash, sign2));
 }


### PR DESCRIPTION
## Description
From the description and implementation of the `signatureToBsase58`, I guess that's a typo, the name should be `signatureToBase58`.

## How to test

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Create pull request as draft initially, unless its complete.
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
- [ ] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [ ] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
