### PR TITLE
Update name for ThunderCore

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
@@ -53,7 +53,7 @@ class CoinAddressDerivationTests {
         POANETWORK -> assertEquals("0xe8a3e8bE17E172B6926130eAfB521e9D2849aca9", address)
         XRP -> assertEquals("rPwE3gChNKtZ1mhH3Ko8YFGqKmGRWLWXV3", address)
         TEZOS -> assertEquals("tz1acnY9VbMagps26Kj3RfoGRWD9nYG5qaRX", address)
-        THUNDERTOKEN -> assertEquals("0x4b92b3ED6d8b24575Bf5ce4C6a86ED261DA0C8d7", address)
+        THUNDERCORE -> assertEquals("0x4b92b3ED6d8b24575Bf5ce4C6a86ED261DA0C8d7", address)
         TOMOCHAIN -> assertEquals("0xC74b6D8897cBa9A4b659d43fEF73C9cA852cE424", address)
         TRON -> assertEquals("TQ5NMqJjhpQGK7YJbESKtNCo86PJ89ujio", address)
         VECHAIN -> assertEquals("0x1a553275dF34195eAf23942CB7328AcF9d48c160", address)

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/TestCoinType.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/TestCoinType.kt
@@ -21,7 +21,7 @@ class TestCoinType {
         assertEquals(CoinType.LITECOIN.value(), 2)
         assertEquals(CoinType.TRON.value(), 195)
         assertEquals(CoinType.ETHEREUM.value(), 60)
-        assertEquals(CoinType.THUNDERTOKEN.value(), 1001)
+        assertEquals(CoinType.THUNDERCORE.value(), 1001)
         assertEquals(CoinType.WANCHAIN.value(), 5718350)
         assertEquals(CoinType.CALLISTO.value(), 820)
         assertEquals(CoinType.ETHEREUMCLASSIC.value(), 61)

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -64,7 +64,7 @@ This list is generated from [./registry.json](../registry.json)
 | 931     | THORChain        | RUNE   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/thorchain/info/logo.png" width="32" />    | <https://thorchain.org>       |
 | 966     | Polygon          | MATIC  | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/info/logo.png" width="32" />      | <https://polygon.technology>  |
 | 996     | OKX Chain        | OKT    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/okc/info/logo.png" width="32" />          | <https://www.okx.com/okc>     |
-| 1001    | ThunderCore    | TT     | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/thundertoken/info/logo.png" width="32" /> | <https://thundercore.com>     |
+| 1001    | ThunderCore      | TT     | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/thundertoken/info/logo.png" width="32" /> | <https://thundercore.com>     |
 | 1023    | Harmony          | ONE    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/harmony/info/logo.png" width="32" />      | <https://harmony.one>         |
 | 1024    | Ontology         | ONT    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ontology/info/logo.png" width="32" />     | <https://ont.io>              |
 | 1729    | Tezos            | XTZ    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tezos/info/logo.png" width="32" />        | <https://tezos.com>           |

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -64,7 +64,7 @@ This list is generated from [./registry.json](../registry.json)
 | 931     | THORChain        | RUNE   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/thorchain/info/logo.png" width="32" />    | <https://thorchain.org>       |
 | 966     | Polygon          | MATIC  | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polygon/info/logo.png" width="32" />      | <https://polygon.technology>  |
 | 996     | OKX Chain        | OKT    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/okc/info/logo.png" width="32" />          | <https://www.okx.com/okc>     |
-| 1001    | Thunder Token    | TT     | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/thundertoken/info/logo.png" width="32" /> | <https://thundercore.com>     |
+| 1001    | ThunderCore    | TT     | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/thundertoken/info/logo.png" width="32" /> | <https://thundercore.com>     |
 | 1023    | Harmony          | ONE    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/harmony/info/logo.png" width="32" />      | <https://harmony.one>         |
 | 1024    | Ontology         | ONT    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ontology/info/logo.png" width="32" />     | <https://ont.io>              |
 | 1729    | Tezos            | XTZ    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tezos/info/logo.png" width="32" />        | <https://tezos.com>           |

--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -68,7 +68,7 @@ enum TWCoinType {
     TWCoinTypeStellar = 148,
     TWCoinTypeTezos = 1729,
     TWCoinTypeTheta = 500,
-    TWCoinTypeThunderToken = 1001,
+    TWCoinTypeThunderCore = 1001,
     TWCoinTypeNEO = 888,
     TWCoinTypeTomoChain = 889,
     TWCoinTypeTron = 195,

--- a/registry.json
+++ b/registry.json
@@ -1574,7 +1574,7 @@
   },
   {
     "id": "thundertoken",
-    "name": "Thunder Token",
+    "name": "ThunderCore",
     "coinId": 1001,
     "symbol": "TT",
     "decimals": 18,

--- a/swift/Tests/Blockchains/RippleTests.swift
+++ b/swift/Tests/Blockchains/RippleTests.swift
@@ -55,7 +55,7 @@ class RippleTests: XCTestCase {
             $0.lastLedgerSequence = 32268269
             $0.account = "rfxdLwsZnoespnTDDb1Xhvbc8EFNdztaoq"
             $0.privateKey = Data(hexString: "a5576c0f63da10e584568c8d134569ff44017b0a249eb70657127ae04f38cc77")!
-            $0.opPayment = operation
+            $0.opPayment = operation2
         }
         let output2: RippleSigningOutput = AnySigner.sign(input: input2, coin: .xrp)
         XCTAssertEqual(output2.encoded, output.encoded)

--- a/swift/Tests/CoinAddressDerivationTests.swift
+++ b/swift/Tests/CoinAddressDerivationTests.swift
@@ -190,7 +190,7 @@ class CoinAddressDerivationTests: XCTestCase {
                 case .theta:
                     let expectedResult = "0x0d1fa20c218Fec2f2C55d52aB267940485fa5DA4"
                     assertCoinDerivation(coin, expectedResult, derivedAddress, address)
-                case .thunderToken:
+                case .thunderCore:
                     let expectedResult = "0x4b92b3ED6d8b24575Bf5ce4C6a86ED261DA0C8d7"
                     assertCoinDerivation(coin, expectedResult, derivedAddress, address)
                 case .tomoChain:

--- a/swift/Tests/CoinTypeTests.swift
+++ b/swift/Tests/CoinTypeTests.swift
@@ -14,7 +14,7 @@ class CoinTypeTests: XCTestCase {
         XCTAssertEqual(CoinType.litecoin.rawValue, 2)
         XCTAssertEqual(CoinType.tron.rawValue, 195)
         XCTAssertEqual(CoinType.ethereum.rawValue, 60)
-        XCTAssertEqual(CoinType.thunderToken.rawValue, 1001)
+        XCTAssertEqual(CoinType.thunderCore.rawValue, 1001)
         XCTAssertEqual(CoinType.wanchain.rawValue, 5718350)
         XCTAssertEqual(CoinType.callisto.rawValue, 820)
         XCTAssertEqual(CoinType.ethereumClassic.rawValue, 61)

--- a/tests/chains/ThunderToken/TWCoinTypeTests.cpp
+++ b/tests/chains/ThunderToken/TWCoinTypeTests.cpp
@@ -30,5 +30,5 @@ TEST(TWThunderTokenCoinType, TWCoinType) {
     assertStringsEqual(txUrl, "https://scan.thundercore.com/transactions/t123");
     assertStringsEqual(accUrl, "https://scan.thundercore.com/address/a12");
     assertStringsEqual(id, "thundertoken");
-    assertStringsEqual(name, "Thunder Token");
+    assertStringsEqual(name, "ThunderCore");
 }

--- a/tests/chains/ThunderToken/TWCoinTypeTests.cpp
+++ b/tests/chains/ThunderToken/TWCoinTypeTests.cpp
@@ -14,18 +14,18 @@
 
 
 TEST(TWThunderTokenCoinType, TWCoinType) {
-    auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeThunderToken));
+    auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeThunderCore));
     auto txId = WRAPS(TWStringCreateWithUTF8Bytes("t123"));
-    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeThunderToken, txId.get()));
+    auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeThunderCore, txId.get()));
     auto accId = WRAPS(TWStringCreateWithUTF8Bytes("a12"));
-    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeThunderToken, accId.get()));
-    auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeThunderToken));
-    auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeThunderToken));
+    auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeThunderCore, accId.get()));
+    auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeThunderCore));
+    auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeThunderCore));
 
-    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeThunderToken), 18);
-    ASSERT_EQ(TWBlockchainEthereum, TWCoinTypeBlockchain(TWCoinTypeThunderToken));
-    ASSERT_EQ(0x0, TWCoinTypeP2shPrefix(TWCoinTypeThunderToken));
-    ASSERT_EQ(0x0, TWCoinTypeStaticPrefix(TWCoinTypeThunderToken));
+    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(TWCoinTypeThunderCore), 18);
+    ASSERT_EQ(TWBlockchainEthereum, TWCoinTypeBlockchain(TWCoinTypeThunderCore));
+    ASSERT_EQ(0x0, TWCoinTypeP2shPrefix(TWCoinTypeThunderCore));
+    ASSERT_EQ(0x0, TWCoinTypeStaticPrefix(TWCoinTypeThunderCore));
     assertStringsEqual(symbol, "TT");
     assertStringsEqual(txUrl, "https://scan.thundercore.com/transactions/t123");
     assertStringsEqual(accUrl, "https://scan.thundercore.com/address/a12");

--- a/tests/common/CoinAddressDerivationTests.cpp
+++ b/tests/common/CoinAddressDerivationTests.cpp
@@ -65,7 +65,7 @@ TEST(Coin, DeriveAddress) {
         case TWCoinTypeSmartChain:
         case TWCoinTypeSmartChainLegacy:
         case TWCoinTypeTheta:
-        case TWCoinTypeThunderToken:
+        case TWCoinTypeThunderCore:
         case TWCoinTypeTomoChain:
         case TWCoinTypeVeChain:
         case TWCoinTypeWanchain:

--- a/tests/interface/TWCoinTypeTests.cpp
+++ b/tests/interface/TWCoinTypeTests.cpp
@@ -55,7 +55,7 @@ TEST(TWCoinType, TWPurpose) {
     ASSERT_EQ(TWPurposeBIP44, TWCoinTypePurpose(TWCoinTypeStellar));
     ASSERT_EQ(TWPurposeBIP44, TWCoinTypePurpose(TWCoinTypeTezos));
     ASSERT_EQ(TWPurposeBIP44, TWCoinTypePurpose(TWCoinTypeTheta));
-    ASSERT_EQ(TWPurposeBIP44, TWCoinTypePurpose(TWCoinTypeThunderToken));
+    ASSERT_EQ(TWPurposeBIP44, TWCoinTypePurpose(TWCoinTypeThunderCore));
     ASSERT_EQ(TWPurposeBIP44, TWCoinTypePurpose(TWCoinTypeTomoChain));
     ASSERT_EQ(TWPurposeBIP44, TWCoinTypePurpose(TWCoinTypeTron));
     ASSERT_EQ(TWPurposeBIP44, TWCoinTypePurpose(TWCoinTypeVeChain));
@@ -127,7 +127,7 @@ TEST(TWCoinType, TWPublicKeyType) {
     ASSERT_EQ(TWPublicKeyTypeED25519, TWCoinTypePublicKeyType(TWCoinTypeStellar));
     ASSERT_EQ(TWPublicKeyTypeED25519, TWCoinTypePublicKeyType(TWCoinTypeTezos));
     ASSERT_EQ(TWPublicKeyTypeSECP256k1Extended, TWCoinTypePublicKeyType(TWCoinTypeTheta));
-    ASSERT_EQ(TWPublicKeyTypeSECP256k1Extended, TWCoinTypePublicKeyType(TWCoinTypeThunderToken));
+    ASSERT_EQ(TWPublicKeyTypeSECP256k1Extended, TWCoinTypePublicKeyType(TWCoinTypeThunderCore));
     ASSERT_EQ(TWPublicKeyTypeSECP256k1Extended, TWCoinTypePublicKeyType(TWCoinTypeTomoChain));
     ASSERT_EQ(TWPublicKeyTypeSECP256k1Extended, TWCoinTypePublicKeyType(TWCoinTypeTron));
     ASSERT_EQ(TWPublicKeyTypeSECP256k1Extended, TWCoinTypePublicKeyType(TWCoinTypeVeChain));

--- a/tests/interface/TWHRPTests.cpp
+++ b/tests/interface/TWHRPTests.cpp
@@ -112,7 +112,7 @@ TEST(TWHPR, HPRByCoinType) {
     ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeStellar));
     ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeTezos));
     ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeTheta));
-    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeThunderToken));
+    ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeThunderCore));
     ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeTomoChain));
     ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeTron));
     ASSERT_EQ(TWHRPUnknown, TWCoinTypeHRP(TWCoinTypeVeChain));


### PR DESCRIPTION
Replace https://github.com/trustwallet/wallet-core/pull/2926, so we have permission to fix mobile tests