### PR TITLE
Fix array with mismatched bound warnings in sha2.c

### DIFF
--- a/trezor-crypto/crypto/sha2.c
+++ b/trezor-crypto/crypto/sha2.c
@@ -589,7 +589,7 @@ void sha1_Update(SHA1_CTX* context, const sha2_byte *data, size_t len) {
 	usedspace = freespace = 0;
 }
 
-void sha1_Final(SHA1_CTX* context, sha2_byte digest[]) {
+void sha1_Final(SHA1_CTX* context, sha2_byte digest[SHA1_DIGEST_LENGTH]) {
 	unsigned int	usedspace = 0;
 
 	/* If no digest buffer is passed, we don't bother doing this: */
@@ -896,7 +896,7 @@ void sha256_Update(SHA256_CTX* context, const sha2_byte *data, size_t len) {
 	usedspace = freespace = 0;
 }
 
-void sha256_Final(SHA256_CTX* context, sha2_byte digest[]) {
+void sha256_Final(SHA256_CTX* context, sha2_byte digest[SHA256_DIGEST_LENGTH]) {
 	unsigned int	usedspace = 0;
 
 	/* If no digest buffer is passed, we don't bother doing this: */
@@ -1250,7 +1250,7 @@ static void sha512_Last(SHA512_CTX* context) {
 	sha512_Transform(context->state, context->buffer, context->state);
 }
 
-void sha512_Final(SHA512_CTX* context, sha2_byte digest[]) {
+void sha512_Final(SHA512_CTX* context, sha2_byte digest[SHA512_DIGEST_LENGTH]) {
 	/* If no digest buffer is passed, we don't bother doing this: */
 	if (digest != (sha2_byte*)0) {
 		sha512_Last(context);


### PR DESCRIPTION
## Description

archlinux os with clang version 14.0.6 reports error (warning) about 
```
.../trust-wallet-core/trezor-crypto/crypto/sha2.c:592:46: error: argument 2 of type ‘sha2_byte[]’ {aka ‘unsigned char[]’} with mismatched bound [-Werror=array-parameter=]
  592 | void sha1_Final(SHA1_CTX* context, sha2_byte digest[]) {
      |                                    ~~~~~~~~~~^~~~~~~~
In file included from .../trust-wallet-core/trezor-crypto/crypto/sha2.c:33:
.../trust-wallet-core/trezor-crypto/include/TrezorCrypto/sha2.h:99:28: note: previously declared as ‘uint8_t[20]’ {aka ‘unsigned char[20]’}
   99 | void sha1_Final(SHA1_CTX*, uint8_t[SHA1_DIGEST_LENGTH]);
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~
.../trust-wallet-core/trezor-crypto/crypto/sha2.c:899:50: error: argument 2 of type ‘sha2_byte[]’ {aka ‘unsigned char[]’} with mismatched bound [-Werror=array-parameter=]
  899 | void sha256_Final(SHA256_CTX* context, sha2_byte digest[]) {
      |                                        ~~~~~~~~~~^~~~~~~~
.../trust-wallet-core/trezor-crypto/include/TrezorCrypto/sha2.h:107:32: note: previously declared as ‘uint8_t[32]’ {aka ‘unsigned char[32]’}
  107 | void sha256_Final(SHA256_CTX*, uint8_t[SHA256_DIGEST_LENGTH]);
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../trust-wallet-core/trezor-crypto/crypto/sha2.c:1253:50: error: argument 2 of type ‘sha2_byte[]’ {aka ‘unsigned char[]’} with mismatched bound [-Werror=array-parameter=]
 1253 | void sha512_Final(SHA512_CTX* context, sha2_byte digest[]) {
      |                                        ~~~~~~~~~~^~~~~~~~
.../trust-wallet-core/trezor-crypto/include/TrezorCrypto/sha2.h:115:32: note: previously declared as ‘uint8_t[64]’ {aka ‘unsigned char[64]’}
  115 | void sha512_Final(SHA512_CTX*, uint8_t[SHA512_DIGEST_LENGTH]);
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Types of changes

inserted the SHA*_DIGEST_LENGTH constants in a square brackets of the function argument array in the trust-wallet-core/trezor-crypto/crypto/sha2.c

