### PR TITLE
[Filecoin]: Support new f4 address types

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/filecoin/TestFilecoin.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/filecoin/TestFilecoin.kt
@@ -9,6 +9,7 @@ import wallet.core.java.AnySigner
 import wallet.core.jni.AnyAddress
 import wallet.core.jni.CoinType
 import wallet.core.jni.CoinType.FILECOIN
+import wallet.core.jni.FilecoinAddressConverter
 import wallet.core.jni.PrivateKey
 import wallet.core.jni.proto.Filecoin
 import wallet.core.jni.proto.Filecoin.SigningOutput
@@ -25,6 +26,15 @@ class TestFilecoin {
         val publicKey = privateKey.getPublicKeySecp256k1(false)
         val address = AnyAddress(publicKey, CoinType.FILECOIN)
         assertEquals("f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq", address.description())
+    }
+
+    @Test
+    fun testAddressConverter() {
+        val ethereumAddress = FilecoinAddressConverter.convertToEthereum("f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky")
+        assertEquals(ethereumAddress, "0x8dbD6c7Ede90646a61Bbc649831b7c298BFd37A0")
+
+        val filecoinAddress = FilecoinAddressConverter.convertFromEthereum("0x8dbD6c7Ede90646a61Bbc649831b7c298BFd37A0")
+        assertEquals(filecoinAddress, "f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky")
     }
 
     @Test

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/filecoin/TestFilecoin.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/filecoin/TestFilecoin.kt
@@ -10,6 +10,7 @@ import wallet.core.jni.AnyAddress
 import wallet.core.jni.CoinType
 import wallet.core.jni.CoinType.FILECOIN
 import wallet.core.jni.FilecoinAddressConverter
+import wallet.core.jni.FilecoinAddressType
 import wallet.core.jni.PrivateKey
 import wallet.core.jni.proto.Filecoin
 import wallet.core.jni.proto.Filecoin.SigningOutput
@@ -21,11 +22,19 @@ class TestFilecoin {
     }
 
     @Test
-    fun testAddress() {
+    fun testCreateAddress() {
         val privateKey = PrivateKey("1d969865e189957b9824bd34f26d5cbf357fda1a6d844cbf0c9ab1ed93fa7dbe".toHexByteArray())
         val publicKey = privateKey.getPublicKeySecp256k1(false)
         val address = AnyAddress(publicKey, CoinType.FILECOIN)
         assertEquals("f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq", address.description())
+    }
+
+    @Test
+    fun testCreateDelegatedAddress() {
+        val privateKey = PrivateKey("825d2bb32965764a98338139412c7591ed54c951dd65504cd8ddaeaa0fea7b2a".toHexByteArray())
+        val publicKey = privateKey.getPublicKeySecp256k1(false)
+        val address = AnyAddress(publicKey, FilecoinAddressType.DELEGATED)
+        assertEquals("f410fvak24cyg3saddajborn6idt7rrtfj2ptauk5pbq", address.description())
     }
 
     @Test

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/filecoin/TestFilecoin.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/filecoin/TestFilecoin.kt
@@ -51,7 +51,7 @@ class TestFilecoin {
             .build()
 
         val output = AnySigner.sign(input, CoinType.FILECOIN, SigningOutput.parser())
-        val expted = """{"Message":{"From":"f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq","GasFeeCap":"700000000000000000000","GasLimit":1000,"GasPremium":"800000000000000000000","Nonce":2,"To":"f3um6uo3qt5of54xjbx3hsxbw5mbsc6auxzrvfxekn5bv3duewqyn2tg5rhrlx73qahzzpkhuj7a34iq7oifsq","Value":"600000000000000000000"},"Signature":{"Data":"jMRu+OZ/lfppgmqSfGsntFrRLWZnUg3ZYmJTTRLsVt4V1310vR3VKGJpaE6S4sNvDOE6sEgmN9YmfTkPVK2qMgE=","Type":1}}"""
+        val expted = """{"Message":{"From":"f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq","GasFeeCap":"700000000000000000000","GasLimit":1000,"GasPremium":"800000000000000000000","Method":0,"Nonce":2,"To":"f3um6uo3qt5of54xjbx3hsxbw5mbsc6auxzrvfxekn5bv3duewqyn2tg5rhrlx73qahzzpkhuj7a34iq7oifsq","Value":"600000000000000000000"},"Signature":{"Data":"jMRu+OZ/lfppgmqSfGsntFrRLWZnUg3ZYmJTTRLsVt4V1310vR3VKGJpaE6S4sNvDOE6sEgmN9YmfTkPVK2qMgE=","Type":1}}"""
         assertEquals(expted, output.json)
     }
 }

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/filecoin/TestFilecoin.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/filecoin/TestFilecoin.kt
@@ -6,12 +6,7 @@ import com.trustwallet.core.app.utils.toHexBytesInByteString
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import wallet.core.java.AnySigner
-import wallet.core.jni.AnyAddress
-import wallet.core.jni.CoinType
-import wallet.core.jni.CoinType.FILECOIN
-import wallet.core.jni.FilecoinAddressConverter
-import wallet.core.jni.FilecoinAddressType
-import wallet.core.jni.PrivateKey
+import wallet.core.jni.*
 import wallet.core.jni.proto.Filecoin
 import wallet.core.jni.proto.Filecoin.SigningOutput
 
@@ -41,9 +36,11 @@ class TestFilecoin {
     fun testAddressConverter() {
         val ethereumAddress = FilecoinAddressConverter.convertToEthereum("f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky")
         assertEquals(ethereumAddress, "0x8dbD6c7Ede90646a61Bbc649831b7c298BFd37A0")
+        assert(AnyAddress.isValid(ethereumAddress, CoinType.ETHEREUM))
 
         val filecoinAddress = FilecoinAddressConverter.convertFromEthereum("0x8dbD6c7Ede90646a61Bbc649831b7c298BFd37A0")
         assertEquals(filecoinAddress, "f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky")
+        assert(AnyAddress.isValid(filecoinAddress, CoinType.FILECOIN))
     }
 
     @Test
@@ -60,7 +57,7 @@ class TestFilecoin {
             .build()
 
         val output = AnySigner.sign(input, CoinType.FILECOIN, SigningOutput.parser())
-        val expted = """{"Message":{"From":"f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq","GasFeeCap":"700000000000000000000","GasLimit":1000,"GasPremium":"800000000000000000000","Method":0,"Nonce":2,"To":"f3um6uo3qt5of54xjbx3hsxbw5mbsc6auxzrvfxekn5bv3duewqyn2tg5rhrlx73qahzzpkhuj7a34iq7oifsq","Value":"600000000000000000000"},"Signature":{"Data":"jMRu+OZ/lfppgmqSfGsntFrRLWZnUg3ZYmJTTRLsVt4V1310vR3VKGJpaE6S4sNvDOE6sEgmN9YmfTkPVK2qMgE=","Type":1}}"""
-        assertEquals(expted, output.json)
+        val expected = """{"Message":{"From":"f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq","GasFeeCap":"700000000000000000000","GasLimit":1000,"GasPremium":"800000000000000000000","Method":0,"Nonce":2,"To":"f3um6uo3qt5of54xjbx3hsxbw5mbsc6auxzrvfxekn5bv3duewqyn2tg5rhrlx73qahzzpkhuj7a34iq7oifsq","Value":"600000000000000000000"},"Signature":{"Data":"jMRu+OZ/lfppgmqSfGsntFrRLWZnUg3ZYmJTTRLsVt4V1310vR3VKGJpaE6S4sNvDOE6sEgmN9YmfTkPVK2qMgE=","Type":1}}"""
+        assertEquals(expected, output.json)
     }
 }

--- a/include/TrustWalletCore/TWAnyAddress.h
+++ b/include/TrustWalletCore/TWAnyAddress.h
@@ -9,6 +9,7 @@
 #include "TWBase.h"
 #include "TWCoinType.h"
 #include "TWData.h"
+#include "TWFilecoinAddressType.h"
 #include "TWString.h"
 
 TW_EXTERN_C_BEGIN
@@ -114,6 +115,14 @@ struct TWAnyAddress* _Nonnull TWAnyAddressCreateBech32WithPublicKey(struct TWPub
 /// \return TWAnyAddress pointer or nullptr if public key is invalid.
 TW_EXPORT_STATIC_METHOD
 struct TWAnyAddress* _Nonnull TWAnyAddressCreateSS58WithPublicKey(struct TWPublicKey* _Nonnull publicKey, enum TWCoinType coin, uint32_t ss58Prefix);
+
+/// Creates a Filecoin address from a public key and a given address type.
+///
+/// \param publicKey derivates the address from the public key.
+/// \param filecoinAddressType Filecoin address type.
+/// \return TWAnyAddress pointer or nullptr if public key is invalid.
+TW_EXPORT_STATIC_METHOD
+struct TWAnyAddress* _Nonnull TWAnyAddressCreateWithPublicKeyFilecoinAddressType(struct TWPublicKey* _Nonnull publicKey, enum TWFilecoinAddressType filecoinAddressType);
 
 /// Deletes an address.
 ///

--- a/include/TrustWalletCore/TWFilecoinAddressConverter.h
+++ b/include/TrustWalletCore/TWFilecoinAddressConverter.h
@@ -1,0 +1,36 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "TWBase.h"
+#include "TWData.h"
+#include "TWString.h"
+
+TW_EXTERN_C_BEGIN
+
+/// Filecoin-Ethereum address converter.
+///
+/// Ethereum and some other wallets support a message signing & verification format, to create a proof (a signature)
+/// that someone has access to the private keys of a specific address.
+TW_EXPORT_STRUCT
+struct TWFilecoinAddressConverter;
+
+/// Converts a Filecoin address to Ethereum.
+///
+/// \param filecoinAddress: a Filecoin address.
+/// \returns the Ethereum address. On invalid input empty string is returned. Returned object needs to be deleted after use.
+TW_EXPORT_STATIC_METHOD
+TWString* _Nonnull TWFilecoinAddressConverterConvertToEthereum(TWString* _Nonnull filecoinAddress);
+
+/// Converts an Ethereum address to Filecoin.
+///
+/// \param ethAddress: an Ethereum address.
+/// \returns the Filecoin address. On invalid input empty string is returned. Returned object needs to be deleted after use.
+TW_EXPORT_STATIC_METHOD
+TWString* _Nonnull TWFilecoinAddressConverterConvertFromEthereum(TWString* _Nonnull ethAddress);
+
+TW_EXTERN_C_END

--- a/include/TrustWalletCore/TWFilecoinAddressConverter.h
+++ b/include/TrustWalletCore/TWFilecoinAddressConverter.h
@@ -13,9 +13,6 @@
 TW_EXTERN_C_BEGIN
 
 /// Filecoin-Ethereum address converter.
-///
-/// Ethereum and some other wallets support a message signing & verification format, to create a proof (a signature)
-/// that someone has access to the private keys of a specific address.
 TW_EXPORT_STRUCT
 struct TWFilecoinAddressConverter;
 

--- a/include/TrustWalletCore/TWFilecoinAddressType.h
+++ b/include/TrustWalletCore/TWFilecoinAddressType.h
@@ -1,0 +1,20 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "TWBase.h"
+
+TW_EXTERN_C_BEGIN
+
+/// Filecoin address type.
+TW_EXPORT_ENUM(uint32_t)
+enum TWFilecoinAddressType {
+    TWFilecoinAddressTypeDefault = 0, // default
+    TWFilecoinAddressTypeDelegated = 1,
+};
+
+TW_EXTERN_C_END

--- a/src/CoinEntry.h
+++ b/src/CoinEntry.h
@@ -8,6 +8,7 @@
 
 #include <TrustWalletCore/TWCoinType.h>
 #include <TrustWalletCore/TWDerivation.h>
+#include <TrustWalletCore/TWFilecoinAddressType.h>
 
 #include "Data.h"
 #include "PublicKey.h"
@@ -32,7 +33,10 @@ struct Base58Prefix {
 using Bech32Prefix = const char *;
 using SS58Prefix = uint32_t;
 
-using PrefixVariant = std::variant<Base58Prefix, Bech32Prefix, SS58Prefix, std::monostate>;
+/// Declare a dummy prefix to notify the entry to derive a delegated address.
+struct DelegatedPrefix {};
+
+using PrefixVariant = std::variant<Base58Prefix, Bech32Prefix, SS58Prefix, DelegatedPrefix, std::monostate>;
 
 /// Interface for coin-specific entry, used to dispatch calls to coins
 /// Implement this for all coins.

--- a/src/Filecoin/Address.cpp
+++ b/src/Filecoin/Address.cpp
@@ -63,7 +63,7 @@ static bool decodeActorID(const Data& bytes, uint64_t& actorID, std::size_t& rem
         }
     }
 
-    // Couldn't find a last byte so `(byte & 0x80) == 0`.
+    // Couldn't find the last byte so `(byte & 0x80) == 0`.
     return false;
 }
 
@@ -95,7 +95,7 @@ static Data calculateChecksum(Address::Type type, uint64_t actorID, const Data& 
 }
 
 /// Decodes `encoded` as a Filecoin address.
-/// Returns `true` if `encoded` on success.
+/// Returns `true` on success.
 static bool decodeAddress(const Data& encoded, Address::Type& type, uint64_t& actorID, Data& payload) {
     if (encoded.size() < 2) {
         return false;
@@ -140,7 +140,7 @@ static bool decodeAddress(const Data& encoded, Address::Type& type, uint64_t& ac
 }
 
 /// Parses `string` as a Filecoin address and validates the checksum.
-/// Returns `true` if `string` is valid address.
+/// Returns `true` if `string` is a valid address.
 static bool parseValidateAddress(const std::string& string, Address::Type& type, uint64_t& actorID, Data& payload) {
     if (string.length() < 3) {
         return false;
@@ -161,11 +161,11 @@ static bool parseValidateAddress(const std::string& string, Address::Type& type,
     }
 
     // For `SECP256K1`, `ACTOR`, `BLS`, the payload starts after the Protocol Type.
-    // For `DELEGATED`, the payload starts after the ActorID and 'f' separator.
+    // For `DELEGATED`, the payload starts after an ActorID and the 'f' separator.
     std::size_t payloadPos = 2;
     if (type == Address::Type::DELEGATED) {
         std::size_t actorIDEnd = string.find('f', 2);
-        // Delegated address must contain 'f' separator.
+        // Delegated address must contain the 'f' separator.
         if (actorIDEnd == std::string::npos || actorIDEnd <= 2) {
             return false;
         }

--- a/src/Filecoin/Address.cpp
+++ b/src/Filecoin/Address.cpp
@@ -6,10 +6,8 @@
 
 #include "Address.h"
 
-#include <cstring>
 #include <climits>
 #include <optional>
-#include <iostream>
 
 #include "../Base32.h"
 
@@ -167,7 +165,7 @@ static bool parseValidateAddress(const std::string& string, Address::Type& type,
     // For `DELEGATED`, the payload starts after the ActorID and 'f' separator.
     std::size_t payloadPos = 2;
     if (type == Address::Type::DELEGATED) {
-        std::size_t actorIDEnd = string.find('f');
+        std::size_t actorIDEnd = string.find('f', 2);
         // Delegated address must contain 'f' separator.
         if (actorIDEnd == std::string::npos || actorIDEnd <= 2) {
             return false;
@@ -242,6 +240,11 @@ std::string Address::string() const {
     if (type == Type::ID) {
         s.append(std::to_string(actorID));
         return s;
+    }
+
+    if (type == Type::DELEGATED) {
+        s.append(std::to_string(actorID));
+        s.push_back('f');
     }
 
     Data toEncode(payload.begin(), payload.end());

--- a/src/Filecoin/Address.cpp
+++ b/src/Filecoin/Address.cpp
@@ -7,7 +7,6 @@
 #include "Address.h"
 
 #include <climits>
-#include <optional>
 
 #include "../Base32.h"
 
@@ -224,6 +223,15 @@ Address::Address(const PublicKey &publicKey):
     type(Type::SECP256K1),
     actorID(0),
     payload(Hash::blake2b(publicKey.bytes, 20)) {
+}
+
+Address::Address(Type type_, uint64_t actorID_, const Data& payload_):
+    type(type_),
+    actorID(actorID_),
+    payload(payload_) {
+    if (!isValidPayloadSize(type_, payload_.size())) {
+        throw std::invalid_argument("Invalid address data");
+    }
 }
 
 Data Address::toBytes() const {

--- a/src/Filecoin/Address.cpp
+++ b/src/Filecoin/Address.cpp
@@ -8,6 +8,7 @@
 
 #include <cstring>
 #include <climits>
+#include <optional>
 
 #include "../Base32.h"
 
@@ -16,153 +17,123 @@ namespace TW::Filecoin {
 static const char BASE32_ALPHABET_FILECOIN[] = "abcdefghijklmnopqrstuvwxyz234567";
 static constexpr size_t checksumSize = 4;
 
-static bool isValidID(const std::string& string) {
-    if (string.length() > 22)
+/// Decodes the given `string` as an ActorID.
+/// Please note `string` must not contain any prefixes.
+static bool decodeActorID(const std::string& string, uint64_t& actorID) {
+    if (string.length() > 20) {
         return false;
-    for (auto i = 2ul; i < string.length(); i++) {
-        if (string[i] < '0' || string[i] > '9') {
-            return false;
-        }
     }
     try {
         size_t chars;
-        [[maybe_unused]] uint64_t id = std::stoull(string.substr(2), &chars);
+        actorID = std::stoull(string, &chars);
         return chars > 0;
     } catch (...) {
         return false;
     }
 }
 
-/// Checks if the given string is a valid Base32.
-/// Please note `string` must not contain any prefixes.
-static bool isValidBase32(const std::string& string, Address::Type type) {
-    Data decoded;
-    if (!Base32::decode(string, decoded, BASE32_ALPHABET_FILECOIN)) {
-        return false;
-    }
-
-    if (decoded.size() < checksumSize) {
-        return false;
-    }
-    const auto payloadSize = decoded.size() - checksumSize;
-
-    // Check size
-    if (Address::isValidPayloadSize(type, payloadSize))
-        return false;
-    }
-
-    // Extract raw address.
-    Data address;
-    address.push_back(static_cast<uint8_t>(type));
-    address.insert(address.end(), decoded.data(), decoded.data() + size);
-
-    // Verify checksum.
-    Data should_sum = Hash::blake2b(address, checksumSize);
-    return std::memcmp(should_sum.data(), decoded.data() + size, checksumSize) == 0;
-}
-
 static void writeActorID(uint64_t actorID, Data& dest) {
-    while (id >= 0x80) {
+    while (actorID >= 0x80) {
         dest.push_back(((uint8_t)actorID) | 0x80);
         actorID >>= 7;
     }
     dest.push_back((uint8_t)actorID);
 }
 
-static Data&& decodeBase32Payload(const std::string& string) {
-    Data decoded;
-    if (!Base32::decode(string, decoded, BASE32_ALPHABET_FILECOIN))
-        throw std::invalid_argument("Invalid address data");
-    return std::move(decoded);
+/// Returns encoded bytes of Address including the protocol byte and actorID (if required)
+/// without the checksum.
+static Data&& addressToBytes(Address::Type type, uint64_t actorID, const Data& payload) {
+    Data encoded;
+    encoded.push_back(static_cast<uint8_t>(type));
+    if (type == Address::Type::ID || type == Address::Type::DELEGATED) {
+        writeActorID(actorID, encoded);
+    }
+    encoded.insert(std::end(encoded), std::begin(payload), std::end(payload));
+    return std::move(encoded);
 }
 
-// static bool decodeAddress(const std::string& string, Type& type, uint64_t& actorID, Data& payload) {
-//     if (string.length() < 3) {
-//         return false;
-//     }
-//     // Only main net addresses supported.
-//     if (string[0] != Address::PREFIX) {
-//         return false;
-//     }
-//
-//     // Get address type.
-//     type = Address::parseType(string[1]);
-//     if (type == Type::Invalid) {
-//         return false;
-//     }
-//
-//     switch (type) {
-//         case Type::ID:
-//             actorID = std::stoull(string.substr(2));
-//             return true;
-//         case Type::SECP256K1:
-//         case Type::ACTOR:
-//             return true;
-//         default:
-//             return false;
-//     }
-// }
+static Data&& calculateChecksum(Address::Type type, uint64_t actorID, const Data& payload) {
+    Data bytesVec(addressToBytes(type, actorID, payload));
+    Data sum(Hash::blake2b(bytesVec, checksumSize));
+    assert(sum.size() == checksumSize);
+    return std::move(sum);
+}
 
-bool Address::isValid(const std::string& string) {
+/// Decodes `string` as a Filecoin address and validates the checksum.
+/// Returns `true` if `string` is valid address.
+static bool decodeValidateAddress(const std::string& string, Address::Type& type, uint64_t& actorID, Data& payload) {
     if (string.length() < 3) {
         return false;
     }
     // Only main net addresses supported.
-    if (string[0] != PREFIX) {
+    if (string[0] != Address::PREFIX) {
         return false;
     }
+
     // Get address type.
-    auto type = parseType(string[1]);
-    if (type == Type::Invalid) {
+    type = Address::parseType(string[1]);
+    if (type == Address::Type::Invalid) {
         return false;
     }
 
-    // ID addresses are special, they are just numbers.
-    return type == Type::ID ? isValidID(string) : isValidBase32(string, type);
-}
-
-Address::Address(const std::string& string) {
-    if (!isValid(string))
-        throw std::invalid_argument("Invalid address data");
-
-    type = parseType(string[1]);
-    switch (type) {
-        case Type::ID:
-            actorID = std::stoull(string.substr(2));
-            break;
-        case Type::SECP256K1:
-        case Type::ACTOR:
+    if (type == Address::Type::ID) {
+        return decodeActorID(string.substr(2), actorID);
     }
 
-    if (type == Type::ID) {
-        actorID = std::stoull(string.substr(2));
-        return;
-    }
-
-    // The position in `string` where the payload starts.
+    // For `SECP256K1`, `ACTOR`, `BLS`, the payload starts after the Protocol Type.
+    // For `DELEGATED`, the payload starts after the ActorID and 'f' separator.
     std::size_t payloadPos = 2;
-    if (type == Type::DELEGATED) {
+    if (type == Address::Type::DELEGATED) {
+        std::size_t actorIDEnd = string.find('f');
+        // Delegated address must contain 'f' separator.
+        if (actorIDEnd == std::string::npos || actorIDEnd <= 2) {
+            return false;
+        }
+        if (!decodeActorID(string.substr(2, actorIDEnd - 2), actorID)) {
+            return false;
+        }
+        // Address payload starts after 'f'.
+        payloadPos = actorIDEnd + 1;
     }
 
     Data decoded;
-    if (!Base32::decode(string.substr(2), decoded, BASE32_ALPHABET_FILECOIN))
-        throw std::invalid_argument("Invalid address data");
-    uint8_t payloadSize = Address::payloadSize(type);
+    if (!Base32::decode(string.substr(payloadPos), decoded, BASE32_ALPHABET_FILECOIN)) {
+        return false;
+    }
+    if (decoded.size() < checksumSize) {
+        return false;
+    }
+    payload.assign(decoded.begin(), decoded.end() - checksumSize);
+    if (!Address::isValidPayloadSize(type, payload.size())) {
+        return false;
+    }
 
-    bytes.insert(bytes.end(), decoded.data(), decoded.data() + payloadSize);
+    Data actualChecksum(decoded.end() - checksumSize, decoded.end());
+    Data expectedChecksum = calculateChecksum(type, actorID, payload);
+    return actualChecksum == expectedChecksum;
 }
 
-Address::Address(const Data& data) {
-    if (!isValid(data)) {
+bool Address::isValid(const std::string& string) {
+    Type type;
+    uint64_t actorID;
+    Data payload;
+    return decodeValidateAddress(string, type, actorID, payload);
+}
+
+Address::Address(const std::string& string) {
+    if (!decodeValidateAddress(string, type, actorID, payload)) {
         throw std::invalid_argument("Invalid address data");
     }
-    bytes = data;
 }
 
-Address::Address(const PublicKey& publicKey) {
-    bytes.push_back(static_cast<uint8_t>(Type::SECP256K1));
-    Data hash = Hash::blake2b(publicKey.bytes, payloadSize(Type::SECP256K1));
-    bytes.insert(bytes.end(), hash.begin(), hash.end());
+Address::Address(const PublicKey &publicKey):
+    type(Type::SECP256K1),
+    actorID(0),
+    payload(Hash::blake2b(publicKey.bytes, 20)) {
+}
+
+Data&& Address::toBytes() const {
+    return std::move(addressToBytes(type, actorID, payload));
 }
 
 std::string Address::string() const {
@@ -170,37 +141,20 @@ std::string Address::string() const {
     // Main net address prefix
     s.push_back(PREFIX);
     // Address type prefix
-    s.push_back(typeAscii(type()));
+    s.push_back(typeAscii(type));
 
-    if (type() == Type::ID) {
-        uint64_t id = 0;
-        unsigned shift = 0;
-        for (auto i = 1ul; i < bytes.size(); i++) {
-            if (bytes[i] <= SCHAR_MAX) {
-                id |= static_cast<uint64_t>(bytes[i]) << shift;
-                break;
-            } else {
-                id |= static_cast<uint64_t>(bytes[i] & SCHAR_MAX) << shift;
-                shift += 7;
-            }
-        }
-        s.append(std::to_string(id));
+    if (type == Type::ID) {
+        s.append(std::to_string(actorID));
         return s;
     }
 
-    uint8_t payloadSize = Address::payloadSize(type());
-    // Base32 encoded body
-    Data toEncode(payloadSize + checksumSize);
-    // Copy address payload without prefix
-    std::copy(bytes.data() + 1, bytes.data() + payloadSize + 1, toEncode.data());
-    // Append Blake2b checksum
-    Data bytesVec;
-    bytesVec.assign(std::begin(bytes), std::end(bytes));
-    Data sum = Hash::blake2b(bytesVec, checksumSize);
-    assert(sum.size() == checksumSize);
-    std::copy(sum.begin(), sum.end(), toEncode.data() + payloadSize);
-    s.append(Base32::encode(toEncode, BASE32_ALPHABET_FILECOIN));
+    Data toEncode(payload.begin(), payload.end());
 
+    // Append Blake2b checksum
+    Data checksum = calculateChecksum(type, actorID, payload);
+    toEncode.insert(toEncode.end(), checksum.begin(), checksum.end());
+
+    s.append(Base32::encode(toEncode, BASE32_ALPHABET_FILECOIN));
     return s;
 }
 

--- a/src/Filecoin/Address.cpp
+++ b/src/Filecoin/Address.cpp
@@ -194,15 +194,15 @@ static bool parseValidateAddress(const std::string& string, Address::Type& type,
 }
 
 bool Address::isValid(const std::string& string) {
-    Type type;
-    uint64_t actorID;
+    Type type = Type::Invalid;
+    uint64_t actorID = 0;
     Data payload;
     return parseValidateAddress(string, type, actorID, payload);
 }
 
 bool Address::isValid(const Data& encoded) {
-    Type type;
-    uint64_t actorID;
+    Type type = Type::Invalid;
+    uint64_t actorID = 0;
     Data payload;
     return decodeAddress(encoded, type, actorID, payload);
 }

--- a/src/Filecoin/Address.cpp
+++ b/src/Filecoin/Address.cpp
@@ -250,9 +250,7 @@ Address::Address(const std::string& string) {
         throw std::invalid_argument("Invalid address data");
     }
 
-    type = addr->type;
-    actorID = addr->actorID;
-    payload = std::move(addr->payload);
+    assign(std::move(*addr));
 }
 
 Address::Address(const Data& encoded) {
@@ -261,9 +259,7 @@ Address::Address(const Data& encoded) {
         throw std::invalid_argument("Invalid address data");
     }
 
-    type = addr->type;
-    actorID = addr->actorID;
-    payload = std::move(addr->payload);
+    assign(std::move(*addr));
 }
 
 Address::Address(Type type, uint64_t actorID, Data&& payload):
@@ -273,6 +269,12 @@ Address::Address(Type type, uint64_t actorID, Data&& payload):
     if (!isValidPayloadSize(this->type, this->payload.size())) {
         throw std::invalid_argument("Invalid address data");
     }
+}
+
+void Address::assign(Address&& other) {
+    type = other.type;
+    actorID = other.actorID;
+    payload = std::move(other.payload);
 }
 
 Data Address::toBytes() const {

--- a/src/Filecoin/Address.h
+++ b/src/Filecoin/Address.h
@@ -42,6 +42,9 @@ class Address {
     /// Initializes an address with a string representation.
     explicit Address(const std::string& string);
 
+    /// Initializes an address from encoded bytes.
+    explicit Address(const Data& encoded);
+
     /// Initializes an address with a secp256k1 public key.
     explicit Address(const PublicKey& publicKey);
 

--- a/src/Filecoin/Address.h
+++ b/src/Filecoin/Address.h
@@ -39,6 +39,9 @@ class Address {
     /// Determines whether a string makes a valid encoded address.
     static bool isValid(const std::string& string);
 
+    /// Determines whether a collection of bytes makes a valid address.
+    static bool isValid(const Data& encoded);
+
     /// Initializes an address with a string representation.
     explicit Address(const std::string& string);
 
@@ -53,7 +56,7 @@ class Address {
 
     /// Returns encoded bytes of Address including the protocol byte and actorID (if required)
     /// without the checksum.
-    Data&& toBytes() const;
+    Data toBytes() const;
 
     /// Address prefix
     static constexpr char PREFIX = 'f';
@@ -97,6 +100,8 @@ class Address {
             case Type::SECP256K1:
             case Type::ACTOR:
                 return payloadSize == 20;
+            case Type::BLS:
+                return payloadSize == 48;
             case Type::DELEGATED:
                 return payloadSize <= 54;
             default:

--- a/src/Filecoin/Address.h
+++ b/src/Filecoin/Address.h
@@ -45,7 +45,7 @@ class Address {
     /// Initializes an address with a string representation.
     explicit Address(const std::string& string);
 
-    /// Initializes an address from encoded bytes.
+    /// Initializes an address with a collection of bytes.
     explicit Address(const Data& encoded);
 
     /// Initializes an address with a secp256k1 public key.
@@ -95,7 +95,7 @@ class Address {
     /// Returns ASCII character of type
     static char typeAscii(Type t) { return '0' + static_cast<char>(t); }
 
-    /// Validates if the payload size (excluding any prefixes) of an address type has an expected value.
+    /// Validates if the payload size (excluding any prefixes and checksum) of an address type has an expected value.
     static bool isValidPayloadSize(Type t, std::size_t payloadSize) {
         switch (t) {
             case Type::ID:

--- a/src/Filecoin/Address.h
+++ b/src/Filecoin/Address.h
@@ -51,6 +51,9 @@ class Address {
     /// Initializes an address with a secp256k1 public key.
     explicit Address(const PublicKey& publicKey);
 
+    /// Initializes an address with a type, actorID and payload.
+    explicit Address(Type type_, uint64_t actorID_, const Data& payload_);
+
     /// Returns a string representation of the address.
     [[nodiscard]] std::string string() const;
 

--- a/src/Filecoin/Address.h
+++ b/src/Filecoin/Address.h
@@ -10,13 +10,17 @@
 
 #include <array>
 #include <cstdint>
-#include <string>
+#include <optional>
 #include <vector>
+#include <string>
 
 namespace TW::Filecoin {
 
 class Address {
   public:
+    /// The actor ID of the Ethereum Address Manager singleton.
+    static constexpr uint64_t ETHEREUM_ADDRESS_MANAGER_ACTOR_ID = 10;
+
     enum class Type : uint8_t {
         ID = 0,
         SECP256K1 = 1,
@@ -36,23 +40,34 @@ class Address {
     /// Address data payload (without prefixes and checksum).
     Data payload;
 
+    /// Decodes `encoded` as a Filecoin address.
+    /// Returns `std::nullopt` on fail.
+    static std::optional<Address> fromBytes(const Data& encoded);
+
+    /// Parses `string` as a Filecoin address and validates the checksum.
+    /// Returns `std::nullopt` if `string` is not a valid address.
+    static std::optional<Address> fromString(const std::string& string);
+
     /// Determines whether a string makes a valid encoded address.
     static bool isValid(const std::string& string);
 
     /// Determines whether a collection of bytes makes a valid address.
     static bool isValid(const Data& encoded);
 
+    /// Initializes a Secp256k1 address with a secp256k1 public key.
+    static Address secp256k1Address(const PublicKey& publicKey);
+
+    /// Initializes a Delegated address with a secp256k1 public key.
+    static Address delegatedAddress(const PublicKey& publicKey);
+
+    /// Initializes a Delegated address with a secp256k1 public key.
+    static Address delegatedAddress(uint64_t actorID, const Data& payload);
+
     /// Initializes an address with a string representation.
     explicit Address(const std::string& string);
 
     /// Initializes an address with a collection of bytes.
     explicit Address(const Data& encoded);
-
-    /// Initializes an address with a secp256k1 public key.
-    explicit Address(const PublicKey& publicKey);
-
-    /// Initializes an address with a type, actorID and payload.
-    explicit Address(Type type_, uint64_t actorID_, const Data& payload_);
 
     /// Returns a string representation of the address.
     [[nodiscard]] std::string string() const;
@@ -64,7 +79,10 @@ class Address {
     /// Address prefix
     static constexpr char PREFIX = 'f';
 
-  public:
+private:
+    /// Initializes an address with a type, actorID and payload.
+    explicit Address(Type type, uint64_t actorID, const Data& payload);
+
     /// Attempts to get the type by number.
     static Type getType(uint8_t raw) {
         switch (raw) {

--- a/src/Filecoin/Address.h
+++ b/src/Filecoin/Address.h
@@ -90,6 +90,9 @@ private:
     /// Initializes an address with a type, actorID and payload.
     explicit Address(Type type, uint64_t actorID, Data&& payload);
 
+    /// Assigns the address to the `other` value.
+    void assign(Address&& other);
+
     /// Attempts to get the type by number.
     static Type getType(uint8_t raw) {
         switch (raw) {

--- a/src/Filecoin/AddressConverter.cpp
+++ b/src/Filecoin/AddressConverter.cpp
@@ -1,0 +1,77 @@
+// Copyright © 2017-2023 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "AddressConverter.h"
+
+#include "Ethereum/Address.h"
+
+namespace TW::Filecoin {
+
+/// The actor ID of the Ethereum Address Manager singleton.
+static constexpr uint64_t ETHEREUM_ADDRESS_MANAGER_ACTOR_ID = 10;
+
+static byte toByte(uint64_t num) {
+  return num & 0xFF;
+}
+
+/// https://cs.opensource.google/go/go/+/refs/tags/go1.20.2:src/encoding/binary/binary.go;l=184
+static void putBigEndian(Data& dest, std::size_t pos, uint64_t num) {
+    assert(dest.size() >= pos + sizeof(num));
+
+    dest[pos] = toByte(num >> 56);
+    dest[pos + 1] = toByte(num >> 48);
+    dest[pos + 2] = toByte(num >> 40);
+    dest[pos + 3] = toByte(num >> 32);
+    dest[pos + 4] = toByte(num >> 24);
+    dest[pos + 5] = toByte(num >> 16);
+    dest[pos + 6] = toByte(num >> 8);
+    dest[pos + 7] = toByte(num);
+}
+
+/// https://github.com/filecoin-project/lotus/blob/61f29a84b5a61060c4ac8aabe9b9360a2cdf5e7e/chain/types/ethtypes/eth_types.go#L279
+bool AddressConverter::convertToEthereum(const std::string& filecoinAddress, std::string& ethereumAddress) {
+    // This may throw an exception if the given address is invalid.
+    Address addr(filecoinAddress);
+
+    switch (addr.type) {
+        case Address::Type::ID: {
+            Data payload(Ethereum::Address::size, 0);
+            payload[0] = 0xFF;
+            putBigEndian(payload, 12, addr.actorID);
+
+            Ethereum::Address ethAddr(payload);
+            ethereumAddress = ethAddr.string();
+            return true;
+        }
+        case Address::Type::DELEGATED: {
+            if (addr.actorID != ETHEREUM_ADDRESS_MANAGER_ACTOR_ID) {
+                return false;
+            }
+
+            if (addr.payload.size() != Ethereum::Address::size) {
+                return false;
+            }
+
+            Ethereum::Address ethAddr(addr.payload);
+            ethereumAddress = ethAddr.string();
+            return true;
+        }
+        default:
+            return false;
+    }
+}
+
+std::string AddressConverter::convertFromEthereum(const std::string& ethereumAddress) {
+    // This may throw an exception if the given address is invalid.
+    Ethereum::Address addr(ethereumAddress);
+
+    Data addrPayload(addr.bytes.begin(), addr.bytes.end());
+    Address filecoinAddr(Address::Type::DELEGATED, ETHEREUM_ADDRESS_MANAGER_ACTOR_ID, addrPayload);
+
+    return filecoinAddr.string();
+}
+
+}

--- a/src/Filecoin/AddressConverter.cpp
+++ b/src/Filecoin/AddressConverter.cpp
@@ -6,44 +6,34 @@
 
 #include "AddressConverter.h"
 
+#include "BinaryCoding.h"
 #include "Ethereum/Address.h"
 
 namespace TW::Filecoin {
 
-static byte toByte(uint64_t num) {
-  return num & 0xFF;
-}
-
-/// https://cs.opensource.google/go/go/+/refs/tags/go1.20.2:src/encoding/binary/binary.go;l=184
-static void putBigEndian(Data& dest, std::size_t pos, uint64_t num) {
-    assert(dest.size() >= pos + sizeof(num));
-
-    dest[pos] = toByte(num >> 56);
-    dest[pos + 1] = toByte(num >> 48);
-    dest[pos + 2] = toByte(num >> 40);
-    dest[pos + 3] = toByte(num >> 32);
-    dest[pos + 4] = toByte(num >> 24);
-    dest[pos + 5] = toByte(num >> 16);
-    dest[pos + 6] = toByte(num >> 8);
-    dest[pos + 7] = toByte(num);
-}
+static constexpr std::size_t ACTOR_ID_ENCODED_LEN = sizeof(uint64_t);
 
 /// https://github.com/filecoin-project/lotus/blob/61f29a84b5a61060c4ac8aabe9b9360a2cdf5e7e/chain/types/ethtypes/eth_types.go#L279
-std::optional<std::string> AddressConverter::convertToEthereumString(const std::string& filecoinAddress) {
+MaybeAddressString AddressConverter::convertToEthereumString(const std::string& filecoinAddress) {
     // This may throw an exception if the given address is invalid.
     Address addr(filecoinAddress);
-    if (auto eth_opt = convertToEthereum(addr); eth_opt) {
+    if (auto &&eth_opt = convertToEthereum(addr); eth_opt) {
         return eth_opt->string();
     }
     return std::nullopt;
 }
 
-std::optional<Ethereum::Address> AddressConverter::convertToEthereum(const Address& filecoinAddress) {
+MaybeEthAddress AddressConverter::convertToEthereum(const Address& filecoinAddress) {
     switch (filecoinAddress.type) {
         case Address::Type::ID: {
-            Data payload(Ethereum::Address::size, 0);
+            Data payload(Ethereum::Address::size - ACTOR_ID_ENCODED_LEN, 0);
             payload[0] = 0xFF;
-            putBigEndian(payload, 12, filecoinAddress.actorID);
+
+            Data encodedActorID;
+            encodedActorID.reserve(ACTOR_ID_ENCODED_LEN);
+            encode64BE(filecoinAddress.actorID, encodedActorID);
+
+            append(payload, encodedActorID);
 
             Ethereum::Address ethAddr(payload);
             return ethAddr;
@@ -74,7 +64,7 @@ std::string AddressConverter::convertFromEthereumString(const std::string& ether
 
 Address AddressConverter::convertFromEthereum(const Ethereum::Address& ethereumAddress) noexcept {
     Data addrPayload(ethereumAddress.bytes.begin(), ethereumAddress.bytes.end());
-    return Address::delegatedAddress(Address::ETHEREUM_ADDRESS_MANAGER_ACTOR_ID, addrPayload);
+    return Address::delegatedAddress(Address::ETHEREUM_ADDRESS_MANAGER_ACTOR_ID, std::move(addrPayload));
 }
 
 }

--- a/src/Filecoin/AddressConverter.cpp
+++ b/src/Filecoin/AddressConverter.cpp
@@ -69,10 +69,7 @@ std::string AddressConverter::convertFromEthereumString(const std::string& ether
     // This may throw an exception if the given address is invalid.
     Ethereum::Address addr(ethereumAddress);
 
-    Data addrPayload(addr.bytes.begin(), addr.bytes.end());
-    Address filecoinAddr = Address::delegatedAddress(Address::ETHEREUM_ADDRESS_MANAGER_ACTOR_ID, addrPayload);
-
-    return filecoinAddr.string();
+    return convertFromEthereum(addr).string();
 }
 
 Address AddressConverter::convertFromEthereum(const Ethereum::Address& ethereumAddress) noexcept {

--- a/src/Filecoin/AddressConverter.h
+++ b/src/Filecoin/AddressConverter.h
@@ -1,0 +1,22 @@
+// Copyright © 2017-2023 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "Address.h"
+
+namespace TW::Filecoin {
+
+class AddressConverter {
+public:
+    /// Converts a Filecoin address to Ethereum.
+    static bool convertToEthereum(const std::string& filecoinAddress, std::string& ethereumAddress);
+
+    /// Converts an Ethereum address to Filecoin.
+    static std::string convertFromEthereum(const std::string& ethereumAddress);
+};
+
+}

--- a/src/Filecoin/AddressConverter.h
+++ b/src/Filecoin/AddressConverter.h
@@ -6,17 +6,26 @@
 
 #pragma once
 
+#include <optional>
+
 #include "Address.h"
+#include "Ethereum/Address.h"
 
 namespace TW::Filecoin {
 
 class AddressConverter {
 public:
     /// Converts a Filecoin address to Ethereum.
-    static bool convertToEthereum(const std::string& filecoinAddress, std::string& ethereumAddress);
+    static std::optional<std::string> convertToEthereumString(const std::string& filecoinAddress);
+
+    /// Converts a Filecoin address to Ethereum.
+    static std::optional<Ethereum::Address> convertToEthereum(const Address& filecoinAddress);
 
     /// Converts an Ethereum address to Filecoin.
-    static std::string convertFromEthereum(const std::string& ethereumAddress);
+    static std::string convertFromEthereumString(const std::string& ethereumAddress);
+
+    /// Converts an Ethereum address to Filecoin.
+    static Address convertFromEthereum(const Ethereum::Address& ethereumAddress) noexcept;
 };
 
 }

--- a/src/Filecoin/AddressConverter.h
+++ b/src/Filecoin/AddressConverter.h
@@ -13,13 +13,16 @@
 
 namespace TW::Filecoin {
 
+using MaybeAddressString = std::optional<std::string>;
+using MaybeEthAddress = std::optional<Ethereum::Address>;
+
 class AddressConverter {
 public:
     /// Converts a Filecoin address to Ethereum.
-    static std::optional<std::string> convertToEthereumString(const std::string& filecoinAddress);
+    static MaybeAddressString convertToEthereumString(const std::string& filecoinAddress);
 
     /// Converts a Filecoin address to Ethereum.
-    static std::optional<Ethereum::Address> convertToEthereum(const Address& filecoinAddress);
+    static MaybeEthAddress convertToEthereum(const Address& filecoinAddress);
 
     /// Converts an Ethereum address to Filecoin.
     static std::string convertFromEthereumString(const std::string& ethereumAddress);

--- a/src/Filecoin/Entry.cpp
+++ b/src/Filecoin/Entry.cpp
@@ -17,8 +17,10 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
-// TODO
-std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, const PrefixVariant& addressPrefix) const {
+    if (std::get_if<DelegatedPrefix>(&addressPrefix)) {
+        return Address::delegatedAddress(publicKey).string();
+    }
     return Address::secp256k1Address(publicKey).string();
 }
 

--- a/src/Filecoin/Entry.cpp
+++ b/src/Filecoin/Entry.cpp
@@ -17,8 +17,9 @@ bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string&
     return Address::isValid(address);
 }
 
+// TODO
 std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
-    return Address(publicKey).string();
+    return Address::secp256k1Address(publicKey).string();
 }
 
 void Entry::sign([[maybe_unused]] TWCoinType coin, const TW::Data& dataIn, TW::Data& dataOut) const {

--- a/src/Filecoin/Signer.cpp
+++ b/src/Filecoin/Signer.cpp
@@ -61,10 +61,10 @@ Proto::SigningOutput Signer::signSecp256k1(const Proto::SigningInput& input) {
     // Load the transaction params.
     Data params(input.params().begin(), input.params().end());
 
-    // Transaction type; 0 for simple transfers.
-    uint64_t method = Transaction::SEND_METHOD;
+    // Simple transfer by default.
+    Transaction::MethodType method = Transaction::MethodType::SEND;
     if (to_address.type == Address::Type::DELEGATED) {
-        method = Transaction::INVOKE_EVM_METHOD;
+        method = Transaction::MethodType::INVOKE_EVM;
     }
 
     Transaction transaction(
@@ -131,7 +131,7 @@ Proto::SigningOutput Signer::signDelegated(const Proto::SigningInput& input) {
         /* gasLimit */   input.gas_limit(),
         /* gasFeeCap */  load(input.gas_fee_cap()),
         /* gasPremium */ load(input.gas_premium()),
-        /* method */     Transaction::INVOKE_EVM_METHOD,
+        /* method */     Transaction::MethodType::INVOKE_EVM,
         /* params */     params
     );
     const auto json = filecoinTransaction.serialize(Transaction::SignatureType::DELEGATED, signature);

--- a/src/Filecoin/Signer.cpp
+++ b/src/Filecoin/Signer.cpp
@@ -4,43 +4,37 @@
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
 
-#include "Signer.h"
-#include "HexCoding.h"
 #include <google/protobuf/util/json_util.h>
+
+#include "AddressConverter.h"
+#include "Ethereum/Transaction.h"
+#include "Signer.h"
 
 namespace TW::Filecoin {
 
-Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) noexcept {
-    // Load private key and transaction from Protobuf input.
-    auto key = PrivateKey(Data(input.private_key().begin(), input.private_key().end()));
-    auto pubkey = key.getPublicKey(TWPublicKeyTypeSECP256k1Extended);
-    Address from_address(pubkey);
-    Address to_address(input.to());
+// ChainId defines the chain ID used in the Ethereum JSON-RPC endpoint.
+// As per https://github.com/ethereum-lists/chains
+static constexpr uint256_t FILECOIN_EIP155_CHAIN_ID = 314;
 
-    // Transaction type; 0 for simple transfers.
-    uint64_t method = Transaction::SEND_METHOD;
-    if (to_address.type == Address::Type::DELEGATED) {
-        method = Transaction::INVOKE_EVM_METHOD;
-    }
-
-    Transaction transaction(
-        /* to */ to_address,
-        /* from */ from_address,
-        /* nonce */ input.nonce(),
-        /* value */ load(input.value()),
-        /* gasLimit */ input.gas_limit(),
-        /* gasFeeCap */ load(input.gas_fee_cap()),
-        /* gasPremium */ load(input.gas_premium()),
-        /* method */ method);
-
-    // Sign transaction.
-    auto signature = sign(key, transaction);
-    const auto json = transaction.serialize(signature);
-
-    // Return Protobuf output.
+static Proto::SigningOutput errorOutput(const char* error) {
     Proto::SigningOutput output;
-    output.set_json(json.data(), json.size());
+    output.set_error_message(error);
     return output;
+}
+
+Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) noexcept {
+    try {
+        switch (input.derivation()) {
+            case Proto::DerivationType::SECP256K1:
+                return signSecp256k1(input);
+            case Proto::DerivationType::DELEGATED:
+                return signDelegated(input);
+            default:
+                return errorOutput("Unknown derivation type");
+        }
+    } catch (const std::exception& exp) {
+        return errorOutput(exp.what());
+    }
 }
 
 Data Signer::sign(const PrivateKey& privateKey, Transaction& transaction) noexcept {
@@ -55,6 +49,97 @@ std::string Signer::signJSON(const std::string& json, const Data& key) {
     input.set_private_key(key.data(), key.size());
     auto output = Signer::sign(input);
     return output.json();
+}
+
+Proto::SigningOutput Signer::signSecp256k1(const Proto::SigningInput& input) {
+    // Load private key and transaction from Protobuf input.
+    auto key = PrivateKey(Data(input.private_key().begin(), input.private_key().end()));
+    auto pubkey = key.getPublicKey(TWPublicKeyTypeSECP256k1Extended);
+    Address from_address = Address::secp256k1Address(pubkey);
+    Address to_address(input.to());
+
+    // Load the transaction params.
+    Data params(input.params().begin(), input.params().end());
+
+    // Transaction type; 0 for simple transfers.
+    uint64_t method = Transaction::SEND_METHOD;
+    if (to_address.type == Address::Type::DELEGATED) {
+        method = Transaction::INVOKE_EVM_METHOD;
+    }
+
+    Transaction transaction(
+        /* to */         to_address,
+        /* from */       from_address,
+        /* nonce */      input.nonce(),
+        /* value */      load(input.value()),
+        /* gasLimit */   input.gas_limit(),
+        /* gasFeeCap */  load(input.gas_fee_cap()),
+        /* gasPremium */ load(input.gas_premium()),
+        /* method */     method,
+        /* params */     params
+    );
+
+    // Sign transaction.
+    auto signature = sign(key, transaction);
+    const auto json = transaction.serialize(Transaction::SignatureType::SECP256K1, signature);
+
+    // Return Protobuf output.
+    Proto::SigningOutput output;
+    output.set_json(json.data(), json.size());
+    return output;
+}
+
+/// https://github.com/filecoin-project/lotus/blob/ce17546a762eef311069e13410d15465d832a45e/chain/messagesigner/messagesigner.go#L197-L211
+Proto::SigningOutput Signer::signDelegated(const Proto::SigningInput& input) {
+    // Load private key from Protobuf input.
+    auto privateKey = PrivateKey(Data(input.private_key().begin(), input.private_key().end()));
+    auto pubkey = privateKey.getPublicKey(TWPublicKeyTypeSECP256k1Extended);
+
+    // Load the transaction params.
+    Data params(input.params().begin(), input.params().end());
+
+    // Generate a Delegated `f4` address.
+    Address fromAddress = Address::delegatedAddress(pubkey);
+
+    // Parse `to` address. Expects either ID `f1` or Delegated `f4` address.
+    Address toAddress(input.to());
+    auto toEth = AddressConverter::convertToEthereum(toAddress);
+    if (!toEth) {
+        throw std::invalid_argument("Expected a Delegated recipient");
+    }
+    Data toBytes(toEth->bytes.begin(), toEth->bytes.end());
+
+    // Sign transaction as an Ethereum EIP1559 native transfer.
+    auto ethTransaction = Ethereum::TransactionEip1559::buildNativeTransfer(
+        /* nonce */                 input.nonce(),
+        /* maxInclusionFeePerGas */ load(input.gas_premium()),
+        /* maxFeePerGas */          load(input.gas_fee_cap()),
+        /* gasLimit */              input.gas_limit(),
+        /* toAddress */             toBytes,
+        /* amount */                load(input.value()),
+        /* data */                  params
+    );
+    Data preHash = ethTransaction->preHash(FILECOIN_EIP155_CHAIN_ID);
+    Data signature = privateKey.sign(preHash, TWCurveSECP256k1);
+
+    // Generate a Filecoin signed message.
+    Transaction filecoinTransaction(
+        /* to */         toAddress,
+        /* from */       fromAddress,
+        /* nonce */      input.nonce(),
+        /* value */      load(input.value()),
+        /* gasLimit */   input.gas_limit(),
+        /* gasFeeCap */  load(input.gas_fee_cap()),
+        /* gasPremium */ load(input.gas_premium()),
+        /* method */     Transaction::INVOKE_EVM_METHOD,
+        /* params */     params
+    );
+    const auto json = filecoinTransaction.serialize(Transaction::SignatureType::DELEGATED, signature);
+
+    // Return Protobuf output.
+    Proto::SigningOutput output;
+    output.set_json(json.data(), json.size());
+    return output;
 }
 
 } // namespace TW::Filecoin

--- a/src/Filecoin/Signer.cpp
+++ b/src/Filecoin/Signer.cpp
@@ -16,6 +16,13 @@ Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) noexcept {
     auto pubkey = key.getPublicKey(TWPublicKeyTypeSECP256k1Extended);
     Address from_address(pubkey);
     Address to_address(input.to());
+
+    // Transaction type; 0 for simple transfers.
+    uint64_t method = Transaction::SEND_METHOD;
+    if (to_address.type == Address::Type::DELEGATED) {
+        method = Transaction::INVOKE_EVM_METHOD;
+    }
+
     Transaction transaction(
         /* to */ to_address,
         /* from */ from_address,
@@ -23,7 +30,8 @@ Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) noexcept {
         /* value */ load(input.value()),
         /* gasLimit */ input.gas_limit(),
         /* gasFeeCap */ load(input.gas_fee_cap()),
-        /* gasPremium */ load(input.gas_premium()));
+        /* gasPremium */ load(input.gas_premium()),
+        /* method */ method);
 
     // Sign transaction.
     auto signature = sign(key, transaction);

--- a/src/Filecoin/Signer.h
+++ b/src/Filecoin/Signer.h
@@ -28,6 +28,13 @@ class Signer {
 
     /// Signs the given transaction.
     static Data sign(const PrivateKey& privateKey, Transaction& transaction) noexcept;
+
+private:
+    /// Signs a Proto::SigningInput transaction.
+    static Proto::SigningOutput signSecp256k1(const Proto::SigningInput& input);
+
+    /// Signs a Proto::SigningInput transaction.
+    static Proto::SigningOutput signDelegated(const Proto::SigningInput& input);
 };
 
 } // namespace TW::Filecoin

--- a/src/Filecoin/Transaction.cpp
+++ b/src/Filecoin/Transaction.cpp
@@ -40,8 +40,8 @@ Cbor::Encode Transaction::message() const {
                                               : Cbor::Encode::negInt((uint64_t)(-gasLimit - 1));
     return Cbor::Encode::array({
         Cbor::Encode::uint(0),                         // version
-        Cbor::Encode::bytes(to.bytes),                 // to address
-        Cbor::Encode::bytes(from.bytes),               // from address
+        Cbor::Encode::bytes(to.toBytes()),                 // to address
+        Cbor::Encode::bytes(from.toBytes()),               // from address
         Cbor::Encode::uint(nonce),                     // nonce
         Cbor::Encode::bytes(encodeBigInt(value)),      // value
         cborGasLimit,                                  // gas limit

--- a/src/Filecoin/Transaction.cpp
+++ b/src/Filecoin/Transaction.cpp
@@ -40,8 +40,8 @@ Cbor::Encode Transaction::message() const {
                                               : Cbor::Encode::negInt((uint64_t)(-gasLimit - 1));
     return Cbor::Encode::array({
         Cbor::Encode::uint(0),                         // version
-        Cbor::Encode::bytes(to.toBytes()),                 // to address
-        Cbor::Encode::bytes(from.toBytes()),               // from address
+        Cbor::Encode::bytes(to.toBytes()),             // to address
+        Cbor::Encode::bytes(from.toBytes()),           // from address
         Cbor::Encode::uint(nonce),                     // nonce
         Cbor::Encode::bytes(encodeBigInt(value)),      // value
         cborGasLimit,                                  // gas limit

--- a/src/Filecoin/Transaction.cpp
+++ b/src/Filecoin/Transaction.cpp
@@ -47,7 +47,7 @@ Cbor::Encode Transaction::message() const {
         cborGasLimit,                                  // gas limit
         Cbor::Encode::bytes(encodeBigInt(gasFeeCap)),  // gas fee cap
         Cbor::Encode::bytes(encodeBigInt(gasPremium)), // gas premium
-        Cbor::Encode::uint(0),                         // abi.MethodNum (0 => send)
+        Cbor::Encode::uint(method),                         // abi.MethodNum
         Cbor::Encode::bytes(Data())                    // data (empty)
     });
 }
@@ -71,6 +71,7 @@ std::string Transaction::serialize(Data& signature) const {
                 {"GasPremium", toString(gasPremium)},
                 {"GasFeeCap", toString(gasFeeCap)},
                 {"GasLimit", gasLimit},
+                {"Method", method},
             }
         },
         {"Signature", json{

--- a/src/Filecoin/Transaction.cpp
+++ b/src/Filecoin/Transaction.cpp
@@ -39,16 +39,16 @@ Cbor::Encode Transaction::message() const {
     Cbor::Encode cborGasLimit = gasLimit >= 0 ? Cbor::Encode::uint((uint64_t)gasLimit)
                                               : Cbor::Encode::negInt((uint64_t)(-gasLimit - 1));
     return Cbor::Encode::array({
-        Cbor::Encode::uint(0),                         // version
-        Cbor::Encode::bytes(to.toBytes()),             // to address
-        Cbor::Encode::bytes(from.toBytes()),           // from address
-        Cbor::Encode::uint(nonce),                     // nonce
-        Cbor::Encode::bytes(encodeBigInt(value)),      // value
-        cborGasLimit,                                  // gas limit
+        Cbor::Encode::uint(0),                             // version
+        Cbor::Encode::bytes(to.toBytes()),                   // to address
+        Cbor::Encode::bytes(from.toBytes()),                 // from address
+        Cbor::Encode::uint(nonce),                         // nonce
+        Cbor::Encode::bytes(encodeBigInt(value)),            // value
+        cborGasLimit,                                            // gas limit
         Cbor::Encode::bytes(encodeBigInt(gasFeeCap)),  // gas fee cap
         Cbor::Encode::bytes(encodeBigInt(gasPremium)), // gas premium
-        Cbor::Encode::uint(method),                         // abi.MethodNum
-        Cbor::Encode::bytes(Data())                    // data (empty)
+        Cbor::Encode::uint(method),                        // abi.MethodNum
+        Cbor::Encode::bytes(params)                          // params
     });
 }
 
@@ -60,22 +60,27 @@ Data Transaction::cid() const {
     cid.insert(cid.end(), hash.begin(), hash.end());
     return cid;
 }
-std::string Transaction::serialize(Data& signature) const {
+
+std::string Transaction::serialize(SignatureType signatureType, Data& signature) const {
     // clang-format off
+    json message = {
+        {"To", to.string()},
+        {"From", from.string()},
+        {"Nonce", nonce},
+        {"Value", toString(value)},
+        {"GasPremium", toString(gasPremium)},
+        {"GasFeeCap", toString(gasFeeCap)},
+        {"GasLimit", gasLimit},
+        {"Method", method},
+    };
+    if (!params.empty()) {
+        message["Params"] = Base64::encode(params);
+    }
+
     json tx = {
-        {"Message", json{
-                {"To", to.string()},
-                {"From", from.string()},
-                {"Nonce", nonce},
-                {"Value", toString(value)},
-                {"GasPremium", toString(gasPremium)},
-                {"GasFeeCap", toString(gasFeeCap)},
-                {"GasLimit", gasLimit},
-                {"Method", method},
-            }
-        },
+        {"Message", message},
         {"Signature", json{
-                {"Type", 1},
+                {"Type", static_cast<uint8_t>(signatureType)},
                 {"Data", Base64::encode(signature)},
             }
         },

--- a/src/Filecoin/Transaction.h
+++ b/src/Filecoin/Transaction.h
@@ -18,6 +18,11 @@ Data encodeBigInt(const uint256_t& value);
 
 class Transaction {
   public:
+    /// Simple transfers.
+    static constexpr uint64_t SEND_METHOD = 0;
+    /// InvokeEVM method.
+    static constexpr uint64_t INVOKE_EVM_METHOD = 3844450837;
+
     // Transaction version
     uint64_t version;
     // Recipient address
@@ -32,13 +37,13 @@ class Transaction {
     int64_t gasLimit;
     uint256_t gasFeeCap;
     uint256_t gasPremium;
-    // Transaction type; 0 for simple transfers
+    // Transaction type
     uint64_t method;
     // Transaction data; empty for simple transfers
     Data params;
 
     Transaction(Address to, Address from, uint64_t nonce, uint256_t value, int64_t gasLimit,
-                uint256_t gasFeeCap, uint256_t gasPremium)
+                uint256_t gasFeeCap, uint256_t gasPremium, uint64_t method)
         : version(0)
         , to(std::move(to))
         , from(std::move(from))
@@ -47,7 +52,7 @@ class Transaction {
         , gasLimit(gasLimit)
         , gasFeeCap(std::move(gasFeeCap))
         , gasPremium(std::move(gasPremium))
-        , method(0) {}
+        , method(method) {}
 
   public:
     // message returns the CBOR encoding of the Filecoin Message to be signed.

--- a/src/Filecoin/Transaction.h
+++ b/src/Filecoin/Transaction.h
@@ -18,10 +18,12 @@ Data encodeBigInt(const uint256_t& value);
 
 class Transaction {
   public:
-    /// Simple transfers.
-    static constexpr uint64_t SEND_METHOD = 0;
-    /// InvokeEVM method.
-    static constexpr uint64_t INVOKE_EVM_METHOD = 3844450837;
+    enum class MethodType: uint64_t {
+        /// Simple transfers.
+        SEND = 0,
+        /// InvokeEVM method.
+        INVOKE_EVM = 3844450837,
+    };
 
     enum class SignatureType: uint8_t {
         SECP256K1 = 1,
@@ -48,7 +50,7 @@ class Transaction {
     Data params;
 
     Transaction(Address to, Address from, uint64_t nonce, uint256_t value, int64_t gasLimit,
-                uint256_t gasFeeCap, uint256_t gasPremium, uint64_t method, Data params)
+                uint256_t gasFeeCap, uint256_t gasPremium, MethodType method, Data params)
         : version(0)
         , to(std::move(to))
         , from(std::move(from))
@@ -57,7 +59,7 @@ class Transaction {
         , gasLimit(gasLimit)
         , gasFeeCap(std::move(gasFeeCap))
         , gasPremium(std::move(gasPremium))
-        , method(method)
+        , method(static_cast<uint64_t>(method))
         , params(std::move(params)) {}
 
   public:

--- a/src/Filecoin/Transaction.h
+++ b/src/Filecoin/Transaction.h
@@ -23,6 +23,11 @@ class Transaction {
     /// InvokeEVM method.
     static constexpr uint64_t INVOKE_EVM_METHOD = 3844450837;
 
+    enum class SignatureType: uint8_t {
+        SECP256K1 = 1,
+        DELEGATED = 3,
+    };
+
     // Transaction version
     uint64_t version;
     // Recipient address
@@ -39,11 +44,11 @@ class Transaction {
     uint256_t gasPremium;
     // Transaction type
     uint64_t method;
-    // Transaction data; empty for simple transfers
+    // Transaction data
     Data params;
 
     Transaction(Address to, Address from, uint64_t nonce, uint256_t value, int64_t gasLimit,
-                uint256_t gasFeeCap, uint256_t gasPremium, uint64_t method)
+                uint256_t gasFeeCap, uint256_t gasPremium, uint64_t method, Data params)
         : version(0)
         , to(std::move(to))
         , from(std::move(from))
@@ -52,7 +57,8 @@ class Transaction {
         , gasLimit(gasLimit)
         , gasFeeCap(std::move(gasFeeCap))
         , gasPremium(std::move(gasPremium))
-        , method(method) {}
+        , method(method)
+        , params(std::move(params)) {}
 
   public:
     // message returns the CBOR encoding of the Filecoin Message to be signed.
@@ -62,7 +68,7 @@ class Transaction {
     Data cid() const;
 
     // serialize returns json ready for MpoolPush rpc
-    std::string serialize(Data& signature) const;
+    std::string serialize(SignatureType signatureType, Data& signature) const;
 };
 
 } // namespace TW::Filecoin

--- a/src/interface/TWAnyAddress.cpp
+++ b/src/interface/TWAnyAddress.cpp
@@ -84,6 +84,14 @@ struct TWAnyAddress* TWAnyAddressCreateSS58WithPublicKey(struct TWPublicKey* pub
     return new TWAnyAddress{TW::AnyAddress::createAddress(publicKey->impl, coin, TWDerivationDefault, TW::SS58Prefix(ss58Prefix))};
 }
 
+struct TWAnyAddress* TWAnyAddressCreateWithPublicKeyFilecoinAddressType(struct TWPublicKey* _Nonnull publicKey, enum TWFilecoinAddressType filecoinAddressType) {
+    TW::PrefixVariant prefix = std::monostate();
+    if (filecoinAddressType == TWFilecoinAddressTypeDelegated) {
+        prefix = TW::DelegatedPrefix();
+    }
+    return new TWAnyAddress{TW::AnyAddress::createAddress(publicKey->impl, TWCoinTypeFilecoin, TWDerivationDefault, prefix)};
+}
+
 void TWAnyAddressDelete(struct TWAnyAddress* _Nonnull address) {
     delete address->impl;
     delete address;

--- a/src/interface/TWFilecoinAddressConverter.cpp
+++ b/src/interface/TWFilecoinAddressConverter.cpp
@@ -1,0 +1,31 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include <TrustWalletCore/TWFilecoinAddressConverter.h>
+#include <Filecoin/AddressConverter.h>
+
+TWString* _Nonnull TWFilecoinAddressConverterConvertToEthereum(TWString* _Nonnull filecoinAddress) {
+    const auto& address = *reinterpret_cast<const std::string*>(filecoinAddress);
+    try {
+        std::string ethereumAddress;
+        if (!TW::Filecoin::AddressConverter::convertToEthereum(address, ethereumAddress)) {
+            return TWStringCreateWithUTF8Bytes("");
+        }
+        return TWStringCreateWithUTF8Bytes(ethereumAddress.c_str());
+    } catch (...) {
+        return TWStringCreateWithUTF8Bytes("");
+    }
+}
+
+TWString* _Nonnull TWFilecoinAddressConverterConvertFromEthereum(TWString* _Nonnull ethAddress) {
+    const auto& address = *reinterpret_cast<const std::string*>(ethAddress);
+    try {
+        std::string filecoinAddress = TW::Filecoin::AddressConverter::convertFromEthereum(address);
+        return TWStringCreateWithUTF8Bytes(filecoinAddress.c_str());
+    } catch (...) {
+        return TWStringCreateWithUTF8Bytes("");
+    }
+}

--- a/src/interface/TWFilecoinAddressConverter.cpp
+++ b/src/interface/TWFilecoinAddressConverter.cpp
@@ -16,6 +16,7 @@ TWString* _Nonnull TWFilecoinAddressConverterConvertToEthereum(TWString* _Nonnul
     } catch (...) {
     }
 
+    // Return an empty string if an error occurs.
     return TWStringCreateWithUTF8Bytes("");
 }
 
@@ -25,6 +26,8 @@ TWString* _Nonnull TWFilecoinAddressConverterConvertFromEthereum(TWString* _Nonn
         std::string filecoinAddress = TW::Filecoin::AddressConverter::convertFromEthereumString(address);
         return TWStringCreateWithUTF8Bytes(filecoinAddress.c_str());
     } catch (...) {
-        return TWStringCreateWithUTF8Bytes("");
     }
+
+    // Return an empty string if an error occurs.
+    return TWStringCreateWithUTF8Bytes("");
 }

--- a/src/interface/TWFilecoinAddressConverter.cpp
+++ b/src/interface/TWFilecoinAddressConverter.cpp
@@ -10,20 +10,19 @@
 TWString* _Nonnull TWFilecoinAddressConverterConvertToEthereum(TWString* _Nonnull filecoinAddress) {
     const auto& address = *reinterpret_cast<const std::string*>(filecoinAddress);
     try {
-        std::string ethereumAddress;
-        if (!TW::Filecoin::AddressConverter::convertToEthereum(address, ethereumAddress)) {
-            return TWStringCreateWithUTF8Bytes("");
+        if (auto eth_opt = TW::Filecoin::AddressConverter::convertToEthereumString(address); eth_opt) {
+            return TWStringCreateWithUTF8Bytes(eth_opt->c_str());
         }
-        return TWStringCreateWithUTF8Bytes(ethereumAddress.c_str());
     } catch (...) {
-        return TWStringCreateWithUTF8Bytes("");
     }
+
+    return TWStringCreateWithUTF8Bytes("");
 }
 
 TWString* _Nonnull TWFilecoinAddressConverterConvertFromEthereum(TWString* _Nonnull ethAddress) {
     const auto& address = *reinterpret_cast<const std::string*>(ethAddress);
     try {
-        std::string filecoinAddress = TW::Filecoin::AddressConverter::convertFromEthereum(address);
+        std::string filecoinAddress = TW::Filecoin::AddressConverter::convertFromEthereumString(address);
         return TWStringCreateWithUTF8Bytes(filecoinAddress.c_str());
     } catch (...) {
         return TWStringCreateWithUTF8Bytes("");

--- a/src/proto/Filecoin.proto
+++ b/src/proto/Filecoin.proto
@@ -3,6 +3,15 @@ syntax = "proto3";
 package TW.Filecoin.Proto;
 option java_package = "wallet.core.jni.proto";
 
+// Defines the type of `from` address derivation.
+enum DerivationType {
+    // Defines a Secp256k1 (`f1`) derivation for the sender address.
+    // Default derivation type.
+    SECP256K1 = 0;
+    // Defines a Delegated (`f4`) derivation for the sender address.
+    DELEGATED = 1;
+}
+
 // Input data necessary to create a signed transaction.
 message SigningInput {
     // The secret private key of the sender account, used for signing (32 bytes).
@@ -25,10 +34,19 @@ message SigningInput {
 
     // Gas premium (uint256, serialized little endian)
     bytes gas_premium = 7;
+
+    // Message params.
+    bytes params = 8;
+
+    // Sender address derivation type.
+    DerivationType derivation = 9;
 }
 
 // Result containing the signed and encoded transaction.
 message SigningOutput {
     // Resulting transaction, in JSON.
     string json = 1;
+
+    // Error description.
+    string error_message = 2;
 }

--- a/swift/Tests/Blockchains/FilecoinTests.swift
+++ b/swift/Tests/Blockchains/FilecoinTests.swift
@@ -16,6 +16,14 @@ class FilecoinTests: XCTestCase {
         XCTAssertEqual(address.description, "f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq")
     }
 
+    func testAddressConverter() {
+        let actualEth = FilecoinAddressConverter.convertToEthereum(filecoinAddress: "f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky")
+        XCTAssertEqual(actualEth, "0x8dbD6c7Ede90646a61Bbc649831b7c298BFd37A0")
+        
+        let actualFilecoin = FilecoinAddressConverter.convertFromEthereum(ethAddress:"0x8dbD6c7Ede90646a61Bbc649831b7c298BFd37A0")
+        XCTAssertEqual(actualFilecoin, "f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky")
+    }
+
     func testSigner() {
         let input = FilecoinSigningInput.with {
             $0.privateKey = Data(hexString: "1d969865e189957b9824bd34f26d5cbf357fda1a6d844cbf0c9ab1ed93fa7dbe")!

--- a/swift/Tests/Blockchains/FilecoinTests.swift
+++ b/swift/Tests/Blockchains/FilecoinTests.swift
@@ -44,12 +44,46 @@ class FilecoinTests: XCTestCase {
                 "GasFeeCap": "700000000000000000000",
                 "GasLimit": 1000,
                 "GasPremium": "800000000000000000000",
+                "Method": 0,
                 "Nonce": 2,
                 "To": "f3um6uo3qt5of54xjbx3hsxbw5mbsc6auxzrvfxekn5bv3duewqyn2tg5rhrlx73qahzzpkhuj7a34iq7oifsq",
                 "Value": "600000000000000000000"
             },
             "Signature": {
                 "Data": "jMRu+OZ/lfppgmqSfGsntFrRLWZnUg3ZYmJTTRLsVt4V1310vR3VKGJpaE6S4sNvDOE6sEgmN9YmfTkPVK2qMgE=",
+                "Type": 1
+            }
+        }
+        """
+        XCTAssertJSONEqual(output.json, json)
+    }
+
+    func testSignerToDelegated() {
+        let input = FilecoinSigningInput.with {
+            $0.privateKey = Data(hexString: "d3d6ed8b97dcd4661f62a1162bee6949401fd3935f394e6eacf15b6d5005483c")!
+            $0.to = "f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky"
+            $0.nonce = 0
+            $0.value = Data(hexString: "038d7ea4c68000")! // 0.001 FIL
+            $0.gasLimit = 6152567
+            $0.gasFeeCap = Data(hexString: "01086714e9")! // 4435940585
+            $0.gasPremium = Data(hexString: "b0f553")! // 11597139
+        }
+
+        let output: FilecoinSigningOutput = AnySigner.sign(input: input, coin: .filecoin)
+        let json = """
+        {
+            "Message": {
+                "From": "f1mzyorxlcvdoqn5cto7urefbucugrcxxghpjc5hi",
+                "GasFeeCap": "4435940585",
+                "GasLimit": 6152567,
+                "GasPremium": "11597139",
+                "Method": 3844450837,
+                "Nonce": 0,
+                "To": "f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky",
+                "Value": "1000000000000000"
+            },
+            "Signature": {
+                "Data": "bxZhnsOYjdArPa3W0SpggwqtXPgvfRSoM2dU5lXYar9lWhTGc6FvPWk2RTUGyA8UtzMIdOPSUKfzU1iA2eA3YwA=",
                 "Type": 1
             }
         }

--- a/swift/Tests/Blockchains/FilecoinTests.swift
+++ b/swift/Tests/Blockchains/FilecoinTests.swift
@@ -26,9 +26,11 @@ class FilecoinTests: XCTestCase {
     func testAddressConverter() {
         let actualEth = FilecoinAddressConverter.convertToEthereum(filecoinAddress: "f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky")
         XCTAssertEqual(actualEth, "0x8dbD6c7Ede90646a61Bbc649831b7c298BFd37A0")
+        XCTAssert(AnyAddress.isValid(string: actualEth, coin: .ethereum))
         
         let actualFilecoin = FilecoinAddressConverter.convertFromEthereum(ethAddress:"0x8dbD6c7Ede90646a61Bbc649831b7c298BFd37A0")
         XCTAssertEqual(actualFilecoin, "f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky")
+        XCTAssert(AnyAddress.isValid(string: actualFilecoin, coin: .filecoin))
     }
 
     func testSigner() {
@@ -65,6 +67,8 @@ class FilecoinTests: XCTestCase {
         XCTAssertJSONEqual(output.json, json)
     }
 
+    /// Successfully broadcasted:
+    /// https://filfox.info/en/message/bafy2bzaceczvto7d2af7cq3kuwlvmanlh5xica4apl3vwxu37yaeozq72mvgm
     func testSignerToDelegated() {
         let input = FilecoinSigningInput.with {
             $0.privateKey = Data(hexString: "d3d6ed8b97dcd4661f62a1162bee6949401fd3935f394e6eacf15b6d5005483c")!

--- a/swift/Tests/Blockchains/FilecoinTests.swift
+++ b/swift/Tests/Blockchains/FilecoinTests.swift
@@ -9,11 +9,18 @@ import WalletCore
 
 class FilecoinTests: XCTestCase {
 
-    func testAddress() {
+    func testCreateAddress() {
         let privateKey = PrivateKey(data: Data(hexString: "1d969865e189957b9824bd34f26d5cbf357fda1a6d844cbf0c9ab1ed93fa7dbe")!)!
         let publicKey = privateKey.getPublicKeySecp256k1(compressed: false)
         let address = AnyAddress(publicKey: publicKey, coin: .filecoin)
         XCTAssertEqual(address.description, "f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq")
+    }
+
+    func testCreateDelegatedAddress() {
+        let privateKey = PrivateKey(data: Data(hexString: "825d2bb32965764a98338139412c7591ed54c951dd65504cd8ddaeaa0fea7b2a")!)!
+        let publicKey = privateKey.getPublicKeySecp256k1(compressed: false)
+        let address = AnyAddress(publicKey: publicKey, filecoinAddressType: .delegated)
+        XCTAssertEqual(address.description, "f410fvak24cyg3saddajborn6idt7rrtfj2ptauk5pbq")
     }
 
     func testAddressConverter() {

--- a/tests/chains/Filecoin/AddressTests.cpp
+++ b/tests/chains/Filecoin/AddressTests.cpp
@@ -32,7 +32,7 @@ static const address_test validAddresses[] = {
     {"f01024",                 "008008",                 1024,                  ""},
     {"f01729",                 "00c10d",                 1729,                  ""},
     {"f0999999",               "00bf843d",               999999,                ""},
-    {"f018446744073709551615", "00ffffffffffffffffff01", 18446744073709551615U, ""}, // TODO same for f4
+    {"f018446744073709551615", "00ffffffffffffffffff01", 18446744073709551615U, ""},
     // secp256k1 addresses
     {"f15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq", "01ea0f0ea039b291a0f08fd179e0556a8c3277c0d3",  0, "ea0f0ea039b291a0f08fd179e0556a8c3277c0d3"},
     {"f12fiakbhe2gwd5cnmrenekasyn6v5tnaxaqizq6a", "01d1500504e4d1ac3e89ac891a4502586fabd9b417", 0, "d1500504e4d1ac3e89ac891a4502586fabd9b417"},

--- a/tests/chains/Filecoin/AddressTests.cpp
+++ b/tests/chains/Filecoin/AddressTests.cpp
@@ -18,41 +18,46 @@ namespace TW::Filecoin::tests {
 struct address_test {
     std::string string;
     std::string encoded;
-    uint8_t type;
     uint64_t actorID;
-    const char* payloadHex;
+    std::string payloadHex;
 };
 
 static const address_test validAddresses[] = {
     // ID addresses
-    {"f00",                    "0000",                 0, 0,                     ""},
-    {"f01",                    "0001",                 0, 1,                     ""},
-    {"f010",                   "000a",                 0, 10,                    ""},
-    {"f0150",                  "009601",               0, 150,                   ""},
-    {"f0499",                  "00f303",               0, 499,                   ""},
-    {"f01024",                 "008008",               0, 1024,                  ""},
-    {"f01729",                 "00c10d",               0, 1729,                  ""},
-    {"f0999999",               "00bf843d",             0, 999999,                ""},
-    {"f018446744073709551615", "00ffffffffffffffffff01", 0, 18446744073709551615U, ""}, // TODO same for f4
+    {"f00",                    "0000",                   0,                     ""},
+    {"f01",                    "0001",                   1,                     ""},
+    {"f010",                   "000a",                   10,                    ""},
+    {"f0150",                  "009601",                 150,                   ""},
+    {"f0499",                  "00f303",                 499,                   ""},
+    {"f01024",                 "008008",                 1024,                  ""},
+    {"f01729",                 "00c10d",                 1729,                  ""},
+    {"f0999999",               "00bf843d",               999999,                ""},
+    {"f018446744073709551615", "00ffffffffffffffffff01", 18446744073709551615U, ""}, // TODO same for f4
     // secp256k1 addresses
-    {"f15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq", "01ea0f0ea039b291a0f08fd179e0556a8c3277c0d3", 1, 0, "ea0f0ea039b291a0f08fd179e0556a8c3277c0d3"},
-    {"f12fiakbhe2gwd5cnmrenekasyn6v5tnaxaqizq6a", "01d1500504e4d1ac3e89ac891a4502586fabd9b417", 1, 0, "d1500504e4d1ac3e89ac891a4502586fabd9b417"},
-    {"f1wbxhu3ypkuo6eyp6hjx6davuelxaxrvwb2kuwva", "01b06e7a6f0f551de261fe3a6fe182b422ee0bc6b6", 1, 0, "b06e7a6f0f551de261fe3a6fe182b422ee0bc6b6"},
-    {"f1xtwapqc6nh4si2hcwpr3656iotzmlwumogqbuaa", "01bcec07c05e69f92468e2b3e3bf77c874f2c5da8c", 1, 0, "bcec07c05e69f92468e2b3e3bf77c874f2c5da8c"},
-    {"f1xcbgdhkgkwht3hrrnui3jdopeejsoatkzmoltqy", "01b882619d46558f3d9e316d11b48dcf211327026a", 1, 0, "b882619d46558f3d9e316d11b48dcf211327026a"},
-    {"f17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy", "01fd1d0f4dfcd7e99afcb99a8326b7dc459d32c628", 1, 0, "fd1d0f4dfcd7e99afcb99a8326b7dc459d32c628"},
+    {"f15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq", "01ea0f0ea039b291a0f08fd179e0556a8c3277c0d3",  0, "ea0f0ea039b291a0f08fd179e0556a8c3277c0d3"},
+    {"f12fiakbhe2gwd5cnmrenekasyn6v5tnaxaqizq6a", "01d1500504e4d1ac3e89ac891a4502586fabd9b417", 0, "d1500504e4d1ac3e89ac891a4502586fabd9b417"},
+    {"f1wbxhu3ypkuo6eyp6hjx6davuelxaxrvwb2kuwva", "01b06e7a6f0f551de261fe3a6fe182b422ee0bc6b6", 0, "b06e7a6f0f551de261fe3a6fe182b422ee0bc6b6"},
+    {"f1xtwapqc6nh4si2hcwpr3656iotzmlwumogqbuaa", "01bcec07c05e69f92468e2b3e3bf77c874f2c5da8c", 0, "bcec07c05e69f92468e2b3e3bf77c874f2c5da8c"},
+    {"f1xcbgdhkgkwht3hrrnui3jdopeejsoatkzmoltqy", "01b882619d46558f3d9e316d11b48dcf211327026a", 0, "b882619d46558f3d9e316d11b48dcf211327026a"},
+    {"f17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy", "01fd1d0f4dfcd7e99afcb99a8326b7dc459d32c628", 0, "fd1d0f4dfcd7e99afcb99a8326b7dc459d32c628"},
     // Actor addresses
-    {"f24vg6ut43yw2h2jqydgbg2xq7x6f4kub3bg6as6i", "02e54dea4f9bc5b47d261819826d5e1fbf8bc5503b", 2, 0, "e54dea4f9bc5b47d261819826d5e1fbf8bc5503b"},
-    {"f25nml2cfbljvn4goqtclhifepvfnicv6g7mfmmvq", "02eb58bd08a15a6ade19d0989674148fa95a8157c6", 2, 0, "eb58bd08a15a6ade19d0989674148fa95a8157c6"},
-    {"f2nuqrg7vuysaue2pistjjnt3fadsdzvyuatqtfei", "026d21137eb4c4814269e894d296cf6500e43cd714", 2, 0, "6d21137eb4c4814269e894d296cf6500e43cd714"},
-    {"f24dd4ox4c2vpf5vk5wkadgyyn6qtuvgcpxxon64a", "02e0c7c75f82d55e5ed55db28033630df4274a984f", 2, 0, "e0c7c75f82d55e5ed55db28033630df4274a984f"},
-    {"f2gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y", "02316b4c1ff5d4afb7826ceab5bb0f2c3e0f364053", 2, 0, "316b4c1ff5d4afb7826ceab5bb0f2c3e0f364053"},
+    {"f24vg6ut43yw2h2jqydgbg2xq7x6f4kub3bg6as6i", "02e54dea4f9bc5b47d261819826d5e1fbf8bc5503b", 0, "e54dea4f9bc5b47d261819826d5e1fbf8bc5503b"},
+    {"f25nml2cfbljvn4goqtclhifepvfnicv6g7mfmmvq", "02eb58bd08a15a6ade19d0989674148fa95a8157c6", 0, "eb58bd08a15a6ade19d0989674148fa95a8157c6"},
+    {"f2nuqrg7vuysaue2pistjjnt3fadsdzvyuatqtfei", "026d21137eb4c4814269e894d296cf6500e43cd714", 0, "6d21137eb4c4814269e894d296cf6500e43cd714"},
+    {"f24dd4ox4c2vpf5vk5wkadgyyn6qtuvgcpxxon64a", "02e0c7c75f82d55e5ed55db28033630df4274a984f", 0, "e0c7c75f82d55e5ed55db28033630df4274a984f"},
+    {"f2gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y", "02316b4c1ff5d4afb7826ceab5bb0f2c3e0f364053", 0, "316b4c1ff5d4afb7826ceab5bb0f2c3e0f364053"},
     // BLS addresses
-    {"f3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss4a","03ad58df696e2d4e91ea86c881e938ba4ea81b395e12797b84b9cf314b9546705e839c7a99d606b247ddb4f9ac7a3414dd", 3, 0, "ad58df696e2d4e91ea86c881e938ba4ea81b395e12797b84b9cf314b9546705e839c7a99d606b247ddb4f9ac7a3414dd"},
-    {"f3wmuu6crofhqmm3v4enos73okk2l366ck6yc4owxwbdtkmpk42ohkqxfitcpa57pjdcftql4tojda2poeruwa","03b3294f0a2e29e0c66ebc235d2fedca5697bf784af605c75af608e6a63d5cd38ea85ca8989e0efde9188b382f9372460d", 3, 0, "b3294f0a2e29e0c66ebc235d2fedca5697bf784af605c75af608e6a63d5cd38ea85ca8989e0efde9188b382f9372460d"},
-    {"f3s2q2hzhkpiknjgmf4zq3ejab2rh62qbndueslmsdzervrhapxr7dftie4kpnpdiv2n6tvkr743ndhrsw6d3a","0396a1a3e4ea7a14d49985e661b22401d44fed402d1d0925b243c923589c0fbc7e32cd04e29ed78d15d37d3aaa3fe6da33", 3, 0, "96a1a3e4ea7a14d49985e661b22401d44fed402d1d0925b243c923589c0fbc7e32cd04e29ed78d15d37d3aaa3fe6da33"},
-    {"f3q22fijmmlckhl56rn5nkyamkph3mcfu5ed6dheq53c244hfmnq2i7efdma3cj5voxenwiummf2ajlsbxc65a","0386b454258c589475f7d16f5aac018a79f6c1169d20fc33921dd8b5ce1cac6c348f90a3603624f6aeb91b64518c2e8095", 3, 0, "86b454258c589475f7d16f5aac018a79f6c1169d20fc33921dd8b5ce1cac6c348f90a3603624f6aeb91b64518c2e8095"},
-    {"f3u5zgwa4ael3vuocgc5mfgygo4yuqocrntuuhcklf4xzg5tcaqwbyfabxetwtj4tsam3pbhnwghyhijr5mixa","03a7726b038022f75a384617585360cee629070a2d9d28712965e5f26ecc40858382803724ed34f2720336f09db631f074", 3, 0, "a7726b038022f75a384617585360cee629070a2d9d28712965e5f26ecc40858382803724ed34f2720336f09db631f074"},
+    {"f3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss4a","03ad58df696e2d4e91ea86c881e938ba4ea81b395e12797b84b9cf314b9546705e839c7a99d606b247ddb4f9ac7a3414dd", 0, "ad58df696e2d4e91ea86c881e938ba4ea81b395e12797b84b9cf314b9546705e839c7a99d606b247ddb4f9ac7a3414dd"},
+    {"f3wmuu6crofhqmm3v4enos73okk2l366ck6yc4owxwbdtkmpk42ohkqxfitcpa57pjdcftql4tojda2poeruwa","03b3294f0a2e29e0c66ebc235d2fedca5697bf784af605c75af608e6a63d5cd38ea85ca8989e0efde9188b382f9372460d", 0, "b3294f0a2e29e0c66ebc235d2fedca5697bf784af605c75af608e6a63d5cd38ea85ca8989e0efde9188b382f9372460d"},
+    {"f3s2q2hzhkpiknjgmf4zq3ejab2rh62qbndueslmsdzervrhapxr7dftie4kpnpdiv2n6tvkr743ndhrsw6d3a","0396a1a3e4ea7a14d49985e661b22401d44fed402d1d0925b243c923589c0fbc7e32cd04e29ed78d15d37d3aaa3fe6da33", 0, "96a1a3e4ea7a14d49985e661b22401d44fed402d1d0925b243c923589c0fbc7e32cd04e29ed78d15d37d3aaa3fe6da33"},
+    {"f3q22fijmmlckhl56rn5nkyamkph3mcfu5ed6dheq53c244hfmnq2i7efdma3cj5voxenwiummf2ajlsbxc65a","0386b454258c589475f7d16f5aac018a79f6c1169d20fc33921dd8b5ce1cac6c348f90a3603624f6aeb91b64518c2e8095", 0, "86b454258c589475f7d16f5aac018a79f6c1169d20fc33921dd8b5ce1cac6c348f90a3603624f6aeb91b64518c2e8095"},
+    {"f3u5zgwa4ael3vuocgc5mfgygo4yuqocrntuuhcklf4xzg5tcaqwbyfabxetwtj4tsam3pbhnwghyhijr5mixa","03a7726b038022f75a384617585360cee629070a2d9d28712965e5f26ecc40858382803724ed34f2720336f09db631f074", 0, "a7726b038022f75a384617585360cee629070a2d9d28712965e5f26ecc40858382803724ed34f2720336f09db631f074"},
+    // Delegated addresses
+    {"f432f77777777x32lpna",                         "0420ffffffffff",                               32,                    "ffffffffff"},
+    {"f418446744073709551615ftnkyfaq",               "04ffffffffffffffffff01",                       18446744073709551615U, ""},
+    {"f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky", "040a8dbd6c7ede90646a61bbc649831b7c298bfd37a0", 10,                    "8dbd6c7ede90646a61bbc649831b7c298bfd37a0"},
+    {"f410f2oekwcmo2pueydmaq53eic2i62crtbeyuzx2gmy", "040ad388ab098ed3e84c0d808776440b48f685198498", 10,                    "d388ab098ed3e84c0d808776440b48f685198498"},
+    {"f418446744073709551615faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafbbuagu","04ffffffffffffffffff01000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", 18446744073709551615U, "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"},
 };
 
 static const std::string invalidAddresses[] = {
@@ -73,21 +78,14 @@ TEST(FilecoinAddress, IsValid) {
     for (const auto& test : validAddresses) {
         ASSERT_TRUE(Address::isValid(test.string))
             << "isValid(string) != true: " << test.string;
-        const Address lhs(test.string);
 
-        ASSERT_TRUE(Address::isValid(parse_hex(test.encoded)))
+        const Data encodedBytes = parse_hex(test.encoded);
+        ASSERT_TRUE(Address::isValid(encodedBytes))
             << "isValid(Data) != true: " << test.encoded;
-        const Address rhs(parse_hex(test.encoded));
-
-        ASSERT_TRUE(lhs == rhs) << "Address(string) != Address(Data)";
-        const auto actualType = static_cast<uint8_t>(lhs.type);
-        ASSERT_TRUE(actualType == test.type)
-            << "Unexpected type: " << actualType << " != " << test.type << ": " << test.string;
-        ASSERT_TRUE(lhs.actorID == test.actorID)
-            << "Unexpected actorID: " << lhs.actorID << " != " << test.actorID << ": " << test.string;
-        ASSERT_TRUE(lhs.payload == parse_hex(test.payloadHex))
-            << "Unexpected payload: " << hex(lhs.payload) << " != " << test.payloadHex;
     }
+}
+
+TEST(FilecoinAddress, IsInvalid) {
     for (const auto& address : invalidAddresses) {
         ASSERT_FALSE(Address::isValid(address))
             << "isValid(string) != false: " << address;
@@ -98,21 +96,46 @@ TEST(FilecoinAddress, IsValid) {
     ASSERT_FALSE(Address::isValid(parse_hex("00ff00ff"))) << "Varuint with hole";
     ASSERT_FALSE(Address::isValid(parse_hex("000101"))) << "Long varuint";
     ASSERT_FALSE(Address::isValid(parse_hex("000000"))) << "Long varuint";
-    ASSERT_FALSE(Address::isValid(parse_hex("00ffffffffffffffffff02"))) << "Overflow";
+    ASSERT_FALSE(Address::isValid(parse_hex("00ffffffffffffffffff80"))) << "Overflow";
 }
 
-// TEST(FilecoinAddress, String) {
-//     for (const auto& test : validAddresses) {
-//         Address a(parse_hex(test.hex));
-//         ASSERT_EQ(a.string(), test.encoded) << "Address(" << test.hex << ")";
-//     }
-// }
+TEST(FilecoinAddress, Equal) {
+    for (const auto& test : validAddresses) {
+        const Data encodedBytes = parse_hex(test.encoded);
+        const Address lhs(test.string), rhs(encodedBytes);
+        ASSERT_EQ(lhs, rhs) << "Address(string) != Address(Data)";
+    }
+}
 
-// TEST(FilecoinAddress, FromString) {
-//     for (const auto& test : validAddresses) {
-//         Address a(test.encoded);
-//         ASSERT_EQ(hex(a.toBytes()), test.hex) << "Address(" << test.encoded << ")";
-//     }
-// }
+TEST(FilecoinAddress, ExpectedProperties) {
+    for (const auto& test : validAddresses) {
+        const Data encodedBytes = parse_hex(test.encoded);
+        const uint8_t expectedType = encodedBytes[0];
+
+        const Address address(encodedBytes);
+
+        const auto actualType = static_cast<uint8_t>(address.type);
+        ASSERT_TRUE(actualType == expectedType)
+            << "Unexpected type: " << actualType << " != " << expectedType << ": " << test.string;
+        ASSERT_TRUE(address.actorID == test.actorID)
+            << "Unexpected actorID: " << address.actorID << " != " << test.actorID << ": " << test.string;
+        ASSERT_TRUE(address.payload == parse_hex(test.payloadHex))
+            << "Unexpected payload: " << hex(address.payload) << " != " << test.payloadHex;
+    }
+}
+
+TEST(FilecoinAddress, ToString) {
+    for (const auto& test : validAddresses) {
+        Address a(parse_hex(test.encoded));
+        ASSERT_EQ(a.string(), test.string) << "Address(" << test.encoded << ")";
+    }
+}
+
+TEST(FilecoinAddress, ToBytes) {
+    for (const auto& test : validAddresses) {
+        Address a(test.string);
+        ASSERT_EQ(hex(a.toBytes()), test.encoded) << "Address(" << test.string << ")";
+    }
+}
 
 }

--- a/tests/chains/Filecoin/AddressTests.cpp
+++ b/tests/chains/Filecoin/AddressTests.cpp
@@ -16,6 +16,7 @@ namespace TW::Filecoin::tests {
 // clang-format off
 
 struct address_test {
+    std::string string;
     std::string encoded;
     uint8_t type;
     uint64_t actorID;
@@ -24,45 +25,40 @@ struct address_test {
 
 static const address_test validAddresses[] = {
     // ID addresses
-    {"f00",                    0, ""},
-    {"f01",                    ""},
-    {"f010",                   ""},
-    {"f0150",                  ""},
-    {"f0499",                  ""},
-    {"f01024",                 ""},
-    {"f01729",                 "c10d"},
-    {"f0999999",               "bf843d"},
-    {"f018446744073709551615", "ffffffffffffffffff01"},
+    {"f00",                    "0000",                 0, 0,                     ""},
+    {"f01",                    "0001",                 0, 1,                     ""},
+    {"f010",                   "000a",                 0, 10,                    ""},
+    {"f0150",                  "009601",               0, 150,                   ""},
+    {"f0499",                  "00f303",               0, 499,                   ""},
+    {"f01024",                 "008008",               0, 1024,                  ""},
+    {"f01729",                 "00c10d",               0, 1729,                  ""},
+    {"f0999999",               "00bf843d",             0, 999999,                ""},
+    {"f018446744073709551615", "00ffffffffffffffffff01", 0, 18446744073709551615U, ""}, // TODO same for f4
     // secp256k1 addresses
-    {"f15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq", "ea0f0ea039b291a0f08fd179e0556a8c3277c0d3"},
-    {"f12fiakbhe2gwd5cnmrenekasyn6v5tnaxaqizq6a", "d1500504e4d1ac3e89ac891a4502586fabd9b417"},
-    {"f1wbxhu3ypkuo6eyp6hjx6davuelxaxrvwb2kuwva", "b06e7a6f0f551de261fe3a6fe182b422ee0bc6b6"},
-    {"f1xtwapqc6nh4si2hcwpr3656iotzmlwumogqbuaa", "bcec07c05e69f92468e2b3e3bf77c874f2c5da8c"},
-    {"f1xcbgdhkgkwht3hrrnui3jdopeejsoatkzmoltqy", "b882619d46558f3d9e316d11b48dcf211327026a"},
-    {"f17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy", "fd1d0f4dfcd7e99afcb99a8326b7dc459d32c628"},
+    {"f15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq", "01ea0f0ea039b291a0f08fd179e0556a8c3277c0d3", 1, 0, "ea0f0ea039b291a0f08fd179e0556a8c3277c0d3"},
+    {"f12fiakbhe2gwd5cnmrenekasyn6v5tnaxaqizq6a", "01d1500504e4d1ac3e89ac891a4502586fabd9b417", 1, 0, "d1500504e4d1ac3e89ac891a4502586fabd9b417"},
+    {"f1wbxhu3ypkuo6eyp6hjx6davuelxaxrvwb2kuwva", "01b06e7a6f0f551de261fe3a6fe182b422ee0bc6b6", 1, 0, "b06e7a6f0f551de261fe3a6fe182b422ee0bc6b6"},
+    {"f1xtwapqc6nh4si2hcwpr3656iotzmlwumogqbuaa", "01bcec07c05e69f92468e2b3e3bf77c874f2c5da8c", 1, 0, "bcec07c05e69f92468e2b3e3bf77c874f2c5da8c"},
+    {"f1xcbgdhkgkwht3hrrnui3jdopeejsoatkzmoltqy", "01b882619d46558f3d9e316d11b48dcf211327026a", 1, 0, "b882619d46558f3d9e316d11b48dcf211327026a"},
+    {"f17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy", "01fd1d0f4dfcd7e99afcb99a8326b7dc459d32c628", 1, 0, "fd1d0f4dfcd7e99afcb99a8326b7dc459d32c628"},
     // Actor addresses
-    {"f24vg6ut43yw2h2jqydgbg2xq7x6f4kub3bg6as6i", "e54dea4f9bc5b47d261819826d5e1fbf8bc5503b"},
-    {"f25nml2cfbljvn4goqtclhifepvfnicv6g7mfmmvq", "eb58bd08a15a6ade19d0989674148fa95a8157c6"},
-    {"f2nuqrg7vuysaue2pistjjnt3fadsdzvyuatqtfei", "6d21137eb4c4814269e894d296cf6500e43cd714"},
-    {"f24dd4ox4c2vpf5vk5wkadgyyn6qtuvgcpxxon64a", "e0c7c75f82d55e5ed55db28033630df4274a984f"},
-    {"f2gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y", "316b4c1ff5d4afb7826ceab5bb0f2c3e0f364053"},
+    {"f24vg6ut43yw2h2jqydgbg2xq7x6f4kub3bg6as6i", "02e54dea4f9bc5b47d261819826d5e1fbf8bc5503b", 2, 0, "e54dea4f9bc5b47d261819826d5e1fbf8bc5503b"},
+    {"f25nml2cfbljvn4goqtclhifepvfnicv6g7mfmmvq", "02eb58bd08a15a6ade19d0989674148fa95a8157c6", 2, 0, "eb58bd08a15a6ade19d0989674148fa95a8157c6"},
+    {"f2nuqrg7vuysaue2pistjjnt3fadsdzvyuatqtfei", "026d21137eb4c4814269e894d296cf6500e43cd714", 2, 0, "6d21137eb4c4814269e894d296cf6500e43cd714"},
+    {"f24dd4ox4c2vpf5vk5wkadgyyn6qtuvgcpxxon64a", "02e0c7c75f82d55e5ed55db28033630df4274a984f", 2, 0, "e0c7c75f82d55e5ed55db28033630df4274a984f"},
+    {"f2gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y", "02316b4c1ff5d4afb7826ceab5bb0f2c3e0f364053", 2, 0, "316b4c1ff5d4afb7826ceab5bb0f2c3e0f364053"},
     // BLS addresses
-    {"f3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss4a","ad58df696e2d4e91ea86c881e938ba4ea81b395e12797b84b9cf314b9546705e839c7a99d606b247ddb4f9ac7a3414dd"},
-    {"f3wmuu6crofhqmm3v4enos73okk2l366ck6yc4owxwbdtkmpk42ohkqxfitcpa57pjdcftql4tojda2poeruwa","b3294f0a2e29e0c66ebc235d2fedca5697bf784af605c75af608e6a63d5cd38ea85ca8989e0efde9188b382f9372460d"},
-    {"f3s2q2hzhkpiknjgmf4zq3ejab2rh62qbndueslmsdzervrhapxr7dftie4kpnpdiv2n6tvkr743ndhrsw6d3a","96a1a3e4ea7a14d49985e661b22401d44fed402d1d0925b243c923589c0fbc7e32cd04e29ed78d15d37d3aaa3fe6da33"},
-    {"f3q22fijmmlckhl56rn5nkyamkph3mcfu5ed6dheq53c244hfmnq2i7efdma3cj5voxenwiummf2ajlsbxc65a","86b454258c589475f7d16f5aac018a79f6c1169d20fc33921dd8b5ce1cac6c348f90a3603624f6aeb91b64518c2e8095"},
-    {"f3u5zgwa4ael3vuocgc5mfgygo4yuqocrntuuhcklf4xzg5tcaqwbyfabxetwtj4tsam3pbhnwghyhijr5mixa","a7726b038022f75a384617585360cee629070a2d9d28712965e5f26ecc40858382803724ed34f2720336f09db631f074"},
+    {"f3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss4a","03ad58df696e2d4e91ea86c881e938ba4ea81b395e12797b84b9cf314b9546705e839c7a99d606b247ddb4f9ac7a3414dd", 3, 0, "ad58df696e2d4e91ea86c881e938ba4ea81b395e12797b84b9cf314b9546705e839c7a99d606b247ddb4f9ac7a3414dd"},
+    {"f3wmuu6crofhqmm3v4enos73okk2l366ck6yc4owxwbdtkmpk42ohkqxfitcpa57pjdcftql4tojda2poeruwa","03b3294f0a2e29e0c66ebc235d2fedca5697bf784af605c75af608e6a63d5cd38ea85ca8989e0efde9188b382f9372460d", 3, 0, "b3294f0a2e29e0c66ebc235d2fedca5697bf784af605c75af608e6a63d5cd38ea85ca8989e0efde9188b382f9372460d"},
+    {"f3s2q2hzhkpiknjgmf4zq3ejab2rh62qbndueslmsdzervrhapxr7dftie4kpnpdiv2n6tvkr743ndhrsw6d3a","0396a1a3e4ea7a14d49985e661b22401d44fed402d1d0925b243c923589c0fbc7e32cd04e29ed78d15d37d3aaa3fe6da33", 3, 0, "96a1a3e4ea7a14d49985e661b22401d44fed402d1d0925b243c923589c0fbc7e32cd04e29ed78d15d37d3aaa3fe6da33"},
+    {"f3q22fijmmlckhl56rn5nkyamkph3mcfu5ed6dheq53c244hfmnq2i7efdma3cj5voxenwiummf2ajlsbxc65a","0386b454258c589475f7d16f5aac018a79f6c1169d20fc33921dd8b5ce1cac6c348f90a3603624f6aeb91b64518c2e8095", 3, 0, "86b454258c589475f7d16f5aac018a79f6c1169d20fc33921dd8b5ce1cac6c348f90a3603624f6aeb91b64518c2e8095"},
+    {"f3u5zgwa4ael3vuocgc5mfgygo4yuqocrntuuhcklf4xzg5tcaqwbyfabxetwtj4tsam3pbhnwghyhijr5mixa","03a7726b038022f75a384617585360cee629070a2d9d28712965e5f26ecc40858382803724ed34f2720336f09db631f074", 3, 0, "a7726b038022f75a384617585360cee629070a2d9d28712965e5f26ecc40858382803724ed34f2720336f09db631f074"},
 };
 
 static const std::string invalidAddresses[] = {
     "",
-    "f0",                 // Empty varuint
-    "f0127"               // Short varuint
-    "f01"                     // Long varuint
-    "f00"                     // Long varuint
     "f0-1",                   // Negative :)
     "f018446744073709551616", // Greater than max uint64_t
-    "f09223372036854775807",  // Overflow
     "f15ihq5ibzwki2b4ep2f46avlkr\0zhpqgtga7pdrq", // Embedded NUL
     "t15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq",  // Test net
     "a15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq",  // Unknown net
@@ -75,20 +71,34 @@ static const std::string invalidAddresses[] = {
 
 TEST(FilecoinAddress, IsValid) {
     for (const auto& test : validAddresses) {
-        ASSERT_TRUE(Address::isValid(test.encoded))
-            << "is_valid() != true: " << test.encoded << std::endl;
-        // ASSERT_TRUE(Address::isValid(parse_hex(test.hex)))
-        //     << "is_valid() != true: " << test.hex << std::endl;
-    }
-    for (const auto& address : invalidAddresses)
-        ASSERT_FALSE(Address::isValid(address)) << "is_valid() != false: " << address << std::endl;
+        ASSERT_TRUE(Address::isValid(test.string))
+            << "isValid(string) != true: " << test.string;
+        const Address lhs(test.string);
 
-    // ASSERT_FALSE(Address::isValid(parse_hex("00"))) << "Empty varuint";
-    // ASSERT_FALSE(Address::isValid(parse_hex("00ff"))) << "Short varuint";
-    // ASSERT_FALSE(Address::isValid(parse_hex("00ff00ff"))) << "Varuint with hole";
-    // ASSERT_FALSE(Address::isValid(parse_hex("000101"))) << "Long varuint";
-    // ASSERT_FALSE(Address::isValid(parse_hex("000000"))) << "Long varuint";
-    // ASSERT_FALSE(Address::isValid(parse_hex("00ffffffffffffffffff02"))) << "Overflow";
+        ASSERT_TRUE(Address::isValid(parse_hex(test.encoded)))
+            << "isValid(Data) != true: " << test.encoded;
+        const Address rhs(parse_hex(test.encoded));
+
+        ASSERT_TRUE(lhs == rhs) << "Address(string) != Address(Data)";
+        const auto actualType = static_cast<uint8_t>(lhs.type);
+        ASSERT_TRUE(actualType == test.type)
+            << "Unexpected type: " << actualType << " != " << test.type << ": " << test.string;
+        ASSERT_TRUE(lhs.actorID == test.actorID)
+            << "Unexpected actorID: " << lhs.actorID << " != " << test.actorID << ": " << test.string;
+        ASSERT_TRUE(lhs.payload == parse_hex(test.payloadHex))
+            << "Unexpected payload: " << hex(lhs.payload) << " != " << test.payloadHex;
+    }
+    for (const auto& address : invalidAddresses) {
+        ASSERT_FALSE(Address::isValid(address))
+            << "isValid(string) != false: " << address;
+    }
+
+    ASSERT_FALSE(Address::isValid(parse_hex("00"))) << "Empty varuint";
+    ASSERT_FALSE(Address::isValid(parse_hex("00ff"))) << "Short varuint";
+    ASSERT_FALSE(Address::isValid(parse_hex("00ff00ff"))) << "Varuint with hole";
+    ASSERT_FALSE(Address::isValid(parse_hex("000101"))) << "Long varuint";
+    ASSERT_FALSE(Address::isValid(parse_hex("000000"))) << "Long varuint";
+    ASSERT_FALSE(Address::isValid(parse_hex("00ffffffffffffffffff02"))) << "Overflow";
 }
 
 // TEST(FilecoinAddress, String) {
@@ -98,11 +108,11 @@ TEST(FilecoinAddress, IsValid) {
 //     }
 // }
 
-TEST(FilecoinAddress, FromString) {
-    for (const auto& test : validAddresses) {
-        Address a(test.encoded);
-        ASSERT_EQ(hex(a.toBytes()), test.hex) << "Address(" << test.encoded << ")";
-    }
-}
+// TEST(FilecoinAddress, FromString) {
+//     for (const auto& test : validAddresses) {
+//         Address a(test.encoded);
+//         ASSERT_EQ(hex(a.toBytes()), test.hex) << "Address(" << test.encoded << ")";
+//     }
+// }
 
 }

--- a/tests/chains/Filecoin/AddressTests.cpp
+++ b/tests/chains/Filecoin/AddressTests.cpp
@@ -17,45 +17,52 @@ namespace TW::Filecoin::tests {
 
 struct address_test {
     std::string encoded;
-    const char* hex;
+    uint8_t type;
+    uint64_t actorID;
+    const char* payloadHex;
 };
 
 static const address_test validAddresses[] = {
     // ID addresses
-    {"f00",                    "0000"},
-    {"f01",                    "0001"},
-    {"f010",                   "000a"},
-    {"f0150",                  "009601"},
-    {"f0499",                  "00f303"},
-    {"f01024",                 "008008"},
-    {"f01729",                 "00c10d"},
-    {"f0999999",               "00bf843d"},
-    {"f018446744073709551615", "00ffffffffffffffffff01"},
+    {"f00",                    0, ""},
+    {"f01",                    ""},
+    {"f010",                   ""},
+    {"f0150",                  ""},
+    {"f0499",                  ""},
+    {"f01024",                 ""},
+    {"f01729",                 "c10d"},
+    {"f0999999",               "bf843d"},
+    {"f018446744073709551615", "ffffffffffffffffff01"},
     // secp256k1 addresses
-    {"f15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq", "01ea0f0ea039b291a0f08fd179e0556a8c3277c0d3"},
-    {"f12fiakbhe2gwd5cnmrenekasyn6v5tnaxaqizq6a", "01d1500504e4d1ac3e89ac891a4502586fabd9b417"},
-    {"f1wbxhu3ypkuo6eyp6hjx6davuelxaxrvwb2kuwva", "01b06e7a6f0f551de261fe3a6fe182b422ee0bc6b6"},
-    {"f1xtwapqc6nh4si2hcwpr3656iotzmlwumogqbuaa", "01bcec07c05e69f92468e2b3e3bf77c874f2c5da8c"},
-    {"f1xcbgdhkgkwht3hrrnui3jdopeejsoatkzmoltqy", "01b882619d46558f3d9e316d11b48dcf211327026a"},
-    {"f17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy", "01fd1d0f4dfcd7e99afcb99a8326b7dc459d32c628"},
+    {"f15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq", "ea0f0ea039b291a0f08fd179e0556a8c3277c0d3"},
+    {"f12fiakbhe2gwd5cnmrenekasyn6v5tnaxaqizq6a", "d1500504e4d1ac3e89ac891a4502586fabd9b417"},
+    {"f1wbxhu3ypkuo6eyp6hjx6davuelxaxrvwb2kuwva", "b06e7a6f0f551de261fe3a6fe182b422ee0bc6b6"},
+    {"f1xtwapqc6nh4si2hcwpr3656iotzmlwumogqbuaa", "bcec07c05e69f92468e2b3e3bf77c874f2c5da8c"},
+    {"f1xcbgdhkgkwht3hrrnui3jdopeejsoatkzmoltqy", "b882619d46558f3d9e316d11b48dcf211327026a"},
+    {"f17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy", "fd1d0f4dfcd7e99afcb99a8326b7dc459d32c628"},
     // Actor addresses
-    {"f24vg6ut43yw2h2jqydgbg2xq7x6f4kub3bg6as6i", "02e54dea4f9bc5b47d261819826d5e1fbf8bc5503b"},
-    {"f25nml2cfbljvn4goqtclhifepvfnicv6g7mfmmvq", "02eb58bd08a15a6ade19d0989674148fa95a8157c6"},
-    {"f2nuqrg7vuysaue2pistjjnt3fadsdzvyuatqtfei", "026d21137eb4c4814269e894d296cf6500e43cd714"},
-    {"f24dd4ox4c2vpf5vk5wkadgyyn6qtuvgcpxxon64a", "02e0c7c75f82d55e5ed55db28033630df4274a984f"},
-    {"f2gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y", "02316b4c1ff5d4afb7826ceab5bb0f2c3e0f364053"},
+    {"f24vg6ut43yw2h2jqydgbg2xq7x6f4kub3bg6as6i", "e54dea4f9bc5b47d261819826d5e1fbf8bc5503b"},
+    {"f25nml2cfbljvn4goqtclhifepvfnicv6g7mfmmvq", "eb58bd08a15a6ade19d0989674148fa95a8157c6"},
+    {"f2nuqrg7vuysaue2pistjjnt3fadsdzvyuatqtfei", "6d21137eb4c4814269e894d296cf6500e43cd714"},
+    {"f24dd4ox4c2vpf5vk5wkadgyyn6qtuvgcpxxon64a", "e0c7c75f82d55e5ed55db28033630df4274a984f"},
+    {"f2gfvuyh7v2sx3patm5k23wdzmhyhtmqctasbr23y", "316b4c1ff5d4afb7826ceab5bb0f2c3e0f364053"},
     // BLS addresses
-    {"f3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss4a","03ad58df696e2d4e91ea86c881e938ba4ea81b395e12797b84b9cf314b9546705e839c7a99d606b247ddb4f9ac7a3414dd"},
-    {"f3wmuu6crofhqmm3v4enos73okk2l366ck6yc4owxwbdtkmpk42ohkqxfitcpa57pjdcftql4tojda2poeruwa","03b3294f0a2e29e0c66ebc235d2fedca5697bf784af605c75af608e6a63d5cd38ea85ca8989e0efde9188b382f9372460d"},
-    {"f3s2q2hzhkpiknjgmf4zq3ejab2rh62qbndueslmsdzervrhapxr7dftie4kpnpdiv2n6tvkr743ndhrsw6d3a","0396a1a3e4ea7a14d49985e661b22401d44fed402d1d0925b243c923589c0fbc7e32cd04e29ed78d15d37d3aaa3fe6da33"},
-    {"f3q22fijmmlckhl56rn5nkyamkph3mcfu5ed6dheq53c244hfmnq2i7efdma3cj5voxenwiummf2ajlsbxc65a","0386b454258c589475f7d16f5aac018a79f6c1169d20fc33921dd8b5ce1cac6c348f90a3603624f6aeb91b64518c2e8095"},
-    {"f3u5zgwa4ael3vuocgc5mfgygo4yuqocrntuuhcklf4xzg5tcaqwbyfabxetwtj4tsam3pbhnwghyhijr5mixa","03a7726b038022f75a384617585360cee629070a2d9d28712965e5f26ecc40858382803724ed34f2720336f09db631f074"},
+    {"f3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss4a","ad58df696e2d4e91ea86c881e938ba4ea81b395e12797b84b9cf314b9546705e839c7a99d606b247ddb4f9ac7a3414dd"},
+    {"f3wmuu6crofhqmm3v4enos73okk2l366ck6yc4owxwbdtkmpk42ohkqxfitcpa57pjdcftql4tojda2poeruwa","b3294f0a2e29e0c66ebc235d2fedca5697bf784af605c75af608e6a63d5cd38ea85ca8989e0efde9188b382f9372460d"},
+    {"f3s2q2hzhkpiknjgmf4zq3ejab2rh62qbndueslmsdzervrhapxr7dftie4kpnpdiv2n6tvkr743ndhrsw6d3a","96a1a3e4ea7a14d49985e661b22401d44fed402d1d0925b243c923589c0fbc7e32cd04e29ed78d15d37d3aaa3fe6da33"},
+    {"f3q22fijmmlckhl56rn5nkyamkph3mcfu5ed6dheq53c244hfmnq2i7efdma3cj5voxenwiummf2ajlsbxc65a","86b454258c589475f7d16f5aac018a79f6c1169d20fc33921dd8b5ce1cac6c348f90a3603624f6aeb91b64518c2e8095"},
+    {"f3u5zgwa4ael3vuocgc5mfgygo4yuqocrntuuhcklf4xzg5tcaqwbyfabxetwtj4tsam3pbhnwghyhijr5mixa","a7726b038022f75a384617585360cee629070a2d9d28712965e5f26ecc40858382803724ed34f2720336f09db631f074"},
 };
 
 static const std::string invalidAddresses[] = {
     "",
+    "f0",                 // Empty varuint
+    "f0127"               // Short varuint
+    "f01"                     // Long varuint
+    "f00"                     // Long varuint
     "f0-1",                   // Negative :)
     "f018446744073709551616", // Greater than max uint64_t
+    "f09223372036854775807",  // Overflow
     "f15ihq5ibzwki2b4ep2f46avlkr\0zhpqgtga7pdrq", // Embedded NUL
     "t15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq",  // Test net
     "a15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq",  // Unknown net
@@ -70,31 +77,31 @@ TEST(FilecoinAddress, IsValid) {
     for (const auto& test : validAddresses) {
         ASSERT_TRUE(Address::isValid(test.encoded))
             << "is_valid() != true: " << test.encoded << std::endl;
-        ASSERT_TRUE(Address::isValid(parse_hex(test.hex)))
-            << "is_valid() != true: " << test.hex << std::endl;
+        // ASSERT_TRUE(Address::isValid(parse_hex(test.hex)))
+        //     << "is_valid() != true: " << test.hex << std::endl;
     }
     for (const auto& address : invalidAddresses)
         ASSERT_FALSE(Address::isValid(address)) << "is_valid() != false: " << address << std::endl;
 
-    ASSERT_FALSE(Address::isValid(parse_hex("00"))) << "Empty varuint";
-    ASSERT_FALSE(Address::isValid(parse_hex("00ff"))) << "Short varuint";
-    ASSERT_FALSE(Address::isValid(parse_hex("00ff00ff"))) << "Varuint with hole";
-    ASSERT_FALSE(Address::isValid(parse_hex("000101"))) << "Long varuint";
-    ASSERT_FALSE(Address::isValid(parse_hex("000000"))) << "Long varuint";
-    ASSERT_FALSE(Address::isValid(parse_hex("00ffffffffffffffffff02"))) << "Overflow";
+    // ASSERT_FALSE(Address::isValid(parse_hex("00"))) << "Empty varuint";
+    // ASSERT_FALSE(Address::isValid(parse_hex("00ff"))) << "Short varuint";
+    // ASSERT_FALSE(Address::isValid(parse_hex("00ff00ff"))) << "Varuint with hole";
+    // ASSERT_FALSE(Address::isValid(parse_hex("000101"))) << "Long varuint";
+    // ASSERT_FALSE(Address::isValid(parse_hex("000000"))) << "Long varuint";
+    // ASSERT_FALSE(Address::isValid(parse_hex("00ffffffffffffffffff02"))) << "Overflow";
 }
 
-TEST(FilecoinAddress, String) {
-    for (const auto& test : validAddresses) {
-        Address a(parse_hex(test.hex));
-        ASSERT_EQ(a.string(), test.encoded) << "Address(" << test.hex << ")";
-    }
-}
+// TEST(FilecoinAddress, String) {
+//     for (const auto& test : validAddresses) {
+//         Address a(parse_hex(test.hex));
+//         ASSERT_EQ(a.string(), test.encoded) << "Address(" << test.hex << ")";
+//     }
+// }
 
 TEST(FilecoinAddress, FromString) {
     for (const auto& test : validAddresses) {
         Address a(test.encoded);
-        ASSERT_EQ(hex(a.bytes), test.hex) << "Address(" << test.encoded << ")";
+        ASSERT_EQ(hex(a.toBytes()), test.hex) << "Address(" << test.encoded << ")";
     }
 }
 

--- a/tests/chains/Filecoin/AddressTests.cpp
+++ b/tests/chains/Filecoin/AddressTests.cpp
@@ -64,6 +64,8 @@ static const std::string invalidAddresses[] = {
     "",
     "f0-1",                   // Negative :)
     "f018446744073709551616", // Greater than max uint64_t
+    "f418446744073709551615", // No "f" separator
+    "f4f77777777vnmsana",     // Empty Actor ID
     "f15ihq5ibzwki2b4ep2f46avlkr\0zhpqgtga7pdrq", // Embedded NUL
     "t15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq",  // Test net
     "a15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq",  // Unknown net
@@ -72,6 +74,7 @@ static const std::string invalidAddresses[] = {
     "f15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7rdrr",
     "f24vg6ut43yw2h2jqydgbg2xq7x6f4kub3bg6as66",
     "f3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss44",
+    "f410f2oekwcmo2pueydmaq53eic2i62crtbeyuzx2gma",
 };
 
 TEST(FilecoinAddress, IsValid) {

--- a/tests/chains/Filecoin/AddressTests.cpp
+++ b/tests/chains/Filecoin/AddressTests.cpp
@@ -78,7 +78,7 @@ static const std::string invalidAddresses[] = {
 };
 
 TEST(FilecoinAddress, IsValid) {
-    for (const auto& test : validAddresses) {
+    for (auto&& test : validAddresses) {
         ASSERT_TRUE(Address::isValid(test.string))
             << "isValid(string) != true: " << test.string;
 
@@ -89,7 +89,7 @@ TEST(FilecoinAddress, IsValid) {
 }
 
 TEST(FilecoinAddress, IsInvalid) {
-    for (const auto& address : invalidAddresses) {
+    for (auto&& address : invalidAddresses) {
         ASSERT_FALSE(Address::isValid(address))
             << "isValid(string) != false: " << address;
     }
@@ -103,7 +103,7 @@ TEST(FilecoinAddress, IsInvalid) {
 }
 
 TEST(FilecoinAddress, Equal) {
-    for (const auto& test : validAddresses) {
+    for (auto&& test : validAddresses) {
         const Data encodedBytes = parse_hex(test.encoded);
         const Address lhs(test.string), rhs(encodedBytes);
         ASSERT_EQ(lhs, rhs) << "Address(string) != Address(Data)";
@@ -111,7 +111,7 @@ TEST(FilecoinAddress, Equal) {
 }
 
 TEST(FilecoinAddress, ExpectedProperties) {
-    for (const auto& test : validAddresses) {
+    for (auto&& test : validAddresses) {
         const Data encodedBytes = parse_hex(test.encoded);
         const uint8_t expectedType = encodedBytes[0];
 
@@ -128,14 +128,14 @@ TEST(FilecoinAddress, ExpectedProperties) {
 }
 
 TEST(FilecoinAddress, ToString) {
-    for (const auto& test : validAddresses) {
+    for (auto&& test : validAddresses) {
         Address a(parse_hex(test.encoded));
         ASSERT_EQ(a.string(), test.string) << "Address(" << test.encoded << ")";
     }
 }
 
 TEST(FilecoinAddress, ToBytes) {
-    for (const auto& test : validAddresses) {
+    for (auto&& test : validAddresses) {
         Address a(test.string);
         ASSERT_EQ(hex(a.toBytes()), test.encoded) << "Address(" << test.string << ")";
     }

--- a/tests/chains/Filecoin/SignerTests.cpp
+++ b/tests/chains/Filecoin/SignerTests.cpp
@@ -17,7 +17,7 @@ TEST(FilecoinSigner, DerivePublicKey) {
     const PrivateKey privateKey(
         parse_hex("1d969865e189957b9824bd34f26d5cbf357fda1a6d844cbf0c9ab1ed93fa7dbe"));
     const PublicKey publicKey((privateKey.getPublicKey(TWPublicKeyTypeSECP256k1Extended)));
-    const Address address(publicKey);
+    const Address address = Address::secp256k1Address(publicKey);
     ASSERT_EQ(address.string(), "f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq");
 }
 
@@ -25,7 +25,7 @@ TEST(FilecoinSigner, Sign) {
     const PrivateKey privateKey(
         parse_hex("1d969865e189957b9824bd34f26d5cbf357fda1a6d844cbf0c9ab1ed93fa7dbe"));
     const PublicKey publicKey((privateKey.getPublicKey(TWPublicKeyTypeSECP256k1Extended)));
-    const Address fromAddress(publicKey);
+    const Address fromAddress = Address::secp256k1Address(publicKey);
     const Address toAddress("f1rletqqhinhagw6nxjcr4kbfws25thgt7owzuruy");
 
     Transaction tx(toAddress, fromAddress,
@@ -34,18 +34,22 @@ TEST(FilecoinSigner, Sign) {
                    /*gasLimit*/ 23423423423423,
                    /*gasFeeCap*/ 456456456456445645,
                    /*gasPremium*/ 5675674564734345,
-                   /*method*/ Transaction::SEND_METHOD);
+                   /*method*/ Transaction::SEND_METHOD,
+                   /*params*/ Data());
 
     Data signature = Signer::sign(privateKey, tx);
 
-    ASSERT_EQ(tx.serialize(signature), R"({"Message":{"From":"f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq","GasFeeCap":"456456456456445645","GasLimit":23423423423423,"GasPremium":"5675674564734345","Method":0,"Nonce":1,"To":"f1rletqqhinhagw6nxjcr4kbfws25thgt7owzuruy","Value":"6000"},"Signature":{"Data":"3GOUpn2Wiwe20QXLC8ixx23WiKDwrVkfxYi3CgzZ5jBVKZT4WUOZNuZhpUFky0PqGaM7vErEOi//yqBGSIQQUAA=","Type":1}})");
+    ASSERT_EQ(
+        tx.serialize(Transaction::SignatureType::SECP256K1, signature),
+        R"({"Message":{"From":"f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq","GasFeeCap":"456456456456445645","GasLimit":23423423423423,"GasPremium":"5675674564734345","Method":0,"Nonce":1,"To":"f1rletqqhinhagw6nxjcr4kbfws25thgt7owzuruy","Value":"6000"},"Signature":{"Data":"3GOUpn2Wiwe20QXLC8ixx23WiKDwrVkfxYi3CgzZ5jBVKZT4WUOZNuZhpUFky0PqGaM7vErEOi//yqBGSIQQUAA=","Type":1}})"
+    );
 }
 
 TEST(FilecoinSigner, SignToDelegated) {
     const PrivateKey privateKey(
         parse_hex("d3d6ed8b97dcd4661f62a1162bee6949401fd3935f394e6eacf15b6d5005483c"));
     const PublicKey publicKey((privateKey.getPublicKey(TWPublicKeyTypeSECP256k1Extended)));
-    const Address fromAddress(publicKey);
+    const Address fromAddress = Address::secp256k1Address(publicKey);
     const Address toAddress("f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky");
 
     Transaction tx(toAddress, fromAddress,
@@ -54,11 +58,41 @@ TEST(FilecoinSigner, SignToDelegated) {
         /*gasLimit*/ 6152567,
         /*gasFeeCap*/ 4435940585,
         /*gasPremium*/ 11597139,
-        /*method*/ Transaction::INVOKE_EVM_METHOD);
+        /*method*/ Transaction::INVOKE_EVM_METHOD,
+        /*params*/ Data());
 
     Data signature = Signer::sign(privateKey, tx);
 
-    ASSERT_EQ(tx.serialize(signature), R"({"Message":{"From":"f1mzyorxlcvdoqn5cto7urefbucugrcxxghpjc5hi","GasFeeCap":"4435940585","GasLimit":6152567,"GasPremium":"11597139","Method":3844450837,"Nonce":0,"To":"f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky","Value":"1000000000000000"},"Signature":{"Data":"bxZhnsOYjdArPa3W0SpggwqtXPgvfRSoM2dU5lXYar9lWhTGc6FvPWk2RTUGyA8UtzMIdOPSUKfzU1iA2eA3YwA=","Type":1}})");
+    ASSERT_EQ(
+        tx.serialize(Transaction::SignatureType::SECP256K1, signature),
+        R"({"Message":{"From":"f1mzyorxlcvdoqn5cto7urefbucugrcxxghpjc5hi","GasFeeCap":"4435940585","GasLimit":6152567,"GasPremium":"11597139","Method":3844450837,"Nonce":0,"To":"f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky","Value":"1000000000000000"},"Signature":{"Data":"bxZhnsOYjdArPa3W0SpggwqtXPgvfRSoM2dU5lXYar9lWhTGc6FvPWk2RTUGyA8UtzMIdOPSUKfzU1iA2eA3YwA=","Type":1}})"
+    );
+}
+
+TEST(FilecoinSigner, SignFromDelegated) {
+    Proto::SigningInput input;
+
+    auto privateKey = parse_hex("825d2bb32965764a98338139412c7591ed54c951dd65504cd8ddaeaa0fea7b2a");
+    auto toAddress = "f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky";
+    uint64_t nonce = 0;
+    // 0.001 FIL
+    auto value = store(uint256_t(1'000'000) * uint256_t(1'000'000'000));
+    uint64_t gasLimit = 2154192;
+    auto gasFeeCap = store(uint256_t(516751679));
+    auto gasPremium = store(uint256_t(12729639));
+
+    input.set_private_key(privateKey.data(), privateKey.size());
+    input.set_to(toAddress);
+    input.set_nonce(nonce);
+    input.set_value(value.data(), value.size());
+    input.set_gas_limit(gasLimit);
+    input.set_gas_fee_cap(gasFeeCap.data(), gasFeeCap.size());
+    input.set_gas_premium(gasPremium.data(), gasPremium.size());
+    input.set_derivation(Proto::DerivationType::DELEGATED);
+
+    Proto::SigningOutput output = Signer::sign(input);
+
+    ASSERT_EQ(output.json(), R"({"Message":{"From":"f410fvak24cyg3saddajborn6idt7rrtfj2ptauk5pbq","GasFeeCap":"516751679","GasLimit":2154192,"GasPremium":"12729639","Method":3844450837,"Nonce":0,"To":"f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky","Value":"1000000000000000"},"Signature":{"Data":"fMOvlBAnc5OYDVEMaSSQURiqmrJbfktSPcUI2ptAoKtK0xl++cnTSKtqZyNV4yH0X5Ly2N2bqeNlFwAFANHoFAE=","Type":3}})");
 }
 
 } // namespace TW::Filecoin

--- a/tests/chains/Filecoin/SignerTests.cpp
+++ b/tests/chains/Filecoin/SignerTests.cpp
@@ -33,11 +33,32 @@ TEST(FilecoinSigner, Sign) {
                    /*value*/ 6000,
                    /*gasLimit*/ 23423423423423,
                    /*gasFeeCap*/ 456456456456445645,
-                   /*gasPremium*/ 5675674564734345);
+                   /*gasPremium*/ 5675674564734345,
+                   /*method*/ Transaction::SEND_METHOD);
 
     Data signature = Signer::sign(privateKey, tx);
 
-    ASSERT_EQ(tx.serialize(signature), R"({"Message":{"From":"f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq","GasFeeCap":"456456456456445645","GasLimit":23423423423423,"GasPremium":"5675674564734345","Nonce":1,"To":"f1rletqqhinhagw6nxjcr4kbfws25thgt7owzuruy","Value":"6000"},"Signature":{"Data":"3GOUpn2Wiwe20QXLC8ixx23WiKDwrVkfxYi3CgzZ5jBVKZT4WUOZNuZhpUFky0PqGaM7vErEOi//yqBGSIQQUAA=","Type":1}})");
+    ASSERT_EQ(tx.serialize(signature), R"({"Message":{"From":"f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq","GasFeeCap":"456456456456445645","GasLimit":23423423423423,"GasPremium":"5675674564734345","Method":0,"Nonce":1,"To":"f1rletqqhinhagw6nxjcr4kbfws25thgt7owzuruy","Value":"6000"},"Signature":{"Data":"3GOUpn2Wiwe20QXLC8ixx23WiKDwrVkfxYi3CgzZ5jBVKZT4WUOZNuZhpUFky0PqGaM7vErEOi//yqBGSIQQUAA=","Type":1}})");
+}
+
+TEST(FilecoinSigner, SignToDelegated) {
+    const PrivateKey privateKey(
+        parse_hex("d3d6ed8b97dcd4661f62a1162bee6949401fd3935f394e6eacf15b6d5005483c"));
+    const PublicKey publicKey((privateKey.getPublicKey(TWPublicKeyTypeSECP256k1Extended)));
+    const Address fromAddress(publicKey);
+    const Address toAddress("f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky");
+
+    Transaction tx(toAddress, fromAddress,
+        /*nonce*/ 0,
+        /*value*/ 1000000000000000,
+        /*gasLimit*/ 6152567,
+        /*gasFeeCap*/ 4435940585,
+        /*gasPremium*/ 11597139,
+        /*method*/ Transaction::INVOKE_EVM_METHOD);
+
+    Data signature = Signer::sign(privateKey, tx);
+
+    ASSERT_EQ(tx.serialize(signature), R"({"Message":{"From":"f1mzyorxlcvdoqn5cto7urefbucugrcxxghpjc5hi","GasFeeCap":"4435940585","GasLimit":6152567,"GasPremium":"11597139","Method":3844450837,"Nonce":0,"To":"f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky","Value":"1000000000000000"},"Signature":{"Data":"bxZhnsOYjdArPa3W0SpggwqtXPgvfRSoM2dU5lXYar9lWhTGc6FvPWk2RTUGyA8UtzMIdOPSUKfzU1iA2eA3YwA=","Type":1}})");
 }
 
 } // namespace TW::Filecoin

--- a/tests/chains/Filecoin/SignerTests.cpp
+++ b/tests/chains/Filecoin/SignerTests.cpp
@@ -34,7 +34,7 @@ TEST(FilecoinSigner, Sign) {
                    /*gasLimit*/ 23423423423423,
                    /*gasFeeCap*/ 456456456456445645,
                    /*gasPremium*/ 5675674564734345,
-                   /*method*/ Transaction::SEND_METHOD,
+                   /*method*/ Transaction::MethodType::SEND,
                    /*params*/ Data());
 
     Data signature = Signer::sign(privateKey, tx);
@@ -58,7 +58,7 @@ TEST(FilecoinSigner, SignToDelegated) {
         /*gasLimit*/ 6152567,
         /*gasFeeCap*/ 4435940585,
         /*gasPremium*/ 11597139,
-        /*method*/ Transaction::INVOKE_EVM_METHOD,
+        /*method*/ Transaction::MethodType::INVOKE_EVM,
         /*params*/ Data());
 
     Data signature = Signer::sign(privateKey, tx);

--- a/tests/chains/Filecoin/SignerTests.cpp
+++ b/tests/chains/Filecoin/SignerTests.cpp
@@ -45,6 +45,8 @@ TEST(FilecoinSigner, Sign) {
     );
 }
 
+/// Successfully broadcasted:
+/// https://filfox.info/en/message/bafy2bzaceczvto7d2af7cq3kuwlvmanlh5xica4apl3vwxu37yaeozq72mvgm
 TEST(FilecoinSigner, SignToDelegated) {
     Proto::SigningInput input;
 
@@ -70,6 +72,8 @@ TEST(FilecoinSigner, SignToDelegated) {
     ASSERT_EQ(output.json(), R"({"Message":{"From":"f1mzyorxlcvdoqn5cto7urefbucugrcxxghpjc5hi","GasFeeCap":"4435940585","GasLimit":6152567,"GasPremium":"11597139","Method":3844450837,"Nonce":0,"To":"f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky","Value":"1000000000000000"},"Signature":{"Data":"bxZhnsOYjdArPa3W0SpggwqtXPgvfRSoM2dU5lXYar9lWhTGc6FvPWk2RTUGyA8UtzMIdOPSUKfzU1iA2eA3YwA=","Type":1}})");
 }
 
+/// Successfully broadcasted:
+/// https://filfox.info/en/message/bafy2bzacea3ioez23o7t2hae6t2qwwkow46nhc42ffm5lqyxzzvrzblofnleu
 TEST(FilecoinSigner, SignFromDelegated) {
     Proto::SigningInput input;
 

--- a/tests/chains/Filecoin/TWAddressConverterTests.cpp
+++ b/tests/chains/Filecoin/TWAddressConverterTests.cpp
@@ -27,7 +27,7 @@ TEST(TWFilecoinAddressConverter, ConvertToEth) {
         {"f15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq", ""},
         {"f24vg6ut43yw2h2jqydgbg2xq7x6f4kub3bg6as6i", ""},
         {"f3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss4a", ""},
-        // Fails since `actorID != 10`. Expect an empty result.
+        // Should fail since `actorID != 10`. Expect an empty result.
         {"f432f77777777x32lpna", ""},
         {"f418446744073709551615ftnkyfaq", ""},
         // The following addresses are invalid. Expect an empty result.

--- a/tests/chains/Filecoin/TWAddressConverterTests.cpp
+++ b/tests/chains/Filecoin/TWAddressConverterTests.cpp
@@ -1,0 +1,62 @@
+// Copyright © 2017-2023 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include <TrustWalletCore/TWFilecoinAddressConverter.h>
+
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "TestUtilities.h"
+
+namespace TW::Filecoin::tests {
+// clang-format off
+
+struct AddressTest {
+    const char* filecoin;
+    const char* eth;
+};
+
+TEST(TWFilecoinAddressConverter, ConvertToEth) {
+    const AddressTest tests[] = {
+        {"f09876", "0xff00000000000000000000000000000000002694"},
+        {"f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky", "0x8dbD6c7Ede90646a61Bbc649831b7c298BFd37A0"},
+        // The following addresses can't be converted to ETH. Expect an empty result.
+        {"f15ihq5ibzwki2b4ep2f46avlkrqzhpqgtga7pdrq", ""},
+        {"f24vg6ut43yw2h2jqydgbg2xq7x6f4kub3bg6as6i", ""},
+        {"f3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss4a", ""},
+        // Fails since `actorID != 10`. Expect an empty result.
+        {"f432f77777777x32lpna", ""},
+        {"f418446744073709551615ftnkyfaq", ""},
+        // The following addresses are invalid. Expect an empty result.
+        {"f432f77777777x32lpn", ""},
+        {"f018446744073709551616", ""},
+    };
+
+    for (const auto& test : tests) {
+        auto filecoinAddress = STRING(test.filecoin);
+        auto result = WRAPS(TWFilecoinAddressConverterConvertToEthereum(filecoinAddress.get()));
+        assertStringsEqual(result, test.eth);
+    }
+}
+
+TEST(TWFilecoinAddressConverter, ConvertFromEth) {
+    const AddressTest tests[] = {
+        {"f410f74aaaaaaaaaaaaaaaaaaaaaaaaaaajuu3nnltyi", "0xff00000000000000000000000000000000002694"},
+        {"f410frw6wy7w6sbsguyn3yzeygg34fgf72n5ao5sxyky", "0x8dbD6c7Ede90646a61Bbc649831b7c298BFd37A0"},
+        {"f410f2oekwcmo2pueydmaq53eic2i62crtbeyuzx2gmy", "0xd388ab098ed3e84c0d808776440b48f685198498"},
+        // The following addresses are invalid. Expect an empty result.
+        {"", "0xd388ab098ed3e84c0d808776440b48f68519849"},
+        {"", "0x"},
+    };
+
+    for (const auto& test : tests) {
+        auto ethAddress = STRING(test.eth);
+        auto result = WRAPS(TWFilecoinAddressConverterConvertFromEthereum(ethAddress.get()));
+        assertStringsEqual(result, test.filecoin);
+    }
+}
+
+}

--- a/tests/chains/Filecoin/TWAnySignerTests.cpp
+++ b/tests/chains/Filecoin/TWAnySignerTests.cpp
@@ -49,7 +49,7 @@ TEST(TWAnySignerFilecoin, Sign) {
     Proto::SigningOutput output;
     output.ParseFromArray(TWDataBytes(outputData.get()), static_cast<int>(TWDataSize(outputData.get())));
 
-    ASSERT_EQ(output.json(), R"({"Message":{"From":"f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq","GasFeeCap":"700000000000000000000","GasLimit":1000,"GasPremium":"800000000000000000000","Nonce":2,"To":"f3um6uo3qt5of54xjbx3hsxbw5mbsc6auxzrvfxekn5bv3duewqyn2tg5rhrlx73qahzzpkhuj7a34iq7oifsq","Value":"600000000000000000000"},"Signature":{"Data":"jMRu+OZ/lfppgmqSfGsntFrRLWZnUg3ZYmJTTRLsVt4V1310vR3VKGJpaE6S4sNvDOE6sEgmN9YmfTkPVK2qMgE=","Type":1}})");
+    ASSERT_EQ(output.json(), R"({"Message":{"From":"f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq","GasFeeCap":"700000000000000000000","GasLimit":1000,"GasPremium":"800000000000000000000","Method":0,"Nonce":2,"To":"f3um6uo3qt5of54xjbx3hsxbw5mbsc6auxzrvfxekn5bv3duewqyn2tg5rhrlx73qahzzpkhuj7a34iq7oifsq","Value":"600000000000000000000"},"Signature":{"Data":"jMRu+OZ/lfppgmqSfGsntFrRLWZnUg3ZYmJTTRLsVt4V1310vR3VKGJpaE6S4sNvDOE6sEgmN9YmfTkPVK2qMgE=","Type":1}})");
 }
 
 TEST(TWAnySignerFilecoin, SignJSON) {
@@ -66,7 +66,7 @@ TEST(TWAnySignerFilecoin, SignJSON) {
     auto result = WRAPS(TWAnySignerSignJSON(json.get(), key.get(), TWCoinTypeFilecoin));
 
     ASSERT_TRUE(TWAnySignerSupportsJSON(TWCoinTypeFilecoin));
-    assertStringsEqual(result, R"({"Message":{"From":"f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq","GasFeeCap":"700000000000000000000","GasLimit":1000,"GasPremium":"800000000000000000000","Nonce":2,"To":"f3um6uo3qt5of54xjbx3hsxbw5mbsc6auxzrvfxekn5bv3duewqyn2tg5rhrlx73qahzzpkhuj7a34iq7oifsq","Value":"600000000000000000000"},"Signature":{"Data":"jMRu+OZ/lfppgmqSfGsntFrRLWZnUg3ZYmJTTRLsVt4V1310vR3VKGJpaE6S4sNvDOE6sEgmN9YmfTkPVK2qMgE=","Type":1}})");
+    assertStringsEqual(result, R"({"Message":{"From":"f1z4a36sc7mfbv4z3qwutblp2flycdui3baffytbq","GasFeeCap":"700000000000000000000","GasLimit":1000,"GasPremium":"800000000000000000000","Method":0,"Nonce":2,"To":"f3um6uo3qt5of54xjbx3hsxbw5mbsc6auxzrvfxekn5bv3duewqyn2tg5rhrlx73qahzzpkhuj7a34iq7oifsq","Value":"600000000000000000000"},"Signature":{"Data":"jMRu+OZ/lfppgmqSfGsntFrRLWZnUg3ZYmJTTRLsVt4V1310vR3VKGJpaE6S4sNvDOE6sEgmN9YmfTkPVK2qMgE=","Type":1}})");
 }
 
 } // namespace TW::Filecoin::tests

--- a/tests/chains/Filecoin/TransactionTests.cpp
+++ b/tests/chains/Filecoin/TransactionTests.cpp
@@ -27,7 +27,7 @@ TEST(FilecoinTransaction, Serialize) {
     const PrivateKey privateKey(
         parse_hex("2f0f1d2c8de955c7c3fb4d9cae02539fadcb13fa998ccd9a1e871bed95f1941e"));
     const auto publicKey = privateKey.getPublicKey(TWPublicKeyTypeSECP256k1Extended);
-    const Address fromAddress(publicKey);
+    const Address fromAddress = Address::secp256k1Address(publicKey);
     const Address toAddress("f1hvadvq4rd2pyayrigjx2nbqz2nvemqouslw4wxi");
 
     Transaction tx(toAddress, fromAddress,
@@ -36,7 +36,8 @@ TEST(FilecoinTransaction, Serialize) {
                    /*gasLimit*/ 3333333333,
                    /*gasFeeCap*/ 11111111,
                    /*gasPremium*/ 333333,
-                   /*method*/ Transaction::SEND_METHOD);
+                   /*method*/ Transaction::SEND_METHOD,
+                   /*params*/ Data());
 
     ASSERT_EQ(hex(tx.message().encoded()),
               "8a0055013d403ac3911e9f806228326fa68619d36a4641d455013d413d4c3fe3d89f99495a48c6046224"

--- a/tests/chains/Filecoin/TransactionTests.cpp
+++ b/tests/chains/Filecoin/TransactionTests.cpp
@@ -35,7 +35,8 @@ TEST(FilecoinTransaction, Serialize) {
                    /*value*/ 1000,
                    /*gasLimit*/ 3333333333,
                    /*gasFeeCap*/ 11111111,
-                   /*gasPremium*/ 333333);
+                   /*gasPremium*/ 333333,
+                   /*method*/ Transaction::SEND_METHOD);
 
     ASSERT_EQ(hex(tx.message().encoded()),
               "8a0055013d403ac3911e9f806228326fa68619d36a4641d455013d413d4c3fe3d89f99495a48c6046224"

--- a/tests/chains/Filecoin/TransactionTests.cpp
+++ b/tests/chains/Filecoin/TransactionTests.cpp
@@ -36,7 +36,7 @@ TEST(FilecoinTransaction, Serialize) {
                    /*gasLimit*/ 3333333333,
                    /*gasFeeCap*/ 11111111,
                    /*gasPremium*/ 333333,
-                   /*method*/ Transaction::SEND_METHOD,
+                   /*method*/ Transaction::MethodType::SEND,
                    /*params*/ Data());
 
     ASSERT_EQ(hex(tx.message().encoded()),

--- a/tests/interface/TWAnyAddressTests.cpp
+++ b/tests/interface/TWAnyAddressTests.cpp
@@ -201,3 +201,19 @@ TEST(TWAnyAddress, createFromPubKeyDerivation) {
         assertStringsEqual(WRAPS(TWAnyAddressDescription(addr.get())), "tb1qcj2vfjec3c3luf9fx9vddnglhh9gawmnjan4v3");
     }
 }
+
+TEST(TWAnyAddress, createFromPubKeyFilecoinAddressType) {
+    constexpr auto pubkey = "0419bf99082cf2fcdaa812d6eba1eba9036ff3a3d84c1817c84954d4e8ae283fec5313e427a0f5f68dec3169b2eda876b1d9f97b1ede7f958baee6a2ce78f6e94a";
+    const auto pubkey_twstring = STRING(pubkey);
+    const auto pubkey_data = WRAPD(TWDataCreateWithHexString(pubkey_twstring.get()));
+    const auto pubkey_obj = WRAP(TWPublicKey, TWPublicKeyCreateWithData(pubkey_data.get(), TWPublicKeyTypeSECP256k1Extended));
+
+    {
+        const auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKeyFilecoinAddressType(pubkey_obj.get(), TWFilecoinAddressTypeDefault));
+        assertStringsEqual(WRAPS(TWAnyAddressDescription(addr.get())), "f1syn25x7infncgfvodhriq2dudvmudabtavm3wyy");
+    }
+    {
+        const auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKeyFilecoinAddressType(pubkey_obj.get(), TWFilecoinAddressTypeDelegated));
+        assertStringsEqual(WRAPS(TWAnyAddressDescription(addr.get())), "f410fvak24cyg3saddajborn6idt7rrtfj2ptauk5pbq");
+    }
+}

--- a/tests/interface/TWAnyAddressTests.cpp
+++ b/tests/interface/TWAnyAddressTests.cpp
@@ -210,10 +210,14 @@ TEST(TWAnyAddress, createFromPubKeyFilecoinAddressType) {
 
     {
         const auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKeyFilecoinAddressType(pubkey_obj.get(), TWFilecoinAddressTypeDefault));
-        assertStringsEqual(WRAPS(TWAnyAddressDescription(addr.get())), "f1syn25x7infncgfvodhriq2dudvmudabtavm3wyy");
+        const auto actual = WRAPS(TWAnyAddressDescription(addr.get()));
+        assertStringsEqual(actual, "f1syn25x7infncgfvodhriq2dudvmudabtavm3wyy");
+        ASSERT_TRUE(TWAnyAddressIsValid(actual.get(), TWCoinTypeFilecoin));
     }
     {
         const auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKeyFilecoinAddressType(pubkey_obj.get(), TWFilecoinAddressTypeDelegated));
-        assertStringsEqual(WRAPS(TWAnyAddressDescription(addr.get())), "f410fvak24cyg3saddajborn6idt7rrtfj2ptauk5pbq");
+        const auto actual = WRAPS(TWAnyAddressDescription(addr.get()));
+        assertStringsEqual(actual, "f410fvak24cyg3saddajborn6idt7rrtfj2ptauk5pbq");
+        ASSERT_TRUE(TWAnyAddressIsValid(actual.get(), TWCoinTypeFilecoin));
     }
 }


### PR DESCRIPTION
## Description

Integrate `f4` address type following the [guideline](https://www.notion.so/Exchange-Integration-Guide-FEVM-Edition-9fe9158360cf423da256b1bb1f47ff26#eb1df3e466cd461788421498feff15e2).

## How to test

```bash
./tools/build-and-test
./tools/ios-test
./tools/android-test
```

## Types of changes

Unlike the `f1`, `f2`, `f3`, the new `f4` address type includes an Actor ID of arbitrary length, and the address payload can also be of arbitrary length.
Thus, I had to significantly refactor `Filecoin::Address`.

## Checklist

- [x] I have read the [guideline](https://www.notion.so/Exchange-Integration-Guide-FEVM-Edition-9fe9158360cf423da256b1bb1f47ff26#eb1df3e466cd461788421498feff15e2) for integrating the `f4` address type.
- [x] Integrate `f4` address type.
- [x] Add `f0`/`f4` -> `0x` address converter.
- [x] Expose the conversion functionality to FFI.
- [x] Add unit tests to cover the new FFI functions.
- [x] Set `3844450837` TX method ([InvokeEVM](https://github.com/filecoin-project/FIPs/blob/956acf61fd911e4eb00b3be0dcc11f2c3cb106b6/FIPS/fip-0054.md#invokecontract-method-number-38444508371)) if `TO` is an f4 address.
- [x] Add sending to `f4` address TX test.
- [x] Add `AnyAddress::createAddress(publicKey, TWDerivationFilecoinDelegated)`
- [x] Add a new `Delegated` signature type (if `FROM` is a Delegated address)