### PR TITLE
[Kotlin] Removed :generateCinterop task

### DIFF
--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -1,5 +1,3 @@
 ### Tasks:
 
 - `./gradlew :wallet-core-kotlin:generateProtos` – Generates Kotlin classes for Protos
-- `./gradlew :wallet-core-kotlin:generateCinterop` – Generates def file
-- `./gradlew :wallet-core-kotlin:generateFiles` – Generates all the above and Kotlin accessors to the library

--- a/kotlin/build-logic/src/main/kotlin/convention.proto-generation.gradle.kts
+++ b/kotlin/build-logic/src/main/kotlin/convention.proto-generation.gradle.kts
@@ -1,27 +1,5 @@
 val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 
-val generateCinteropTask = task("generateCinterop") {
-    doFirst {
-        val headersDir = rootDir.parentFile.resolve("include/TrustWalletCore")
-        val headers = headersDir
-            .listFiles { file -> file.extension == "h" }
-            .orEmpty()
-            .sortedBy { it.name }
-            .joinToString(separator = " ") { it.name }
-
-        val defFile = projectDir.resolve("src/nativeInterop/cinterop/walletCore.def")
-        defFile.parentFile.mkdirs()
-        defFile.writeText(
-            text =
-            """
-                headers = $headers
-                package = com.trustwallet.core
-
-            """.trimIndent(),
-        )
-    }
-}
-
 val copyProtoTask = task<Copy>("copyProtos") {
     val sourceDir = rootDir.parentFile.resolve("src/proto")
     val destinationDir = projectDir.resolve("build/tmp/proto")
@@ -75,12 +53,4 @@ val generateProtosTask = task<JavaExec>("generateProtos") {
         "--proto_path=$sourceDir",
         "--kotlin_out=$destinationDir",
     )
-}
-
-task<Exec>("generateFiles") {
-    dependsOn(generateCinteropTask)
-    dependsOn(generateProtosTask)
-
-    workingDir(rootDir.parentFile)
-    commandLine("./codegen/bin/codegen")
 }

--- a/kotlin/wallet-core-kotlin/.gitignore
+++ b/kotlin/wallet-core-kotlin/.gitignore
@@ -1,3 +1,2 @@
 /src/**/generated/
 /src/**/proto/
-/src/nativeInterop/

--- a/kotlin/wallet-core-kotlin/build.gradle.kts
+++ b/kotlin/wallet-core-kotlin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     kotlin("multiplatform")
     id("com.android.library")
     id("convention.maven-publish")
-    id("convention.file-generation")
+    id("convention.proto-generation")
 }
 
 kotlin {
@@ -71,8 +71,9 @@ kotlin {
     nativeTargets.forEach { nativeTarget ->
         nativeTarget.apply {
             val main by compilations.getting
-            val walletCore by main.cinterops.creating {
-                includeDirs.allHeaders(rootDir.parentFile.resolve("include/TrustWalletCore"))
+            main.cinterops.create("WalletCore") {
+                packageName = "com.trustwallet.core"
+                headers(rootDir.parentFile.resolve("include/TrustWalletCore").listFiles()!!)
             }
         }
     }

--- a/tools/kotlin-build
+++ b/tools/kotlin-build
@@ -3,6 +3,6 @@
 set -e
 
 pushd kotlin
-./gradlew :wallet-core-kotlin:generateFiles
+./gradlew :wallet-core-kotlin:generateProtos
 ./gradlew :wallet-core-kotlin:assemble
 popd

--- a/tools/kotlin-release
+++ b/tools/kotlin-release
@@ -10,7 +10,7 @@ echo "Building $version"
 export ANDROID_HOME="$HOME/Library/Android/sdk"
 
 pushd kotlin
-./gradlew :wallet-core-kotlin:generateFiles
+./gradlew :wallet-core-kotlin:generateProtos
 ./gradlew :wallet-core-kotlin:assemble :wallet-core-kotlin:publish -Pversion="$version"
 popd
 


### PR DESCRIPTION
## Description

- Remove :generateCinterop task
- Leave WalletCore.def file empty
- Specify all C interop stuff in build.gradle.kts
