### PR TITLE
Unify Entry::deriveAddress() methods

### DIFF
--- a/codegen/lib/templates/newcoin/Entry.cpp.erb
+++ b/codegen/lib/templates/newcoin/Entry.cpp.erb
@@ -13,11 +13,11 @@ namespace TW::<%= format_name(coin) %> {
 
 // Note: avoid business logic from here, rather just call into classes like Address, Signer, etc.
 
-bool Entry::validateAddress(TWCoinType coin, [[maybe_unused]] const std::string& address, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
+bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string& address, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/codegen/lib/templates/newcoin/Entry.h.erb
+++ b/codegen/lib/templates/newcoin/Entry.h.erb
@@ -14,9 +14,9 @@ namespace TW::<%= format_name(coin) %> {
 /// Note: do not put the implementation here (no matter how simple), to avoid having coin-specific includes in this file
 class Entry final : public CoinEntry {
 public:
-    virtual bool validateAddress(TWCoinType coin, const std::string& address, TW::byte p2pkh, const PrefixVariant& addressPrefix) const;
-    virtual std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
-    virtual void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
+    bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
+    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
+    void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
     // normalizeAddress(): implement this if needed, e.g. Ethereum address is EIP55 checksummed
     // plan(): implement this if the blockchain is UTXO based
 };

--- a/src/Aeternity/Entry.cpp
+++ b/src/Aeternity/Entry.cpp
@@ -18,7 +18,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Aeternity/Entry.h
+++ b/src/Aeternity/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Aeternity {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
     void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };
 

--- a/src/Aion/Entry.cpp
+++ b/src/Aion/Entry.cpp
@@ -20,7 +20,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Aion/Entry.h
+++ b/src/Aion/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Aion {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      Data addressToData(TWCoinType coin, const std::string& address) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };

--- a/src/Algorand/Entry.cpp
+++ b/src/Algorand/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Algorand/Entry.h
+++ b/src/Algorand/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Algorand {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
     void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
     bool supportsJSONSigning() const { return true; }
     std::string signJSON(TWCoinType coin, const std::string& json, const Data& key) const;

--- a/src/AnyAddress.cpp
+++ b/src/AnyAddress.cpp
@@ -26,14 +26,14 @@ AnyAddress* AnyAddress::createAddress(const std::string& address, enum TWCoinTyp
 }
 
 AnyAddress* AnyAddress::createAddress(const PublicKey& publicKey, enum TWCoinType coin, const std::string& hrp, TWDerivation derivation) {
-
-    auto derivedAddress = TW::deriveAddress(coin, publicKey, derivation, hrp);
+    PrefixVariant prefix = hrp.empty() ? static_cast<PrefixVariant>(std::monostate()) : static_cast<PrefixVariant>(Bech32Prefix(hrp.c_str()));
+    const auto derivedAddress = TW::deriveAddress(coin, publicKey, derivation, prefix);
     return new AnyAddress{.address = std::move(derivedAddress), .coin = coin};
 }
 
 AnyAddress* AnyAddress::createAddress(const PublicKey& publicKey, enum TWCoinType coin, const PrefixVariant& addressPrefix, TWDerivation derivation) {
 
-    auto derivedAddress = TW::deriveAddress(coin, publicKey, addressPrefix, derivation);
+    const auto derivedAddress = TW::deriveAddress(coin, publicKey, derivation, addressPrefix);
     return new AnyAddress{.address = std::move(derivedAddress), .coin = coin};
 }
 

--- a/src/AnyAddress.cpp
+++ b/src/AnyAddress.cpp
@@ -25,15 +25,8 @@ AnyAddress* AnyAddress::createAddress(const std::string& address, enum TWCoinTyp
     return new AnyAddress{.address = std::move(normalized), .coin = coin};
 }
 
-AnyAddress* AnyAddress::createAddress(const PublicKey& publicKey, enum TWCoinType coin, const std::string& hrp, TWDerivation derivation) {
-    PrefixVariant prefix = hrp.empty() ? static_cast<PrefixVariant>(std::monostate()) : static_cast<PrefixVariant>(Bech32Prefix(hrp.c_str()));
+AnyAddress* AnyAddress::createAddress(const PublicKey& publicKey, enum TWCoinType coin, TWDerivation derivation, const PrefixVariant& prefix) {
     const auto derivedAddress = TW::deriveAddress(coin, publicKey, derivation, prefix);
-    return new AnyAddress{.address = std::move(derivedAddress), .coin = coin};
-}
-
-AnyAddress* AnyAddress::createAddress(const PublicKey& publicKey, enum TWCoinType coin, const PrefixVariant& addressPrefix, TWDerivation derivation) {
-
-    const auto derivedAddress = TW::deriveAddress(coin, publicKey, derivation, addressPrefix);
     return new AnyAddress{.address = std::move(derivedAddress), .coin = coin};
 }
 

--- a/src/AnyAddress.h
+++ b/src/AnyAddress.h
@@ -23,9 +23,10 @@ public:
 
     enum TWCoinType coin;
 
+    // Create address from string address and optional prefix; also normalizes the address.
     static AnyAddress* createAddress(const std::string& address, enum TWCoinType coin, const PrefixVariant& prefix = std::monostate());
-    static AnyAddress* createAddress(const PublicKey& publicKey, enum TWCoinType coin, const std::string& hrp = "", TWDerivation derivation = TWDerivationDefault);
-    static AnyAddress* createAddress(const PublicKey& publicKey, enum TWCoinType coin, const PrefixVariant& prefix, TWDerivation derivation = TWDerivationDefault);
+    // Create address from private key, with optional non-standard derivation and prefix
+    static AnyAddress* createAddress(const PublicKey& publicKey, enum TWCoinType coin, TWDerivation derivation = TWDerivationDefault, const PrefixVariant& prefix = std::monostate());
 
     Data getData() const;
 };

--- a/src/Aptos/Entry.cpp
+++ b/src/Aptos/Entry.cpp
@@ -15,7 +15,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
     return Address(publicKey).string();
 }
 

--- a/src/Aptos/Entry.cpp
+++ b/src/Aptos/Entry.cpp
@@ -15,7 +15,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Aptos/Entry.h
+++ b/src/Aptos/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Aptos {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
     void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };
 

--- a/src/Binance/Entry.cpp
+++ b/src/Binance/Entry.cpp
@@ -16,7 +16,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
     return Address(publicKey).string();
 }
 

--- a/src/Binance/Entry.cpp
+++ b/src/Binance/Entry.cpp
@@ -16,7 +16,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Binance/Entry.h
+++ b/src/Binance/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Binance {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
     Data addressToData(TWCoinType coin, const std::string& address) const;
     void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
     bool supportsJSONSigning() const { return true; }

--- a/src/Bitcoin/Entry.cpp
+++ b/src/Bitcoin/Entry.cpp
@@ -10,7 +10,6 @@
 #include "CashAddress.h"
 #include "SegwitAddress.h"
 #include "Signer.h"
-#include "Coin.h"
 
 namespace TW::Bitcoin {
 

--- a/src/Bitcoin/Entry.cpp
+++ b/src/Bitcoin/Entry.cpp
@@ -10,6 +10,7 @@
 #include "CashAddress.h"
 #include "SegwitAddress.h"
 #include "Signer.h"
+#include "Coin.h"
 
 namespace TW::Bitcoin {
 
@@ -63,8 +64,10 @@ std::string Entry::normalizeAddress(TWCoinType coin, const std::string& address)
     }
 }
 
-std::string Entry::deriveAddress(TWCoinType coin, TWDerivation derivation, const PublicKey& publicKey,
-                                 byte p2pkh, const char* hrp) const {
+std::string Entry::deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const {
+    byte p2pkh = getFromPrefixPkhOrDefault(addressPrefix, coin);
+    const char* hrp = getFromPrefixHrpOrDefault(addressPrefix, coin);
+
     switch (coin) {
     case TWCoinTypeBitcoin:
     case TWCoinTypeLitecoin:

--- a/src/Bitcoin/Entry.h
+++ b/src/Bitcoin/Entry.h
@@ -17,12 +17,7 @@ class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
     std::string normalizeAddress(TWCoinType coin, const std::string& address) const;
-    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh,
-                              const char* hrp) const {
-        return deriveAddress(coin, TWDerivationDefault, publicKey, p2pkh, hrp);
-    }
-    std::string deriveAddress(TWCoinType coin, TWDerivation derivation, const PublicKey& publicKey,
-                              TW::byte p2pkh, const char* hrp) const;
+    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
     Data addressToData(TWCoinType coin, const std::string& address) const;
     void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
     void plan(TWCoinType coin, const Data& dataIn, Data& dataOut) const;

--- a/src/Cardano/Entry.cpp
+++ b/src/Cardano/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return AddressV3::isValidLegacy(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return AddressV3(publicKey).string();
 }
 

--- a/src/Cardano/Entry.cpp
+++ b/src/Cardano/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return AddressV3::isValidLegacy(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
     return AddressV3(publicKey).string();
 }
 

--- a/src/Cardano/Entry.h
+++ b/src/Cardano/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Cardano {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      Data addressToData(TWCoinType coin, const std::string& address) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
      void plan(TWCoinType coin, const Data& dataIn, Data& dataOut) const;

--- a/src/Coin.cpp
+++ b/src/Coin.cpp
@@ -243,21 +243,10 @@ std::string TW::deriveAddress(TWCoinType coin, const PrivateKey& privateKey, TWD
     return TW::deriveAddress(coin, privateKey.getPublicKey(keyType), derivation);
 }
 
-std::string TW::deriveAddress(TWCoinType coin, const PublicKey& publicKey, const PrefixVariant& addressPrefix, TWDerivation derivation) {
+std::string TW::deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) {
     auto const* dispatcher = coinDispatcher(coin);
     assert(dispatcher != nullptr);
     return dispatcher->deriveAddress(coin, publicKey, derivation, addressPrefix);
-}
-
-std::string TW::deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const std::string& hrp) {
-    // replace empty hrp with coin-default
-    const char* hrpRaw = hrp.empty() ? stringForHRP(TW::hrp(coin)) : hrp.c_str();
-    // dispatch
-    auto* dispatcher = coinDispatcher(coin);
-    assert(dispatcher != nullptr);
-    // Use hrp-case for prefix variant
-    const PrefixVariant prefix = Bech32Prefix(hrpRaw);
-    return dispatcher->deriveAddress(coin, publicKey, derivation, prefix);
 }
 
 Data TW::addressToData(TWCoinType coin, const std::string& address) {

--- a/src/Coin.cpp
+++ b/src/Coin.cpp
@@ -250,14 +250,14 @@ std::string TW::deriveAddress(TWCoinType coin, const PublicKey& publicKey, const
 }
 
 std::string TW::deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const std::string& hrp) {
-    auto p2pkh = TW::p2pkhPrefix(coin);
-    const char* hrpRaw = [&hrp, coin]() {
-        return hrp.empty() ? stringForHRP(TW::hrp(coin)) : hrp.c_str();
-    }();
+    // replace empty hrp with coin-default
+    const char* hrpRaw = hrp.empty() ? stringForHRP(TW::hrp(coin)) : hrp.c_str();
     // dispatch
     auto* dispatcher = coinDispatcher(coin);
     assert(dispatcher != nullptr);
-    return dispatcher->deriveAddress(coin, derivation, publicKey, p2pkh, hrpRaw);
+    // Use hrp-case for prefix variant
+    const PrefixVariant prefix = Bech32Prefix(hrpRaw);
+    return dispatcher->deriveAddress(coin, publicKey, derivation, prefix);
 }
 
 Data TW::addressToData(TWCoinType coin, const std::string& address) {

--- a/src/Coin.h
+++ b/src/Coin.h
@@ -1,4 +1,4 @@
-// Copyright © 2017-2020 Trust Wallet.
+// Copyright © 2017-2022 Trust Wallet.
 //
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
@@ -78,10 +78,8 @@ std::string deriveAddress(TWCoinType coin, const PrivateKey& privateKey);
 /// Derives the address for a particular coin from the private key, with given derivation.
 std::string deriveAddress(TWCoinType coin, const PrivateKey& privateKey, TWDerivation derivation);
 
-/// Derives the address for a particular coin from the public key, with given derivation.
-std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation = TWDerivationDefault, const std::string& hrp = "");
-/// Derives the address for a particular coin from the public key, with given derivation and explicit addressPrefix.
-std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, const PrefixVariant& addressPrefix, TWDerivation derivation = TWDerivationDefault);
+/// Derives the address for a particular coin from the public key, with given derivation and addressPrefix.
+std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation = TWDerivationDefault, const PrefixVariant& addressPrefix = std::monostate());
 
 /// Returns the binary representation of a string address
 Data addressToData(TWCoinType coin, const std::string& address);

--- a/src/CoinEntry.cpp
+++ b/src/CoinEntry.cpp
@@ -1,0 +1,32 @@
+// Copyright © 2017-2022 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "CoinEntry.h"
+#include "Coin.h"
+#include <variant>
+
+namespace TW {
+
+const char* getFromPrefixHrpOrDefault(const PrefixVariant &prefix, TWCoinType coin) {
+    if (std::holds_alternative<Bech32Prefix>(prefix)) {
+        const char* fromPrefix = std::get<Bech32Prefix>(prefix);
+        if (fromPrefix != nullptr && *fromPrefix != 0) {
+            return fromPrefix;
+        }
+    }
+    // Prefix contains no hrp or empty, return coin-default
+    return stringForHRP(TW::hrp(coin));
+}
+
+byte getFromPrefixPkhOrDefault(const PrefixVariant &prefix, TWCoinType coin) {
+    if (std::holds_alternative<Base58Prefix>(prefix)) {
+        return std::get<Base58Prefix>(prefix).p2pkh;
+    }
+    // Prefix contains no base58 prefixes, return coin-default
+    return TW::p2pkhPrefix(coin);
+}
+
+} // namespace TW

--- a/src/CoinEntry.h
+++ b/src/CoinEntry.h
@@ -1,4 +1,4 @@
-// Copyright © 2017-2020 Trust Wallet.
+// Copyright © 2017-2022 Trust Wallet.
 //
 // This file is part of Trust. The full Trust copyright notice, including
 // terms governing use, modification, and redistribution, is contained in the
@@ -42,15 +42,8 @@ public:
     virtual bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const = 0;
     // normalizeAddress is optional, it may leave this default, no-change implementation
     virtual std::string normalizeAddress([[maybe_unused]] TWCoinType coin, const std::string& address) const { return address; }
-    // Address derivation, default derivation
-    virtual std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const = 0;
-    virtual std::string deriveAddress([[maybe_unused]] TWCoinType coin, [[maybe_unused]] const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
-        return "";
-    };
-    // Address derivation, by default invoking default
-    virtual std::string deriveAddress(TWCoinType coin, [[maybe_unused]] TWDerivation derivation, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const {
-        return deriveAddress(coin, publicKey, p2pkh, hrp);
-    }
+    // Address derivation
+    virtual std::string deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const = 0;
     // Return the binary representation of a string address, used by AnyAddress
     // It is optional, if not defined, 'AnyAddress' interface will not support this coin.
     virtual Data addressToData([[maybe_unused]] TWCoinType coin, [[maybe_unused]] const std::string& address) const { return {}; }
@@ -116,5 +109,11 @@ Data txCompilerTemplate(const Data& dataIn, Func&& fnHandler) {
     }
     return TW::data(output.SerializeAsString());
 }
+
+// Get the hrp from the prefix variant, or the coin-default if it is empty or it is not an hrp
+const char* getFromPrefixHrpOrDefault(const PrefixVariant &prefix, TWCoinType coin);
+
+// Get the p2pkh prefix from the prefix variant, or the coin-default if it does not contain base58 prefixes
+byte getFromPrefixPkhOrDefault(const PrefixVariant &prefix, TWCoinType coin);
 
 } // namespace TW

--- a/src/Cosmos/Entry.cpp
+++ b/src/Cosmos/Entry.cpp
@@ -26,8 +26,9 @@ bool Entry::validateAddress(TWCoinType coin, const std::string& address, const P
     return false;
 }
 
-string Entry::deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte, const char* hrp) const {
-    if (!std::string(hrp).empty()) {
+std::string Entry::deriveAddress(TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, const PrefixVariant& addressPrefix) const {
+    if (std::holds_alternative<Bech32Prefix>(addressPrefix)) {
+        const std::string hrp = std::get<Bech32Prefix>(addressPrefix);
         return Address(hrp, publicKey, coin).string();
     }
     return Address(coin, publicKey).string();

--- a/src/Cosmos/Entry.cpp
+++ b/src/Cosmos/Entry.cpp
@@ -29,7 +29,9 @@ bool Entry::validateAddress(TWCoinType coin, const std::string& address, const P
 std::string Entry::deriveAddress(TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, const PrefixVariant& addressPrefix) const {
     if (std::holds_alternative<Bech32Prefix>(addressPrefix)) {
         const std::string hrp = std::get<Bech32Prefix>(addressPrefix);
-        return Address(hrp, publicKey, coin).string();
+        if (!hrp.empty()) {
+            return Address(hrp, publicKey, coin).string();
+        }
     }
     return Address(coin, publicKey).string();
 }

--- a/src/Cosmos/Entry.h
+++ b/src/Cosmos/Entry.h
@@ -15,11 +15,11 @@ namespace TW::Cosmos {
 class Entry : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const final;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const final;
-     Data addressToData(TWCoinType coin, const std::string& address) const final;
-     void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const override;
-     bool supportsJSONSigning() const final { return true; }
-     std::string signJSON(TWCoinType coin, const std::string& json, const Data& key) const override;
+    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const override;
+    Data addressToData(TWCoinType coin, const std::string& address) const final;
+    void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const override;
+    bool supportsJSONSigning() const final { return true; }
+    std::string signJSON(TWCoinType coin, const std::string& json, const Data& key) const override;
 };
 
 } // namespace TW::Cosmos

--- a/src/Decred/Entry.cpp
+++ b/src/Decred/Entry.cpp
@@ -15,7 +15,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TW::byte p2pkh, [[maybe_unused]] const char* hrp) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Decred/Entry.h
+++ b/src/Decred/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Decred {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
     Data addressToData(TWCoinType coin, const std::string& address) const;
     void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
     void plan(TWCoinType coin, const Data& dataIn, Data& dataOut) const;

--- a/src/EOS/Entry.cpp
+++ b/src/EOS/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
     return Address(publicKey).string();
 }
 

--- a/src/EOS/Entry.cpp
+++ b/src/EOS/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/EOS/Entry.h
+++ b/src/EOS/Entry.h
@@ -15,7 +15,7 @@ namespace TW::EOS {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
     void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };
 

--- a/src/Elrond/Entry.cpp
+++ b/src/Elrond/Entry.cpp
@@ -19,7 +19,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Elrond/Entry.cpp
+++ b/src/Elrond/Entry.cpp
@@ -19,7 +19,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
     return Address(publicKey).string();
 }
 

--- a/src/Elrond/Entry.h
+++ b/src/Elrond/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Elrond {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
     Data addressToData(TWCoinType coin, const std::string& address) const;
     void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
     bool supportsJSONSigning() const { return true; }

--- a/src/Ethereum/Entry.cpp
+++ b/src/Ethereum/Entry.cpp
@@ -24,7 +24,7 @@ string Entry::normalizeAddress([[maybe_unused]] TWCoinType coin, const string& a
     return Address(address).string();
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Ethereum/Entry.cpp
+++ b/src/Ethereum/Entry.cpp
@@ -24,7 +24,7 @@ string Entry::normalizeAddress([[maybe_unused]] TWCoinType coin, const string& a
     return Address(address).string();
 }
 
-string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
     return Address(publicKey).string();
 }
 

--- a/src/Ethereum/Entry.h
+++ b/src/Ethereum/Entry.h
@@ -16,7 +16,7 @@ class Entry : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const final;
      std::string normalizeAddress(TWCoinType coin, const std::string& address) const final;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const final;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const final;
      Data addressToData(TWCoinType coin, const std::string& address) const final;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const override;
      bool supportsJSONSigning() const final { return true; }

--- a/src/Everscale/Entry.cpp
+++ b/src/Everscale/Entry.cpp
@@ -25,7 +25,7 @@ string Entry::normalizeAddress([[maybe_unused]] TWCoinType coin, const string& a
     return Address(address).string();
 }
 
-string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey, WorkchainType::Basechain).string();
 }
 

--- a/src/Everscale/Entry.h
+++ b/src/Everscale/Entry.h
@@ -16,7 +16,7 @@ class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
      std::string normalizeAddress(TWCoinType coin, const std::string& address) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* d) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };
 

--- a/src/FIO/Entry.cpp
+++ b/src/FIO/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
     return Address(publicKey).string();
 }
 

--- a/src/FIO/Entry.cpp
+++ b/src/FIO/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/FIO/Entry.h
+++ b/src/FIO/Entry.h
@@ -15,7 +15,7 @@ namespace TW::FIO {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };
 

--- a/src/Filecoin/Entry.cpp
+++ b/src/Filecoin/Entry.cpp
@@ -17,8 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte,
-                            const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Filecoin/Entry.h
+++ b/src/Filecoin/Entry.h
@@ -15,12 +15,11 @@ namespace TW::Filecoin {
 /// includes in this file
 class Entry final : public CoinEntry {
   public:
-      bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh,
-                                      const char* hrp) const;
-     void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
-     bool supportsJSONSigning() const { return true; }
-     std::string signJSON(TWCoinType coin, const std::string& json, const Data& key) const;
+    bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
+    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
+    void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
+    bool supportsJSONSigning() const { return true; }
+    std::string signJSON(TWCoinType coin, const std::string& json, const Data& key) const;
 };
 
 } // namespace TW::Filecoin

--- a/src/Groestlcoin/Entry.cpp
+++ b/src/Groestlcoin/Entry.cpp
@@ -9,6 +9,8 @@
 #include "Address.h"
 #include "../Bitcoin/SegwitAddress.h"
 #include "Signer.h"
+#include "Coin.h"
+#include <TrustWalletCore/TWHRP.h>
 
 namespace TW::Groestlcoin {
 
@@ -19,7 +21,8 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return TW::Bitcoin::SegwitAddress::isValid(address, std::get<Bech32Prefix>(addressPrefix));
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TW::byte p2pkh, const char* hrp) const {
+std::string Entry::deriveAddress(TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, const PrefixVariant& addressPrefix) const {
+    std::string hrp = getFromPrefixHrpOrDefault(addressPrefix, coin);
     return TW::Bitcoin::SegwitAddress(publicKey, hrp).string();
 }
 

--- a/src/Groestlcoin/Entry.cpp
+++ b/src/Groestlcoin/Entry.cpp
@@ -9,8 +9,6 @@
 #include "Address.h"
 #include "../Bitcoin/SegwitAddress.h"
 #include "Signer.h"
-#include "Coin.h"
-#include <TrustWalletCore/TWHRP.h>
 
 namespace TW::Groestlcoin {
 

--- a/src/Groestlcoin/Entry.h
+++ b/src/Groestlcoin/Entry.h
@@ -15,9 +15,9 @@ namespace TW::Groestlcoin {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
-     void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
-     void plan(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
+    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
+    void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
+    void plan(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };
 
 } // namespace TW::Groestlcoin

--- a/src/Harmony/Entry.cpp
+++ b/src/Harmony/Entry.cpp
@@ -20,7 +20,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Harmony/Entry.h
+++ b/src/Harmony/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Harmony {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      Data addressToData(TWCoinType coin, const std::string& address) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
      bool supportsJSONSigning() const { return true; }

--- a/src/Hedera/Entry.cpp
+++ b/src/Hedera/Entry.cpp
@@ -15,7 +15,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
     return Address(publicKey).string();
 }
 

--- a/src/Hedera/Entry.cpp
+++ b/src/Hedera/Entry.cpp
@@ -15,7 +15,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Hedera/Entry.h
+++ b/src/Hedera/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Hedera {
 class Entry final : public CoinEntry {
 public:
     virtual bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-    virtual std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+    virtual std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
     virtual void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };
 

--- a/src/Icon/Entry.cpp
+++ b/src/Icon/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey, Icon::TypeAddress).string();
 }
 

--- a/src/Icon/Entry.cpp
+++ b/src/Icon/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
     return Address(publicKey, Icon::TypeAddress).string();
 }
 

--- a/src/Icon/Entry.h
+++ b/src/Icon/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Icon {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };
 

--- a/src/IoTeX/Entry.cpp
+++ b/src/IoTeX/Entry.cpp
@@ -19,7 +19,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/IoTeX/Entry.h
+++ b/src/IoTeX/Entry.h
@@ -15,7 +15,7 @@ namespace TW::IoTeX {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };
 

--- a/src/Kusama/Entry.cpp
+++ b/src/Kusama/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
     return Address(publicKey).string();
 }
 

--- a/src/Kusama/Entry.cpp
+++ b/src/Kusama/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Kusama/Entry.h
+++ b/src/Kusama/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Kusama {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      Data addressToData(TWCoinType coin, const std::string& address) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };

--- a/src/NEAR/Entry.cpp
+++ b/src/NEAR/Entry.cpp
@@ -24,7 +24,7 @@ string Entry::normalizeAddress([[maybe_unused]] TWCoinType coin, const string& a
     return Address(address).string();
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/NEAR/Entry.cpp
+++ b/src/NEAR/Entry.cpp
@@ -24,7 +24,7 @@ string Entry::normalizeAddress([[maybe_unused]] TWCoinType coin, const string& a
     return Address(address).string();
 }
 
-string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
     return Address(publicKey).string();
 }
 

--- a/src/NEAR/Entry.h
+++ b/src/NEAR/Entry.h
@@ -16,7 +16,7 @@ class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
      std::string normalizeAddress(TWCoinType coin, const std::string& address) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      Data addressToData(TWCoinType coin, const std::string& address) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };

--- a/src/NEO/Entry.cpp
+++ b/src/NEO/Entry.cpp
@@ -18,7 +18,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TW::byte p2pkh, [[maybe_unused]] const char* hrp) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/NEO/Entry.h
+++ b/src/NEO/Entry.h
@@ -15,7 +15,7 @@ namespace TW::NEO {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      Data addressToData(TWCoinType coin, const std::string& address) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
      void plan(TWCoinType coin, const Data& dataIn, Data& dataOut) const;

--- a/src/NULS/Entry.cpp
+++ b/src/NULS/Entry.cpp
@@ -19,7 +19,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/NULS/Entry.h
+++ b/src/NULS/Entry.h
@@ -15,7 +15,7 @@ namespace TW::NULS {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };
 

--- a/src/Nano/Entry.cpp
+++ b/src/Nano/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
     return Address(publicKey).string();
 }
 

--- a/src/Nano/Entry.cpp
+++ b/src/Nano/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Nano/Entry.h
+++ b/src/Nano/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Nano {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      Data addressToData(TWCoinType coin, const std::string& address) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
      bool supportsJSONSigning() const { return true; }

--- a/src/Nebulas/Entry.cpp
+++ b/src/Nebulas/Entry.cpp
@@ -18,7 +18,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Nebulas/Entry.h
+++ b/src/Nebulas/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Nebulas {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };
 

--- a/src/Nervos/Entry.cpp
+++ b/src/Nervos/Entry.cpp
@@ -8,6 +8,8 @@
 
 #include "Address.h"
 #include "Signer.h"
+#include "Coin.h"
+#include <TrustWalletCore/TWHRP.h>
 
 namespace TW::Nervos {
 using namespace std;
@@ -17,8 +19,8 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address, hrpPrefix ? *hrpPrefix : HRP_NERVOS);
 }
 
-string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, byte,
-                            const char* hrp) const {
+std::string Entry::deriveAddress(TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, const PrefixVariant& addressPrefix) const {
+    const char* hrp = getFromPrefixHrpOrDefault(addressPrefix, coin);
     return Address(publicKey, hrp).string();
 }
 

--- a/src/Nervos/Entry.cpp
+++ b/src/Nervos/Entry.cpp
@@ -8,8 +8,6 @@
 
 #include "Address.h"
 #include "Signer.h"
-#include "Coin.h"
-#include <TrustWalletCore/TWHRP.h>
 
 namespace TW::Nervos {
 using namespace std;

--- a/src/Nervos/Entry.h
+++ b/src/Nervos/Entry.h
@@ -18,8 +18,7 @@ namespace TW::Nervos {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, byte p2pkh,
-                              const char* hrp) const;
+    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
     void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
     void plan(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };

--- a/src/Nimiq/Entry.cpp
+++ b/src/Nimiq/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
     return Address(publicKey).string();
 }
 

--- a/src/Nimiq/Entry.cpp
+++ b/src/Nimiq/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Nimiq/Entry.h
+++ b/src/Nimiq/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Nimiq {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };
 

--- a/src/Oasis/Entry.cpp
+++ b/src/Oasis/Entry.cpp
@@ -19,7 +19,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Oasis/Entry.cpp
+++ b/src/Oasis/Entry.cpp
@@ -19,7 +19,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
     return Address(publicKey).string();
 }
 

--- a/src/Oasis/Entry.h
+++ b/src/Oasis/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Oasis {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };
 

--- a/src/Ontology/Entry.cpp
+++ b/src/Ontology/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
     return Address(publicKey).string();
 }
 

--- a/src/Ontology/Entry.cpp
+++ b/src/Ontology/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Ontology/Entry.h
+++ b/src/Ontology/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Ontology {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };
 

--- a/src/Polkadot/Entry.cpp
+++ b/src/Polkadot/Entry.cpp
@@ -20,7 +20,10 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, const PrefixVariant& addressPrefix) const {
+    if (auto* ss58Prefix = std::get_if<SS58Prefix>(&addressPrefix); ss58Prefix) {
+        return Address(publicKey, *ss58Prefix).string();
+    }
     return Address(publicKey).string();
 }
 
@@ -31,13 +34,6 @@ Data Entry::addressToData([[maybe_unused]] TWCoinType coin, const std::string& a
 
 void Entry::sign([[maybe_unused]] TWCoinType coin, const TW::Data& dataIn, TW::Data& dataOut) const {
     signTemplate<Signer, Proto::SigningInput>(dataIn, dataOut);
-}
-
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, const PrefixVariant& addressPrefix) const {
-    if (auto* ss58Prefix = std::get_if<SS58Prefix>(&addressPrefix); ss58Prefix) {
-        return Address(publicKey, *ss58Prefix).string();
-    }
-    return "";
 }
 
 } // namespace TW::Polkadot

--- a/src/Polkadot/Entry.h
+++ b/src/Polkadot/Entry.h
@@ -15,7 +15,6 @@ namespace TW::Polkadot {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
     Data addressToData(TWCoinType coin, const std::string& address) const;
     void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;

--- a/src/Ronin/Entry.cpp
+++ b/src/Ronin/Entry.cpp
@@ -22,7 +22,7 @@ string Entry::normalizeAddress([[maybe_unused]] TWCoinType coin, const string& a
     return Address(address).string();
 }
 
-string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Ronin/Entry.h
+++ b/src/Ronin/Entry.h
@@ -15,7 +15,7 @@ class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
      std::string normalizeAddress(TWCoinType coin, const std::string& address) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      Data addressToData(TWCoinType coin, const std::string& address) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
      bool supportsJSONSigning() const { return true; }

--- a/src/Solana/Entry.cpp
+++ b/src/Solana/Entry.cpp
@@ -20,7 +20,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Solana/Entry.h
+++ b/src/Solana/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Solana {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      Data addressToData(TWCoinType coin, const std::string& address) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
      bool supportsJSONSigning() const { return true; }

--- a/src/Stellar/Entry.cpp
+++ b/src/Stellar/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
     return Address(publicKey).string();
 }
 

--- a/src/Stellar/Entry.cpp
+++ b/src/Stellar/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Stellar/Entry.h
+++ b/src/Stellar/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Stellar {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };
 

--- a/src/Tezos/Entry.cpp
+++ b/src/Tezos/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
     return Address(publicKey).string();
 }
 

--- a/src/Tezos/Entry.cpp
+++ b/src/Tezos/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Tezos/Entry.h
+++ b/src/Tezos/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Tezos {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
      bool supportsJSONSigning() const { return true; }
      std::string signJSON(TWCoinType coin, const std::string& json, const Data& key) const;

--- a/src/Tron/Entry.cpp
+++ b/src/Tron/Entry.cpp
@@ -18,7 +18,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Tron/Entry.h
+++ b/src/Tron/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Tron {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };
 

--- a/src/Waves/Entry.cpp
+++ b/src/Waves/Entry.cpp
@@ -19,7 +19,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Waves/Entry.h
+++ b/src/Waves/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Waves {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };
 

--- a/src/XRP/Entry.cpp
+++ b/src/XRP/Entry.cpp
@@ -18,7 +18,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address) || XAddress::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
     return Address(publicKey).string();
 }
 

--- a/src/XRP/Entry.cpp
+++ b/src/XRP/Entry.cpp
@@ -18,7 +18,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address) || XAddress::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {  
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/XRP/Entry.h
+++ b/src/XRP/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Ripple {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
 };
 

--- a/src/Zcash/Entry.cpp
+++ b/src/Zcash/Entry.cpp
@@ -8,9 +8,6 @@
 
 #include "Signer.h"
 #include "TAddress.h"
-#include "Coin.h"
-
-#include <variant>
 
 namespace TW::Zcash {
 

--- a/src/Zcash/Entry.cpp
+++ b/src/Zcash/Entry.cpp
@@ -8,6 +8,9 @@
 
 #include "Signer.h"
 #include "TAddress.h"
+#include "Coin.h"
+
+#include <variant>
 
 namespace TW::Zcash {
 
@@ -15,7 +18,8 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return TAddress::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, [[maybe_unused]] const char* hrp) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, const PrefixVariant& addressPrefix) const {
+    byte p2pkh = getFromPrefixPkhOrDefault(addressPrefix, coin);
     return TAddress(publicKey, p2pkh).string();
 }
 

--- a/src/Zcash/Entry.h
+++ b/src/Zcash/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Zcash {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      Data addressToData(TWCoinType coin, const std::string& address) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
      void plan(TWCoinType coin, const Data& dataIn, Data& dataOut) const;

--- a/src/Zilliqa/Entry.cpp
+++ b/src/Zilliqa/Entry.cpp
@@ -17,7 +17,7 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, byte, const char*) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
     return Address(publicKey).string();
 }
 

--- a/src/Zilliqa/Entry.h
+++ b/src/Zilliqa/Entry.h
@@ -15,7 +15,7 @@ namespace TW::Zilliqa {
 class Entry final : public CoinEntry {
 public:
     bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
-     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW::byte p2pkh, const char* hrp) const;
+     std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
      Data addressToData(TWCoinType coin, const std::string& address) const;
      void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
      bool supportsJSONSigning() const { return true; }

--- a/src/interface/TWAnyAddress.cpp
+++ b/src/interface/TWAnyAddress.cpp
@@ -10,6 +10,7 @@
 
 #include "Data.h"
 #include "Coin.h"
+#include "CoinEntry.h"
 #include "AnyAddress.h"
 
 bool TWAnyAddressEqual(struct TWAnyAddress* _Nonnull lhs, struct TWAnyAddress* _Nonnull rhs) {
@@ -70,17 +71,17 @@ struct TWAnyAddress* _Nonnull TWAnyAddressCreateWithPublicKey(
 
 struct TWAnyAddress* _Nonnull TWAnyAddressCreateWithPublicKeyDerivation(
     struct TWPublicKey* _Nonnull publicKey, enum TWCoinType coin, enum TWDerivation derivation) {
-    return new TWAnyAddress{TW::AnyAddress::createAddress(publicKey->impl, coin, std::string(""), derivation)};
+    return new TWAnyAddress{TW::AnyAddress::createAddress(publicKey->impl, coin, derivation)};
 }
 
 struct TWAnyAddress* _Nonnull TWAnyAddressCreateBech32WithPublicKey(
     struct TWPublicKey* _Nonnull publicKey, enum TWCoinType coin, TWString* _Nonnull hrp) {
     const auto& hrpStr = *reinterpret_cast<const std::string*>(hrp);
-    return new TWAnyAddress{TW::AnyAddress::createAddress(publicKey->impl, coin, hrpStr)};
+    return new TWAnyAddress{TW::AnyAddress::createAddress(publicKey->impl, coin, TWDerivationDefault, Bech32Prefix(hrpStr.c_str()))};
 }
 
 struct TWAnyAddress* TWAnyAddressCreateSS58WithPublicKey(struct TWPublicKey* publicKey, enum TWCoinType coin, uint32_t ss58Prefix) {
-    return new TWAnyAddress{TW::AnyAddress::createAddress(publicKey->impl, coin, ss58Prefix)};
+    return new TWAnyAddress{TW::AnyAddress::createAddress(publicKey->impl, coin, TWDerivationDefault, SS58Prefix(ss58Prefix))};
 }
 
 void TWAnyAddressDelete(struct TWAnyAddress* _Nonnull address) {

--- a/src/interface/TWAnyAddress.cpp
+++ b/src/interface/TWAnyAddress.cpp
@@ -77,11 +77,11 @@ struct TWAnyAddress* _Nonnull TWAnyAddressCreateWithPublicKeyDerivation(
 struct TWAnyAddress* _Nonnull TWAnyAddressCreateBech32WithPublicKey(
     struct TWPublicKey* _Nonnull publicKey, enum TWCoinType coin, TWString* _Nonnull hrp) {
     const auto& hrpStr = *reinterpret_cast<const std::string*>(hrp);
-    return new TWAnyAddress{TW::AnyAddress::createAddress(publicKey->impl, coin, TWDerivationDefault, Bech32Prefix(hrpStr.c_str()))};
+    return new TWAnyAddress{TW::AnyAddress::createAddress(publicKey->impl, coin, TWDerivationDefault, TW::Bech32Prefix(hrpStr.c_str()))};
 }
 
 struct TWAnyAddress* TWAnyAddressCreateSS58WithPublicKey(struct TWPublicKey* publicKey, enum TWCoinType coin, uint32_t ss58Prefix) {
-    return new TWAnyAddress{TW::AnyAddress::createAddress(publicKey->impl, coin, TWDerivationDefault, SS58Prefix(ss58Prefix))};
+    return new TWAnyAddress{TW::AnyAddress::createAddress(publicKey->impl, coin, TWDerivationDefault, TW::SS58Prefix(ss58Prefix))};
 }
 
 void TWAnyAddressDelete(struct TWAnyAddress* _Nonnull address) {

--- a/tests/common/AnyAddressTests.cpp
+++ b/tests/common/AnyAddressTests.cpp
@@ -30,11 +30,11 @@ TEST(AnyAddress, createFromPubKeyDerivation) {
     const Data key = parse_hex(ANY_ADDRESS_TEST_PUBKEY);
     PublicKey publicKey(key, TWPublicKeyTypeSECP256k1);
     {
-        std::unique_ptr<AnyAddress> addr(AnyAddress::createAddress(publicKey, TWCoinTypeBitcoin, std::string(""), TWDerivationDefault));
+        std::unique_ptr<AnyAddress> addr(AnyAddress::createAddress(publicKey, TWCoinTypeBitcoin, TWDerivationDefault, std::monostate()));
         EXPECT_EQ(addr->address, ANY_ADDRESS_TEST_ADDRESS);
     }
     {
-        std::unique_ptr<AnyAddress> addr(AnyAddress::createAddress(publicKey, TWCoinTypeBitcoin, std::string(""), TWDerivationBitcoinLegacy));
+        std::unique_ptr<AnyAddress> addr(AnyAddress::createAddress(publicKey, TWCoinTypeBitcoin, TWDerivationBitcoinLegacy, std::monostate()));
         EXPECT_EQ(addr->address, "1JvRfEQFv5q5qy9uTSAezH7kVQf4hqnHXx");
     }
 }


### PR DESCRIPTION
## Description

Unify the 3 deriveAddress() methods in the coin Entry classes; internal refactor with no change exposed outside.

There are 3 variants of the deriveAddress() methods:

1. The original one, with p2pkh and hrp prefix parameters, used by most coins
2. Version with extra `derivation` parameter, used by Bitcoin. This became a separate variant not to touch all Entry classes.
3. Version with extra `PrefixVariant` parameters.

All these can be replaced by one version, with `derivation` and `prefix` parameters.

## How to test

All tests.

## Types of changes

* Non-breaking refactor

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.
- [x] update the code generation templates.

If you're adding a new blockchain

- [ ] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
