### PR TITLE
Updated docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,8 @@ ENV CXX=/usr/bin/clang++-14
 RUN wget "https://sh.rustup.rs" -O rustup.sh \
     && sh rustup.sh -y
 ENV PATH="/root/.cargo/bin:${PATH}"
+RUN cargo install --force cbindgen \
+    && rustup target add wasm32-unknown-emscripten
 
 # ↑ Setup build environment
 # ↓ Build and compile wallet core

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key 
     && apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
 
 
-RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb && dpkg -i ./libssl1.1_1.1.0g-2ubuntu4_amd64.deb
+RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb && dpkg -i ./libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
 # Install required packages for dev
 RUN apt-get update \
     && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,10 @@ RUN apt-get update \
 ENV CC=/usr/bin/clang-14
 ENV CXX=/usr/bin/clang++-14
 
+# Install rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 # ↑ Setup build environment
 # ↓ Build and compile wallet core
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,8 @@ ENV CC=/usr/bin/clang-14
 ENV CXX=/usr/bin/clang++-14
 
 # Install rust
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN wget "https://sh.rustup.rs" -O rustup.sh \
+    && sh rustup.sh -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # ↑ Setup build environment

--- a/src/Ethereum/EIP2645.cpp
+++ b/src/Ethereum/EIP2645.cpp
@@ -8,6 +8,7 @@
 #include <Hash.h>
 #include <HexCoding.h>
 
+#include <optional>
 #include <sstream>
 
 namespace TW::Ethereum::internal {


### PR DESCRIPTION
## Description

Fixes docker build not working due to changes in cmake and recent addition of rust library (([#2706](https://github.com/trustwallet/wallet-core/pull/2706))

## How to test

Run the docker build steps.

## Types of changes

* Updates libssl in the docker container to 1.1.1 as required per the latest version of cmake that ubuntu installs.
* Installs rustc and cargo, which are required after (([#2706](https://github.com/trustwallet/wallet-core/pull/2706)) was merged in.

## Checklist

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.
