### PR TITLE
[Aptos]: add register token capabilities

### DIFF
--- a/src/Aptos/MoveTypes.h
+++ b/src/Aptos/MoveTypes.h
@@ -35,6 +35,7 @@ private:
 
 inline ModuleId gAptosAccountModule{gAddressOne, "aptos_account"};
 inline ModuleId gAptosCoinModule{gAddressOne, "coin"};
+inline ModuleId gAptosManagedCoinsModule{gAddressOne, "managed_coin"};
 inline ModuleId gAptosTokenTransfersModule{gAddressThree, "token_transfers"};
 
 BCS::Serializer& operator<<(BCS::Serializer& stream, const ModuleId& module) noexcept;

--- a/src/Aptos/Signer.cpp
+++ b/src/Aptos/Signer.cpp
@@ -120,6 +120,15 @@ TransactionPayload tokenTransferPayload(const Proto::SigningInput& input) {
     return payload;
 }
 
+TransactionPayload registerTokenPayload(const Proto::SigningInput& input) {
+
+    auto& function = input.register_token().function();
+    TypeTag tokenRegisterTag = {TypeTag::TypeTagVariant(TStructTag{.st = StructTag(Address(function.account_address()),
+                                                                                   function.module(), function.name(), {})})};
+    TransactionPayload payload = EntryFunction(gAptosManagedCoinsModule, "register", {tokenRegisterTag}, {});
+    return payload;
+}
+
 Proto::SigningOutput blindSign(const Proto::SigningInput& input) {
     auto output = Proto::SigningOutput();
     BCS::Serializer serializer;
@@ -174,9 +183,12 @@ Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) {
         case Proto::SigningInput::kNftMessage: {
             return nftPayloadFunctor(input.nft_message());
         }
-        case Proto::SigningInput::kCreateAccount:
+        case Proto::SigningInput::kCreateAccount: {
             return createAccountPayload(input);
-
+        }
+        case Proto::SigningInput::kRegisterToken: {
+            return registerTokenPayload(input);
+        }
         case Proto::SigningInput::TRANSACTION_PAYLOAD_NOT_SET:
             throw std::runtime_error("Transaction payload should be set");
         }

--- a/src/Aptos/TransactionPayload.cpp
+++ b/src/Aptos/TransactionPayload.cpp
@@ -48,7 +48,7 @@ nlohmann::json EntryFunction::json() const noexcept {
         {"type", "entry_function_payload"},
         {"function", mModule.shortString() + "::" + mFunction},
         {"type_arguments", tyArgsJson},
-        {"arguments", mJsonArgs}
+        {"arguments", mJsonArgs.empty() ? nlohmann::json::array() : mJsonArgs}
     };
     // clang-format on
     return out;

--- a/src/proto/Aptos.proto
+++ b/src/proto/Aptos.proto
@@ -37,6 +37,12 @@ message TokenTransferMessage {
   StructTag function = 3;
 }
 
+// Necessary fields to process a ManagedTokensRegisterMessage
+message ManagedTokensRegisterMessage {
+  // token function to register, e.g BTC: 0x43417434fd869edee76cca2a4d2301e528a1551b1d719b75c350c3c97d15b8b9::coins::BTC
+  StructTag function = 1;
+}
+
 // Necessary fields to process a CreateAccountMessage
 message CreateAccountMessage {
   // auth account address to create
@@ -101,24 +107,26 @@ message SigningInput {
   string sender = 1;
   // Sequence number, incremented atomically for each tx present on the account, start at 0 (int64)
   int64 sequence_number = 2;
-  oneof transaction_payload {
-    TransferMessage transfer = 3;
-    TokenTransferMessage token_transfer = 4;
-    CreateAccountMessage create_account = 5;
-    NftMessage nft_message = 6;
-  }
   // Max gas amount that the user is willing to pay (uint64)
-  uint64 max_gas_amount = 7;
+  uint64 max_gas_amount = 3;
   // Gas unit price - queried through API (uint64)
-  uint64 gas_unit_price = 8;
+  uint64 gas_unit_price = 4;
   // Expiration timestamp for the transaction, can't be in the past (uint64)
-  uint64 expiration_timestamp_secs = 9;
+  uint64 expiration_timestamp_secs = 5;
   //  Chain id 1 (mainnet) 32(devnet) (uint32 - casted in uint8_t later)
-  uint32 chain_id = 10;
+  uint32 chain_id = 6;
   //  Private key to sign the transaction (bytes)
-  bytes private_key = 11;
+  bytes private_key = 7;
   // hex encoded function to sign, use it for smart contract approval (string)
-  string any_encoded = 12;
+  string any_encoded = 8;
+
+  oneof transaction_payload {
+    TransferMessage transfer = 9;
+    TokenTransferMessage token_transfer = 10;
+    CreateAccountMessage create_account = 11;
+    NftMessage nft_message = 12;
+    ManagedTokensRegisterMessage register_token = 13;
+  }
 }
 
 // Information related to the signed transaction

--- a/tests/chains/Aptos/SignerTests.cpp
+++ b/tests/chains/Aptos/SignerTests.cpp
@@ -288,6 +288,49 @@ TEST(AptosSigner, BlindSign) {
     assertJSONEqual(expectedJson, parsedJson);
 }
 
+TEST(AptosSigner, TokenRegisterTxSign) {
+    // Successfully broadcasted https://explorer.aptoslabs.com/txn/0xe591252daed785641bfbbcf72a5d17864568cf32e04c0cc9129f3a13834d0e8e?network=testnet
+    Proto::SigningInput input;
+    input.set_sender("0x07968dab936c1bad187c60ce4082f307d030d780e91e694ae03aef16aba73f30");
+    input.set_sequence_number(23);
+    auto& tf = *input.mutable_register_token();
+    tf.mutable_function()->set_account_address("0xe4497a32bf4a9fd5601b27661aa0b933a923191bf403bd08669ab2468d43b379");
+    tf.mutable_function()->set_module("move_coin");
+    tf.mutable_function()->set_name("MoveCoin");
+    input.set_max_gas_amount(2000000);
+    input.set_gas_unit_price(100);
+    input.set_expiration_timestamp_secs(3664390082);
+    input.set_chain_id(2);
+    auto privateKey = PrivateKey(parse_hex("5d996aa76b3212142792d9130796cd2e11e3c445a93118c08414df4f66bc60ec"));
+    input.set_private_key(privateKey.bytes.data(), privateKey.bytes.size());
+    auto result = Signer::sign(input);
+    ASSERT_EQ(hex(result.raw_txn()), "07968dab936c1bad187c60ce4082f307d030d780e91e694ae03aef16aba73f3017000000000000000200000000000000000000000000000000000000000000000000000000000000010c6d616e616765645f636f696e0872656769737465720107e4497a32bf4a9fd5601b27661aa0b933a923191bf403bd08669ab2468d43b379096d6f76655f636f696e084d6f7665436f696e000080841e00000000006400000000000000c2276ada0000000002");
+    ASSERT_EQ(hex(result.authenticator().signature()), "e230b49f552fb85356dbec9df13f0dc56228eb7a9c29a8af3a99f4ae95b86c72bdcaa4ff1e9beb0bd81c298b967b9d97449856ec8bc672a08e2efef345c37100");
+    ASSERT_EQ(hex(result.encoded()), "07968dab936c1bad187c60ce4082f307d030d780e91e694ae03aef16aba73f3017000000000000000200000000000000000000000000000000000000000000000000000000000000010c6d616e616765645f636f696e0872656769737465720107e4497a32bf4a9fd5601b27661aa0b933a923191bf403bd08669ab2468d43b379096d6f76655f636f696e084d6f7665436f696e000080841e00000000006400000000000000c2276ada00000000020020ea526ba1710343d953461ff68641f1b7df5f23b9042ffa2d2a798d3adb3f3d6c40e230b49f552fb85356dbec9df13f0dc56228eb7a9c29a8af3a99f4ae95b86c72bdcaa4ff1e9beb0bd81c298b967b9d97449856ec8bc672a08e2efef345c37100");
+    nlohmann::json expectedJson = R"(
+                {
+                    "expiration_timestamp_secs": "3664390082",
+                    "gas_unit_price": "100",
+                    "max_gas_amount": "2000000",
+                    "payload": {
+                        "arguments": [],
+                        "function": "0x1::managed_coin::register",
+                        "type": "entry_function_payload",
+                        "type_arguments": ["0xe4497a32bf4a9fd5601b27661aa0b933a923191bf403bd08669ab2468d43b379::move_coin::MoveCoin"]
+                    },
+                    "sender": "0x07968dab936c1bad187c60ce4082f307d030d780e91e694ae03aef16aba73f30",
+                    "sequence_number": "23",
+                    "signature": {
+                        "public_key": "0xea526ba1710343d953461ff68641f1b7df5f23b9042ffa2d2a798d3adb3f3d6c",
+                        "signature": "0xe230b49f552fb85356dbec9df13f0dc56228eb7a9c29a8af3a99f4ae95b86c72bdcaa4ff1e9beb0bd81c298b967b9d97449856ec8bc672a08e2efef345c37100",
+                        "type": "ed25519_signature"
+                    }
+                }
+        )"_json;
+    nlohmann::json parsedJson = nlohmann::json::parse(result.json());
+    assertJSONEqual(expectedJson, parsedJson);
+}
+
 TEST(AptosSigner, TokenTxSign) {
     // Successfully broadcasted https://explorer.aptoslabs.com/txn/0xb5b383a5c7f99b2edb3bed9533f8169a89051b149d65876a82f4c0b9bf78a15b?network=Devnet
     Proto::SigningInput input;


### PR DESCRIPTION
## Description

For token transfer, a registration is required before sending: https://aptos.dev/tutorials/your-first-coin/#step-432-registering-a-coin

I didn't see it during first iteration as swapping on the AMM I was using implicitly register the token for me

![image](https://user-images.githubusercontent.com/21139416/195628717-cefb772c-d4e2-41ad-8cc3-6c06f796c07b.png)

My understanding is that it's a security feature to avoid unwanted airdrop

Note that implementation team can still use `encode_submission` with the payload in the screenshot to register - this PR aims to give an handy way to generate this kind of transaction.

## How to test

Run C++ unit tests

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
