### PR TITLE
BitcoinScript/ThorSwap: Treat memo too long as error.

### DIFF
--- a/src/Bitcoin/Script.cpp
+++ b/src/Bitcoin/Script.cpp
@@ -260,11 +260,15 @@ Script Script::buildPayToV1WitnessProgram(const Data& publicKey) {
 
 Script Script::buildOpReturnScript(const Data& data) {
     static const size_t MaxOpReturnLength = 80;
+    if (data.size() > MaxOpReturnLength) {
+        // data too long, cannot fit, fail (do not truncate)
+        return Script();
+    }
+    assert(data.size() <= MaxOpReturnLength);
     Script script;
     script.bytes.push_back(OP_RETURN);
-    size_t size = std::min(data.size(), MaxOpReturnLength);
-    script.bytes.push_back(static_cast<byte>(size));
-    script.bytes.insert(script.bytes.end(), data.begin(), data.begin() + size);
+    script.bytes.push_back(static_cast<byte>(data.size()));
+    script.bytes.insert(script.bytes.end(), data.begin(), data.begin() + data.size());
     return script;
 }
 

--- a/src/Bitcoin/Script.h
+++ b/src/Bitcoin/Script.h
@@ -1,4 +1,4 @@
-// Copyright © 2017-2021 Trust Wallet.
+// Copyright © 2017-2022 Trust Wallet.
 //
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
@@ -91,7 +91,7 @@ class Script {
     /// Builds a V1 pay-to-witness-program script, P2TR (from a 32-byte Schnorr public key).
     static Script buildPayToV1WitnessProgram(const Data& publicKey);
 
-    /// Builds an OP_RETURN script with given data
+    /// Builds an OP_RETURN script with given data. Returns empty script on error, if data is too long (>80).
     static Script buildOpReturnScript(const Data& data);
 
     /// Builds a appropriate lock script for the given

--- a/src/Bitcoin/TransactionSigner.cpp
+++ b/src/Bitcoin/TransactionSigner.cpp
@@ -27,7 +27,11 @@ Result<Transaction, Common::Proto::SigningError> TransactionSigner<Transaction, 
     } else {
         plan = TransactionBuilder::plan(input);
     }
-    auto transaction = TransactionBuilder::template build<Transaction>(plan, input.toAddress, input.changeAddress, input.coinType, input.lockTime);
+    auto tx_result = TransactionBuilder::template build<Transaction>(plan, input.toAddress, input.changeAddress, input.coinType, input.lockTime);
+    if (!tx_result) {
+        return Result<Transaction, Common::Proto::SigningError>::failure(tx_result.error());
+    }
+    Transaction transaction = tx_result.payload();
     SigningMode signingMode =
         estimationMode ? SigningMode_SizeEstimationOnly : optionalExternalSigs.has_value() ? SigningMode_External
                                                                                            : SigningMode_Normal;
@@ -43,7 +47,11 @@ Result<HashPubkeyList, Common::Proto::SigningError> TransactionSigner<Transactio
     } else {
         plan = TransactionBuilder::plan(input);
     }
-    auto transaction = TransactionBuilder::template build<Transaction>(plan, input.toAddress, input.changeAddress, input.coinType, input.lockTime);
+    auto tx_result = TransactionBuilder::template build<Transaction>(plan, input.toAddress, input.changeAddress, input.coinType, input.lockTime);
+    if (!tx_result) {
+        return Result<HashPubkeyList, Common::Proto::SigningError>::failure(tx_result.error());
+    }
+    Transaction transaction = tx_result.payload();
     SignatureBuilder<Transaction> signer(std::move(input), plan, transaction, SigningMode_HashOnly);
     auto signResult = signer.sign();
     if (!signResult) {

--- a/tests/chains/Bitcoin/BitcoinScriptTests.cpp
+++ b/tests/chains/Bitcoin/BitcoinScriptTests.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2017-2021 Trust Wallet.
+// Copyright © 2017-2022 Trust Wallet.
 //
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
@@ -319,13 +319,14 @@ TEST(BitcoinScript, OpReturn) {
         Script script = Script::buildOpReturnScript(data);
         EXPECT_EQ(hex(script.bytes), "6a46000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab");
     }
-    {
-        // too long, truncated
-        Data data = Data(89);
-        data.push_back(0xab);
-        Script script = Script::buildOpReturnScript(data);
-        EXPECT_EQ(hex(script.bytes), "6a500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
-    }
+}
+
+TEST(BitcoinScript, OpReturnTooLong) {
+    // too long, truncated
+    Data data = Data(89);
+    data.push_back(0xab);
+    Script script = Script::buildOpReturnScript(data);
+    EXPECT_EQ(hex(script.bytes), "");
 }
 
 TEST(BitcoinTransactionSigner, PushAllEmpty) {

--- a/tests/chains/Bitcoin/TWBitcoinSigningTests.cpp
+++ b/tests/chains/Bitcoin/TWBitcoinSigningTests.cpp
@@ -1071,7 +1071,7 @@ TEST(BitcoinSigning, Sign_NegativeInvalidAddress) {
     auto result = TransactionSigner<Transaction, TransactionBuilder>::sign(input);
 
     ASSERT_FALSE(result);
-    EXPECT_EQ(result.error(), Common::Proto::Error_missing_input_utxos);
+    EXPECT_EQ(result.error(), Common::Proto::Error_invalid_address);
 }
 
 TEST(BitcoinSigning, Plan_10input_MaxAmount) {

--- a/tests/chains/THORChain/SwapTests.cpp
+++ b/tests/chains/THORChain/SwapTests.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2017-2021 Trust Wallet.
+// Copyright © 2017-2022 Trust Wallet.
 //
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
@@ -366,10 +366,10 @@ TEST(THORChainSwap, SwapBnbBnbToken) {
 }
 
 TEST(THORChainSwap, SwapBtcEthWithAffFee) {
-    auto res = Swap::build(Chain::BTC, Chain::ETH, Address1Btc, "ETH", "", Address1Eth, VaultBtc, "", "1000000", "140000000000000000", "tthor1ql2tcqyrqsgnql2tcqyj2n8kfdmt9lh0yzql2tcqy", "10");
+    auto res = Swap::build(Chain::BTC, Chain::ETH, Address1Btc, "ETH", "", Address1Eth, VaultBtc, "", "1000000", "140000000000000000", "thrnm", "10");
     ASSERT_EQ(std::get<1>(res), 0);
     ASSERT_EQ(std::get<2>(res), "");
-    EXPECT_EQ(hex(std::get<0>(res)), "080110c0843d1801222a62633171366d397532717375386d68387937763872723279776176746a38673561727a6c796863656a372a2a62633171706a756c7433346b3973706a66796d38687373326a72776a676630786a6634307a65307070386a7a3d3a4554482e4554483a3078623966353737316332373636346266323238326439386530396437663530636563376362303161373a3134303030303030303030303030303030303a7474686f7231716c3274637179727173676e716c32746371796a326e386b66646d74396c6830797a716c32746371793a3130");
+    EXPECT_EQ(hex(std::get<0>(res)), "080110c0843d1801222a62633171366d397532717375386d68387937763872723279776176746a38673561727a6c796863656a372a2a62633171706a756c7433346b3973706a66796d38687373326a72776a676630786a6634307a65307070386a503d3a4554482e4554483a3078623966353737316332373636346266323238326439386530396437663530636563376362303161373a3134303030303030303030303030303030303a7468726e6d3a3130");
 
     auto tx = Bitcoin::Proto::SigningInput();
     ASSERT_TRUE(tx.ParseFromArray(std::get<0>(res).data(), (int)std::get<0>(res).size()));
@@ -378,7 +378,7 @@ TEST(THORChainSwap, SwapBtcEthWithAffFee) {
     EXPECT_EQ(tx.amount(), 1000000);
     EXPECT_EQ(tx.to_address(), VaultBtc);
     EXPECT_EQ(tx.change_address(), Address1Btc);
-    EXPECT_EQ(tx.output_op_return(), "=:ETH.ETH:0xb9f5771c27664bf2282d98e09d7f50cec7cb01a7:140000000000000000:tthor1ql2tcqyrqsgnql2tcqyj2n8kfdmt9lh0yzql2tcqy:10");
+    EXPECT_EQ(tx.output_op_return(), "=:ETH.ETH:0xb9f5771c27664bf2282d98e09d7f50cec7cb01a7:140000000000000000:thrnm:10");
     EXPECT_EQ(tx.coin_type(), 0ul);
     EXPECT_EQ(tx.private_key_size(), 0);
     EXPECT_FALSE(tx.has_plan());
@@ -409,10 +409,10 @@ TEST(THORChainSwap, SwapBtcEthWithAffFee) {
         "03" // outputs
             "40420f0000000000"  "16"  "0014d6cbc5021c3eee72798718d447758b91d14e8c5f"
             "209ceb0200000000"  "16"  "00140cb9f5c6b62c03249367bc20a90dd2425e6926af"
-            "0000000000000000"  "52"  "6a503d3a4554482e4554483a3078623966353737316332373636346266323238326439386530396437663530636563376362303161373a3134303030303030303030303030303030303a7474686f7231716c"
+            "0000000000000000"  "52"  "6a503d3a4554482e4554483a3078623966353737316332373636346266323238326439386530396437663530636563376362303161373a3134303030303030303030303030303030303a7468726e6d3a3130"
         // witness
             "02"
-                "48"  "3045022100d655ed4d84a5308f206039ff6125e456134e606fe620a81bc86c142a024226eb02207e53622e7572b7099b73af60ffdcc1e1e983f7ccca07dc3e3d496efb2270ada701"
+                "48"  "3045022100801dc46b14eb1b630050d48db27557b66254c3b9439909d864747eafbb12f7e902201fdf5433eaf4968a5596989330bc56513b5769c5c9fd77c41f9bdb55cf8202cd01"
                 "21"  "021e582a887bd94d648a9267143eb600449a8d59a0db0653740b1378067a6d0cee"
         "00000000" // nLockTime
     );
@@ -473,6 +473,46 @@ TEST(THORChainSwap, SwapEthBnbWithAffFee) {
     Ethereum::Proto::SigningOutput output;
     ANY_SIGN(tx, TWCoinTypeEthereum);
     EXPECT_EQ(hex(output.encoded()), "f90192038506fc23ac00830138809442a5ed456650a09dc10ebc6361a7480fdd61f27b87b1a2bc2ec50000b901241fece7b40000000000000000000000001091c4de6a3cf09cda00abdaed42c7c3b69c83ec000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000b1a2bc2ec5000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000071535741503a424e422e424e423a626e62317573343777646866783038636839377a6475656833783375356d757266727833306a656372783a3630303030333a7474686f7231716c3274637179727173676e716c32746371796a326e386b66646d74396c6830797a716c32746371793a313000000000000000000000000000000026a027da86e94739f39e8b493f240eb043888a0dd6962a657963ff7fb26f10291ca8a03fed75d6703d5036402be4d0197432725e17fe6a5d3059abdcca74bd7a789cc8");
+}
+
+TEST(THORChainSwap, SwapBtcNegativeMemoTooLong) {
+    auto res = Swap::build(Chain::BTC, Chain::ETH, Address1Btc, "ETH", "", Address1Eth, VaultBtc, "", "1000000", "140000000000000000", "affiliate_address", "10", "extra_memo_very_loooooooooooooong");
+    ASSERT_EQ(std::get<1>(res), 0);
+    ASSERT_EQ(std::get<2>(res), "");
+    EXPECT_EQ(hex(std::get<0>(res)), "080110c0843d1801222a62633171366d397532717375386d68387937763872723279776176746a38673561727a6c796863656a372a2a62633171706a756c7433346b3973706a66796d38687373326a72776a676630786a6634307a65307070386a7e3d3a4554482e4554483a3078623966353737316332373636346266323238326439386530396437663530636563376362303161373a3134303030303030303030303030303030303a616666696c696174655f616464726573733a31303a65787472615f6d656d6f5f766572795f6c6f6f6f6f6f6f6f6f6f6f6f6f6f6f6e67");
+
+    auto tx = Bitcoin::Proto::SigningInput();
+    ASSERT_TRUE(tx.ParseFromArray(std::get<0>(res).data(), (int)std::get<0>(res).size()));
+
+    // check fields
+    EXPECT_EQ(tx.amount(), 1000000);
+    EXPECT_EQ(tx.to_address(), VaultBtc);
+    EXPECT_EQ(tx.change_address(), Address1Btc);
+    EXPECT_EQ(tx.output_op_return(), "=:ETH.ETH:0xb9f5771c27664bf2282d98e09d7f50cec7cb01a7:140000000000000000:affiliate_address:10:extra_memo_very_loooooooooooooong");
+    EXPECT_EQ(tx.output_op_return().length(), 126ul);
+    EXPECT_EQ(tx.coin_type(), 0ul);
+    EXPECT_EQ(tx.private_key_size(), 0);
+    EXPECT_FALSE(tx.has_plan());
+
+    // set few fields before signing
+    tx.set_byte_fee(20);
+    EXPECT_EQ(Bitcoin::SegwitAddress(PrivateKey(TestKey1Btc).getPublicKey(TWPublicKeyTypeSECP256k1), "bc").string(), Address1Btc);
+    tx.add_private_key(TestKey1Btc.data(), TestKey1Btc.size());
+    auto& utxo = *tx.add_utxo();
+    Data utxoHash = parse_hex("1234000000000000000000000000000000000000000000000000000000005678");
+    utxo.mutable_out_point()->set_hash(utxoHash.data(), utxoHash.size());
+    utxo.mutable_out_point()->set_index(0);
+    utxo.mutable_out_point()->set_sequence(UINT32_MAX);
+    auto utxoScript = Bitcoin::Script::lockScriptForAddress(Address1Btc, TWCoinTypeBitcoin);
+    utxo.set_script(utxoScript.bytes.data(), utxoScript.bytes.size());
+    utxo.set_amount(50000000);
+    tx.set_use_max_amount(false);
+
+    // sign and encode resulting input
+    Bitcoin::Proto::SigningOutput output;
+    ANY_SIGN(tx, TWCoinTypeBitcoin);
+    EXPECT_EQ(output.error(), Common::Proto::Error_invalid_memo);
+    EXPECT_EQ(hex(output.encoded()), "");
 }
 
 TEST(THORChainSwap, Memo) {


### PR DESCRIPTION
## Description

BitcoinScript/ThorSwap: Treat as error cases when memo is too long (do not truncate as currently).
- OpReturn building: treat as error if data is >80 bytes, as opposed to just truncate it.
- Bitcoin signing: propagate errors over several layers.
- One ThorSwap test changed as it produced memo > 80 bytes.
- Extra ThorSwap test with very long memo.
- In one non-ThorSwap case the error has changed, to a more meaningful one, in case of invalid output address, to `Error_invalid_address` from `Error_missing_input_utxos`.  https://github.com/trustwallet/wallet-core/pull/2741/files#diff-052bd5fec61fdb691c9327c764820d095121cc4e6bdc90c2ae651da8b9f02cbcR1074

Fixes #2730 .

<!--- Describe your changes in detail -->

## How to test

Unit tests, esp. `SwapBtcNegativeMemoTooLong`.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [ ] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
