### PR TITLE
[Cardano]: support NFT on Cardano

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/cardano/TestCardanoSigning.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/cardano/TestCardanoSigning.kt
@@ -16,6 +16,7 @@ import org.junit.Test
 import wallet.core.java.AnySigner
 import wallet.core.jni.*
 import wallet.core.jni.Cardano.getStakingAddress
+import wallet.core.jni.Cardano.outputMinAdaAmount
 import wallet.core.jni.CoinType.CARDANO
 import wallet.core.jni.proto.Cardano
 import wallet.core.jni.proto.Common.SigningError
@@ -264,6 +265,7 @@ class TestCardanoSigning {
     fun testSignNftTransfer() {
         val fromAddress = "addr1qy5eme9r6frr0m6q2qpncg282jtrhq5lg09uxy2j0545hj8rv7v2ntdxuv6p4s3eq4lqzg39lewgvt6fk5kmpa0zppesufzjud"
         val toAddress = "addr1qy9wjfn6nd8kak6dd8z53u7t5wt9f4lx0umll40px5hnq05avwcsq5r3ytdp36wttzv4558jaq8lvhgqhe3y8nuf5xrquju7z4"
+        val coinsPerUtxoByte = 4310
 
         val tokenAmount = Cardano.TokenAmount.newBuilder()
             .setPolicyId("219820e6cb04316f41a337fea356480f412e7acc147d28f175f21b5e")
@@ -307,10 +309,15 @@ class TestCardanoSigning {
         val toTokenBundle = Cardano.TokenBundle.newBuilder()
             .addToken(tokenAmount)
             .build()
+
+        // Check min ADA amount, set it
+        val minAmount = outputMinAdaAmount(toAddress, toTokenBundle.toByteArray(), coinsPerUtxoByte.toLong())
+        assertEquals(minAmount, 1_202_490)
+
         val transfer = Cardano.Transfer.newBuilder()
             .setToAddress(toAddress)
             .setChangeAddress(fromAddress)
-            .setAmount(1202490) // The same output as locked in UTXO#1
+            .setAmount(minAmount)
             .setTokenAmount(toTokenBundle)
             .build()
         val signInput = Cardano.SigningInput.newBuilder()

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/cardano/TestCardanoSigning.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/cardano/TestCardanoSigning.kt
@@ -261,6 +261,8 @@ class TestCardanoSigning {
         assertEquals(Numeric.toHexString(txid.toByteArray()), "0x6dcf3956232953fc25b8355fb1ded1e912b5802090fd21434d789087d6329683");
     }
 
+    // Successfully broadcasted:
+    // https://cardanoscan.io/transaction/87ca43a36b09c0b140f0ef2b71fbdcfcf1fdc88f7aa378b861e8eed3e8974628
     @Test
     fun testSignNftTransfer() {
         val fromAddress = "addr1qy5eme9r6frr0m6q2qpncg282jtrhq5lg09uxy2j0545hj8rv7v2ntdxuv6p4s3eq4lqzg39lewgvt6fk5kmpa0zppesufzjud"

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/cardano/TestCardanoSigning.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/cardano/TestCardanoSigning.kt
@@ -18,8 +18,6 @@ import wallet.core.jni.*
 import wallet.core.jni.Cardano.getStakingAddress
 import wallet.core.jni.CoinType.CARDANO
 import wallet.core.jni.proto.Cardano
-import wallet.core.jni.proto.Cardano.SigningInput
-import wallet.core.jni.proto.Cardano.SigningOutput
 import wallet.core.jni.proto.Common.SigningError
 
 
@@ -65,7 +63,7 @@ class TestCardanoSigning {
             .build()
         input.addUtxos(utxo2)
         
-        val output = AnySigner.sign(input.build(), CARDANO, SigningOutput.parser())
+        val output = AnySigner.sign(input.build(), CARDANO, Cardano.SigningOutput.parser())
         assertEquals(output.error, SigningError.OK)
 
         val encoded = output.encoded
@@ -143,7 +141,7 @@ class TestCardanoSigning {
         utxo2.addTokenAmount(token2)
         input.addUtxos(utxo2.build())
         
-        val output = AnySigner.sign(input.build(), CARDANO, SigningOutput.parser())
+        val output = AnySigner.sign(input.build(), CARDANO, Cardano.SigningOutput.parser())
         assertEquals(output.error, SigningError.OK)
 
         val encoded = output.encoded
@@ -206,7 +204,7 @@ class TestCardanoSigning {
             .build()
         input.addUtxos(utxo2)
         
-        val output = AnySigner.sign(input.build(), CARDANO, SigningOutput.parser())
+        val output = AnySigner.sign(input.build(), CARDANO, Cardano.SigningOutput.parser())
         assertEquals(output.error, SigningError.OK)
 
         val encoded = output.encoded
@@ -251,7 +249,7 @@ class TestCardanoSigning {
             .build()
         input.addUtxos(utxo1)
         
-        val output = AnySigner.sign(input.build(), CARDANO, SigningOutput.parser())
+        val output = AnySigner.sign(input.build(), CARDANO, Cardano.SigningOutput.parser())
         assertEquals(output.error, SigningError.OK)
 
         val encoded = output.encoded
@@ -260,5 +258,79 @@ class TestCardanoSigning {
 
         val txid = output.txId
         assertEquals(Numeric.toHexString(txid.toByteArray()), "0x6dcf3956232953fc25b8355fb1ded1e912b5802090fd21434d789087d6329683");
+    }
+
+    @Test
+    fun testSignNftTransfer() {
+        val fromAddress = "addr1qy5eme9r6frr0m6q2qpncg282jtrhq5lg09uxy2j0545hj8rv7v2ntdxuv6p4s3eq4lqzg39lewgvt6fk5kmpa0zppesufzjud"
+        val toAddress = "addr1qy9wjfn6nd8kak6dd8z53u7t5wt9f4lx0umll40px5hnq05avwcsq5r3ytdp36wttzv4558jaq8lvhgqhe3y8nuf5xrquju7z4"
+
+        val tokenAmount = Cardano.TokenAmount.newBuilder()
+            .setPolicyId("219820e6cb04316f41a337fea356480f412e7acc147d28f175f21b5e")
+            .setAssetName("coolcatssociety4567")
+            .setAmount(ByteString.copyFrom(Numeric.hexStringToByteArray("01"))) // 1
+            .build()
+
+        // UTXOs
+
+        val outpoint1 = Cardano.OutPoint.newBuilder()
+            .setTxHash(ByteString.copyFrom(Numeric.hexStringToByteArray("aba499ec2f23529e70bb256ceaffcc6274a882cf02f29e5670c75ee980d7c2b8")))
+            .setOutputIndex(0)
+            .build()
+        val utxo1 = Cardano.TxInput.newBuilder()
+            .setOutPoint(outpoint1)
+            .setAddress(fromAddress)
+            .setAmount(1_202_490)
+            .addTokenAmount(tokenAmount)
+
+        val outpoint2 = Cardano.OutPoint.newBuilder()
+            .setTxHash(ByteString.copyFrom(Numeric.hexStringToByteArray("ee414d635b3bc67831907354d274a31174664777c57c21ae923b9459e5644840")))
+            .setOutputIndex(0)
+            .build()
+        val utxo2 = Cardano.TxInput.newBuilder()
+            .setOutPoint(outpoint2)
+            .setAddress(fromAddress)
+            .setAmount(1_000_000)
+
+        val outpoint3 = Cardano.OutPoint.newBuilder()
+            .setTxHash(ByteString.copyFrom(Numeric.hexStringToByteArray("6a7221dcc28353ed69b733391ffeb984a34c1e72293af111d59f9ddfa8639167")))
+            .setOutputIndex(0)
+            .build()
+        val utxo3 = Cardano.TxInput.newBuilder()
+            .setOutPoint(outpoint3)
+            .setAddress(fromAddress)
+            .setAmount(2_000_000)
+
+        // Transfer TX
+
+        val privKey = Numeric.hexStringToByteArray("d09831a668db6b36ffb747600cb1cd3e3d34f36e1e6feefc11b5f988719b7557a7029ab80d3e6fe4180ad07a59ddf742ea9730f3c4145df6365fa4ae2ee49c3392e19444caf461567727b7fefec40a3763bdb6ce5e0e8c05f5e340355a8fef4528dfe7502cfbda49e38f5a0021962d52dc3dee82834a23abb6750981799b75577d1ed9af9853707f0ef74264274e71b2f12e86e3c91314b6efa75ef750d9711b84cedd742ab873ef2f9566ad20b3fc702232c6d2f5d83ff425019234037d1e58")
+        val toTokenBundle = Cardano.TokenBundle.newBuilder()
+            .addToken(tokenAmount)
+            .build()
+        val transfer = Cardano.Transfer.newBuilder()
+            .setToAddress(toAddress)
+            .setChangeAddress(fromAddress)
+            .setAmount(1202490) // The same output as locked in UTXO#1
+            .setTokenAmount(toTokenBundle)
+            .build()
+        val signInput = Cardano.SigningInput.newBuilder()
+            .setTransferMessage(transfer)
+            .setTtl(89130965)
+            .addUtxos(utxo1)
+            .addUtxos(utxo2)
+            .addUtxos(utxo3)
+            .addPrivateKey(ByteString.copyFrom(privKey))
+
+        // Sign and check
+
+        val output = AnySigner.sign(signInput.build(), CARDANO, Cardano.SigningOutput.parser())
+        assertEquals(output.error, SigningError.OK)
+
+        val encoded = output.encoded
+        assertEquals(Numeric.toHexString(encoded.toByteArray()),
+            "0x83a400838258206a7221dcc28353ed69b733391ffeb984a34c1e72293af111d59f9ddfa863916700825820aba499ec2f23529e70bb256ceaffcc6274a882cf02f29e5670c75ee980d7c2b800825820ee414d635b3bc67831907354d274a31174664777c57c21ae923b9459e5644840000182825839010ae9267a9b4f6edb4d69c548f3cba39654d7e67f37ffd5e1352f303e9d63b100507122da18e9cb58995a50f2e80ff65d00be6243cf89a186821a0012593aa1581c219820e6cb04316f41a337fea356480f412e7acc147d28f175f21b5ea153636f6f6c63617473736f6369657479343536370182583901299de4a3d24637ef4050033c214754963b829f43cbc311527d2b4bc8e36798a9ada6e3341ac239057e012225fe5c862f49b52db0f5e208731a002b1525021a0002b19b031a055007d5a1008182582088bd26e8656fa7dead846c3373588f0192da5bfb90bf5d3fb877decfb3b3fd085840da8656aca0dacc57d4c2d957fc7dff03908f6dcf60c48f1e40b3006e2fd0cfacfa4c24fa02e35a310572526586d4ce0d30bf660ba274c8efd507848cbe177d09f6");
+
+        val txid = output.txId
+        assertEquals(Numeric.toHexString(txid.toByteArray()), "0x87ca43a36b09c0b140f0ef2b71fbdcfcf1fdc88f7aa378b861e8eed3e8974628");
     }
 }

--- a/include/TrustWalletCore/TWCardano.h
+++ b/include/TrustWalletCore/TWCardano.h
@@ -18,11 +18,22 @@ struct TWCardano;
 
 /// Calculates the minimum ADA amount needed for a UTXO.
 ///
+/// \deprecated consider using `TWCardanoOutputMinAdaAmount` instead.
 /// \see reference https://docs.cardano.org/native-tokens/minimum-ada-value-requirement
 /// \param tokenBundle serialized data of TW.Cardano.Proto.TokenBundle.
 /// \return the minimum ADA amount.
 TW_EXPORT_STATIC_METHOD
 uint64_t TWCardanoMinAdaAmount(TWData *_Nonnull tokenBundle) TW_VISIBILITY_DEFAULT;
+
+/// Calculates the minimum ADA amount needed for an output.
+///
+/// \see reference https://docs.cardano.org/native-tokens/minimum-ada-value-requirement
+/// \param toAddress valid destination address, as string.
+/// \param tokenBundle serialized data of TW.Cardano.Proto.TokenBundle.
+/// \param coinsPerUtxoByte cost per one byte of a serialized UTXO.
+/// \return the minimum ADA amount.
+TW_EXPORT_STATIC_METHOD
+uint64_t TWCardanoOutputMinAdaAmount(TWString *_Nonnull toAddress, TWData *_Nonnull tokenBundle, uint64_t coinsPerUtxoByte) TW_VISIBILITY_DEFAULT;
 
 /// Return the staking address associated to (contained in) this address. Must be a Base address.
 /// Empty string is returned on error. Result must be freed.

--- a/src/Cardano/Transaction.cpp
+++ b/src/Cardano/Transaction.cpp
@@ -313,4 +313,25 @@ Data Transaction::getId() const {
     return hash;
 }
 
+/// https://github.com/Emurgo/cardano-serialization-lib/blob/78184e0a2c207c2f8bba57b0d3c437f4c808c125/rust/src/utils.rs#L1415
+uint64_t minAdaAmountHelper(const TxOutput& output, uint64_t coinsPerUtxoByte) {
+    const size_t outputSize = cborizeOutput(output).encoded().size();
+    return static_cast<uint64_t>(outputSize + 160) * coinsPerUtxoByte;
+}
+
+/// https://github.com/Emurgo/cardano-serialization-lib/blob/78184e0a2c207c2f8bba57b0d3c437f4c808c125/rust/src/utils.rs#L1388
+uint64_t TxOutput::minAdaAmount(uint64_t coinsPerUtxoByte) const {
+    // A copy of `this`.
+    TxOutput output(address, amount, tokenBundle);
+
+    while (true) {
+        const auto minAmount = minAdaAmountHelper(output, coinsPerUtxoByte);
+        if (output.amount >= minAmount) {
+            return minAmount;
+        }
+        // Set the amount to `minAmount` and re-try again.
+        output.amount = minAmount;
+    }
+}
+
 } // namespace TW::Cardano

--- a/src/Cardano/Transaction.cpp
+++ b/src/Cardano/Transaction.cpp
@@ -314,13 +314,13 @@ Data Transaction::getId() const {
 }
 
 /// https://github.com/Emurgo/cardano-serialization-lib/blob/78184e0a2c207c2f8bba57b0d3c437f4c808c125/rust/src/utils.rs#L1415
-uint64_t minAdaAmountHelper(const TxOutput& output, uint64_t coinsPerUtxoByte) {
+uint64_t minAdaAmountHelper(const TxOutput& output, uint64_t coinsPerUtxoByte) noexcept {
     const size_t outputSize = cborizeOutput(output).encoded().size();
     return static_cast<uint64_t>(outputSize + 160) * coinsPerUtxoByte;
 }
 
 /// https://github.com/Emurgo/cardano-serialization-lib/blob/78184e0a2c207c2f8bba57b0d3c437f4c808c125/rust/src/utils.rs#L1388
-uint64_t TxOutput::minAdaAmount(uint64_t coinsPerUtxoByte) const {
+uint64_t TxOutput::minAdaAmount(uint64_t coinsPerUtxoByte) const noexcept {
     // A copy of `this`.
     TxOutput output(address, amount, tokenBundle);
 

--- a/src/Cardano/Transaction.h
+++ b/src/Cardano/Transaction.h
@@ -103,6 +103,9 @@ public:
     /// Token amounts (optional)
     TokenBundle tokenBundle;
 
+    /// Returns minimal amount of ADA for the output.
+    uint64_t minAdaAmount(uint64_t coinsPerUtxoByte) const;
+
     TxOutput() = default;
     TxOutput(Data address, Amount amount)
         : address(std::move(address)), amount(amount) {}

--- a/src/Cardano/Transaction.h
+++ b/src/Cardano/Transaction.h
@@ -104,7 +104,7 @@ public:
     TokenBundle tokenBundle;
 
     /// Returns minimal amount of ADA for the output.
-    uint64_t minAdaAmount(uint64_t coinsPerUtxoByte) const;
+    uint64_t minAdaAmount(uint64_t coinsPerUtxoByte) const noexcept;
 
     TxOutput() = default;
     TxOutput(Data address, Amount amount)

--- a/src/interface/TWCardano.cpp
+++ b/src/interface/TWCardano.cpp
@@ -21,6 +21,29 @@ uint64_t TWCardanoMinAdaAmount(TWData *_Nonnull tokenBundle) {
     return 0;
 }
 
+uint64_t TWCardanoOutputMinAdaAmount(TWString *_Nonnull toAddress, TWData *_Nonnull tokenBundle, uint64_t coinsPerUtxoByte) {
+    const std::string& address = *reinterpret_cast<const std::string*>(toAddress);
+    const Data* bundleData = static_cast<const Data*>(tokenBundle);
+
+    try {
+        // Set the initial amount to 0.
+        const uint64_t amount = 0;
+        const TW::Cardano::AddressV3 cardanoAddress(address);
+
+        TW::Cardano::Proto::TokenBundle bundleProto;
+        if (!bundleData || !bundleProto.ParseFromArray(bundleData->data(), (int)bundleData->size())) {
+            // Expect at least an empty `TokenBundle`.
+            return 0;
+        }
+        const auto tokens = TW::Cardano::TokenBundle::fromProto(bundleProto);
+
+        const TW::Cardano::TxOutput output(cardanoAddress.data(), amount, tokens);
+        return output.minAdaAmount(coinsPerUtxoByte);
+    } catch (...) {
+        return 0;
+    }
+}
+
 TWString *_Nonnull TWCardanoGetStakingAddress(TWString *_Nonnull baseAddress) {
     const auto& address = *reinterpret_cast<const std::string*>(baseAddress);
     try {

--- a/src/proto/Cardano.proto
+++ b/src/proto/Cardano.proto
@@ -177,7 +177,7 @@ message SigningInput {
     Delegate delegate = 7;
 
     // Optional, used in case of withdraw
-    Withdraw withdraw = 8;    
+    Withdraw withdraw = 8;
 
     // Optional
     DeregisterStakingKey deregister_staking_key = 9;

--- a/swift/Tests/Blockchains/CardanoTests.swift
+++ b/swift/Tests/Blockchains/CardanoTests.swift
@@ -225,6 +225,7 @@ class CardanoTests: XCTestCase {
     func testSignNftTransfer() throws {
         let fromAddress = "addr1qy5eme9r6frr0m6q2qpncg282jtrhq5lg09uxy2j0545hj8rv7v2ntdxuv6p4s3eq4lqzg39lewgvt6fk5kmpa0zppesufzjud"
         let toAddress = "addr1qy9wjfn6nd8kak6dd8z53u7t5wt9f4lx0umll40px5hnq05avwcsq5r3ytdp36wttzv4558jaq8lvhgqhe3y8nuf5xrquju7z4"
+        let coinsPerUtxoByte = 4310;
 
         let tokenAmount = CardanoTokenAmount.with {
             $0.policyID = "219820e6cb04316f41a337fea356480f412e7acc147d28f175f21b5e"
@@ -234,10 +235,16 @@ class CardanoTests: XCTestCase {
         var input = CardanoSigningInput.with {
             $0.transferMessage.toAddress = toAddress
             $0.transferMessage.changeAddress = fromAddress
-            $0.transferMessage.amount = 1202490
             $0.ttl = 89130965
         }
         input.transferMessage.tokenAmount.token.append(tokenAmount);
+        
+        // check min ADA amount, set it
+        let inputTokenAmountSerialized = try input.transferMessage.tokenAmount.serializedData()
+        let minAmount = Cardano.outputMinAdaAmount(toAddress: toAddress, tokenBundle: inputTokenAmountSerialized, coinsPerUtxoByte: UInt64(coinsPerUtxoByte));
+        XCTAssertEqual(minAmount, 1202490)
+        input.transferMessage.amount = minAmount
+        
         input.privateKey.append(Data(hexString: "d09831a668db6b36ffb747600cb1cd3e3d34f36e1e6feefc11b5f988719b7557a7029ab80d3e6fe4180ad07a59ddf742ea9730f3c4145df6365fa4ae2ee49c3392e19444caf461567727b7fefec40a3763bdb6ce5e0e8c05f5e340355a8fef4528dfe7502cfbda49e38f5a0021962d52dc3dee82834a23abb6750981799b75577d1ed9af9853707f0ef74264274e71b2f12e86e3c91314b6efa75ef750d9711b84cedd742ab873ef2f9566ad20b3fc702232c6d2f5d83ff425019234037d1e58")!)
 
         let utxo1 = CardanoTxInput.with {

--- a/swift/Tests/Blockchains/CardanoTests.swift
+++ b/swift/Tests/Blockchains/CardanoTests.swift
@@ -221,4 +221,59 @@ class CardanoTests: XCTestCase {
         let txid = output.txID
         XCTAssertEqual(txid.hexString, "6dcf3956232953fc25b8355fb1ded1e912b5802090fd21434d789087d6329683")
     }
+    
+    func testSignNftTransfer() throws {
+        let fromAddress = "addr1qy5eme9r6frr0m6q2qpncg282jtrhq5lg09uxy2j0545hj8rv7v2ntdxuv6p4s3eq4lqzg39lewgvt6fk5kmpa0zppesufzjud"
+        let toAddress = "addr1qy9wjfn6nd8kak6dd8z53u7t5wt9f4lx0umll40px5hnq05avwcsq5r3ytdp36wttzv4558jaq8lvhgqhe3y8nuf5xrquju7z4"
+
+        let tokenAmount = CardanoTokenAmount.with {
+            $0.policyID = "219820e6cb04316f41a337fea356480f412e7acc147d28f175f21b5e"
+            $0.assetName = "coolcatssociety4567"
+            $0.amount = Data(hexString: "01")! // 1
+        };
+        var input = CardanoSigningInput.with {
+            $0.transferMessage.toAddress = toAddress
+            $0.transferMessage.changeAddress = fromAddress
+            $0.transferMessage.amount = 1202490
+            $0.ttl = 89130965
+        }
+        input.transferMessage.tokenAmount.token.append(tokenAmount);
+        input.privateKey.append(Data(hexString: "d09831a668db6b36ffb747600cb1cd3e3d34f36e1e6feefc11b5f988719b7557a7029ab80d3e6fe4180ad07a59ddf742ea9730f3c4145df6365fa4ae2ee49c3392e19444caf461567727b7fefec40a3763bdb6ce5e0e8c05f5e340355a8fef4528dfe7502cfbda49e38f5a0021962d52dc3dee82834a23abb6750981799b75577d1ed9af9853707f0ef74264274e71b2f12e86e3c91314b6efa75ef750d9711b84cedd742ab873ef2f9566ad20b3fc702232c6d2f5d83ff425019234037d1e58")!)
+
+        let utxo1 = CardanoTxInput.with {
+            $0.outPoint.txHash = Data(hexString: "aba499ec2f23529e70bb256ceaffcc6274a882cf02f29e5670c75ee980d7c2b8")!
+            $0.outPoint.outputIndex = 0
+            $0.address = fromAddress
+            $0.amount = 1202490
+            $0.tokenAmount = [tokenAmount]
+        }
+        input.utxos.append(utxo1)
+        
+        let utxo2 = CardanoTxInput.with {
+            $0.outPoint.txHash = Data(hexString: "ee414d635b3bc67831907354d274a31174664777c57c21ae923b9459e5644840")!
+            $0.outPoint.outputIndex = 0
+            $0.address = fromAddress
+            $0.amount = 1000000
+        }
+        input.utxos.append(utxo2)
+        
+        let utxo3 = CardanoTxInput.with {
+            $0.outPoint.txHash = Data(hexString: "6a7221dcc28353ed69b733391ffeb984a34c1e72293af111d59f9ddfa8639167")!
+            $0.outPoint.outputIndex = 0
+            $0.address = fromAddress
+            $0.amount = 2000000
+        }
+        input.utxos.append(utxo3)
+
+        // Sign
+        let output: CardanoSigningOutput = AnySigner.sign(input: input, coin: .cardano)
+        XCTAssertEqual(output.error, TW_Common_Proto_SigningError.ok)
+
+        let encoded = output.encoded
+        XCTAssertEqual(encoded.hexString,
+            "83a400838258206a7221dcc28353ed69b733391ffeb984a34c1e72293af111d59f9ddfa863916700825820aba499ec2f23529e70bb256ceaffcc6274a882cf02f29e5670c75ee980d7c2b800825820ee414d635b3bc67831907354d274a31174664777c57c21ae923b9459e5644840000182825839010ae9267a9b4f6edb4d69c548f3cba39654d7e67f37ffd5e1352f303e9d63b100507122da18e9cb58995a50f2e80ff65d00be6243cf89a186821a0012593aa1581c219820e6cb04316f41a337fea356480f412e7acc147d28f175f21b5ea153636f6f6c63617473736f6369657479343536370182583901299de4a3d24637ef4050033c214754963b829f43cbc311527d2b4bc8e36798a9ada6e3341ac239057e012225fe5c862f49b52db0f5e208731a002b1525021a0002b19b031a055007d5a1008182582088bd26e8656fa7dead846c3373588f0192da5bfb90bf5d3fb877decfb3b3fd085840da8656aca0dacc57d4c2d957fc7dff03908f6dcf60c48f1e40b3006e2fd0cfacfa4c24fa02e35a310572526586d4ce0d30bf660ba274c8efd507848cbe177d09f6")
+
+        let txid = output.txID
+        XCTAssertEqual(txid.hexString, "87ca43a36b09c0b140f0ef2b71fbdcfcf1fdc88f7aa378b861e8eed3e8974628")
+    }
 }

--- a/swift/Tests/Blockchains/CardanoTests.swift
+++ b/swift/Tests/Blockchains/CardanoTests.swift
@@ -221,7 +221,9 @@ class CardanoTests: XCTestCase {
         let txid = output.txID
         XCTAssertEqual(txid.hexString, "6dcf3956232953fc25b8355fb1ded1e912b5802090fd21434d789087d6329683")
     }
-    
+
+    // Successfully broadcasted:
+    // https://cardanoscan.io/transaction/87ca43a36b09c0b140f0ef2b71fbdcfcf1fdc88f7aa378b861e8eed3e8974628
     func testSignNftTransfer() throws {
         let fromAddress = "addr1qy5eme9r6frr0m6q2qpncg282jtrhq5lg09uxy2j0545hj8rv7v2ntdxuv6p4s3eq4lqzg39lewgvt6fk5kmpa0zppesufzjud"
         let toAddress = "addr1qy9wjfn6nd8kak6dd8z53u7t5wt9f4lx0umll40px5hnq05avwcsq5r3ytdp36wttzv4558jaq8lvhgqhe3y8nuf5xrquju7z4"

--- a/tests/chains/Cardano/SigningTests.cpp
+++ b/tests/chains/Cardano/SigningTests.cpp
@@ -99,131 +99,98 @@ Proto::SigningInput createSampleInput(uint64_t amount, int utxoCount = 10,
     return input;
 }
 
+/// Successfully broadcasted:
+/// https://cardanoscan.io/transaction/87ca43a36b09c0b140f0ef2b71fbdcfcf1fdc88f7aa378b861e8eed3e8974628
 TEST(CardanoSigning, SendNft) {
-    const auto toAddress = "addr1qy5eme9r6frr0m6q2qpncg282jtrhq5lg09uxy2j0545hj8rv7v2ntdxuv6p4s3eq4lqzg39lewgvt6fk5kmpa0zppesufzjud";
-    const auto fromAddress = "addr1qy9wjfn6nd8kak6dd8z53u7t5wt9f4lx0umll40px5hnq05avwcsq5r3ytdp36wttzv4558jaq8lvhgqhe3y8nuf5xrquju7z4";
+    const auto fromAddressPrivKey = "d09831a668db6b36ffb747600cb1cd3e3d34f36e1e6feefc11b5f988719b7557a7029ab80d3e6fe4180ad07a59ddf742ea9730f3c4145df6365fa4ae2ee49c3392e19444caf461567727b7fefec40a3763bdb6ce5e0e8c05f5e340355a8fef4528dfe7502cfbda49e38f5a0021962d52dc3dee82834a23abb6750981799b75577d1ed9af9853707f0ef74264274e71b2f12e86e3c91314b6efa75ef750d9711b84cedd742ab873ef2f9566ad20b3fc702232c6d2f5d83ff425019234037d1e58";
+    const auto fromAddress = "addr1qy5eme9r6frr0m6q2qpncg282jtrhq5lg09uxy2j0545hj8rv7v2ntdxuv6p4s3eq4lqzg39lewgvt6fk5kmpa0zppesufzjud";
+    const auto toAddress = "addr1qy9wjfn6nd8kak6dd8z53u7t5wt9f4lx0umll40px5hnq05avwcsq5r3ytdp36wttzv4558jaq8lvhgqhe3y8nuf5xrquju7z4";
     const auto nftPolicyId = "219820e6cb04316f41a337fea356480f412e7acc147d28f175f21b5e";
-    const auto nftAssetName = "636f6f6c63617473736f636965747934353637";
+    const auto nftAssetName = "coolcatssociety4567";
+    const auto nftTokenAmount = 1ul;
+    // 1.20249 ADA. Amount locked by the NFT.
+    const auto nftInputAmount = 1202490ul;
+    const auto ttl = 89130965ul;
 
     Proto::SigningInput input;
 
     // Set the first utxo (NFT token and locked ADA).
 
     auto* utxo1 = input.add_utxos();
-    // The NFT output
-    const auto txHash1 = parse_hex("5df2257e86acc36b95e331e6048dc424f638962a99524ee643651a80445e4e84");
+    // NFT unspent output.
+    const auto txHash1 = parse_hex("aba499ec2f23529e70bb256ceaffcc6274a882cf02f29e5670c75ee980d7c2b8");
     utxo1->mutable_out_point()->set_tx_hash(txHash1.data(), txHash1.size());
-    utxo1->mutable_out_point()->set_output_index(3);
+    utxo1->mutable_out_point()->set_output_index(0);
     utxo1->set_address(fromAddress);
-    utxo1->set_amount(1202490);
+    utxo1->set_amount(nftInputAmount);
 
     auto* token1 = utxo1->add_token_amount();
     token1->set_policy_id(nftPolicyId);
     token1->set_asset_name(nftAssetName);
-    const auto tokenAmount1 = store(uint256_t(1));
+    const auto tokenAmount1 = store(uint256_t(nftTokenAmount));
     token1->set_amount(tokenAmount1.data(), tokenAmount1.size());
 
-    // Set the second utxo (to pay fee).
+    // Set additional utxos to pay fee.
 
     auto* utxo2 = input.add_utxos();
-    const auto txHash2 = parse_hex("5df2257e86acc36b95e331e6048dc424f638962a99524ee643651a80445e4e84");
+    const auto txHash2 = parse_hex("ee414d635b3bc67831907354d274a31174664777c57c21ae923b9459e5644840");
     utxo2->mutable_out_point()->set_tx_hash(txHash2.data(), txHash2.size());
-    utxo2->mutable_out_point()->set_output_index(4);
+    utxo2->mutable_out_point()->set_output_index(0);
     utxo2->set_address(fromAddress);
-    utxo2->set_amount(9555841);
+    utxo2->set_amount(1000000);
 
-    HDWallet hdWallet("chapter upper fetch maple balcony resist jazz dance fetch blush cruise fame measure suspect patient", "");
-    ASSERT_EQ(hdWallet.deriveAddress(TWCoinTypeCardano, TWDerivationDefault), fromAddress);
-    const auto privKey = hdWallet.getKey(TWCoinTypeCardano, TWDerivationDefault);
-    std::cout << "privKey: " << hex(privKey.bytes) << std::endl;
+    auto* utxo3 = input.add_utxos();
+    const auto txHash3 = parse_hex("6a7221dcc28353ed69b733391ffeb984a34c1e72293af111d59f9ddfa8639167");
+    utxo3->mutable_out_point()->set_tx_hash(txHash3.data(), txHash3.size());
+    utxo3->mutable_out_point()->set_output_index(0);
+    utxo3->set_address(fromAddress);
+    utxo3->set_amount(2000000);
 
+    PrivateKey privKey(parse_hex(fromAddressPrivKey));
     input.add_private_key(privKey.bytes.data(), privKey.bytes.size());
 
     // Set an output info.
 
     input.mutable_transfer_message()->set_to_address(toAddress);
     input.mutable_transfer_message()->set_change_address(fromAddress);
-    input.mutable_transfer_message()->set_amount(1202490);
+    input.mutable_transfer_message()->set_amount(nftInputAmount);
 
     auto* toToken = input.mutable_transfer_message()->mutable_token_amount()->add_token();
     toToken->set_policy_id(nftPolicyId);
     toToken->set_asset_name(nftAssetName);
-    const auto toTokenAmount = store(uint256_t(1)); // Always 1 for NFT transfer
+    const auto toTokenAmount = store(uint256_t(nftTokenAmount));
     toToken->set_amount(toTokenAmount.data(), toTokenAmount.size());
-    // Current slotNo (89043320) + 1000
-    input.set_ttl(89044320);
+    input.set_ttl(ttl);
 
-    // { // check min ADA amount, set it
+    // TODO
+    // { // check min ADA amount
     //     const auto bundleProtoData = data(input.transfer_message().token_amount().SerializeAsString());
     //     const auto minAdaAmount = TWCardanoMinAdaAmount(&bundleProtoData);
-    //     EXPECT_EQ(minAdaAmount, 1592591ul);
-    //     input.mutable_transfer_message()->set_amount(minAdaAmount);
+    //     EXPECT_EQ(minAdaAmount, nftInputAmount);
+    //     EXPECT_EQ(input.transfer_message().amount(), minAdaAmount);
     // }
 
-    {
-        // run plan and check result
-        auto signer = Signer(input);
-        const auto plan = signer.doPlan();
-        std::cout
-            << "availableAmount: " << plan.availableAmount << std::endl
-            << "amount: " << plan.amount << std::endl
-            << "fee: " << plan.fee << std::endl
-            << "change: " << plan.change << std::endl
-            << "utxos: " << plan.utxos.size() << std::endl
-            << "availableTokens: " << plan.availableTokens.size() << std::endl
-            << "availableTokens.getAmount(): " << plan.availableTokens.getAmount("219820e6cb04316f41a337fea356480f412e7acc147d28f175f21b5e_636f6f6c63617473736f636965747934353637") << std::endl
-            << "outputTokens: " << plan.outputTokens.size() << std::endl
-            << "outputTokens.getAmount(): " << plan.outputTokens.getAmount("219820e6cb04316f41a337fea356480f412e7acc147d28f175f21b5e_636f6f6c63617473736f636965747934353637") << std::endl
-            << "changeTokens: " << plan.changeTokens.size() << std::endl
-            << "changeTokens.getAmount(): " << plan.changeTokens.getAmount("219820e6cb04316f41a337fea356480f412e7acc147d28f175f21b5e_636f6f6c63617473736f636965747934353637") << std::endl;
-
-        const auto output = signer.sign();
-        const auto txid = data(output.tx_id());
-        std::cout << "hex(encoded): " << hex(data(output.encoded())) << std::endl << "txid: " << hex(txid);
-        // EXPECT_EQ(hex(txid), "1dd24872d93d3b5091b98e19b9f920cd0c4369e4c5ca178e898152c52f00c162");
-
-        // EXPECT_EQ(plan.availableAmount, 11758890ul);
-        // EXPECT_EQ(plan.amount, 11758890 - 9984729 - 174161ul);
-        // EXPECT_EQ(plan.fee, 174161ul);
-        // EXPECT_EQ(plan.change, 9984729ul);
-        // EXPECT_EQ(plan.utxos.size(), 2ul);
-        // EXPECT_EQ(plan.availableTokens.size(), 1ul);
-        // EXPECT_EQ(plan.availableTokens.getAmount("219820e6cb04316f41a337fea356480f412e7acc147d28f175f21b5e_636f6f6c63617473736f636965747934353637"), 1);
-        // EXPECT_EQ(plan.outputTokens.size(), 1ul);
-        // EXPECT_EQ(plan.outputTokens.getAmount("9a9693a9a37912a5097918f97918d15240c92ab729a0b7c4aa144d77_SUNDAE"), 11000000);
-        // EXPECT_EQ(plan.changeTokens.size(), 1ul);
-        // EXPECT_EQ(plan.changeTokens.getAmount("9a9693a9a37912a5097918f97918d15240c92ab729a0b7c4aa144d77_SUNDAE"), 9000000);
-    }
-
-    // set plan with specific fee, to match the real transaction
-    input.mutable_plan()->set_available_amount(10758331);
-    input.mutable_plan()->set_amount(1202490);
-    input.mutable_plan()->set_fee(176715);
-    input.mutable_plan()->set_change(9379126);
-    *(input.mutable_plan()->add_available_tokens()) = input.utxos(0).token_amount(0);
-    *(input.mutable_plan()->add_output_tokens()) = input.utxos(0).token_amount(0);
-    input.mutable_plan()->mutable_output_tokens(0)->set_amount(toTokenAmount.data(), toTokenAmount.size());
-    *(input.mutable_plan()->add_change_tokens()) = input.utxos(0).token_amount(0);
-    const auto changeTokenAmount = store(uint256_t(0));
-    input.mutable_plan()->mutable_change_tokens(0)->set_amount(changeTokenAmount.data(), changeTokenAmount.size());
-    *(input.mutable_plan()->add_utxos()) = input.utxos(1);
-    *(input.mutable_plan()->add_utxos()) = input.utxos(0);
-    input.mutable_plan()->set_error(Common::Proto::OK);
-
+    // run plan and check result
     auto signer = Signer(input);
+    const auto plan = signer.doPlan();
     const auto output = signer.sign();
 
-    const auto txid = data(output.tx_id());
-    std::cout << "hex(encoded): " << hex(data(output.encoded())) << std::endl << "txid: " << hex(txid);
-    // EXPECT_EQ(hex(txid), "1dd24872d93d3b5091b98e19b9f920cd0c4369e4c5ca178e898152c52f00c162");
+    const auto txid = hex(data(output.tx_id()));
+    EXPECT_EQ(txid, "87ca43a36b09c0b140f0ef2b71fbdcfcf1fdc88f7aa378b861e8eed3e8974628");
 
-    // // https://cardanoscan.io/transaction/1dd24872d93d3b5091b98e19b9f920cd0c4369e4c5ca178e898152c52f00c162
-    // // curl -d '{"txHash":"1dd248..c162","txBody":"83a400..08f6"}' -H "Content-Type: application/json" https://<cardano-node>/api/txs/submit
-    // EXPECT_EQ(output.error(), Common::Proto::OK);
-    // const auto encoded = data(output.encoded());
-    // EXPECT_EQ(hex(encoded), "83a400828258206975fcf7bbca745c85f50777f956219868fd9cad14ba496fed1371252e8df60f00825820f2d2b11c8c07c5c646f5b5af20fddf2f0a174743c6a1b13cca27e28a6ca34710000182825839018d98bea0414243dc84070f96265577e7e6cf702d62e871016885034ecc64bf258b8e330cf0cdd9fdb03e10b4e4ac08f5da1fdec6222a3468821a00186a00a1581c9a9693a9a37912a5097918f97918d15240c92ab729a0b7c4aa144d77a14653554e4441451a00a7d8c082583901df58ee97ce7a46cd8bdeec4e5f3a03297eb197825ed5681191110804df22424b6880b39e4bac8c58de9fe6d23d79aaf44756389d827aa09b821a00985b14a1581c9a9693a9a37912a5097918f97918d15240c92ab729a0b7c4aa144d77a14653554e4441451a00895440021a0002a816031a03a6541ea100818258206d8a0b425bd2ec9692af39b1c0cf0e51caa07a603550e22f54091e872c7df2905840c8cdee32bfd584f55cf334b4ec6f734635144736d48f882e647a7a6283f230bc5a67d4dd66a9e523e0c29c812ed1e3589febbcf96547a1fc6d061a7ccfb81308f6");
-    // const auto txid = data(output.tx_id());
-    // EXPECT_EQ(hex(txid), "1dd24872d93d3b5091b98e19b9f920cd0c4369e4c5ca178e898152c52f00c162");
+    EXPECT_EQ(plan.availableAmount, nftInputAmount + 1000000ul + 2000000ul);
+    EXPECT_EQ(plan.amount, nftInputAmount);
+    EXPECT_EQ(plan.fee, 176539ul);
+    EXPECT_EQ(plan.change, 1000000ul + 2000000ul - 176539ul);
+    EXPECT_EQ(plan.utxos.size(), 3ul);
+    EXPECT_EQ(plan.availableTokens.size(), nftTokenAmount);
+    EXPECT_EQ(plan.availableTokens.getAmount("219820e6cb04316f41a337fea356480f412e7acc147d28f175f21b5e_coolcatssociety4567"), nftTokenAmount);
+    EXPECT_EQ(plan.outputTokens.size(), 1ul);
+    EXPECT_EQ(plan.outputTokens.getAmount("219820e6cb04316f41a337fea356480f412e7acc147d28f175f21b5e_coolcatssociety4567"), nftTokenAmount);
+    EXPECT_EQ(plan.changeTokens.size(), 0ul);
+
+    const auto txHex = hex(data(output.encoded()));
+    EXPECT_EQ(txHex, "83a400838258206a7221dcc28353ed69b733391ffeb984a34c1e72293af111d59f9ddfa863916700825820aba499ec2f23529e70bb256ceaffcc6274a882cf02f29e5670c75ee980d7c2b800825820ee414d635b3bc67831907354d274a31174664777c57c21ae923b9459e5644840000182825839010ae9267a9b4f6edb4d69c548f3cba39654d7e67f37ffd5e1352f303e9d63b100507122da18e9cb58995a50f2e80ff65d00be6243cf89a186821a0012593aa1581c219820e6cb04316f41a337fea356480f412e7acc147d28f175f21b5ea153636f6f6c63617473736f6369657479343536370182583901299de4a3d24637ef4050033c214754963b829f43cbc311527d2b4bc8e36798a9ada6e3341ac239057e012225fe5c862f49b52db0f5e208731a002b1525021a0002b19b031a055007d5a1008182582088bd26e8656fa7dead846c3373588f0192da5bfb90bf5d3fb877decfb3b3fd085840da8656aca0dacc57d4c2d957fc7dff03908f6dcf60c48f1e40b3006e2fd0cfacfa4c24fa02e35a310572526586d4ce0d30bf660ba274c8efd507848cbe177d09f6");
 }
 
 TEST(CardanoSigning, Plan) {

--- a/tests/chains/Cardano/SigningTests.cpp
+++ b/tests/chains/Cardano/SigningTests.cpp
@@ -15,7 +15,6 @@
 #include "uint256.h"
 #include "TestUtilities.h"
 #include <TrustWalletCore/TWAnySigner.h>
-#include "HDWallet.h"
 
 #include <gtest/gtest.h>
 #include <vector>

--- a/tests/chains/Cardano/SigningTests.cpp
+++ b/tests/chains/Cardano/SigningTests.cpp
@@ -162,13 +162,19 @@ TEST(CardanoSigning, SendNft) {
     toToken->set_amount(toTokenAmount.data(), toTokenAmount.size());
     input.set_ttl(ttl);
 
-    // TODO
-    // { // check min ADA amount
-    //     const auto bundleProtoData = data(input.transfer_message().token_amount().SerializeAsString());
-    //     const auto minAdaAmount = TWCardanoMinAdaAmount(&bundleProtoData);
-    //     EXPECT_EQ(minAdaAmount, nftInputAmount);
-    //     EXPECT_EQ(input.transfer_message().amount(), minAdaAmount);
-    // }
+    { // check min ADA amount
+        // The byte cost at the moment when the transaction was constructed.
+        // See `ProtocolParams::coinsPerUtxoByte`:
+        // https://input-output-hk.github.io/cardano-graphql/
+        const uint64_t coinsPerUtxoByte = 4310;
+
+        const auto bundleProtoData = data(input.transfer_message().token_amount().SerializeAsString());
+        const auto toAddressPtr = STRING(toAddress);
+
+        const auto minAdaAmount = TWCardanoOutputMinAdaAmount(toAddressPtr.get(), &bundleProtoData, coinsPerUtxoByte);
+        EXPECT_EQ(minAdaAmount, nftInputAmount);
+        EXPECT_EQ(input.transfer_message().amount(), minAdaAmount);
+    }
 
     // run plan and check result
     auto signer = Signer(input);

--- a/tests/chains/Cardano/TransactionTests.cpp
+++ b/tests/chains/Cardano/TransactionTests.cpp
@@ -10,6 +10,7 @@
 
 #include "HexCoding.h"
 #include "Cbor.h"
+#include "TestUtilities.h"
 
 #include <gtest/gtest.h>
 
@@ -120,6 +121,56 @@ TEST(TWCardanoTransaction, minAdaAmount) {
         const auto bundleProto = bundle.toProto();
         const auto bundleProtoData = data(bundleProto.SerializeAsString());
         EXPECT_EQ(TWCardanoMinAdaAmount(&bundleProtoData), 1629628ul);
+    }
+}
+
+TEST(TWCardanoTransaction, outputMinAdaAmount) {
+    // For an actual value see `ProtocolParams::coinsPerUtxoByte`:
+    // https://input-output-hk.github.io/cardano-graphql/
+    const uint64_t coinsPerUtxoByte = 4310;
+    const auto toAddress = STRING("addr1q8043m5heeaydnvtmmkyuhe6qv5havvhsf0d26q3jygsspxlyfpyk6yqkw0yhtyvtr0flekj84u64az82cufmqn65zdsylzk23");
+    const auto toLegacy = STRING("Ae2tdPwUPEZ4YjgvykNpoFeYUxoyhNj2kg8KfKWN2FizsSpLUPv68MpTVDo");
+
+    { // ADA-only
+        const auto bundleProto = TokenBundle().toProto();
+        const auto bundleProtoData = data(bundleProto.SerializeAsString());
+        const auto actual = TWCardanoOutputMinAdaAmount(toAddress.get(), &bundleProtoData, coinsPerUtxoByte);
+        EXPECT_EQ(actual, 969750ul);
+    }
+    { // ADA-only (to legacy address)
+        const auto bundleProto = TokenBundle().toProto();
+        const auto bundleProtoData = data(bundleProto.SerializeAsString());
+        const auto actual = TWCardanoOutputMinAdaAmount(toLegacy.get(), &bundleProtoData, coinsPerUtxoByte);
+        EXPECT_EQ(actual, 909410ul);
+    }
+    { // 1 NFT
+        auto bundle = TokenBundle();
+        bundle.add(TokenAmount("219820e6cb04316f41a337fea356480f412e7acc147d28f175f21b5e", "coolcatssociety4567", 1));
+        const auto bundleProto = bundle.toProto();
+        const auto bundleProtoData = data(bundleProto.SerializeAsString());
+        const auto actual = TWCardanoOutputMinAdaAmount(toAddress.get(), &bundleProtoData, coinsPerUtxoByte);
+        EXPECT_EQ(actual, 1202490ul);
+    }
+    { // 2 policyId, 2 4-char asset names
+        auto bundle = TokenBundle();
+        bundle.add(TokenAmount("8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f69587", "AADA", 20));
+        bundle.add(TokenAmount("6ac8ef33b510ec004fe11585f7c5a9f0c07f0c23428ab4f29c1d7d10", "MELD", 20));
+        const auto bundleProto = bundle.toProto();
+        const auto bundleProtoData = data(bundleProto.SerializeAsString());
+        const auto actual = TWCardanoOutputMinAdaAmount(toAddress.get(), &bundleProtoData, coinsPerUtxoByte);
+        EXPECT_EQ(actual, 1297310ul);
+    }
+    { // Invalid token bundle
+        Data invalidTokenBundleData {1, 2, 3, 4, 5};
+        const auto actual = TWCardanoOutputMinAdaAmount(toAddress.get(), &invalidTokenBundleData, coinsPerUtxoByte);
+        EXPECT_EQ(actual, 0ul);
+    }
+    { // Invalid address
+        const auto invalidAddress = STRING("foobar");
+        const auto bundleProto = TokenBundle().toProto();
+        const auto bundleProtoData = data(bundleProto.SerializeAsString());
+        const auto actual = TWCardanoOutputMinAdaAmount(invalidAddress.get(), &bundleProtoData, coinsPerUtxoByte);
+        EXPECT_EQ(actual, 0ul);
     }
 }
 


### PR DESCRIPTION
## Description

Cardano NFTs are supported in wallet-core. This pull request adds multiple samples (tests) in C++, Kotlin and Swift to explain how to generate and sign an NFT transfer transaction.

## Improvements

This pull request also adds the `TWCardanoOutputMinAdaAmount` FFI that should be used instead of `TWCardanoMinAdaAmount` as it returns a more accurate value for the minimum output amount.

## How to test

```shell
./tools/build-and-test
./tools/ios-test
./tools/android-test
```

## Checklist

- [x] Add multiple samples (tests) in C++, Kotlin and Swift.
- [x] Add `TWCardanoOutputMinAdaAmount`, an alternative to `TWCardanoMinAdaAmount`, with the same behaviour as [cardano-serialization-lib::min_ada_for_output](https://github.com/Emurgo/cardano-serialization-lib/blob/78184e0a2c207c2f8bba57b0d3c437f4c808c125/rust/src/utils.rs#L1424)
- [x] Cover `TWCardanoOutputMinAdaAmount` with Kotlin, Swift tests.