### PR TITLE
[Docker]: Push Docker image to TW registry on push to master branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,12 @@ jobs:
         curl -L https://github.com/hadolint/hadolint/releases/download/v1.17.6/hadolint-Linux-x86_64 -o hadolint && chmod +x hadolint
         ./hadolint Dockerfile
 
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        aws-region: us-east-1
+
     - name: Login to Amazon ECR Public
       id: login-ecr-public
       uses: aws-actions/amazon-ecr-login@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,9 +7,9 @@ on:
       - "*.*.*"
   pull_request:
     branches: [ master ]
-#    paths:
-#      - Dockerfile
-#      - tools/install-dependencies
+    paths:
+      - Dockerfile
+      - tools/install-dependencies
 
 permissions:
   id-token: write
@@ -59,6 +59,6 @@ jobs:
 
     - name: Push docker image to Amazon ECR Public
       # Run on push commit to master branch only.
-      # if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/master') TODO
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/master')
       run: |
         docker push $IMAGE_NAME:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,10 @@ on:
 #      - Dockerfile
 #      - tools/install-dependencies
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,11 +3,13 @@ name: Docker CI
 on:
   push:
     branches: [ master ]
+    tags:
+      - "*.*.*"
   pull_request:
     branches: [ master ]
-    paths:
-      - Dockerfile
-      - tools/install-dependencies
+#    paths:
+#      - Dockerfile
+#      - tools/install-dependencies
 
 jobs:
   build:
@@ -19,9 +21,34 @@ jobs:
         curl -L https://github.com/hadolint/hadolint/releases/download/v1.17.6/hadolint-Linux-x86_64 -o hadolint && chmod +x hadolint
         ./hadolint Dockerfile
 
-    - name: Build Dockerfile
-      uses: docker/build-push-action@v1.1.0
+    - name: Login to Amazon ECR Public
+      id: login-ecr-public
+      uses: aws-actions/amazon-ecr-login@v1
       with:
-        repository: trustwallet/wallet-core
-        tags: latest
-        push: false
+        registry-type: public
+
+    - name: Set docker image name
+      env:
+        REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+        REGISTRY_ALIAS: y4f6g9v9 # Given by AWS
+        REPOSITORY: wallet-core
+      run: |
+        echo "IMAGE_NAME=$REGISTRY/$REGISTRY_ALIAS/$REPOSITORY" >> $GITHUB_ENV
+
+    - name: Build docker image
+      run: |
+        docker build -t $IMAGE_NAME .
+
+    - name: Push docker image with Git tag to Amazon ECR Public
+      # Run on tag push only.
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
+      run: |
+        TAG_VERSION=${GITHUB_REF#refs/tags/}
+        docker tag $IMAGE_NAME $IMAGE_NAME:$TAG_VERSION
+        docker push $IMAGE_NAME:$TAG_VERSION
+
+    - name: Push docker image to Amazon ECR Public
+      # Run on push commit to master branch only.
+      # if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/master') TODO
+      run: |
+        docker push $IMAGE_NAME:latest


### PR DESCRIPTION
## Description

Backend team is integrating wallet-core to one of their backend project, and they need the Docker image as a basis.
If push commit to `master`, Docker CI will publish the `wallet-core:latest` docker image.
If push new tag (release), Docker CI will publish the `wallet-core:$TAG` docker image.

## Types of changes

Changed `.github/workflows/docker.yml` CI workflow.

## Refs

[Docker CI run](https://github.com/trustwallet/wallet-core/actions/runs/4680852152/jobs/8292718795?pr=3075) has produced and published this docker image: https://gallery.ecr.aws/y4f6g9v9/wallet-core

**Checklist**

<!--- Group checklist per issue needed, one specific feature of your goal -->
<!--- Each big task can have subtask, doesn't hesitate to split into small pull request to simplify the review process -->

- [x] Push Docker image on `push:master` and `push:tags` events only