### PR TITLE
[WASM] Export all Wallet Core classes

### DIFF
--- a/wasm/index.ts
+++ b/wasm/index.ts
@@ -5,11 +5,9 @@
 // file LICENSE at the root of the source code distribution tree.
 
 import * as Loader from "./lib/wallet-core";
-import { TW } from "./generated/core_proto";
 import { WalletCore } from "./src/wallet-core";
-import * as KeyStore from "./src/keystore";
 
-declare function load(): Promise<WalletCore>;
-
-export const initWasm: typeof load = Loader;
-export { TW, WalletCore, KeyStore };
+export const initWasm: () => Promise<WalletCore> = Loader;
+export { TW } from "./generated/core_proto";
+export * as KeyStore from "./src/keystore";
+export * from "./src/wallet-core";


### PR DESCRIPTION
## Description

Instead of importing classes like this:
```ts
import { Account, CoinType, HDWallet } from "@trustwallet/wallet-core/dist/src/wallet-core";
```

Now we can import it like normal:
```ts
import { Account, CoinType, HDWallet } from "@trustwallet/wallet-core";
```
