### PR TITLE
Replace string to string_view in the functions arguments

### DIFF
--- a/src/AnyAddress.cpp
+++ b/src/AnyAddress.cpp
@@ -6,8 +6,8 @@
 
 #include "AnyAddress.h"
 
-#include <utility>
 #include "Coin.h"
+#include <utility>
 
 namespace TW {
 
@@ -15,7 +15,7 @@ Data AnyAddress::getData() const {
     return TW::addressToData(coin, address);
 }
 
-AnyAddress* AnyAddress::createAddress(const std::string& address, enum TWCoinType coin, const PrefixVariant& prefix) {
+AnyAddress* AnyAddress::createAddress(std::string_view address, enum TWCoinType coin, const PrefixVariant& prefix) {
     const bool hasPrefix = !std::holds_alternative<std::monostate>(prefix);
     auto normalized = hasPrefix ? TW::normalizeAddress(coin, address, prefix) : TW::normalizeAddress(coin, address);
     if (normalized.empty()) {

--- a/src/AnyAddress.h
+++ b/src/AnyAddress.h
@@ -10,10 +10,10 @@
 #include "PublicKey.h"
 
 #include <TrustWalletCore/TWCoinType.h>
-#include <TrustWalletCore/TWPublicKey.h>
 #include <TrustWalletCore/TWData.h>
+#include <TrustWalletCore/TWPublicKey.h>
 #include <CoinEntry.h>
-#include <string>
+#include <string_view>
 
 namespace TW {
 
@@ -24,7 +24,7 @@ public:
     enum TWCoinType coin;
 
     // Create address from string address and optional prefix; also normalizes the address.
-    static AnyAddress* createAddress(const std::string& address, enum TWCoinType coin, const PrefixVariant& prefix = std::monostate());
+    static AnyAddress* createAddress(std::string_view address, enum TWCoinType coin, const PrefixVariant& prefix = std::monostate());
     // Create address from private key, with optional non-standard derivation and prefix
     static AnyAddress* createAddress(const PublicKey& publicKey, enum TWCoinType coin, TWDerivation derivation = TWDerivationDefault, const PrefixVariant& prefix = std::monostate());
 

--- a/src/Base32.h
+++ b/src/Base32.h
@@ -11,7 +11,9 @@
 #include <TrezorCrypto/base32.h>
 
 #include <cassert>
+#include <cstdint>
 #include <string_view>
+#include <vector>
 
 namespace TW::Base32 {
 
@@ -21,13 +23,12 @@ inline bool decode(std::string_view encoded_in, Data& decoded_out, std::string_v
     size_t inLen = encoded_in.size();
     // obtain output length first
     size_t outLen = base32_decoded_length(inLen);
-    std::string buf;
-    buf.reserve(outLen);
+	std::vector<uint8_t> buf(outLen);
     if (!alphabet_in.empty()) {
         alphabet_in = BASE32_ALPHABET_RFC4648;
     }
     // perform the base32 decode
-    uint8_t* retval = base32_decode(encoded_in.data(), inLen, &buf.front(), outLen, alphabet_in.data());
+    uint8_t* retval = base32_decode(encoded_in.data(), inLen, buf.data(), outLen, alphabet_in.data());
     if (!retval) {
         return false;
     }

--- a/src/Base58.cpp
+++ b/src/Base58.cpp
@@ -10,9 +10,9 @@
 #include "Hash.h"
 
 #include <algorithm>
-#include <iterator>
-#include <cctype>
 #include <cassert>
+#include <cctype>
+#include <iterator>
 
 using namespace TW;
 
@@ -79,7 +79,7 @@ Data Base58::decode(const char* begin, const char* end) const {
     const auto* it = begin;
 
     // Skip leading spaces.
-    it = std::find_if_not(it, end, [](char c) { return std::isspace(c);});
+    it = std::find_if_not(it, end, [](char c) { return std::isspace(c); });
 
     // Skip and count leading zeros.
     std::size_t zeroes = 0;
@@ -120,7 +120,7 @@ Data Base58::decode(const char* begin, const char* end) const {
     }
 
     // Skip trailing spaces.
-    it = std::find_if_not(it, end, [](char c) { return std::isspace(c);});
+    it = std::find_if_not(it, end, [](char c) { return std::isspace(c); });
     if (it != end) {
         // Extra charaters at the end
         return {};

--- a/src/Base58.h
+++ b/src/Base58.h
@@ -11,18 +11,19 @@
 
 #include <array>
 #include <string>
+#include <string_view>
 
 namespace TW {
 
 class Base58 {
-  public:
+public:
     /// Base58 coder with Bitcoin character map.
     static Base58 bitcoin;
 
     /// Base58 coder with Ripple character map.
     static Base58 ripple;
 
-  public:
+public:
     /// Ordered list of valid characters.
     const std::array<char, 58> digits;
 
@@ -34,7 +35,7 @@ class Base58 {
         : digits(digits), characterMap(characterMap) {}
 
     /// Decodes a base 58 string verifying the checksum, returns empty on failure.
-    Data decodeCheck(const std::string& string, Hash::Hasher hasher = Hash::HasherSha256d) const {
+    Data decodeCheck(std::string_view string, Hash::Hasher hasher = Hash::HasherSha256d) const {
         return decodeCheck(string.data(), string.data() + string.size(), hasher);
     }
 
@@ -42,12 +43,12 @@ class Base58 {
     Data decodeCheck(const char* begin, const char* end, Hash::Hasher hasher = Hash::HasherSha256d) const;
 
     /// Decodes a base 58 string into `result`, returns `false` on failure.
-    Data decode(const std::string& string) const {
+    Data decode(std::string_view string) const {
         return decode(string.data(), string.data() + string.size());
     }
 
     /// Decodes a base 58 string into `result`, returns `false` on failure.
-    Data decode(const char* begin, const char* end) const;
+    Data decode(std::string_view begin, std::string_view end) const;
 
     /// Encodes data as a base 58 string with a checksum.
     template <typename T>

--- a/src/Base58Address.h
+++ b/src/Base58Address.h
@@ -12,14 +12,15 @@
 
 #include <array>
 #include <string>
+#include <string_view>
 
 namespace TW {
 
 template <std::size_t S>
 class Base58Address {
-  public:
+public:
     /// Number of bytes in an address.
-    static const size_t size = S;
+    static constexpr size_t size = S;
 
     /// Address data consisting of a prefix byte followed by the public key
     /// hash.
@@ -32,7 +33,7 @@ class Base58Address {
     }
 
     /// Determines whether a string makes a valid address.
-    static bool isValid(const std::string& string) {
+    static bool isValid(std::string_view string) {
         const auto decoded = Base58::bitcoin.decodeCheck(string);
         if (decoded.size() != Base58Address::size) {
             return false;
@@ -42,7 +43,7 @@ class Base58Address {
 
     /// Determines whether a string makes a valid address, and the prefix is
     /// within the valid set.
-    static bool isValid(const std::string& string, const std::vector<Data>& validPrefixes) {
+    static bool isValid(std::string_view string, const std::vector<Data>& validPrefixes) {
         const auto decoded = Base58::bitcoin.decodeCheck(string);
         if (decoded.size() != Base58Address::size) {
             return false;
@@ -58,7 +59,7 @@ class Base58Address {
     Base58Address() = default;
 
     /// Initializes an address with a string representation.
-    explicit Base58Address(const std::string& string) {
+    explicit Base58Address(std::string_view string) {
         const auto decoded = Base58::bitcoin.decodeCheck(string);
         if (decoded.size() != Base58Address::size) {
             throw std::invalid_argument("Invalid address string");

--- a/src/Base64.cpp
+++ b/src/Base64.cpp
@@ -16,29 +16,29 @@ namespace TW::Base64 {
 using namespace TW;
 using namespace std;
 
-static bool isBase64Any(const string& val, const char* alphabet) {
+static bool isBase64Any(std::string_view val, std::string_view alphabet) {
     if (val.length() % 4 != 0) {
         return false;
     }
     size_t first_non_alphabet = val.find_first_not_of(alphabet);
     size_t first_non_padding = val.find_first_not_of("=", first_non_alphabet);
 
-    if (first_non_alphabet == std::string::npos ||
-        (first_non_padding == std::string::npos && (val.length() - first_non_alphabet < 3))) {
+    if (first_non_alphabet == std::string_view::npos ||
+        (first_non_padding == std::string_view::npos && (val.length() - first_non_alphabet < 3))) {
         return true;
     }
     return false;
 }
 
-bool isBase64orBase64Url(const string& val) {
+bool isBase64orBase64Url(std::string_view val) {
     const char* base64_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     const char* base64_url_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
     return isBase64Any(val, base64_chars) || isBase64Any(val, base64_url_chars);
 }
 
-Data decode(const string& val) {
+Data decode(std::string_view val) {
     using namespace boost::archive::iterators;
-    using It = transform_width<binary_from_base64<string::const_iterator>, 8, 6>;
+    using It = transform_width<binary_from_base64<string_view::const_iterator>, 8, 6>;
     return boost::algorithm::trim_right_copy_if(Data(It(begin(val)), It(end(val))),
                                                 [](char c) { return c == '\0'; });
 }
@@ -54,14 +54,11 @@ string encode(const Data& val) {
 void convertFromBase64Url(string& b) {
     // '-' and '_' (Base64URL format) are changed to '+' and '/'
     // in-place replace
-    size_t n = b.length();
-    char* start = b.data();
-    char* end = start + n;
-    for (auto* p = start; p < end; ++p) {
-        if (*p == '-') {
-            *p = '+';
-        } else if (*p == '_') {
-            *p = '/';
+    for (auto p : b) {
+        if (p == '-') {
+            p = '+';
+        } else if (p == '_') {
+            p = '/';
         }
     }
 }
@@ -70,19 +67,16 @@ void convertFromBase64Url(string& b) {
 void convertToBase64Url(string& b) {
     // '+' and '/' are changed to '-' and '_' (Base64URL format)
     // in-place replace
-    size_t n = b.length();
-    char* start = b.data();
-    char* end = start + n;
-    for (auto* p = start; p < end; ++p) {
-        if (*p == '+') {
-            *p = '-';
-        } else if (*p == '/') {
-            *p = '_';
+    for (auto p : b) {
+        if (p == '+') {
+            p = '-';
+        } else if (p == '/') {
+            p = '_';
         }
     }
 }
 
-Data decodeBase64Url(const string& val) {
+Data decodeBase64Url(std::string_view val) {
     string base64Url = val;
     convertFromBase64Url(base64Url);
     return decode(base64Url);

--- a/src/Base64.h
+++ b/src/Base64.h
@@ -7,21 +7,22 @@
 #pragma once
 
 #include "Data.h"
+#include <string_view>
 
 namespace TW::Base64 {
 
 // Checks if as string is in Base64-format or Base64Url-format
-bool isBase64orBase64Url(const std::string& val);
+bool isBase64orBase64Url(std::string_view val);
 
 // Decode a Base64-format string
-Data decode(const std::string& val);
+Data decode(std::string_view val);
 
 // Encode bytes into Base64 string
 std::string encode(const Data& val);
 
 // Decode a Base64Url-format or a regular Base64 string.
 // Base64Url format uses '-' and '_' as the two special characters, Base64 uses '+'and '/'.
-Data decodeBase64Url(const std::string& val);
+Data decodeBase64Url(std::string_view val);
 
 // Encode bytes into Base64Url string (uses '-' and '_' as special characters)
 std::string encodeBase64Url(const Data& val);

--- a/src/Bech32.cpp
+++ b/src/Bech32.cpp
@@ -33,8 +33,8 @@ constexpr std::array<int8_t, 128> charset_rev = {
     6, 4, 2, -1, -1, -1, -1, -1, -1, 29, -1, 24, 13, 25, 9, 8, 23, -1, 18, 22, 31, 27,
     19, -1, 1, 0, 3, 16, 11, 28, 12, 14, 6, 4, 2, -1, -1, -1, -1, -1};
 
-const uint32_t BECH32_XOR_CONST = 0x01;
-const uint32_t BECH32M_XOR_CONST = 0x2bc830a3;
+constexpr uint32_t BECH32_XOR_CONST = 0x01;
+constexpr uint32_t BECH32M_XOR_CONST = 0x2bc830a3;
 
 /** Find the polynomial with value coefficients mod the generator as 30-bit. */
 uint32_t polymod(const Data& values) {
@@ -54,7 +54,7 @@ unsigned char lc(unsigned char c) {
 }
 
 /** Expand a HRP for use in checksum computation. */
-Data expand_hrp(const std::string& hrp) {
+Data expand_hrp(std::string_view hrp) {
     Data ret;
     ret.resize(hrp.size() * 2 + 1);
     for (size_t i = 0; i < hrp.size(); ++i) {
@@ -75,7 +75,7 @@ inline uint32_t xorConstant(ChecksumVariant variant) {
 }
 
 /** Verify a checksum. */
-ChecksumVariant verify_checksum(const std::string& hrp, const Data& values) {
+ChecksumVariant verify_checksum(std::string_view hrp, const Data& values) {
     Data enc = expand_hrp(hrp);
     append(enc, values);
     auto poly = polymod(enc);
@@ -89,7 +89,7 @@ ChecksumVariant verify_checksum(const std::string& hrp, const Data& values) {
 }
 
 /** Create a checksum. */
-Data create_checksum(const std::string& hrp, const Data& values, ChecksumVariant variant) {
+Data create_checksum(std::string_view hrp, const Data& values, ChecksumVariant variant) {
     Data enc = expand_hrp(hrp);
     append(enc, values);
     enc.resize(enc.size() + 6);
@@ -106,7 +106,7 @@ Data create_checksum(const std::string& hrp, const Data& values, ChecksumVariant
 } // namespace
 
 /** Encode a Bech32 string. */
-std::string encode(const std::string& hrp, const Data& values, ChecksumVariant variant) {
+std::string encode(std::string_view hrp, const Data& values, ChecksumVariant variant) {
     Data checksum = create_checksum(hrp, values, variant);
     Data combined = values;
     append(combined, checksum);
@@ -119,7 +119,7 @@ std::string encode(const std::string& hrp, const Data& values, ChecksumVariant v
 }
 
 /** Decode a Bech32 string. */
-std::tuple<std::string, Data, ChecksumVariant> decode(const std::string& str) {
+std::tuple<std::string, Data, ChecksumVariant> decode(std::string_view str) {
     if (str.length() > 120 || str.length() < 2) {
         // too long or too short
         return std::make_tuple(std::string(), Data(), None);

--- a/src/Bech32.h
+++ b/src/Bech32.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 #include <tuple>
+#include <string_view>
 
 namespace TW::Bech32 {
 
@@ -25,7 +26,7 @@ enum ChecksumVariant {
 /// Encodes a Bech32 string.
 ///
 /// \returns the encoded string, or an empty string in case of failure.
-std::string encode(const std::string& hrp, const Data& values, ChecksumVariant variant);
+std::string encode(std::string_view hrp, const Data& values, ChecksumVariant variant);
 
 /// Decodes a Bech32 string.
 ///
@@ -34,7 +35,7 @@ std::string encode(const std::string& hrp, const Data& values, ChecksumVariant v
 /// - data, or a pair or
 /// - ChecksumVariant used
 /// or empty values on failure.
-std::tuple<std::string, Data, ChecksumVariant> decode(const std::string& str);
+std::tuple<std::string, Data, ChecksumVariant> decode(std::string_view str);
 
 /// Converts from one power-of-2 number base to another.
 template <int frombits, int tobits, bool pad>

--- a/src/Bech32Address.cpp
+++ b/src/Bech32Address.cpp
@@ -11,11 +11,11 @@
 
 using namespace TW;
 
-bool Bech32Address::isValid(const std::string& addr) {
+bool Bech32Address::isValid(std::string_view addr) {
     return isValid(addr, "");
 }
 
-bool Bech32Address::isValid(const std::string& addr, const std::string& hrp) {
+bool Bech32Address::isValid(std::string_view addr, std::string_view hrp) {
     auto dec = Bech32::decode(addr);
     // check hrp prefix (if given)
     if (hrp.length() > 0 && std::get<0>(dec).compare(0, hrp.length(), hrp) != 0) {
@@ -34,7 +34,7 @@ bool Bech32Address::isValid(const std::string& addr, const std::string& hrp) {
     return true;
 }
 
-bool Bech32Address::decode(const std::string& addr, Bech32Address& obj_out, const std::string& hrp) {
+bool Bech32Address::decode(std::string_view addr, Bech32Address& obj_out, std::string_view hrp) {
     auto dec = Bech32::decode(addr);
     // check hrp prefix (if given)
     if (hrp.length() > 0 && std::get<0>(dec).compare(0, hrp.length(), hrp) != 0) {
@@ -55,7 +55,7 @@ bool Bech32Address::decode(const std::string& addr, Bech32Address& obj_out, cons
     return true;
 }
 
-Bech32Address::Bech32Address(const std::string& hrp, Hash::Hasher hasher, const PublicKey& publicKey)
+Bech32Address::Bech32Address(std::string_view hrp, Hash::Hasher hasher, const PublicKey& publicKey)
 : hrp(hrp) {
     bool skipTypeByte = false;
     // Extended-key / keccak-hash skips first byte (Evmos)

--- a/src/Bech32Address.h
+++ b/src/Bech32Address.h
@@ -7,11 +7,12 @@
 #pragma once
 
 #include "Data.h"
-#include "PublicKey.h"
 #include "Hash.h"
+#include "PublicKey.h"
 
-#include <string>
 #include <memory>
+#include <string>
+#include <string_view>
 
 namespace TW {
 
@@ -27,30 +28,32 @@ private:
 
 public:
     /// Determines whether a string makes a valid Bech32 address.
-    static bool isValid(const std::string& addr);
+    static bool isValid(std::string_view addr);
 
     /// Determines whether a string makes a valid Bech32 address, and the HRP matches.
-    static bool isValid(const std::string& addr, const std::string& hrp);
+    static bool isValid(std::string_view addr, std::string_view hrp);
 
-    /// Decodes an address and create an address object out of it.  
+    /// Decodes an address and create an address object out of it.
     /// obj_out:  Pass-by-ref, result is initialized here if possible, it can be a derived address type.
     /// hrp: the expected hrp prefix (if missing ("") no prefix check is done).
     /// \returns true if success.
-    static bool decode(const std::string& addr, Bech32Address& obj_out, const std::string& hrp);
+    static bool decode(std::string_view addr, Bech32Address& obj_out, std::string_view hrp);
 
     /// Initializes an empty address.
-    Bech32Address(const std::string& hrp_in) : hrp(std::move(hrp_in)) {}
+    Bech32Address(std::string hrp_in)
+        : hrp(std::move(hrp_in)) {}
 
     /// Initializes an address with a key hash.
-    Bech32Address(const std::string& hrp, const Data& keyHash) : hrp(std::move(hrp)), keyHash(std::move(keyHash)) {}
+    Bech32Address(std::string hrp, const Data& keyHash)
+        : hrp(std::move(hrp)), keyHash(std::move(keyHash)) {}
 
     /// Initialization from public key --> chain specific hash methods
-    Bech32Address(const std::string& hrp, Hash::Hasher hasher, const PublicKey& publicKey);
+    Bech32Address(std::string_view hrp, Hash::Hasher hasher, const PublicKey& publicKey);
 
-    void setHrp(const std::string& hrp_in) { hrp = std::move(hrp_in); }
+    void setHrp(std::string_view hrp_in) { hrp = std::move(hrp_in); }
     void setKey(const Data& keyHash_in) { keyHash = std::move(keyHash_in); }
 
-    inline const std::string& getHrp() const { return hrp; }
+    inline std::string_view getHrp() const { return hrp; }
 
     inline const Data& getKeyHash() const { return keyHash; }
 

--- a/src/BinaryCoding.cpp
+++ b/src/BinaryCoding.cpp
@@ -137,13 +137,13 @@ uint64_t decode64BE(const uint8_t* _Nonnull src) {
     // clang-format on
 }
 
-void encodeString(const string& str, vector<uint8_t>& data) {
+void encodeString(std::string_view str, vector<uint8_t>& data) {
     size_t size = str.size();
     encodeVarInt(size, data);
-    data.insert(data.end(), str.data(), str.data() + size);
+    data.insert(data.end(), str.begin(), str.end());
 }
 
-/// Decodes an ASCII string prefixed by its length (varInt) 
+/// Decodes an ASCII string prefixed by its length (varInt)
 tuple<bool, string>  decodeString(const Data& in, size_t& indexInOut) {
     const auto lenTup = decodeVarInt(in, indexInOut);
     if (!get<0>(lenTup)) { return make_tuple(false, ""); }

--- a/src/BinaryCoding.h
+++ b/src/BinaryCoding.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <tuple>
 #include <vector>
+#include <string_view>
 
 namespace TW {
 
@@ -106,9 +107,9 @@ void encode64BE(uint64_t val, std::vector<uint8_t>& data);
 uint64_t decode64BE(const uint8_t* _Nonnull src);
 
 /// Encodes an ASCII string prefixed by the length (varInt)
-void encodeString(const std::string& str, std::vector<uint8_t>& data);
+void encodeString(std::string_view str, std::vector<uint8_t>& data);
 
-/// Decodes an ASCII string prefixed by its length (varInt) 
+/// Decodes an ASCII string prefixed by its length (varInt)
 /// \returns a tuple with a success indicator and the decoded string.
 std::tuple<bool, std::string> decodeString(const Data& in, size_t& indexInOut);
 

--- a/src/Cbor.cpp
+++ b/src/Cbor.cpp
@@ -34,7 +34,7 @@ Encode Encode::negInt(uint64_t value) {
     return Encode().appendValue(Decode::MT_negint, value - 1);
 }
 
-Encode Encode::string(const std::string& str) {
+Encode Encode::string(std::string_view str) {
     return Encode().appendValue(Decode::MT_string, str.size()).append(TW::data(str));
 }
 
@@ -251,7 +251,7 @@ uint64_t Decode::getValue() const {
 
 std::string Decode::getString() const {
     Data strData = getBytes();
-    return std::string((const char*)strData.data(), strData.size()); 
+    return std::string((const char*)strData.data(), strData.size());
 }
 
 Data Decode::getBytes() const {
@@ -264,7 +264,7 @@ Data Decode::getBytes() const {
         throw std::invalid_argument("CBOR bytes/string data too short");
     }
     assert(subStart + typeDesc.byteCount + len <= data->origData.size());
-    return TW::data(data->origData.data() + (subStart + typeDesc.byteCount), len); 
+    return TW::data(data->origData.data() + (subStart + typeDesc.byteCount), len);
 }
 
 bool Decode::isBreak() const {

--- a/src/Cbor.h
+++ b/src/Cbor.h
@@ -10,6 +10,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <memory>
 #include <vector>
 #include <map>
@@ -34,7 +35,7 @@ public:
     /// encode a negative int (positive is given)
     static Encode negInt(uint64_t value);
     /// encode a string
-    static Encode string(const std::string& str);
+    static Encode string(std::string_view str);
     /// encode a byte array
     static Encode bytes(const Data& str);
     /// encode an array of elements (of different types)
@@ -118,7 +119,7 @@ public: // decoding
         MT_tag = 6,
         MT_special = 7,
     };
-    
+
 private:
     /// Struct used to keep reference to original data
     struct OrigDataRef {

--- a/src/Coin.cpp
+++ b/src/Coin.cpp
@@ -179,14 +179,14 @@ const Derivation CoinInfo::derivationByName(TWDerivation nameIn) const {
     return Derivation();
 }
 
-bool TW::validateAddress(TWCoinType coin, const string& address, const PrefixVariant& prefix) {
+bool TW::validateAddress(TWCoinType coin, std::string_view address, const PrefixVariant& prefix) {
     // dispatch
     auto* dispatcher = coinDispatcher(coin);
     assert(dispatcher != nullptr);
     return dispatcher->validateAddress(coin, address, prefix);
 }
 
-bool TW::validateAddress(TWCoinType coin, const std::string& string) {
+bool TW::validateAddress(TWCoinType coin, std::string_view string) {
     const auto* hrp = stringForHRP(TW::hrp(coin));
     auto p2pkh = TW::p2pkhPrefix(coin);
     auto p2sh = TW::p2shPrefix(coin);
@@ -211,7 +211,7 @@ bool TW::validateAddress(TWCoinType coin, const std::string& string) {
 }
 
 namespace TW::internal {
-    inline std::string normalizeAddress(TWCoinType coin, const string& address) {
+    inline std::string normalizeAddress(TWCoinType coin, std::string_view address) {
         // dispatch
         auto* dispatcher = coinDispatcher(coin);
         assert(dispatcher != nullptr);
@@ -219,7 +219,7 @@ namespace TW::internal {
     }
 }
 
-std::string TW::normalizeAddress(TWCoinType coin, const string& address) {;
+std::string TW::normalizeAddress(TWCoinType coin, std::string_view address) {;
     if (!TW::validateAddress(coin, address)) {
         // invalid address, not normalizing
         return "";
@@ -228,7 +228,7 @@ std::string TW::normalizeAddress(TWCoinType coin, const string& address) {;
     return internal::normalizeAddress(coin, address);
 }
 
-std::string TW::normalizeAddress(TWCoinType coin, const std::string& address, const PrefixVariant& prefix) {
+std::string TW::normalizeAddress(TWCoinType coin, std::string_view address, const PrefixVariant& prefix) {
     if (!TW::validateAddress(coin, address, prefix)) {
         // invalid address, not normalizing
         return "";
@@ -252,7 +252,7 @@ std::string TW::deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDer
     return dispatcher->deriveAddress(coin, publicKey, derivation, addressPrefix);
 }
 
-Data TW::addressToData(TWCoinType coin, const std::string& address) {
+Data TW::addressToData(TWCoinType coin, std::string_view address) {
     const auto* dispatcher = coinDispatcher(coin);
     assert(dispatcher != nullptr);
     return dispatcher->addressToData(coin, address);
@@ -264,7 +264,7 @@ void TW::anyCoinSign(TWCoinType coinType, const Data& dataIn, Data& dataOut) {
     dispatcher->sign(coinType, dataIn, dataOut);
 }
 
-std::string TW::anySignJSON(TWCoinType coinType, const std::string& json, const Data& key) {
+std::string TW::anySignJSON(TWCoinType coinType, std::string_view json, const Data& key) {
     auto* dispatcher = coinDispatcher(coinType);
     assert(dispatcher != nullptr);
     return dispatcher->signJSON(coinType, json, key);
@@ -294,7 +294,7 @@ void TW::anyCoinCompileWithSignatures(TWCoinType coinType, const Data& txInputDa
     dispatcher->compile(coinType, txInputData, signatures, publicKeys, txOutputOut);
 }
 
-Data TW::anyCoinBuildTransactionInput(TWCoinType coinType, const std::string& from, const std::string& to, const uint256_t& amount, const std::string& asset, const std::string& memo, const std::string& chainId) {
+Data TW::anyCoinBuildTransactionInput(TWCoinType coinType, std::string_view from, std::string_view to, const uint256_t& amount, std::string_view asset, std::string_view memo, std::string_view chainId) {
     auto* dispatcher = coinDispatcher(coinType);
     assert(dispatcher != nullptr);
     return dispatcher->buildTransactionInput(coinType, from, to, amount, asset, memo, chainId);

--- a/src/Coin.h
+++ b/src/Coin.h
@@ -22,6 +22,7 @@
 #include <TrustWalletCore/TWDerivation.h>
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace TW {
@@ -30,14 +31,14 @@ namespace TW {
 std::vector<TWCoinType> getCoinTypes();
 
 /// Validates an address for a particular coin.
-bool validateAddress(TWCoinType coin, const std::string& address);
+bool validateAddress(TWCoinType coin, std::string_view address);
 
 /// Validates an address for a particular coin.
-bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& prefix);
+bool validateAddress(TWCoinType coin, std::string_view address, const PrefixVariant& prefix);
 
 /// Validates and normalizes an address for a particular coin.
-std::string normalizeAddress(TWCoinType coin, const std::string& address);
-std::string normalizeAddress(TWCoinType coin, const std::string& address, const PrefixVariant& prefix);
+std::string normalizeAddress(TWCoinType coin, std::string_view address);
+std::string normalizeAddress(TWCoinType coin, std::string_view address, const PrefixVariant& prefix);
 
 /// Returns the blockchain for a coin type.
 TWBlockchain blockchain(TWCoinType coin);
@@ -82,7 +83,7 @@ std::string deriveAddress(TWCoinType coin, const PrivateKey& privateKey, TWDeriv
 std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation = TWDerivationDefault, const PrefixVariant& addressPrefix = std::monostate());
 
 /// Returns the binary representation of a string address
-Data addressToData(TWCoinType coin, const std::string& address);
+Data addressToData(TWCoinType coin, std::string_view address);
 
 /// Hasher for deriving the extended public key
 Hash::Hasher publicKeyHasher(TWCoinType coin);
@@ -116,7 +117,7 @@ void anyCoinSign(TWCoinType coinType, const Data& dataIn, Data& dataOut);
 
 uint32_t slip44Id(TWCoinType coin);
 
-std::string anySignJSON(TWCoinType coinType, const std::string& json, const Data& key);
+std::string anySignJSON(TWCoinType coinType, std::string_view json, const Data& key);
 
 bool supportsJSONSigning(TWCoinType coinType);
 
@@ -126,7 +127,7 @@ Data anyCoinPreImageHashes(TWCoinType coinType, const Data& txInputData);
 
 void anyCoinCompileWithSignatures(TWCoinType coinType, const Data& txInputData, const std::vector<Data>& signatures, const std::vector<PublicKey>& publicKeys, Data& txOutputOut);
 
-Data anyCoinBuildTransactionInput(TWCoinType coinType, const std::string& from, const std::string& to, const uint256_t& amount, const std::string& asset, const std::string& memo, const std::string& chainId);
+Data anyCoinBuildTransactionInput(TWCoinType coinType, std::string_view from, std::string_view to, const uint256_t& amount, std::string_view asset, std::string_view memo, std::string_view chainId);
 
 // Describes a derivation: path + optional format + optional name
 struct Derivation {

--- a/src/Data.h
+++ b/src/Data.h
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <vector>
 #include <string>
+#include <string_view>
 #include <array>
 
 namespace TW {
@@ -20,7 +21,7 @@ inline void pad_left(Data& data, const uint32_t size) {
     data.insert(data.begin(), size - data.size(), 0);
 }
 
-inline Data data(const std::string& data) {
+inline Data data(std::string_view data) {
     return Data(data.begin(), data.end());
 }
 

--- a/src/Data.h
+++ b/src/Data.h
@@ -22,11 +22,11 @@ inline void pad_left(Data& data, const uint32_t size) {
 }
 
 inline Data data(std::string_view data) {
-    return Data(data.begin(), data.end());
+    return Data{data.begin(), data.end()};
 }
 
 inline Data data(const byte* data, size_t size) {
-    return Data(data, data + size);
+    return Data{data, data + size};
 }
 
 inline void append(Data& data, const Data& suffix) {

--- a/src/DerivationPath.cpp
+++ b/src/DerivationPath.cpp
@@ -11,7 +11,7 @@
 
 using namespace TW;
 
-DerivationPath::DerivationPath(const std::string& string) {
+DerivationPath::DerivationPath(std::string_view string) {
     const auto* it = string.data();
     const auto* end = string.data() + string.size();
 

--- a/src/DerivationPath.h
+++ b/src/DerivationPath.h
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <initializer_list>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace TW {
@@ -137,7 +138,7 @@ struct DerivationPath {
     ///
     /// \throws std::invalid_argument if the string is not a valid derivation
     /// path.
-    explicit DerivationPath(const std::string& string);
+    explicit DerivationPath(std::string_view string);
 
     /// String representation.
     std::string string() const noexcept;

--- a/src/HDWallet.cpp
+++ b/src/HDWallet.cpp
@@ -34,7 +34,7 @@ namespace {
 
 uint32_t fingerprint(HDNode* node, Hash::Hasher hasher);
 std::string serialize(const HDNode* node, uint32_t fingerprint, uint32_t version, bool use_public, Hash::Hasher hasher);
-bool deserialize(const std::string& extended, TWCurve curve, Hash::Hasher hasher, HDNode* node);
+bool deserialize(std::string_view extended, TWCurve curve, Hash::Hasher hasher, HDNode* node);
 const char* curveName(TWCurve curve);
 } // namespace
 
@@ -62,7 +62,7 @@ void HDWallet<seedSize>::updateSeedAndEntropy(bool check) {
 }
 
 template <std::size_t seedSize>
-HDWallet<seedSize>::HDWallet(int strength, const std::string& passphrase)
+HDWallet<seedSize>::HDWallet(int strength, std::string_view passphrase)
     : passphrase(passphrase) {
     char buf[MnemonicBufLength];
     const char* mnemonic_chars = mnemonic_generate(strength, buf, MnemonicBufLength);
@@ -75,7 +75,7 @@ HDWallet<seedSize>::HDWallet(int strength, const std::string& passphrase)
 }
 
 template <std::size_t seedSize>
-HDWallet<seedSize>::HDWallet(const std::string& mnemonic, const std::string& passphrase, const bool check)
+HDWallet<seedSize>::HDWallet(std::string_view mnemonic, std::string_view passphrase, const bool check)
     : mnemonic(mnemonic), passphrase(passphrase) {
     if (mnemonic.length() == 0 ||
         (check && !Mnemonic::isValid(mnemonic))) {
@@ -85,7 +85,7 @@ HDWallet<seedSize>::HDWallet(const std::string& mnemonic, const std::string& pas
 }
 
 template <std::size_t seedSize>
-HDWallet<seedSize>::HDWallet(const Data& entropy, const std::string& passphrase)
+HDWallet<seedSize>::HDWallet(const Data& entropy, std::string_view passphrase)
     : passphrase(passphrase) {
     char buf[MnemonicBufLength];
     const char* mnemonic_chars = mnemonic_from_data(entropy.data(), static_cast<int>(entropy.size()), buf, MnemonicBufLength);
@@ -266,7 +266,7 @@ std::string HDWallet<seedSize>::getExtendedPublicKeyAccount(TWPurpose purpose, T
 }
 
 template <std::size_t seedSize>
-std::optional<PublicKey> HDWallet<seedSize>::getPublicKeyFromExtended(const std::string& extended, TWCoinType coin, const DerivationPath& path) {
+std::optional<PublicKey> HDWallet<seedSize>::getPublicKeyFromExtended(std::string_view extended, TWCoinType coin, const DerivationPath& path) {
     const auto curve = TW::curve(coin);
     const auto hasher = TW::base58Hasher(coin);
 
@@ -303,7 +303,7 @@ std::optional<PublicKey> HDWallet<seedSize>::getPublicKeyFromExtended(const std:
 }
 
 template <std::size_t seedSize>
-std::optional<PrivateKey> HDWallet<seedSize>::getPrivateKeyFromExtended(const std::string& extended, TWCoinType coin, const DerivationPath& path) {
+std::optional<PrivateKey> HDWallet<seedSize>::getPrivateKeyFromExtended(std::string_view extended, TWCoinType coin, const DerivationPath& path) {
     const auto curve = TW::curve(coin);
     const auto hasher = TW::base58Hasher(coin);
 
@@ -351,7 +351,7 @@ std::string serialize(const HDNode* node, uint32_t fingerprint, uint32_t version
     return Base58::bitcoin.encodeCheck(node_data, hasher);
 }
 
-bool deserialize(const std::string& extended, TWCurve curve, Hash::Hasher hasher, HDNode* node) {
+bool deserialize(std::string_view extended, TWCurve curve, Hash::Hasher hasher, HDNode* node) {
     TW::memzero(node);
     const char* curveNameStr = curveName(curve);
     if (curveNameStr == nullptr || std::string(curveNameStr).empty()) {

--- a/src/HDWallet.h
+++ b/src/HDWallet.h
@@ -21,6 +21,7 @@
 #include <array>
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace TW {
 
@@ -46,25 +47,25 @@ class HDWallet {
 
 public:
     const std::array<byte, seedSize>& getSeed() const { return seed; }
-    const std::string& getMnemonic() const { return mnemonic; }
-    const std::string& getPassphrase() const { return passphrase; }
+	std::string_view getMnemonic() const { return mnemonic; }
+    std::string_view getPassphrase() const { return passphrase; }
     const TW::Data& getEntropy() const { return entropy; }
 
   public:
     /// Initializes an HDWallet from given seed.
     HDWallet(const Data& seed);
 
-    /// Initializes a new random HDWallet with the provided strength in bits.  
+    /// Initializes a new random HDWallet with the provided strength in bits.
     /// Throws on invalid strength.
-    HDWallet(int strength, const std::string& passphrase);
+    HDWallet(int strength, std::string_view passphrase);
 
     /// Initializes an HDWallet from a BIP39 mnemonic and a passphrase, check English dict by default.
     /// Throws on invalid mnemonic.
-    HDWallet(const std::string& mnemonic, const std::string& passphrase, const bool check = true);
+    HDWallet(std::string_view mnemonic, std::string_view passphrase, const bool check = true);
 
     /// Initializes an HDWallet from an entropy.
     /// Throws on invalid data.
-    HDWallet(const Data& entropy, const std::string& passphrase);
+    HDWallet(const Data& entropy, std::string_view passphrase);
 
     HDWallet(const HDWallet& other) = default;
     HDWallet(HDWallet&& other) = default;
@@ -124,10 +125,10 @@ public:
     std::string getRootKey(TWCoinType coin, TWHDVersion version) const;
 
     /// Computes the public key from an extended public key representation.
-    static std::optional<PublicKey> getPublicKeyFromExtended(const std::string& extended, TWCoinType coin, const DerivationPath& path);
+    static std::optional<PublicKey> getPublicKeyFromExtended(std::string_view extended, TWCoinType coin, const DerivationPath& path);
 
     /// Computes the private key from an extended private key representation.
-    static std::optional<PrivateKey> getPrivateKeyFromExtended(const std::string& extended, TWCoinType coin, const DerivationPath& path);
+    static std::optional<PrivateKey> getPrivateKeyFromExtended(std::string_view extended, TWCoinType coin, const DerivationPath& path);
 
     /// Derive the given seed for the given coin, with the given Derivation path
     /// \param coin Coin to be used in order to retrieve the curve type

--- a/src/HexCoding.h
+++ b/src/HexCoding.h
@@ -13,11 +13,12 @@
 #include <array>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <tuple>
 
 namespace TW {
 
-inline bool is_hex_encoded(const std::string& s)
+inline bool is_hex_encoded(std::string_view s)
 {
     bool with_0x = s.compare(0, 2, "0x") == 0
            && s.size() > 2
@@ -91,9 +92,9 @@ inline Data parse_hex(const Iter begin, const Iter end) {
 ///
 /// \returns the array or parsed bytes or an empty array if the string is not
 /// valid hexadecimal.
-inline Data parse_hex(const std::string& string, bool padLeft = false) {
+inline Data parse_hex(std::string_view string, bool padLeft = false) {
     if (string.size() % 2 != 0 && padLeft) {
-        std::string temp = string;
+        std::string temp{string};
         if (temp.compare(0, 2, "0x") == 0) {
             temp.erase(0, 2);
         }
@@ -142,7 +143,7 @@ inline const char* hex_char_to_bin(char c) {
     }
 }
 
-inline std::string hex_str_to_bin_str(const std::string& hex) {
+inline std::string hex_str_to_bin_str(std::string_view hex) {
     std::stringstream ss;
     for (auto&& c: hex) {
         ss << hex_char_to_bin(c);

--- a/src/Mnemonic.cpp
+++ b/src/Mnemonic.cpp
@@ -25,8 +25,8 @@ bool Mnemonic::isValid(const std::string& mnemonic) {
 
 inline const char* const* mnemonicWordlist() { return wordlist; }
 
-bool Mnemonic::isValidWord(const std::string& word) {
-    const char* wordC = word.c_str();
+bool Mnemonic::isValidWord(std::string_view word) {
+    const char* wordC = word.data();
     const auto len = word.length();
     // Although this operation is not security-critical, we aim for constant-time operation here as well
     // (i.e., no early exit on match)
@@ -39,7 +39,7 @@ bool Mnemonic::isValidWord(const std::string& word) {
     return found;
 }
 
-std::string Mnemonic::suggest(const std::string& prefix) {
+std::string Mnemonic::suggest(std::string_view prefix) {
     if (prefix.size() == 0) {
         return "";
     }

--- a/src/Mnemonic.h
+++ b/src/Mnemonic.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 namespace TW {
 
@@ -23,7 +24,7 @@ public:
     static bool isValid(const std::string& mnemonic);
 
     /// Determines whether word is a valid BIP39 English menemonic word.
-    static bool isValidWord(const std::string& word);
+    static bool isValidWord(std::string_view word);
 
     /// Return BIP39 English words that match the given prefix.
     // - A single string is returned, with space-separated list of words (or single word or empty string)
@@ -38,7 +39,7 @@ public:
     // - 'ai' -> 'aim air airport aisle'
     // - 'an' -> 'analyst anchor ancient anger angle angry animal ankle announce annual'
     // - 'a'-> 'abandon ability able about above absent absorb abstract absurd abuse'
-    static std::string suggest(const std::string& prefix);
+    static std::string suggest(std::string_view prefix);
 
     static const int SuggestMaxCount;
 };

--- a/src/PrivateKey.h
+++ b/src/PrivateKey.h
@@ -11,6 +11,7 @@
 
 #include <TrustWalletCore/TWPrivateKeyType.h>
 #include <TrustWalletCore/TWCurve.h>
+#include <string_view>
 
 namespace TW {
 
@@ -47,7 +48,7 @@ class PrivateKey {
     explicit PrivateKey(const Data& data);
 
     /// Initializes a private key from a string of bytes.
-    explicit PrivateKey(const std::string& data) : PrivateKey(TW::data(data)) {}
+    explicit PrivateKey(std::string_view data) : PrivateKey(TW::data(data)) {}
 
     /// Initializes a Cardano style key
     explicit PrivateKey(

--- a/src/TransactionCompiler.cpp
+++ b/src/TransactionCompiler.cpp
@@ -11,7 +11,7 @@
 using namespace TW;
 
 
-Data TransactionCompiler::buildInput(TWCoinType coinType, const std::string& from, const std::string& to, const std::string& amount, const std::string& asset, const std::string& memo, const std::string& chainId) {
+Data TransactionCompiler::buildInput(TWCoinType coinType, std::string_view from, std::string_view to, std::string_view amount, std::string_view asset, std::string_view memo, std::string_view chainId) {
     // parse amount
     uint256_t amount256 { amount };
     return anyCoinBuildTransactionInput(coinType, from, to, amount256, asset, memo, chainId);

--- a/src/TransactionCompiler.h
+++ b/src/TransactionCompiler.h
@@ -11,6 +11,7 @@
 #include "CoinEntry.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace TW {
@@ -19,9 +20,9 @@ namespace TW {
 class TransactionCompiler {
 public:
     /// Build a coin-specific SigningInput protobuf transaction input, from simple transaction parameters
-    static Data buildInput(TWCoinType coinType, const std::string& from, const std::string& to, const std::string& amount, const std::string& asset, const std::string& memo, const std::string& chainId);
+    static Data buildInput(TWCoinType coinType, std::string_view from, std::string_view to, std::string_view amount, std::string_view asset, std::string_view memo, std::string_view chainId);
 
-    /// Obtain pre-signing hash of a transaction. 
+    /// Obtain pre-signing hash of a transaction.
     /// It will return a proto object named `PreSigningOutput` which will include hash.
     /// We provide a default `PreSigningOutput` in TransactionCompiler.proto.
     /// For some special coins, such as bitcoin, we will create a custom `PreSigningOutput` object in its proto file.

--- a/src/interface/TWHDWallet.cpp
+++ b/src/interface/TWHDWallet.cpp
@@ -55,7 +55,7 @@ TWData *_Nonnull TWHDWalletSeed(struct TWHDWallet *_Nonnull wallet) {
 }
 
 TWString *_Nonnull TWHDWalletMnemonic(struct TWHDWallet *_Nonnull wallet){
-    return TWStringCreateWithUTF8Bytes(wallet->impl.getMnemonic().c_str());
+    return TWStringCreateWithUTF8Bytes(wallet->impl.getMnemonic().data());
 }
 
 TWData *_Nonnull TWHDWalletEntropy(struct TWHDWallet *_Nonnull wallet) {
@@ -78,7 +78,7 @@ TWString *_Nonnull TWHDWalletGetAddressDerivation(struct TWHDWallet *wallet, TWC
     auto derivationPath = TW::derivationPath(coin, derivation);
     PrivateKey privateKey = wallet->impl.getKey(coin, derivationPath);
     std::string address = deriveAddress(coin, privateKey, derivation);
-    return TWStringCreateWithUTF8Bytes(address.c_str());
+    return TWStringCreateWithUTF8Bytes(address.data());
 }
 
 struct TWPrivateKey *_Nonnull TWHDWalletGetKey(struct TWHDWallet *_Nonnull wallet, enum TWCoinType coin, TWString *_Nonnull derivationPath) {

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -10,6 +10,7 @@
 
 #include <boost/lexical_cast.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
+#include <string_view>
 
 namespace TW {
 
@@ -44,7 +45,7 @@ inline uint256_t loadWithOffset(const Data& data, size_t offset) {
 
 /// Loads a `uint256_t` from Protobuf bytes (which are wrongly represented as
 /// std::string).
-inline uint256_t load(const std::string& data) {
+inline uint256_t load(std::string_view data) {
     using boost::multiprecision::cpp_int;
     if (data.empty()) {
         return uint256_t(0);

--- a/trezor-crypto/crypto/sha2.c
+++ b/trezor-crypto/crypto/sha2.c
@@ -589,7 +589,7 @@ void sha1_Update(SHA1_CTX* context, const sha2_byte *data, size_t len) {
 	usedspace = freespace = 0;
 }
 
-void sha1_Final(SHA1_CTX* context, sha2_byte digest[]) {
+void sha1_Final(SHA1_CTX* context, sha2_byte digest[SHA1_DIGEST_LENGTH]) {
 	unsigned int	usedspace = 0;
 
 	/* If no digest buffer is passed, we don't bother doing this: */
@@ -896,7 +896,7 @@ void sha256_Update(SHA256_CTX* context, const sha2_byte *data, size_t len) {
 	usedspace = freespace = 0;
 }
 
-void sha256_Final(SHA256_CTX* context, sha2_byte digest[]) {
+void sha256_Final(SHA256_CTX* context, sha2_byte digest[SHA256_DIGEST_LENGTH]) {
 	unsigned int	usedspace = 0;
 
 	/* If no digest buffer is passed, we don't bother doing this: */
@@ -1250,7 +1250,7 @@ static void sha512_Last(SHA512_CTX* context) {
 	sha512_Transform(context->state, context->buffer, context->state);
 }
 
-void sha512_Final(SHA512_CTX* context, sha2_byte digest[]) {
+void sha512_Final(SHA512_CTX* context, sha2_byte digest[SHA512_DIGEST_LENGTH]) {
 	/* If no digest buffer is passed, we don't bother doing this: */
 	if (digest != (sha2_byte*)0) {
 		sha512_Last(context);


### PR DESCRIPTION
## Description

`const std::string&` is aka `const char*&`, is an extra level of transition on the pointer.
`std::string_view` aka `const char*` solves that trouble.

## How to test
it is described in the standard с++17 and later.

## Types of changes
replace `const std::string&` to `std::string_view` in the function arguments.
