### PR TITLE
[Codegen] Fix _Nullable String param codegen for swift, make params _Nullable where needed

### DIFF
--- a/codegen/lib/templates/swift/parameter_access.erb
+++ b/codegen/lib/templates/swift/parameter_access.erb
@@ -10,11 +10,13 @@
         let <%= param.name %>String: UnsafeRawPointer?
         if let s = <%= param.name %> {
             <%= param.name %>String = TWStringCreateWithNSString(s)
-            defer {
-                TWStringDelete(s)
-            }
         } else {
             <%= param.name %>String = nil
+        }
+        defer {
+            if let s = <%= param.name %>String {
+                TWStringDelete(s)
+            }
         }
 <%      else -%>
         let <%= param.name %>String = TWStringCreateWithNSString(<%= param.name %>)

--- a/include/TrustWalletCore/TWBase32.h
+++ b/include/TrustWalletCore/TWBase32.h
@@ -19,34 +19,34 @@ struct TWBase32;
 /// Decode a Base32 input with the given alphabet
 ///
 /// \param string Encoded base32 input to be decoded
-/// \param alphabet Decode with the given alphabet, if empty ALPHABET_RFC4648 is used by default
+/// \param alphabet Decode with the given alphabet, if nullptr ALPHABET_RFC4648 is used by default
 /// \return The decoded data, can be null.
 /// \note ALPHABET_RFC4648 doesn't support padding in the default alphabet
 TW_EXPORT_STATIC_METHOD
-TWData* _Nullable TWBase32DecodeWithAlphabet(TWString* _Nonnull string, TWString* _Nonnull alphabet);
+TWData* _Nullable TWBase32DecodeWithAlphabet(TWString* _Nonnull string, TWString* _Nullable alphabet);
 
 /// Decode a Base32 input with the default alphabet (ALPHABET_RFC4648)
 ///
 /// \param string Encoded input to be decoded
 /// \return The decoded data
-/// \note Call TWBase32DecodeWithAlphabet with empty string.
+/// \note Call TWBase32DecodeWithAlphabet with nullptr.
 TW_EXPORT_STATIC_METHOD
 TWData* _Nullable TWBase32Decode(TWString* _Nonnull string);
 
 /// Encode an input to Base32 with the given alphabet
 ///
 /// \param data Data to be encoded (raw bytes)
-/// \param alphabet Encode with the given alphabet, if empty ALPHABET_RFC4648 is used by default
+/// \param alphabet Encode with the given alphabet, if nullptr ALPHABET_RFC4648 is used by default
 /// \return The encoded data
 /// \note ALPHABET_RFC4648 doesn't support padding in the default alphabet
 TW_EXPORT_STATIC_METHOD
-TWString *_Nonnull TWBase32EncodeWithAlphabet(TWData *_Nonnull data, TWString* _Nonnull alphabet);
+TWString *_Nonnull TWBase32EncodeWithAlphabet(TWData *_Nonnull data, TWString* _Nullable alphabet);
 
 /// Encode an input to Base32 with the default alphabet (ALPHABET_RFC4648)
 ///
 /// \param data Data to be encoded (raw bytes)
 /// \return The encoded data
-/// \note Call TWBase32EncodeWithAlphabet with empty string.
+/// \note Call TWBase32EncodeWithAlphabet with nullptr.
 TW_EXPORT_STATIC_METHOD
 TWString *_Nonnull TWBase32Encode(TWData *_Nonnull data);
 

--- a/src/interface/TWBase32.cpp
+++ b/src/interface/TWBase32.cpp
@@ -12,11 +12,11 @@
 
 using namespace TW;
 
-TWData* TWBase32DecodeWithAlphabet(TWString* _Nonnull string, TWString* _Nonnull alphabet) {
+TWData* TWBase32DecodeWithAlphabet(TWString* _Nonnull string, TWString* _Nullable alphabet) {
     Data decodedOut;
     auto cppString = *reinterpret_cast<const std::string*>(string);
     const char* alphabetRaw = nullptr;
-    if (TWStringSize(alphabet) > 0) {
+    if (alphabet != nullptr) {
         alphabetRaw = TWStringUTF8Bytes(alphabet);
     }
     auto result = Base32::decode(cppString, decodedOut, alphabetRaw);
@@ -24,14 +24,13 @@ TWData* TWBase32DecodeWithAlphabet(TWString* _Nonnull string, TWString* _Nonnull
 }
 
 TWData* _Nullable TWBase32Decode(TWString* _Nonnull string) {
-    std::string empty;
-    return TWBase32DecodeWithAlphabet(string, &empty);
+    return TWBase32DecodeWithAlphabet(string, nullptr);
 }
 
-TWString* _Nonnull TWBase32EncodeWithAlphabet(TWData* _Nonnull data, TWString* _Nonnull alphabet) {
+TWString* _Nonnull TWBase32EncodeWithAlphabet(TWData* _Nonnull data, TWString* _Nullable alphabet) {
     auto cppData = *reinterpret_cast<const Data*>(data);
     const char* alphabetRaw = nullptr;
-    if (TWStringSize(alphabet) > 0) {
+    if (alphabet != nullptr) {
         alphabetRaw = TWStringUTF8Bytes(alphabet);
     }
     auto result = Base32::encode(cppData, alphabetRaw);
@@ -39,6 +38,5 @@ TWString* _Nonnull TWBase32EncodeWithAlphabet(TWData* _Nonnull data, TWString* _
 }
 
 TWString* _Nonnull TWBase32Encode(TWData* _Nonnull data) {
-    std::string empty;
-    return TWBase32EncodeWithAlphabet(data, &empty);
+    return TWBase32EncodeWithAlphabet(data, nullptr);
 }


### PR DESCRIPTION
fix(codegen): correct swift template for _Nullable string parameter handling

## Description

Before the change, we couldn't use _Nullable strings in C interfaces because incorrect code was generated in Swift resulting in immediate string object de-allocation. See #2368.

## How to test

Unit tests

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] Create pull request as draft initially, unless its complete.
- [X] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [X] If there is a related Issue, mention it in the description.
