### PR TITLE
Expose derivation option in AnyAddress, HDWallet

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestAnyAddress.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestAnyAddress.kt
@@ -1,0 +1,93 @@
+// Copyright © 2017-2022 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+package com.trustwallet.core.app.utils
+
+import com.trustwallet.core.app.utils.Numeric
+import com.trustwallet.core.app.utils.toHex
+import com.trustwallet.core.app.utils.toHexByteArray
+import wallet.core.jni.CoinType
+import wallet.core.jni.Curve
+import wallet.core.jni.Derivation
+import wallet.core.jni.HDWallet
+import java.security.InvalidParameterException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class TestAnyAddress {
+    init {
+        System.loadLibrary("TrustWalletCore");
+    }
+
+    val ANY_ADDRESS_TEST_ADDRESS = "bc1qcj2vfjec3c3luf9fx9vddnglhh9gawmncmgxhz"
+    val ANY_ADDRESS_TEST_PUBKEY = "02753f5c275e1847ba4d2fd3df36ad00af2e165650b35fe3991e9c9c46f68b12bc"
+
+    @Test
+    fun testCreateWithString() {
+        val coin = CoinType.BITCOIN
+        val address = AnyAddress(ANY_ADDRESS_TEST_ADDRESS, coin)
+        assertEquals(address.coin(), coin)
+        assertEquals(address.description(), ANY_ADDRESS_TEST_ADDRESS)
+    }
+
+    @Test
+    fun testCreateWithStringBech32() {
+        val coin = CoinType.BITCOIN
+        val address1 = AnyAddress(ANY_ADDRESS_TEST_ADDRESS, coin, "bc")
+        assertEquals(address1.description(), ANY_ADDRESS_TEST_ADDRESS)
+
+        val address2 = AnyAddress("tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3", coin, "tb")
+        assertEquals(address2.description(), "tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3")
+    }
+
+    @Test
+    fun testCreateWithPublicKey() {
+        val coin = CoinType.BITCOIN
+        val pubkey = PublicKey(ANY_ADDRESS_TEST_PUBKEY.toHexByteArray(), Curve.SECP256K1)
+        val address = AnyAddress(pubkey, coin)
+        assertEquals(address.description(), ANY_ADDRESS_TEST_ADDRESS)
+    }
+
+    @Test
+    fun testCreateWithPublicKeyDerivation() {
+        val coin = CoinType.BITCOIN
+        val pubkey = PublicKey(ANY_ADDRESS_TEST_PUBKEY.toHexByteArray(), Curve.SECP256K1)
+        val address1 = AnyAddress(pubkey, coin, Derivation.BITCOINSEGWIT)
+        assertEquals(address1.description(), ANY_ADDRESS_TEST_ADDRESS)
+
+        val address2 = AnyAddress(pubkey, coin, Derivation.BITCOINLEGACY)
+        assertEquals(address2.description(), "1JvRfEQFv5q5qy9uTSAezH7kVQf4hqnHXx")
+    }
+
+    @Test
+    fun testCreateBech32WithPublicKey() {
+        val coin = CoinType.BITCOIN
+        val pubkey = PublicKey(ANY_ADDRESS_TEST_PUBKEY.toHexByteArray(), Curve.SECP256K1)
+        val address1 = AnyAddress(pubkey, coin, "bc")
+        assertEquals(address1.description(), ANY_ADDRESS_TEST_ADDRESS)
+
+        val address2 = AnyAddress(pubkey, coin, "tb")
+        assertEquals(address2.description(), "tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3")
+    }
+
+    @Test
+    fun testIsValid() {
+        val coin = CoinType.BITCOIN
+        XCTAssertTrue(AnyAddress.isValid(ANY_ADDRESS_TEST_ADDRESS, coin));
+        XCTAssertFalse(AnyAddress.isValid(ANY_ADDRESS_TEST_ADDRESS, CoinType.ETHEREUEM));
+        XCTAssertFalse(AnyAddress.isValid("__INVALID_ADDRESS__", CoinType.ETHEREUEM));
+    }
+
+    @Test
+    fun testIsValidBech32() {
+        val coin = CoinType.BITCOIN
+        XCTAssertTrue(AnyAddress.isValidBech32(ANY_ADDRESS_TEST_ADDRESS, coin, "bc"));
+        XCTAssertFalse(AnyAddress.isValidBech32(ANY_ADDRESS_TEST_ADDRESS, coin, "tb"));
+    }
+}

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestAnyAddress.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestAnyAddress.kt
@@ -14,6 +14,7 @@ import wallet.core.jni.CoinType
 import wallet.core.jni.Curve
 import wallet.core.jni.Derivation
 import wallet.core.jni.HDWallet
+import wallet.core.jni.PublicKey
 import java.security.InvalidParameterException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestAnyAddress.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestAnyAddress.kt
@@ -9,12 +9,7 @@ package com.trustwallet.core.app.utils
 import com.trustwallet.core.app.utils.Numeric
 import com.trustwallet.core.app.utils.toHex
 import com.trustwallet.core.app.utils.toHexByteArray
-import wallet.core.jni.AnyAddress
-import wallet.core.jni.CoinType
-import wallet.core.jni.Curve
-import wallet.core.jni.Derivation
-import wallet.core.jni.HDWallet
-import wallet.core.jni.PublicKey
+import wallet.core.jni.*
 import java.security.InvalidParameterException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -51,7 +46,7 @@ class TestAnyAddress {
     @Test
     fun testCreateWithPublicKey() {
         val coin = CoinType.BITCOIN
-        val pubkey = PublicKey(ANY_ADDRESS_TEST_PUBKEY.toHexByteArray(), Curve.SECP256K1)
+        val pubkey = PublicKey(ANY_ADDRESS_TEST_PUBKEY.toHexByteArray(), PublicKeyType.SECP256K1)
         val address = AnyAddress(pubkey, coin)
         assertEquals(address.description(), ANY_ADDRESS_TEST_ADDRESS)
     }
@@ -59,7 +54,7 @@ class TestAnyAddress {
     @Test
     fun testCreateWithPublicKeyDerivation() {
         val coin = CoinType.BITCOIN
-        val pubkey = PublicKey(ANY_ADDRESS_TEST_PUBKEY.toHexByteArray(), Curve.SECP256K1)
+        val pubkey = PublicKey(ANY_ADDRESS_TEST_PUBKEY.toHexByteArray(), PublicKeyType.SECP256K1)
         val address1 = AnyAddress(pubkey, coin, Derivation.BITCOINSEGWIT)
         assertEquals(address1.description(), ANY_ADDRESS_TEST_ADDRESS)
 
@@ -70,7 +65,7 @@ class TestAnyAddress {
     @Test
     fun testCreateBech32WithPublicKey() {
         val coin = CoinType.BITCOIN
-        val pubkey = PublicKey(ANY_ADDRESS_TEST_PUBKEY.toHexByteArray(), Curve.SECP256K1)
+        val pubkey = PublicKey(ANY_ADDRESS_TEST_PUBKEY.toHexByteArray(), PublicKeyType.SECP256K1)
         val address1 = AnyAddress(pubkey, coin, "bc")
         assertEquals(address1.description(), ANY_ADDRESS_TEST_ADDRESS)
 

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestAnyAddress.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestAnyAddress.kt
@@ -9,6 +9,7 @@ package com.trustwallet.core.app.utils
 import com.trustwallet.core.app.utils.Numeric
 import com.trustwallet.core.app.utils.toHex
 import com.trustwallet.core.app.utils.toHexByteArray
+import wallet.core.jni.AnyAddress
 import wallet.core.jni.CoinType
 import wallet.core.jni.Curve
 import wallet.core.jni.Derivation
@@ -79,17 +80,17 @@ class TestAnyAddress {
     @Test
     fun testIsValid() {
         val coin = CoinType.BITCOIN
-        XCTAssertTrue(AnyAddress.isValid(ANY_ADDRESS_TEST_ADDRESS, coin));
-        XCTAssertFalse(AnyAddress.isValid(ANY_ADDRESS_TEST_ADDRESS, CoinType.ETHEREUEM));
-        XCTAssertFalse(AnyAddress.isValid("__INVALID_ADDRESS__", CoinType.ETHEREUEM));
+        assertTrue(AnyAddress.isValid(ANY_ADDRESS_TEST_ADDRESS, coin));
+        assertFalse(AnyAddress.isValid(ANY_ADDRESS_TEST_ADDRESS, CoinType.ETHEREUM));
+        assertFalse(AnyAddress.isValid("__INVALID_ADDRESS__", CoinType.ETHEREUM));
     }
 
     @Test
     fun testIsValidBech32() {
         val coin = CoinType.BITCOIN
-        XCTAssertTrue(AnyAddress.isValidBech32(ANY_ADDRESS_TEST_ADDRESS, coin, "bc"));
-        XCTAssertFalse(AnyAddress.isValidBech32(ANY_ADDRESS_TEST_ADDRESS, coin, "tb"));
-        XCTAssertTrue(AnyAddress.isValidBech32("tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3", coin, "tb"));
-        XCTAssertFalse(AnyAddress.isValidBech32("tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3", coin, "bc"));
+        assertTrue(AnyAddress.isValidBech32(ANY_ADDRESS_TEST_ADDRESS, coin, "bc"));
+        assertFalse(AnyAddress.isValidBech32(ANY_ADDRESS_TEST_ADDRESS, coin, "tb"));
+        assertTrue(AnyAddress.isValidBech32("tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3", coin, "tb"));
+        assertFalse(AnyAddress.isValidBech32("tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3", coin, "bc"));
     }
 }

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestAnyAddress.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestAnyAddress.kt
@@ -89,5 +89,7 @@ class TestAnyAddress {
         val coin = CoinType.BITCOIN
         XCTAssertTrue(AnyAddress.isValidBech32(ANY_ADDRESS_TEST_ADDRESS, coin, "bc"));
         XCTAssertFalse(AnyAddress.isValidBech32(ANY_ADDRESS_TEST_ADDRESS, coin, "tb"));
+        XCTAssertTrue(AnyAddress.isValidBech32("tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3", coin, "tb"));
+        XCTAssertFalse(AnyAddress.isValidBech32("tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3", coin, "bc"));
     }
 }

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestAnyAddress.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestAnyAddress.kt
@@ -22,22 +22,22 @@ class TestAnyAddress {
         System.loadLibrary("TrustWalletCore");
     }
 
-    val ANY_ADDRESS_TEST_ADDRESS = "bc1qcj2vfjec3c3luf9fx9vddnglhh9gawmncmgxhz"
-    val ANY_ADDRESS_TEST_PUBKEY = "02753f5c275e1847ba4d2fd3df36ad00af2e165650b35fe3991e9c9c46f68b12bc"
+    val any_address_test_address = "bc1qcj2vfjec3c3luf9fx9vddnglhh9gawmncmgxhz"
+    val any_address_test_pubkey = "02753f5c275e1847ba4d2fd3df36ad00af2e165650b35fe3991e9c9c46f68b12bc"
 
     @Test
     fun testCreateWithString() {
         val coin = CoinType.BITCOIN
-        val address = AnyAddress(ANY_ADDRESS_TEST_ADDRESS, coin)
+        val address = AnyAddress(any_address_test_address, coin)
         assertEquals(address.coin(), coin)
-        assertEquals(address.description(), ANY_ADDRESS_TEST_ADDRESS)
+        assertEquals(address.description(), any_address_test_address)
     }
 
     @Test
     fun testCreateWithStringBech32() {
         val coin = CoinType.BITCOIN
-        val address1 = AnyAddress(ANY_ADDRESS_TEST_ADDRESS, coin, "bc")
-        assertEquals(address1.description(), ANY_ADDRESS_TEST_ADDRESS)
+        val address1 = AnyAddress(any_address_test_address, coin, "bc")
+        assertEquals(address1.description(), any_address_test_address)
 
         val address2 = AnyAddress("tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3", coin, "tb")
         assertEquals(address2.description(), "tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3")
@@ -46,17 +46,17 @@ class TestAnyAddress {
     @Test
     fun testCreateWithPublicKey() {
         val coin = CoinType.BITCOIN
-        val pubkey = PublicKey(ANY_ADDRESS_TEST_PUBKEY.toHexByteArray(), PublicKeyType.SECP256K1)
+        val pubkey = PublicKey(any_address_test_pubkey.toHexByteArray(), PublicKeyType.SECP256K1)
         val address = AnyAddress(pubkey, coin)
-        assertEquals(address.description(), ANY_ADDRESS_TEST_ADDRESS)
+        assertEquals(address.description(), any_address_test_address)
     }
 
     @Test
     fun testCreateWithPublicKeyDerivation() {
         val coin = CoinType.BITCOIN
-        val pubkey = PublicKey(ANY_ADDRESS_TEST_PUBKEY.toHexByteArray(), PublicKeyType.SECP256K1)
+        val pubkey = PublicKey(any_address_test_pubkey.toHexByteArray(), PublicKeyType.SECP256K1)
         val address1 = AnyAddress(pubkey, coin, Derivation.BITCOINSEGWIT)
-        assertEquals(address1.description(), ANY_ADDRESS_TEST_ADDRESS)
+        assertEquals(address1.description(), any_address_test_address)
 
         val address2 = AnyAddress(pubkey, coin, Derivation.BITCOINLEGACY)
         assertEquals(address2.description(), "1JvRfEQFv5q5qy9uTSAezH7kVQf4hqnHXx")
@@ -65,9 +65,9 @@ class TestAnyAddress {
     @Test
     fun testCreateBech32WithPublicKey() {
         val coin = CoinType.BITCOIN
-        val pubkey = PublicKey(ANY_ADDRESS_TEST_PUBKEY.toHexByteArray(), PublicKeyType.SECP256K1)
+        val pubkey = PublicKey(any_address_test_pubkey.toHexByteArray(), PublicKeyType.SECP256K1)
         val address1 = AnyAddress(pubkey, coin, "bc")
-        assertEquals(address1.description(), ANY_ADDRESS_TEST_ADDRESS)
+        assertEquals(address1.description(), any_address_test_address)
 
         val address2 = AnyAddress(pubkey, coin, "tb")
         assertEquals(address2.description(), "tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3")
@@ -76,16 +76,16 @@ class TestAnyAddress {
     @Test
     fun testIsValid() {
         val coin = CoinType.BITCOIN
-        assertTrue(AnyAddress.isValid(ANY_ADDRESS_TEST_ADDRESS, coin));
-        assertFalse(AnyAddress.isValid(ANY_ADDRESS_TEST_ADDRESS, CoinType.ETHEREUM));
+        assertTrue(AnyAddress.isValid(any_address_test_address, coin));
+        assertFalse(AnyAddress.isValid(any_address_test_address, CoinType.ETHEREUM));
         assertFalse(AnyAddress.isValid("__INVALID_ADDRESS__", CoinType.ETHEREUM));
     }
 
     @Test
     fun testIsValidBech32() {
         val coin = CoinType.BITCOIN
-        assertTrue(AnyAddress.isValidBech32(ANY_ADDRESS_TEST_ADDRESS, coin, "bc"));
-        assertFalse(AnyAddress.isValidBech32(ANY_ADDRESS_TEST_ADDRESS, coin, "tb"));
+        assertTrue(AnyAddress.isValidBech32(any_address_test_address, coin, "bc"));
+        assertFalse(AnyAddress.isValidBech32(any_address_test_address, coin, "tb"));
         assertTrue(AnyAddress.isValidBech32("tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3", coin, "tb"));
         assertFalse(AnyAddress.isValidBech32("tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3", coin, "bc"));
     }

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestHDWallet.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestHDWallet.kt
@@ -10,6 +10,7 @@ import com.trustwallet.core.app.utils.Numeric
 import com.trustwallet.core.app.utils.toHex
 import wallet.core.jni.CoinType
 import wallet.core.jni.Curve
+import wallet.core.jni.Derivation
 import wallet.core.jni.HDVersion
 import wallet.core.jni.HDWallet
 import wallet.core.jni.Mnemonic

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestHDWallet.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestHDWallet.kt
@@ -1,6 +1,13 @@
+// Copyright © 2017-2022 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
 package com.trustwallet.core.app.utils
 
 import com.trustwallet.core.app.utils.Numeric
+import com.trustwallet.core.app.utils.toHex
 import wallet.core.jni.CoinType
 import wallet.core.jni.Curve
 import wallet.core.jni.HDVersion
@@ -63,6 +70,52 @@ class TestHDWallet {
         val hd = HDWallet(Numeric.hexStringToByteArray("ba5821e8c356c05ba5f025d9532fe0f21f65d594"), "TREZOR")
         assertEquals(hd.mnemonic(), words)
         assertEquals(Numeric.toHexString(hd.entropy()), "0xba5821e8c356c05ba5f025d9532fe0f21f65d594")
+    }
+
+    @Test
+    fun testGetKeyForCoin() {
+        val coin = CoinType.BITCOIN
+        val wallet = HDWallet(words, password)
+        val key = wallet.getKeyForCoin(coin)
+
+        val address = coin.deriveAddress(key)
+        assertEquals(address, "bc1qumwjg8danv2vm29lp5swdux4r60ezptzz7ce85")
+    }
+
+    @Test
+    fun testGetKeyDerivation() {
+        val coin = CoinType.BITCOIN
+        val wallet = HDWallet(words, password)
+
+        val key1 = wallet.getKeyDerivation(coin, Derivation.BITCOINSEGWIT)
+        assertEquals(key1.data().toHex(), "0x1901b5994f075af71397f65bd68a9fff8d3025d65f5a2c731cf90f5e259d6aac")
+
+        val key2 = wallet.getKeyDerivation(coin, Derivation.BITCOINLEGACY)
+        assertEquals(key2.data().toHex(), "0x28071bf4e2b0340db41b807ed8a5514139e5d6427ff9d58dbd22b7ed187103a4")
+
+        val key3 = wallet.getKeyDerivation(coin, Derivation.BITCOINTESTNET)
+        assertEquals(key3.data().toHex(), "0xca5845e1b43e3adf577b7f110b60596479425695005a594c88f9901c3afe864f")
+    }
+
+    @Test
+    fun testGetAddressForCoin() {
+        val coin = CoinType.BITCOIN
+        val wallet = HDWallet(words, password)
+
+        val address = wallet.getAddressForCoin(coin)
+        assertEquals(address, "bc1qumwjg8danv2vm29lp5swdux4r60ezptzz7ce85")
+    }
+
+    @Test
+    fun testGetAddressDerivation() {
+        val coin = CoinType.BITCOIN
+        val wallet = HDWallet(words, password)
+
+        val address1 = wallet.getAddressDerivation(coin, Derivation.BITCOINSEGWIT)
+        assertEquals(address1, "bc1qumwjg8danv2vm29lp5swdux4r60ezptzz7ce85")
+
+        val address2 = wallet.getAddressDerivation(coin, Derivation.BITCOINLEGACY)
+        assertEquals(address2, "1PeUvjuxyf31aJKX6kCXuaqxhmG78ZUdL1")
     }
 
     @Test

--- a/include/TrustWalletCore/TWAnyAddress.h
+++ b/include/TrustWalletCore/TWAnyAddress.h
@@ -88,6 +88,15 @@ struct TWAnyAddress* _Nullable TWAnyAddressCreateSS58(TWString* _Nonnull string,
 TW_EXPORT_STATIC_METHOD
 struct TWAnyAddress* _Nonnull TWAnyAddressCreateWithPublicKey(struct TWPublicKey* _Nonnull publicKey, enum TWCoinType coin);
 
+/// Creates an address from a public key and derivation option.
+///
+/// \param publicKey derivates the address from the public key.
+/// \param coin coin type of the address.
+/// \param derivation the custom derivation to use.
+/// \return TWAnyAddress pointer or nullptr if public key is invalid.
+TW_EXPORT_STATIC_METHOD
+struct TWAnyAddress* _Nonnull TWAnyAddressCreateWithPublicKeyDerivation(struct TWPublicKey* _Nonnull publicKey, enum TWCoinType coin, enum TWDerivation derivation);
+
 /// Creates an bech32 address from a public key and a given hrp.
 ///
 /// \param publicKey derivates the address from the public key.

--- a/include/TrustWalletCore/TWHDWallet.h
+++ b/include/TrustWalletCore/TWHDWallet.h
@@ -1,4 +1,4 @@
-// Copyright © 2017-2021 Trust Wallet.
+// Copyright © 2017-2022 Trust Wallet.
 //
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
@@ -100,7 +100,8 @@ TWData* _Nonnull TWHDWalletEntropy(struct TWHDWallet* _Nonnull wallet);
 TW_EXPORT_METHOD
 struct TWPrivateKey* _Nonnull TWHDWalletGetMasterKey(struct TWHDWallet* _Nonnull wallet, enum TWCurve curve);
 
-/// Generates the default private key for the specified coin.
+/// Generates the default private key for the specified coin, using default derivation.
+/// See also TWHDWalletGetKey, TWHDWalletGetKeyDerivation
 ///
 /// \param wallet non-null TWHDWallet
 /// \param coin  a coin type
@@ -118,6 +119,7 @@ TW_EXPORT_METHOD
 TWString* _Nonnull TWHDWalletGetAddressForCoin(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin);
 
 /// Generates the private key for the specified derivation path.
+/// See also TWHDWalletGetKeyForCoin, TWHDWalletGetKeyDerivation
 ///
 /// \param wallet non-null TWHDWallet
 /// \param coin a coin type
@@ -126,6 +128,17 @@ TWString* _Nonnull TWHDWalletGetAddressForCoin(struct TWHDWallet* _Nonnull walle
 /// \return The private key for the specified derivation path/coin
 TW_EXPORT_METHOD
 struct TWPrivateKey* _Nonnull TWHDWalletGetKey(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin, TWString* _Nonnull derivationPath);
+
+/// Generates the private key for the specified derivation.
+/// See also TWHDWalletGetKey, TWHDWalletGetKeyForCoin
+///
+/// \param wallet non-null TWHDWallet
+/// \param coin a coin type
+/// \param derivation a (custom) derivation to use
+/// \note Returned object needs to be deleted with \TWPrivateKeyDelete
+/// \return The private key for the specified derivation path/coin
+TW_EXPORT_METHOD
+struct TWPrivateKey* _Nonnull TWHDWalletGetKeyDerivation(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin, enum TWDerivation derivation);
 
 /// Generates the private key for the specified derivation path and curve.
 ///

--- a/include/TrustWalletCore/TWHDWallet.h
+++ b/include/TrustWalletCore/TWHDWallet.h
@@ -110,13 +110,24 @@ struct TWPrivateKey* _Nonnull TWHDWalletGetMasterKey(struct TWHDWallet* _Nonnull
 TW_EXPORT_METHOD
 struct TWPrivateKey* _Nonnull TWHDWalletGetKeyForCoin(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin);
 
-/// Generates the default address for the specified coin (without exposing intermediary private key).
+/// Generates the default address for the specified coin (without exposing intermediary private key), default derivation.
+/// See also TWHDWalletGetAddressDerivation
 ///
 /// \param wallet non-null TWHDWallet
 /// \param coin  a coin type
 /// \return return the default address for the specified coin as a non-null TWString
 TW_EXPORT_METHOD
 TWString* _Nonnull TWHDWalletGetAddressForCoin(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin);
+
+/// Generates the default address for the specified coin and derivation (without exposing intermediary private key).
+/// See also TWHDWalletGetAddressForCoin
+///
+/// \param wallet non-null TWHDWallet
+/// \param coin  a coin type
+/// \param derivation  a (custom) derivation to use
+/// \return return the default address for the specified coin as a non-null TWString
+TW_EXPORT_METHOD
+TWString* _Nonnull TWHDWalletGetAddressDerivation(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin, enum TWDerivation derivation);
 
 /// Generates the private key for the specified derivation path.
 /// See also TWHDWalletGetKeyForCoin, TWHDWalletGetKeyDerivation

--- a/include/TrustWalletCore/TWHDWallet.h
+++ b/include/TrustWalletCore/TWHDWallet.h
@@ -101,8 +101,9 @@ TW_EXPORT_METHOD
 struct TWPrivateKey* _Nonnull TWHDWalletGetMasterKey(struct TWHDWallet* _Nonnull wallet, enum TWCurve curve);
 
 /// Generates the default private key for the specified coin, using default derivation.
-/// See also TWHDWalletGetKey, TWHDWalletGetKeyDerivation
 ///
+/// \see TWHDWalletGetKey
+/// \see TWHDWalletGetKeyDerivation
 /// \param wallet non-null TWHDWallet
 /// \param coin  a coin type
 /// \note Returned object needs to be deleted with \TWPrivateKeyDelete
@@ -111,8 +112,8 @@ TW_EXPORT_METHOD
 struct TWPrivateKey* _Nonnull TWHDWalletGetKeyForCoin(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin);
 
 /// Generates the default address for the specified coin (without exposing intermediary private key), default derivation.
-/// See also TWHDWalletGetAddressDerivation
 ///
+/// \see TWHDWalletGetAddressDerivation
 /// \param wallet non-null TWHDWallet
 /// \param coin  a coin type
 /// \return return the default address for the specified coin as a non-null TWString
@@ -120,8 +121,8 @@ TW_EXPORT_METHOD
 TWString* _Nonnull TWHDWalletGetAddressForCoin(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin);
 
 /// Generates the default address for the specified coin and derivation (without exposing intermediary private key).
-/// See also TWHDWalletGetAddressForCoin
 ///
+/// \see TWHDWalletGetAddressForCoin
 /// \param wallet non-null TWHDWallet
 /// \param coin  a coin type
 /// \param derivation  a (custom) derivation to use
@@ -130,8 +131,9 @@ TW_EXPORT_METHOD
 TWString* _Nonnull TWHDWalletGetAddressDerivation(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin, enum TWDerivation derivation);
 
 /// Generates the private key for the specified derivation path.
-/// See also TWHDWalletGetKeyForCoin, TWHDWalletGetKeyDerivation
 ///
+/// \see TWHDWalletGetKeyForCoin
+/// \see TWHDWalletGetKeyDerivation
 /// \param wallet non-null TWHDWallet
 /// \param coin a coin type
 /// \param derivationPath  a non-null derivation path
@@ -141,8 +143,9 @@ TW_EXPORT_METHOD
 struct TWPrivateKey* _Nonnull TWHDWalletGetKey(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin, TWString* _Nonnull derivationPath);
 
 /// Generates the private key for the specified derivation.
-/// See also TWHDWalletGetKey, TWHDWalletGetKeyForCoin
 ///
+/// \see TWHDWalletGetKey
+/// \see TWHDWalletGetKeyForCoin
 /// \param wallet non-null TWHDWallet
 /// \param coin a coin type
 /// \param derivation a (custom) derivation to use

--- a/samples/typescript/devconsole.ts/package-lock.json
+++ b/samples/typescript/devconsole.ts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@trustwallet/wallet-core": "3.0.4",
+        "@trustwallet/wallet-core": "3.0.8",
         "chalk": "^4.1.2",
         "clear": "^0.1.0",
         "figlet": "^1.5.2",
@@ -116,9 +116,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@trustwallet/wallet-core": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@trustwallet/wallet-core/-/wallet-core-3.0.4.tgz",
-      "integrity": "sha512-FrIVEwRmUYFuwU9IoXg0J8fngeW7nlJZZAsrnOWba2g/yGWZl4FQ4z87MEQ5ROOGW9jJzsdWG4PRZffvYzhqsg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@trustwallet/wallet-core/-/wallet-core-3.0.8.tgz",
+      "integrity": "sha512-u0ST2xZL6oWCAMmZRKQVxBLhNtOu/tYByVl9OEfd8SbAGHVjW/6V+oVmHAqBL/z3fwfZfYg2LY08AW831ZNwoQ==",
       "dependencies": {
         "protobufjs": ">=6.11.3"
       }
@@ -964,9 +964,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@trustwallet/wallet-core": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@trustwallet/wallet-core/-/wallet-core-3.0.4.tgz",
-      "integrity": "sha512-FrIVEwRmUYFuwU9IoXg0J8fngeW7nlJZZAsrnOWba2g/yGWZl4FQ4z87MEQ5ROOGW9jJzsdWG4PRZffvYzhqsg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@trustwallet/wallet-core/-/wallet-core-3.0.8.tgz",
+      "integrity": "sha512-u0ST2xZL6oWCAMmZRKQVxBLhNtOu/tYByVl9OEfd8SbAGHVjW/6V+oVmHAqBL/z3fwfZfYg2LY08AW831ZNwoQ==",
       "requires": {
         "protobufjs": ">=6.11.3"
       }

--- a/samples/typescript/devconsole.ts/package.json
+++ b/samples/typescript/devconsole.ts/package.json
@@ -14,7 +14,7 @@
   "author": "Trust Wallet",
   "license": "MIT",
   "dependencies": {
-    "@trustwallet/wallet-core": "3.0.4",
+    "@trustwallet/wallet-core": "3.0.8",
     "chalk": "^4.1.2",
     "clear": "^0.1.0",
     "figlet": "^1.5.2",

--- a/samples/typescript/devconsole.ts/samplescripts/bitcoin.addresses.sampleinput.txt
+++ b/samples/typescript/devconsole.ts/samplescripts/bitcoin.addresses.sampleinput.txt
@@ -1,0 +1,19 @@
+// Derive Bitcoin addresses of different flavor
+
+coin = CoinType.bitcoin
+
+privKeyData = '0xafeefca74d9a325cf1d6b6911d61a65c32afa8e02bd5e78e2e4ac2910bab45f5';
+privKey = PrivateKey.createWithData(HexCoding.decode(privKeyData));
+pubKey = privKey.getPublicKeySecp256k1(true);
+address11 = SegwitAddress.createWithPublicKey(HRP.bitcoin, pubKey).description();
+
+// This is not yet possible yet through AnyAddress
+// TWAnyAddressCreateWithPublicKeyDerivation
+address21 = AnyAddress.createWithPublicKey(pubKey, coin);
+address21.description()
+
+// This is not yet possible yet through HDWallet
+// TWHDWalletGetKeyDerivation
+// TWHDWalletGetAddressDerivation
+wallet = HDWallet.createWithMnemonic('ripple scissors kick mammal hire column oak again sun offer wealth tomorrow wagon turn fatal', '');
+address = wallet.getAddressForCoin(coin);

--- a/src/AnyAddress.cpp
+++ b/src/AnyAddress.cpp
@@ -25,15 +25,15 @@ AnyAddress* AnyAddress::createAddress(const std::string& address, enum TWCoinTyp
     return new AnyAddress{.address = std::move(normalized), .coin = coin};
 }
 
-AnyAddress* AnyAddress::createAddress(const PublicKey& publicKey, enum TWCoinType coin, const std::string& hrp) {
+AnyAddress* AnyAddress::createAddress(const PublicKey& publicKey, enum TWCoinType coin, const std::string& hrp, TWDerivation derivation) {
 
-    auto derivedAddress = TW::deriveAddress(coin, publicKey, TWDerivationDefault, hrp);
+    auto derivedAddress = TW::deriveAddress(coin, publicKey, derivation, hrp);
     return new AnyAddress{.address = std::move(derivedAddress), .coin = coin};
 }
 
-AnyAddress* AnyAddress::createAddress(const PublicKey& publicKey, enum TWCoinType coin, const PrefixVariant& addressPrefix) {
+AnyAddress* AnyAddress::createAddress(const PublicKey& publicKey, enum TWCoinType coin, const PrefixVariant& addressPrefix, TWDerivation derivation) {
 
-    auto derivedAddress = TW::deriveAddress(coin, publicKey, addressPrefix);
+    auto derivedAddress = TW::deriveAddress(coin, publicKey, addressPrefix, derivation);
     return new AnyAddress{.address = std::move(derivedAddress), .coin = coin};
 }
 

--- a/src/AnyAddress.h
+++ b/src/AnyAddress.h
@@ -24,8 +24,8 @@ public:
     enum TWCoinType coin;
 
     static AnyAddress* createAddress(const std::string& address, enum TWCoinType coin, const PrefixVariant& prefix = std::monostate());
-    static AnyAddress* createAddress(const PublicKey& publicKey, enum TWCoinType coin, const std::string& hrp = "");
-    static AnyAddress* createAddress(const PublicKey& publicKey, enum TWCoinType coin, const PrefixVariant& prefix);
+    static AnyAddress* createAddress(const PublicKey& publicKey, enum TWCoinType coin, const std::string& hrp = "", TWDerivation derivation = TWDerivationDefault);
+    static AnyAddress* createAddress(const PublicKey& publicKey, enum TWCoinType coin, const PrefixVariant& prefix, TWDerivation derivation = TWDerivationDefault);
 
     Data getData() const;
 };

--- a/src/interface/TWAnyAddress.cpp
+++ b/src/interface/TWAnyAddress.cpp
@@ -68,6 +68,11 @@ struct TWAnyAddress* _Nonnull TWAnyAddressCreateWithPublicKey(
     return new TWAnyAddress{TW::AnyAddress::createAddress(publicKey->impl, coin)};
 }
 
+struct TWAnyAddress* _Nonnull TWAnyAddressCreateWithPublicKeyDerivation(
+    struct TWPublicKey* _Nonnull publicKey, enum TWCoinType coin, enum TWDerivation derivation) {
+    return new TWAnyAddress{TW::AnyAddress::createAddress(publicKey->impl, coin, std::string(""), derivation)};
+}
+
 struct TWAnyAddress* _Nonnull TWAnyAddressCreateBech32WithPublicKey(
     struct TWPublicKey* _Nonnull publicKey, enum TWCoinType coin, TWString* _Nonnull hrp) {
     const auto& hrpStr = *reinterpret_cast<const std::string*>(hrp);

--- a/src/interface/TWHDWallet.cpp
+++ b/src/interface/TWHDWallet.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2017-2021 Trust Wallet.
+// Copyright © 2017-2022 Trust Wallet.
 //
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
@@ -71,9 +71,13 @@ struct TWPrivateKey *_Nonnull TWHDWalletGetKeyForCoin(struct TWHDWallet *wallet,
 }
 
 TWString *_Nonnull TWHDWalletGetAddressForCoin(struct TWHDWallet *wallet, TWCoinType coin) {
-    auto derivationPath = TW::derivationPath(coin);
+    return TWHDWalletGetAddressDerivation(wallet, coin, TWDerivationDefault);
+}
+
+TWString *_Nonnull TWHDWalletGetAddressDerivation(struct TWHDWallet *wallet, TWCoinType coin, enum TWDerivation derivation) {
+    auto derivationPath = TW::derivationPath(coin, derivation);
     PrivateKey privateKey = wallet->impl.getKey(coin, derivationPath);
-    std::string address = deriveAddress(coin, privateKey);
+    std::string address = deriveAddress(coin, privateKey, derivation);
     return TWStringCreateWithUTF8Bytes(address.c_str());
 }
 

--- a/src/interface/TWHDWallet.cpp
+++ b/src/interface/TWHDWallet.cpp
@@ -67,8 +67,7 @@ struct TWPrivateKey *_Nonnull TWHDWalletGetMasterKey(struct TWHDWallet *_Nonnull
 }
 
 struct TWPrivateKey *_Nonnull TWHDWalletGetKeyForCoin(struct TWHDWallet *wallet, TWCoinType coin) {
-    auto derivationPath = TW::derivationPath(coin);
-    return new TWPrivateKey{ wallet->impl.getKey(coin, derivationPath) };
+    return TWHDWalletGetKeyDerivation(wallet, coin, TWDerivationDefault);
 }
 
 TWString *_Nonnull TWHDWalletGetAddressForCoin(struct TWHDWallet *wallet, TWCoinType coin) {
@@ -82,6 +81,11 @@ struct TWPrivateKey *_Nonnull TWHDWalletGetKey(struct TWHDWallet *_Nonnull walle
     auto& s = *reinterpret_cast<const std::string*>(derivationPath);
     const auto path = DerivationPath(s);
     return new TWPrivateKey{ wallet->impl.getKey(coin, path) };
+}
+
+struct TWPrivateKey *_Nonnull TWHDWalletGetKeyDerivation(struct TWHDWallet *_Nonnull wallet, enum TWCoinType coin, enum TWDerivation derivation) {
+    auto derivationPath = TW::derivationPath(coin, derivation);
+    return new TWPrivateKey{ wallet->impl.getKey(coin, derivationPath) };
 }
 
 struct TWPrivateKey *_Nonnull TWHDWalletGetDerivedKey(struct TWHDWallet *_Nonnull wallet, enum TWCoinType coin, uint32_t account, uint32_t change, uint32_t address) {

--- a/swift/Tests/AnyAddressTests.swift
+++ b/swift/Tests/AnyAddressTests.swift
@@ -8,20 +8,20 @@ import WalletCore
 import XCTest
 
 class AnyAddressTests: XCTestCase {
-    let ANY_ADDRESS_TEST_ADDRESS = "bc1qcj2vfjec3c3luf9fx9vddnglhh9gawmncmgxhz"
-    let ANY_ADDRESS_TEST_PUBKEY = "02753f5c275e1847ba4d2fd3df36ad00af2e165650b35fe3991e9c9c46f68b12bc"
+    let any_address_test_address = "bc1qcj2vfjec3c3luf9fx9vddnglhh9gawmncmgxhz"
+    let any_address_test_pubkey = "02753f5c275e1847ba4d2fd3df36ad00af2e165650b35fe3991e9c9c46f68b12bc"
 
     func testCreateWithString() {
         let coin = CoinType.bitcoin
-        let address = AnyAddress(string: ANY_ADDRESS_TEST_ADDRESS, coin: coin)!
+        let address = AnyAddress(string: any_address_test_address, coin: coin)!
         XCTAssertEqual(address.coin, coin)
-        XCTAssertEqual(address.description, ANY_ADDRESS_TEST_ADDRESS)
+        XCTAssertEqual(address.description, any_address_test_address)
     }
 
     func testCreateWithStringBech32() {
         let coin = CoinType.bitcoin
-        let address1 = AnyAddress(string: ANY_ADDRESS_TEST_ADDRESS, coin: coin, hrp: "bc")!
-        XCTAssertEqual(address1.description, ANY_ADDRESS_TEST_ADDRESS)
+        let address1 = AnyAddress(string: any_address_test_address, coin: coin, hrp: "bc")!
+        XCTAssertEqual(address1.description, any_address_test_address)
 
         let address2 = AnyAddress(string: "tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3", coin: coin, hrp: "tb")!
         XCTAssertEqual(address2.description, "tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3")
@@ -29,16 +29,16 @@ class AnyAddressTests: XCTestCase {
 
     func testCreateWithPublicKey() {
         let coin = CoinType.bitcoin
-        let pubkey = PublicKey(data: Data(hexString: ANY_ADDRESS_TEST_PUBKEY)!, type: .secp256k1)!
+        let pubkey = PublicKey(data: Data(hexString: any_address_test_pubkey)!, type: .secp256k1)!
         let address = AnyAddress(publicKey: pubkey, coin: coin)
-        XCTAssertEqual(address.description, ANY_ADDRESS_TEST_ADDRESS)
+        XCTAssertEqual(address.description, any_address_test_address)
     }
 
     func testCreateWithPublicKeyDerivation() {
         let coin = CoinType.bitcoin
-        let pubkey = PublicKey(data: Data(hexString: ANY_ADDRESS_TEST_PUBKEY)!, type: .secp256k1)!
+        let pubkey = PublicKey(data: Data(hexString: any_address_test_pubkey)!, type: .secp256k1)!
         let address1 = AnyAddress(publicKey: pubkey, coin: coin, derivation: .bitcoinSegwit)
-        XCTAssertEqual(address1.description, ANY_ADDRESS_TEST_ADDRESS)
+        XCTAssertEqual(address1.description, any_address_test_address)
 
         let address2 = AnyAddress(publicKey: pubkey, coin: coin, derivation: .bitcoinLegacy)
         XCTAssertEqual(address2.description, "1JvRfEQFv5q5qy9uTSAezH7kVQf4hqnHXx")
@@ -46,9 +46,9 @@ class AnyAddressTests: XCTestCase {
 
     func testCreateBech32WithPublicKey() {
         let coin = CoinType.bitcoin
-        let pubkey = PublicKey(data: Data(hexString: ANY_ADDRESS_TEST_PUBKEY)!, type: .secp256k1)!
+        let pubkey = PublicKey(data: Data(hexString: any_address_test_pubkey)!, type: .secp256k1)!
         let address1 = AnyAddress(publicKey: pubkey, coin: coin, hrp: "bc")
-        XCTAssertEqual(address1.description, ANY_ADDRESS_TEST_ADDRESS)
+        XCTAssertEqual(address1.description, any_address_test_address)
 
         let address2 = AnyAddress(publicKey: pubkey, coin: coin, hrp: "tb")
         XCTAssertEqual(address2.description, "tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3")
@@ -56,14 +56,14 @@ class AnyAddressTests: XCTestCase {
 
     func testIsValid() {
         let coin = CoinType.bitcoin
-        XCTAssertTrue(AnyAddress.isValid(string: ANY_ADDRESS_TEST_ADDRESS, coin: coin));
-        XCTAssertFalse(AnyAddress.isValid(string: ANY_ADDRESS_TEST_ADDRESS, coin: .ethereum));
+        XCTAssertTrue(AnyAddress.isValid(string: any_address_test_address, coin: coin));
+        XCTAssertFalse(AnyAddress.isValid(string: any_address_test_address, coin: .ethereum));
         XCTAssertFalse(AnyAddress.isValid(string: "__INVALID_ADDRESS__", coin: .ethereum));
     }
 
     func testIsValidBech32() {
         let coin = CoinType.bitcoin
-        XCTAssertTrue(AnyAddress.isValidBech32(string: ANY_ADDRESS_TEST_ADDRESS, coin: coin, hrp: "bc"));
-        XCTAssertFalse(AnyAddress.isValidBech32(string: ANY_ADDRESS_TEST_ADDRESS, coin: coin, hrp: "tb"));
+        XCTAssertTrue(AnyAddress.isValidBech32(string: any_address_test_address, coin: coin, hrp: "bc"));
+        XCTAssertFalse(AnyAddress.isValidBech32(string: any_address_test_address, coin: coin, hrp: "tb"));
     }
 }

--- a/swift/Tests/AnyAddressTests.swift
+++ b/swift/Tests/AnyAddressTests.swift
@@ -1,0 +1,57 @@
+// Copyright © 2017-2022 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+import WalletCore
+import XCTest
+
+class AnyAddressTests: XCTestCase {
+    let ANY_ADDRESS_TEST_ADDRESS = "bc1qcj2vfjec3c3luf9fx9vddnglhh9gawmncmgxhz"
+    let ANY_ADDRESS_TEST_PUBKEY = "02753f5c275e1847ba4d2fd3df36ad00af2e165650b35fe3991e9c9c46f68b12bc"
+
+    func testCreateWithString() {
+        let coin = CoinType.bitcoin
+        let address = AnyAddress(string: ANY_ADDRESS_TEST_ADDRESS, coin: coin)!
+        XCTAssertEqual(address.coin, coin)
+        XCTAssertEqual(address.description, ANY_ADDRESS_TEST_ADDRESS)
+    }
+
+    func testCreateWithStringBech32() {
+        let coin = CoinType.bitcoin
+        let address = AnyAddress(string: ANY_ADDRESS_TEST_ADDRESS, coin: coin, hrp: "bc")!
+        XCTAssertEqual(address.coin, coin)
+        XCTAssertEqual(address.description, ANY_ADDRESS_TEST_ADDRESS)
+    }
+
+    func testCreateWithPublicKey() {
+        let coin = CoinType.bitcoin
+        let pubkey = PublicKey(data: Data(hexString: ANY_ADDRESS_TEST_PUBKEY)!, type: .secp256k1)!
+        let address = AnyAddress(publicKey: pubkey, coin: coin)
+        XCTAssertEqual(address.description, ANY_ADDRESS_TEST_ADDRESS)
+    }
+
+    func testCreateWithPublicKeyDerivation() {
+        let coin = CoinType.bitcoin
+        let pubkey = PublicKey(data: Data(hexString: ANY_ADDRESS_TEST_PUBKEY)!, type: .secp256k1)!
+        let address1 = AnyAddress(publicKey: pubkey, coin: coin, derivation: .bitcoinSegwit)
+        XCTAssertEqual(address1.description, ANY_ADDRESS_TEST_ADDRESS)
+
+        let address3 = AnyAddress(publicKey: pubkey, coin: coin, derivation: .bitcoinLegacy)
+        XCTAssertEqual(address3.description, "1JvRfEQFv5q5qy9uTSAezH7kVQf4hqnHXx")
+    }
+
+    func testIsValid() {
+        let coin = CoinType.bitcoin
+        XCTAssertTrue(AnyAddress.isValid(string: ANY_ADDRESS_TEST_ADDRESS, coin: coin));
+        XCTAssertFalse(AnyAddress.isValid(string: ANY_ADDRESS_TEST_ADDRESS, coin: .ethereum));
+        XCTAssertFalse(AnyAddress.isValid(string: "__INVALID_ADDRESS__", coin: .ethereum));
+    }
+
+    func testIsValidBech32() {
+        let coin = CoinType.bitcoin
+        XCTAssertTrue(AnyAddress.isValidBech32(string: ANY_ADDRESS_TEST_ADDRESS, coin: coin, hrp: "bc"));
+        XCTAssertFalse(AnyAddress.isValidBech32(string: ANY_ADDRESS_TEST_ADDRESS, coin: coin, hrp: "tb"));
+    }
+}

--- a/swift/Tests/AnyAddressTests.swift
+++ b/swift/Tests/AnyAddressTests.swift
@@ -20,9 +20,11 @@ class AnyAddressTests: XCTestCase {
 
     func testCreateWithStringBech32() {
         let coin = CoinType.bitcoin
-        let address = AnyAddress(string: ANY_ADDRESS_TEST_ADDRESS, coin: coin, hrp: "bc")!
-        XCTAssertEqual(address.coin, coin)
-        XCTAssertEqual(address.description, ANY_ADDRESS_TEST_ADDRESS)
+        let address1 = AnyAddress(string: ANY_ADDRESS_TEST_ADDRESS, coin: coin, hrp: "bc")!
+        XCTAssertEqual(address1.description, ANY_ADDRESS_TEST_ADDRESS)
+
+        let address2 = AnyAddress(string: "tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3", coin: coin, hrp: "tb")!
+        XCTAssertEqual(address2.description, "tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3")
     }
 
     func testCreateWithPublicKey() {
@@ -38,8 +40,18 @@ class AnyAddressTests: XCTestCase {
         let address1 = AnyAddress(publicKey: pubkey, coin: coin, derivation: .bitcoinSegwit)
         XCTAssertEqual(address1.description, ANY_ADDRESS_TEST_ADDRESS)
 
-        let address3 = AnyAddress(publicKey: pubkey, coin: coin, derivation: .bitcoinLegacy)
-        XCTAssertEqual(address3.description, "1JvRfEQFv5q5qy9uTSAezH7kVQf4hqnHXx")
+        let address2 = AnyAddress(publicKey: pubkey, coin: coin, derivation: .bitcoinLegacy)
+        XCTAssertEqual(address2.description, "1JvRfEQFv5q5qy9uTSAezH7kVQf4hqnHXx")
+    }
+
+    func testCreateBech32WithPublicKey() {
+        let coin = CoinType.bitcoin
+        let pubkey = PublicKey(data: Data(hexString: ANY_ADDRESS_TEST_PUBKEY)!, type: .secp256k1)!
+        let address1 = AnyAddress(publicKey: pubkey, coin: coin, hrp: "bc")
+        XCTAssertEqual(address1.description, ANY_ADDRESS_TEST_ADDRESS)
+
+        let address2 = AnyAddress(publicKey: pubkey, coin: coin, hrp: "tb")
+        XCTAssertEqual(address2.description, "tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3")
     }
 
     func testIsValid() {

--- a/swift/Tests/HDWalletTests.swift
+++ b/swift/Tests/HDWalletTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2017-2021 Trust Wallet.
+// Copyright © 2017-2022 Trust Wallet.
 //
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
@@ -47,6 +47,48 @@ class HDWalletTests: XCTestCase {
         XCTAssertEqual(wallet.seed.hexString, "d430216f5b506dfd281d6ff6e92150d205868923df00774bc301e5ffdc2f4d1ad38a602017ddea6fc7d6315345d8b9cadbd8213ed2ffce5dfc550fa918665eb8")
         let masterKey = wallet.getMasterKey(curve: Curve.secp256k1)
         XCTAssertEqual(masterKey.data.hexString, "e120fc1ef9d193a851926ebd937c3985dc2c4e642fb3d0832317884d5f18f3b3")
+    }
+
+    func testGetKeyForCoin() {
+        let coin = CoinType.bitcoin
+        let wallet = HDWallet.test
+        let key = wallet.getKeyForCoin(coin: coin)
+
+        let address = coin.deriveAddress(privateKey: key)
+        XCTAssertEqual(address, "bc1qumwjg8danv2vm29lp5swdux4r60ezptzz7ce85")
+    }
+
+    func testGetKeyDerivation() {
+        let coin = CoinType.bitcoin
+        let wallet = HDWallet.test
+
+        let key1 = wallet.getKeyDerivation(coin: coin, derivation: .bitcoinSegwit)
+        XCTAssertEqual(key1.data.hexString, "1901b5994f075af71397f65bd68a9fff8d3025d65f5a2c731cf90f5e259d6aac")
+
+        let key2 = wallet.getKeyDerivation(coin: coin, derivation: .bitcoinLegacy)
+        XCTAssertEqual(key2.data.hexString, "28071bf4e2b0340db41b807ed8a5514139e5d6427ff9d58dbd22b7ed187103a4")
+
+        let key3 = wallet.getKeyDerivation(coin: coin, derivation: .bitcoinTestnet)
+        XCTAssertEqual(key3.data.hexString, "ca5845e1b43e3adf577b7f110b60596479425695005a594c88f9901c3afe864f")
+    }
+
+    func testGetAddressForCoin() {
+        let coin = CoinType.bitcoin
+        let wallet = HDWallet.test
+
+        let address = wallet.getAddressForCoin(coin: coin)
+        XCTAssertEqual(address, "bc1qumwjg8danv2vm29lp5swdux4r60ezptzz7ce85")
+    }
+
+    func testGetAddressDerivation() {
+        let coin = CoinType.bitcoin
+        let wallet = HDWallet.test
+
+        let address1 = wallet.getAddressDerivation(coin: coin, derivation: .bitcoinSegwit)
+        XCTAssertEqual(address1, "bc1qumwjg8danv2vm29lp5swdux4r60ezptzz7ce85")
+
+        let address2 = wallet.getAddressDerivation(coin: coin, derivation: .bitcoinLegacy)
+        XCTAssertEqual(address2, "1PeUvjuxyf31aJKX6kCXuaqxhmG78ZUdL1")
     }
 
     func testDerive() {

--- a/tests/common/AnyAddressTests.cpp
+++ b/tests/common/AnyAddressTests.cpp
@@ -26,6 +26,19 @@ TEST(AnyAddress, createFromPubKey) {
     EXPECT_EQ(ANY_ADDRESS_TEST_ADDRESS, addr->address);
 }
 
+TEST(AnyAddress, createFromPubKeyDerivation) {
+    const Data key = parse_hex(ANY_ADDRESS_TEST_PUBKEY);
+    PublicKey publicKey(key, TWPublicKeyTypeSECP256k1);
+    {
+        std::unique_ptr<AnyAddress> addr(AnyAddress::createAddress(publicKey, TWCoinTypeBitcoin, std::string(""), TWDerivationDefault));
+        EXPECT_EQ(addr->address, ANY_ADDRESS_TEST_ADDRESS);
+    }
+    {
+        std::unique_ptr<AnyAddress> addr(AnyAddress::createAddress(publicKey, TWCoinTypeBitcoin, std::string(""), TWDerivationBitcoinLegacy));
+        EXPECT_EQ(addr->address, "1JvRfEQFv5q5qy9uTSAezH7kVQf4hqnHXx");
+    }
+}
+
 TEST(AnyAddress, createFromWrongString) {
     std::unique_ptr<AnyAddress> addr(AnyAddress::createAddress("1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaax", TWCoinTypeBitcoin));
     EXPECT_EQ(nullptr, addr);

--- a/tests/interface/TWAnyAddressTests.cpp
+++ b/tests/interface/TWAnyAddressTests.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2017-2020 Trust Wallet.
+// Copyright © 2017-2022 Trust Wallet.
 //
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
@@ -9,12 +9,13 @@
 #include "HexCoding.h"
 #include <TrustWalletCore/TWAnyAddress.h>
 #include <TrustWalletCore/TWCoinType.h>
+#include <TrustWalletCore/TWPublicKey.h>
 
 #include <gtest/gtest.h>
 
 using namespace TW;
 
-TEST(AnyAddress, InvalidString) {
+TEST(TWAnyAddress, InvalidString) {
     auto string = STRING("0x4E5B2e1dc63F6b91cb6Cd759936495434C7e972F");
     auto btcAddress = TWAnyAddressCreateWithString(string.get(), TWCoinTypeBitcoin);
     auto ethAaddress = WRAP(TWAnyAddress, TWAnyAddressCreateWithString(string.get(), TWCoinTypeEthereum));
@@ -24,7 +25,7 @@ TEST(AnyAddress, InvalidString) {
     ASSERT_EQ(TWAnyAddressCoin(ethAaddress.get()), TWCoinTypeEthereum);
 }
 
-TEST(AnyAddress, Data) {
+TEST(TWAnyAddress, Data) {
     // ethereum
     {
         auto string = STRING("0x4E5B2e1dc63F6b91cb6Cd759936495434C7e972F");
@@ -167,5 +168,36 @@ TEST(AnyAddress, Data) {
         auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithString(string.get(), TWCoinTypeSolana));
         auto keyHash = WRAPD(TWAnyAddressData(addr.get()));
         assertHexEqual(keyHash, "18f9d8d877393bbbe8d697a8a2e52879cc7e84f467656d1cce6bab5a8d2637ec");
+    }
+}
+
+TEST(TWAnyAddress, createFromPubKey) {
+    constexpr auto pubkey = "02753f5c275e1847ba4d2fd3df36ad00af2e165650b35fe3991e9c9c46f68b12bc";
+    const auto pubkey_twstring = STRING(pubkey);
+    const auto pubkey_data = WRAPD(TWDataCreateWithHexString(pubkey_twstring.get()));
+    const auto pubkey_obj = WRAP(TWPublicKey, TWPublicKeyCreateWithData(pubkey_data.get(), TWPublicKeyTypeSECP256k1));
+
+    const auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(pubkey_obj.get(), TWCoinTypeBitcoin));
+
+    EXPECT_EQ(std::string(TWStringUTF8Bytes(WRAPS(TWAnyAddressDescription(addr.get())).get())), "bc1qcj2vfjec3c3luf9fx9vddnglhh9gawmncmgxhz");
+}
+
+TEST(TWAnyAddress, createFromPubKeyDerivation) {
+    constexpr auto pubkey = "02753f5c275e1847ba4d2fd3df36ad00af2e165650b35fe3991e9c9c46f68b12bc";
+    const auto pubkey_twstring = STRING(pubkey);
+    const auto pubkey_data = WRAPD(TWDataCreateWithHexString(pubkey_twstring.get()));
+    const auto pubkey_obj = WRAP(TWPublicKey, TWPublicKeyCreateWithData(pubkey_data.get(), TWPublicKeyTypeSECP256k1));
+
+    {
+        const auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKeyDerivation(pubkey_obj.get(), TWCoinTypeBitcoin, TWDerivationDefault));
+        EXPECT_EQ(std::string(TWStringUTF8Bytes(WRAPS(TWAnyAddressDescription(addr.get())).get())), "bc1qcj2vfjec3c3luf9fx9vddnglhh9gawmncmgxhz");
+    }
+    {
+        const auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKeyDerivation(pubkey_obj.get(), TWCoinTypeBitcoin, TWDerivationBitcoinLegacy));
+        EXPECT_EQ(std::string(TWStringUTF8Bytes(WRAPS(TWAnyAddressDescription(addr.get())).get())), "1JvRfEQFv5q5qy9uTSAezH7kVQf4hqnHXx");
+    }
+    {
+        const auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKeyDerivation(pubkey_obj.get(), TWCoinTypeBitcoin, TWDerivationBitcoinTestnet));
+        EXPECT_EQ(std::string(TWStringUTF8Bytes(WRAPS(TWAnyAddressDescription(addr.get())).get())), "tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3");
     }
 }

--- a/tests/interface/TWAnyAddressTests.cpp
+++ b/tests/interface/TWAnyAddressTests.cpp
@@ -179,7 +179,7 @@ TEST(TWAnyAddress, createFromPubKey) {
 
     const auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKey(pubkey_obj.get(), TWCoinTypeBitcoin));
 
-    EXPECT_EQ(std::string(TWStringUTF8Bytes(WRAPS(TWAnyAddressDescription(addr.get())).get())), "bc1qcj2vfjec3c3luf9fx9vddnglhh9gawmncmgxhz");
+    assertStringsEqual(WRAPS(TWAnyAddressDescription(addr.get())), "bc1qcj2vfjec3c3luf9fx9vddnglhh9gawmncmgxhz");
 }
 
 TEST(TWAnyAddress, createFromPubKeyDerivation) {
@@ -190,14 +190,14 @@ TEST(TWAnyAddress, createFromPubKeyDerivation) {
 
     {
         const auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKeyDerivation(pubkey_obj.get(), TWCoinTypeBitcoin, TWDerivationDefault));
-        EXPECT_EQ(std::string(TWStringUTF8Bytes(WRAPS(TWAnyAddressDescription(addr.get())).get())), "bc1qcj2vfjec3c3luf9fx9vddnglhh9gawmncmgxhz");
+        assertStringsEqual(WRAPS(TWAnyAddressDescription(addr.get())), "bc1qcj2vfjec3c3luf9fx9vddnglhh9gawmncmgxhz");
     }
     {
         const auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKeyDerivation(pubkey_obj.get(), TWCoinTypeBitcoin, TWDerivationBitcoinLegacy));
-        EXPECT_EQ(std::string(TWStringUTF8Bytes(WRAPS(TWAnyAddressDescription(addr.get())).get())), "1JvRfEQFv5q5qy9uTSAezH7kVQf4hqnHXx");
+        assertStringsEqual(WRAPS(TWAnyAddressDescription(addr.get())), "1JvRfEQFv5q5qy9uTSAezH7kVQf4hqnHXx");
     }
     {
         const auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKeyDerivation(pubkey_obj.get(), TWCoinTypeBitcoin, TWDerivationBitcoinTestnet));
-        EXPECT_EQ(std::string(TWStringUTF8Bytes(WRAPS(TWAnyAddressDescription(addr.get())).get())), "tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3");
+        assertStringsEqual(WRAPS(TWAnyAddressDescription(addr.get())), "tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3");
     }
 }

--- a/tests/interface/TWHDWalletTests.cpp
+++ b/tests/interface/TWHDWalletTests.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2017-2021 Trust Wallet.
+// Copyright © 2017-2022 Trust Wallet.
 //
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
@@ -155,6 +155,18 @@ TEST(HDWallet, DeriveAddressBitcoin) {
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(gWords.get(), gPassphrase.get()));
     auto address = WRAP(TWString, TWHDWalletGetAddressForCoin(wallet.get(), TWCoinTypeBitcoin));
     assertStringsEqual(address, "bc1qumwjg8danv2vm29lp5swdux4r60ezptzz7ce85");
+}
+
+TEST(HDWallet, DeriveAddressBitcoinDerivation) {
+    auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(gWords.get(), gPassphrase.get()));
+    {
+        auto address = WRAP(TWString, TWHDWalletGetAddressDerivation(wallet.get(), TWCoinTypeBitcoin, TWDerivationBitcoinSegwit));
+        assertStringsEqual(address, "bc1qumwjg8danv2vm29lp5swdux4r60ezptzz7ce85");
+    }
+    {
+        auto address = WRAP(TWString, TWHDWalletGetAddressDerivation(wallet.get(), TWCoinTypeBitcoin, TWDerivationBitcoinLegacy));
+        assertStringsEqual(address, "1PeUvjuxyf31aJKX6kCXuaqxhmG78ZUdL1");
+    }
 }
 
 TEST(HDWallet, DeriveEthereum) {

--- a/tests/interface/TWHDWalletTests.cpp
+++ b/tests/interface/TWHDWalletTests.cpp
@@ -133,6 +133,24 @@ TEST(HDWallet, DeriveBitcoinExtended) {
     assertStringsEqual(address, "bc1qumwjg8danv2vm29lp5swdux4r60ezptzz7ce85");
 }
 
+TEST(HDWallet, GetKeyDerivation) {
+    auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(gWords.get(), gPassphrase.get()));
+    {
+        auto key = WRAP(TWPrivateKey, TWHDWalletGetKeyDerivation(wallet.get(), TWCoinTypeBitcoin, TWDerivationBitcoinSegwit));
+        assertHexEqual(WRAPD(TWPrivateKeyData(key.get())), "1901b5994f075af71397f65bd68a9fff8d3025d65f5a2c731cf90f5e259d6aac");
+        auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(key.get(), true));
+        auto publicKeyData = WRAPD(TWPublicKeyData(publicKey.get()));
+        assertHexEqual(publicKeyData, "037ea5dff03f677502c4a1d73c5ac897200e56b155e876774c8fba0cc22f80b941");
+    }
+    {
+        auto key = WRAP(TWPrivateKey, TWHDWalletGetKeyDerivation(wallet.get(), TWCoinTypeBitcoin, TWDerivationBitcoinLegacy));
+        assertHexEqual(WRAPD(TWPrivateKeyData(key.get())), "28071bf4e2b0340db41b807ed8a5514139e5d6427ff9d58dbd22b7ed187103a4");
+        auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(key.get(), true));
+        auto publicKeyData = WRAPD(TWPublicKeyData(publicKey.get()));
+        assertHexEqual(publicKeyData, "0240ebf906b948281289405317a5eb9a98045af8a8ab5311b2e3060cfb66c507a1");
+    }
+}
+
 TEST(HDWallet, DeriveAddressBitcoin) {
     auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(gWords.get(), gPassphrase.get()));
     auto address = WRAP(TWString, TWHDWalletGetAddressForCoin(wallet.get(), TWCoinTypeBitcoin));


### PR DESCRIPTION
## Description

Expose derivation option on `TWAnyAddressCreateWithPublicKey` and `TWHDWalletGetKey`.

New variants:
- `TWAnyAddressCreateWithPublicKeyDerivation` similar to `TWAnyAddressCreateWithPublicKey`
- `TWHDWalletGetAddressDerivation` similar to `TWHDWalletGetAddressForCoin`
- `TWHDWalletGetKeyDerivation` similar to `TWHDWalletGetKeyForCoin`, 

but with an extra `derivation` parameter.

Fixes #2682.

## How to test

Unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (minor, non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [ ] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
