### PR TITLE
[Codegen]: mark java class as final to avoid kt doc confusion

### DIFF
--- a/codegen/lib/templates/java/class.erb
+++ b/codegen/lib/templates/java/class.erb
@@ -5,9 +5,9 @@ import java.util.HashSet;
 <%  equal = entity.static_methods.detect{ |i| i.name == 'Equal' } -%>
 <%= entity.comment %>
 <%  if !less.nil? && !equal.nil? -%>
-public class <%= entity.name %> implements Comparable<<%= entity.name %>> {
+public final class <%= entity.name %> implements Comparable<<%= entity.name %>> {
 <%  else -%>
-public class <%= entity.name %> {
+public final class <%= entity.name %> {
 <%  end -%>
     private long nativeHandle;
 

--- a/codegen/lib/templates/java/struct.erb
+++ b/codegen/lib/templates/java/struct.erb
@@ -4,9 +4,9 @@ import java.security.InvalidParameterException;
 <%  equal = entity.static_methods.detect{ |i| i.name == 'Equal' } -%>
 <%= entity.comment %>
 <%  if !less.nil? && !equal.nil? -%>
-public class <%= entity.name %> implements Comparable<<%= entity.name %>> {
+public final class <%= entity.name %> implements Comparable<<%= entity.name %>> {
 <%  else -%>
-public class <%= entity.name %> {
+public final class <%= entity.name %> {
 <%  end -%>
     private byte[] bytes;
 


### PR DESCRIPTION
## Description

To avoid open keywork on the doc

Before:
<img width="1268" alt="Screenshot 2023-01-18 at 10 57 48" src="https://user-images.githubusercontent.com/21139416/213141187-54339aeb-3c39-4151-937d-b235f381c3f4.png">

After:

<img width="1253" alt="Screenshot 2023-01-18 at 10 58 05" src="https://user-images.githubusercontent.com/21139416/213141256-75b21c8f-661a-4046-838d-11d7e684cd6e.png">

Todo: do the same for the function

## How to test

Run dokka doc and check