### PR TITLE
Add extra hrp and coin check to lockScriptForAddress()

### DIFF
--- a/tests/chains/Bitcoin/TWBitcoinScriptTests.cpp
+++ b/tests/chains/Bitcoin/TWBitcoinScriptTests.cpp
@@ -210,11 +210,11 @@ TEST(TWBitcoinScript, LockScriptForP2WSHAddress) {
 }
 
 TEST(TWBitcoinScript, LockScriptForCashAddress) {
-    auto script = WRAP(TWBitcoinScript, TWBitcoinScriptLockScriptForAddress(STRING("bitcoincash:pzclklsyx9f068hd00a0vene45akeyrg7vv0053uqf").get(), TWCoinTypeBitcoin));
+    auto script = WRAP(TWBitcoinScript, TWBitcoinScriptLockScriptForAddress(STRING("bitcoincash:pzclklsyx9f068hd00a0vene45akeyrg7vv0053uqf").get(), TWCoinTypeBitcoinCash));
     auto scriptData = WRAPD(TWBitcoinScriptData(script.get()));
     assertHexEqual(scriptData, "a914b1fb7e043152fd1eed7bfaf66679ad3b6c9068f387");
 
-    auto script2 = WRAP(TWBitcoinScript, TWBitcoinScriptLockScriptForAddress(STRING("bitcoincash:qpk05r5kcd8uuzwqunn8rlx5xvuvzjqju5rch3tc0u").get(), TWCoinTypeBitcoin));
+    auto script2 = WRAP(TWBitcoinScript, TWBitcoinScriptLockScriptForAddress(STRING("bitcoincash:qpk05r5kcd8uuzwqunn8rlx5xvuvzjqju5rch3tc0u").get(), TWCoinTypeBitcoinCash));
     auto scriptData2 = WRAPD(TWBitcoinScriptData(script2.get()));
     assertHexEqual(scriptData2, "76a9146cfa0e96c34fce09c0e4e671fcd43338c14812e588ac");
 }

--- a/tests/chains/DigiByte/TWDigiByteTests.cpp
+++ b/tests/chains/DigiByte/TWDigiByteTests.cpp
@@ -32,6 +32,7 @@ TEST(DigiByteTransaction, SignTransaction) {
     const int64_t fee = 1000;
 
     auto input = Bitcoin::Proto::SigningInput();
+    input.set_coin_type(TWCoinTypeDigiByte);
     input.set_hash_type(TWBitcoinSigHashTypeAll);
     input.set_amount(amount);
     input.set_byte_fee(1);
@@ -98,6 +99,7 @@ TEST(DigiByteTransaction, SignP2WPKH) {
     const int64_t amount = 2000000;
 
     Proto::SigningInput input;
+    input.set_coin_type(TWCoinTypeDigiByte);
     input.set_hash_type(TWBitcoinSigHashTypeAll);
     input.set_amount(amount);
     input.set_byte_fee(1);

--- a/tests/chains/ECash/TWECashTests.cpp
+++ b/tests/chains/ECash/TWECashTests.cpp
@@ -124,6 +124,7 @@ TEST(ECash, SignTransaction) {
     // https://blockchair.com/ecash/transaction/96ee20002b34e468f9d3c5ee54f6a8ddaa61c118889c4f35395c2cd93ba5bbb4
 
     auto input = Proto::SigningInput();
+    input.set_coin_type(TWCoinTypeECash);
     input.set_hash_type(hashTypeForCoin(TWCoinTypeECash));
     input.set_amount(amount);
     input.set_byte_fee(1);

--- a/tests/chains/Groestlcoin/TWGroestlcoinSigningTests.cpp
+++ b/tests/chains/Groestlcoin/TWGroestlcoinSigningTests.cpp
@@ -22,6 +22,7 @@ namespace TW::Bitcoin {
 
 TEST(GroestlcoinSigning, SignP2WPKH) {
     Proto::SigningInput input;
+    input.set_coin_type(TWCoinTypeGroestlcoin);
     input.set_hash_type(TWBitcoinSigHashTypeAll);
     input.set_amount(2500);
     input.set_byte_fee(1);
@@ -64,6 +65,7 @@ TEST(GroestlcoinSigning, SignP2WPKH) {
 
 TEST(GroestlcoinSigning, SignP2PKH) {
     Proto::SigningInput input;
+    input.set_coin_type(TWCoinTypeGroestlcoin);
     input.set_hash_type(TWBitcoinSigHashTypeAll);
     input.set_amount(2500);
     input.set_byte_fee(1);
@@ -107,6 +109,7 @@ TEST(GroestlcoinSigning, SignP2PKH) {
 TEST(GroestlcoinSigning, SignP2SH_P2WPKH) {
     // TX outputs
     Proto::SigningInput input;
+    input.set_coin_type(TWCoinTypeGroestlcoin);
     input.set_hash_type(TWBitcoinSigHashTypeAll);
     input.set_amount(5'000);
     input.set_byte_fee(1);
@@ -159,6 +162,7 @@ TEST(GroestlcoinSigning, SignP2SH_P2WPKH) {
 
 TEST(GroestlcoinSigning, PlanP2WPKH) {
     Proto::SigningInput input;
+    input.set_coin_type(TWCoinTypeGroestlcoin);
     input.set_hash_type(TWBitcoinSigHashTypeAll);
     input.set_amount(2500);
     input.set_byte_fee(1);


### PR DESCRIPTION
## Description

The method `Script::lockScriptForAddress()` creates a Bitcoin Segwith lock script for any valid Bech32 string with any prefix, for a Bitcoin-type blockchain. While this does not cause any issues with the supported coins, it is safer to check for the HRP to match the coin type.
Also included: 
- explicit coin type for some coin-specific address types
- some missing coin field setting in some Bitcoin-clone signing tests.

Fixes #2804 .

## How to test

Unit tests.

## Types of changes

* No-behavior change, non-breaking refactoring

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [ ] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
