### PR TITLE
[Kotlin] Nullable constructors throw exception

### DIFF
--- a/.github/workflows/kotlin-ci.yml
+++ b/.github/workflows/kotlin-ci.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
 
     - name: Setup Gradle

--- a/.github/workflows/kotlin-sample-ci.yml
+++ b/.github/workflows/kotlin-sample-ci.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
 
     - name: Install Kotlin Dependencies

--- a/codegen/lib/kotlin_helper.rb
+++ b/codegen/lib/kotlin_helper.rb
@@ -222,8 +222,8 @@ module KotlinHelper
     end
   end
 
-  def self.js_type(t, is_constructor = false)
-    nullable = "#{if t.is_nullable && !is_constructor then '?' else '' end}"
+  def self.js_type(t)
+    nullable = "#{if t.is_nullable then '?' else '' end}"
     case t.name
     when :void
       ""
@@ -240,12 +240,12 @@ module KotlinHelper
     end
   end
 
-  def self.js_return_type(t, is_constructor = false)
+  def self.js_return_type(t)
     case t.name
     when :void
       ""
     else
-      ": #{js_type(t, is_constructor)}"
+      ": #{js_type(t)}"
     end
   end
 

--- a/codegen/lib/templates/kotlin/android_class.erb
+++ b/codegen/lib/templates/kotlin/android_class.erb
@@ -6,9 +6,16 @@
 actual class <%= entity.name %> private constructor(
     private val nativeHandle: Long,
 ) {
+
+    init {
+        if (nativeHandle == 0L) throw IllegalArgumentException()
+    }
 <%# Constructors -%>
 <%- constructors.each do |constructor| -%>
 
+<%  if constructor.return_type.is_nullable -%>
+    @Throws(IllegalArgumentException::class)
+<%  end -%>
     actual constructor(<%= KotlinHelper.parameters(constructor.parameters) %>) : this(<%= KotlinHelper.format_name(constructor.name) %>(<%= KotlinHelper.calling_parameters_android(constructor.parameters) %>))
 <%  end -%>
 <%# Property declarations -%>

--- a/codegen/lib/templates/kotlin/android_enum.erb
+++ b/codegen/lib/templates/kotlin/android_enum.erb
@@ -1,12 +1,20 @@
 <%= render('kotlin/package.erb') %>
 
+<%  has_string = entity.cases.all? { |c| !c.string.nil? } -%>
 actual enum class <%= entity.name %>(
     @get:JvmName("value")
     val value: UInt,
+<%  if has_string -%>
+    actual val stringValue: String,
+<%  end -%>
 ) {
 <%# Cases -%>
 <%  entity.cases.each_with_index do |c, i| -%>
+<%  if has_string -%>
+    <%= c.name %>(<%= c.value %>u, <%= c.string %>),
+<%  else -%>
     <%= c.name %>(<%= c.value %>u),
+<%  end -%>
 <%  end -%>
     ;
 <%# Property declarations -%>

--- a/codegen/lib/templates/kotlin/common_class.erb
+++ b/codegen/lib/templates/kotlin/common_class.erb
@@ -4,7 +4,11 @@
 <% methods = entity.methods.select { |method| not method.name.start_with?('Delete') } -%>
 <% static_methods = entity.static_methods.select { |method| not method.name.start_with?('Create') } -%>
 <%  if constructors.one? -%>
+<%  if constructors.first.return_type.is_nullable -%>
+expect class <%= entity.name %> @Throws(IllegalArgumentException::class) constructor(
+<%  else -%>
 expect class <%= entity.name %>(
+<%  end -%>
 <%- constructors.first.parameters.each do |parameter| -%>
     <%= KotlinHelper.parameters([parameter]) %>,
 <%- end -%>
@@ -12,10 +16,11 @@ expect class <%= entity.name %>(
 <%- else -%>
 expect class <%= entity.name %> {
 <%# Constructors -%>
-<%  if constructors.any? -%>
-
-<%  end -%>
 <%- constructors.each do |constructor| -%>
+
+<%  if constructor.return_type.is_nullable -%>
+    @Throws(IllegalArgumentException::class)
+<%  end -%>
     constructor(<%= KotlinHelper.parameters(constructor.parameters) %>)
 <%- end -%>
 <%  end -%>

--- a/codegen/lib/templates/kotlin/common_enum.erb
+++ b/codegen/lib/templates/kotlin/common_enum.erb
@@ -1,11 +1,16 @@
 <%= render('kotlin/package.erb') %>
 
+<%  has_string = entity.cases.all? { |c| !c.string.nil? } -%>
 expect enum class <%= entity.name %> {
 <%# Cases -%>
 <%  entity.cases.each_with_index do |c, i| -%>
     <%= c.name %>,
 <%  end -%>
     ;
+
+<%  if has_string -%>
+    val stringValue: String
+<%  end -%>
 <%# Property declarations -%>
 <%- entity.properties.each do |property| -%>
     val <%= KotlinHelper.format_name(property.name) %><%= KotlinHelper.return_type(property.return_type) %>

--- a/codegen/lib/templates/kotlin/ios_class.erb
+++ b/codegen/lib/templates/kotlin/ios_class.erb
@@ -12,8 +12,14 @@ actual class <%= entity.name %> constructor(
 <%# Constructors -%>
 <%- constructors.each do |constructor| -%>
 
+<%  if constructor.return_type.is_nullable -%>
+    @Throws(IllegalArgumentException::class)
+    actual constructor(<%= KotlinHelper.parameters(constructor.parameters) %>) : this(
+        TW<%= entity.name %><%= constructor.name %>(<%= KotlinHelper.calling_parameters_ios(constructor.parameters) %>) ?: throw IllegalArgumentException()
+<%  else -%>
     actual constructor(<%= KotlinHelper.parameters(constructor.parameters) %>) : this(
         TW<%= entity.name %><%= constructor.name %>(<%= KotlinHelper.calling_parameters_ios(constructor.parameters) %>)!!
+<%  end -%>
     )
 <%  end -%>
 <%# Property declarations -%>

--- a/codegen/lib/templates/kotlin/ios_enum.erb
+++ b/codegen/lib/templates/kotlin/ios_enum.erb
@@ -2,13 +2,21 @@
 
 import com.trustwallet.core.<%= "TW#{entity.name}" %>.*
 
+<%  has_string = entity.cases.all? { |c| !c.string.nil? } -%>
 <%  type = ": TW#{entity.name}" -%>
 actual enum class <%= entity.name %>(
     val value<%= type %>,
+<%  if has_string -%>
+    actual val stringValue: String,
+<%  end -%>
 ) {
 <%# Cases -%>
 <%  entity.cases.each_with_index do |c, i| -%>
+<%  if has_string -%>
+    <%= c.name %>(TW<%= entity.name %><%= c.name %>, <%= c.string %>),
+<%  else -%>
     <%= c.name %>(TW<%= entity.name %><%= c.name %>),
+<%  end -%>
 <%  end -%>
     ;
 <%# Property declarations -%>

--- a/codegen/lib/templates/kotlin/js_accessors_class.erb
+++ b/codegen/lib/templates/kotlin/js_accessors_class.erb
@@ -1,8 +1,10 @@
+@file:Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
+
 <%= render('kotlin/package.erb') %>
 
 @JsModule("@trustwallet/wallet-core")
 @JsName("<%= entity.name %>")
-external class Js<%= entity.name %> {
+external interface Js<%= entity.name %> {
 <%- entity.properties.each do |property| -%>
     fun <%= KotlinHelper.fix_name(WasmCppHelper.format_name(property.name)) %>()<%= KotlinHelper.js_return_type(property.return_type) %>
 <%- end -%>
@@ -12,7 +14,7 @@ external class Js<%= entity.name %> {
 <% end -%>
     companion object {
 <%  entity.static_methods.each do |method| -%>
-        fun <%= KotlinHelper.fix_name(WasmCppHelper.function_name(entity: entity, function: method)) %>(<%= KotlinHelper.js_parameters(method.parameters) %>)<%= KotlinHelper.js_return_type(method.return_type, method.name.start_with?("Create")) %>
+        fun <%= KotlinHelper.fix_name(WasmCppHelper.function_name(entity: entity, function: method)) %>(<%= KotlinHelper.js_parameters(method.parameters) %>)<%= KotlinHelper.js_return_type(method.return_type) %>
 <%  end -%>
     }
 }

--- a/codegen/lib/templates/kotlin/js_accessors_enum.erb
+++ b/codegen/lib/templates/kotlin/js_accessors_enum.erb
@@ -1,8 +1,10 @@
+@file:Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
+
 <%= render('kotlin/package.erb') %>
 
 @JsModule("@trustwallet/wallet-core")
 @JsName("<%= entity.name %>")
-external class Js<%= entity.name %> {
+external interface Js<%= entity.name %> {
     val value: Number
     companion object {
 <%  entity.cases.each do |c| -%>
@@ -17,7 +19,7 @@ inline val JsWalletCore.<%= entity.name %>: Js<%= entity.name %>.Companion
 <%  if entity.properties.any? || entity.methods.any? -%>
 @JsModule("@trustwallet/wallet-core")
 @JsName("<%= entity.name %>Ext")
-external object Js<%= entity.name %>Ext {
+external interface Js<%= entity.name %>Ext {
 <%# Static method declarations -%>
 <%- entity.properties.each do |property| -%>
     fun <%= KotlinHelper.fix_name(WasmCppHelper.format_name(property.name)) %>(<%= KotlinHelper.js_parameters(property.parameters) %>)<%= KotlinHelper.js_return_type(property.return_type) %>

--- a/codegen/lib/templates/kotlin/js_accessors_struct.erb
+++ b/codegen/lib/templates/kotlin/js_accessors_struct.erb
@@ -2,7 +2,7 @@
 
 @JsModule("@trustwallet/wallet-core")
 @JsName("<%= entity.name %>")
-external object Js<%= entity.name %> {
+external interface Js<%= entity.name %> {
 <%# Static method declarations -%>
 <%  entity.static_methods.each do |method| -%>
 <%    next if method.name.start_with?('Create') -%>

--- a/codegen/lib/templates/kotlin/js_class.erb
+++ b/codegen/lib/templates/kotlin/js_class.erb
@@ -10,7 +10,11 @@ actual class <%= entity.name %> constructor(
 <%- constructors.each do |constructor| -%>
 
     actual constructor(<%= KotlinHelper.parameters(constructor.parameters) %>) :
+<%  if constructor.return_type.is_nullable -%>
+        this(WalletCore.Instance.<%= entity.name %>.<%= WasmCppHelper.function_name(entity: entity, function: constructor) %>(<%= KotlinHelper.calling_parameters_js(constructor.parameters) %>) ?: throw IllegalArgumentException())
+<%  else -%>
         this(WalletCore.Instance.<%= entity.name %>.<%= WasmCppHelper.function_name(entity: entity, function: constructor) %>(<%= KotlinHelper.calling_parameters_js(constructor.parameters) %>))
+<%  end -%>
 <%  end -%>
 <%# Property declarations -%>
 <%  entity.properties.each do |property| -%>

--- a/codegen/lib/templates/kotlin/js_enum.erb
+++ b/codegen/lib/templates/kotlin/js_enum.erb
@@ -1,11 +1,19 @@
 <%= render('kotlin/package.erb') %>
 
+<%  has_string = entity.cases.all? { |c| !c.string.nil? } -%>
 actual enum class <%= entity.name %>(
     val jsValue: Js<%= entity.name %>,
+<%  if has_string -%>
+    actual val stringValue: String,
+<%  end -%>
 ) {
 <%# Cases -%>
 <%  entity.cases.each_with_index do |c, i| -%>
+<%  if has_string -%>
+    <%= c.name %>(WalletCore.Instance.<%= entity.name %>.<%= KotlinHelper.fix_name(WasmCppHelper.format_name(c.name)) %>, <%= c.string %>),
+<%  else -%>
     <%= c.name %>(WalletCore.Instance.<%= entity.name %>.<%= KotlinHelper.fix_name(WasmCppHelper.format_name(c.name)) %>),
+<%  end -%>
 <%  end -%>
     ;
 <%# Property declarations -%>

--- a/kotlin/build-logic/build.gradle.kts
+++ b/kotlin/build-logic/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -6,9 +7,9 @@ plugins {
 
 allprojects {
     tasks.withType<KotlinCompile> {
-        kotlinOptions {
-            allWarningsAsErrors = true
-            jvmTarget = JavaVersion.VERSION_11.toString()
+        compilerOptions {
+            allWarningsAsErrors.set(true)
+            jvmTarget.set(JvmTarget.JVM_17)
         }
     }
 }

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -1,6 +1,7 @@
 // Workaround https://github.com/gradle/gradle/issues/22797
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -12,9 +13,9 @@ plugins {
 
 allprojects {
     tasks.withType<KotlinCompile> {
-        kotlinOptions {
-            allWarningsAsErrors = true
-            jvmTarget = JavaVersion.VERSION_11.toString()
+        compilerOptions {
+            allWarningsAsErrors.set(true)
+            jvmTarget.set(JvmTarget.JVM_17)
         }
     }
 }

--- a/kotlin/wallet-core-kotlin/build.gradle.kts
+++ b/kotlin/wallet-core-kotlin/build.gradle.kts
@@ -83,8 +83,8 @@ android {
     buildToolsVersion = libs.versions.android.sdk.tools.get()
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/kotlin/wallet-core-kotlin/src/jsMain/kotlin/WalletCore.kt
+++ b/kotlin/wallet-core-kotlin/src/jsMain/kotlin/WalletCore.kt
@@ -11,7 +11,8 @@ import kotlin.js.Promise
 @JsName("WalletCoreKotlin")
 object WalletCore {
 
-    internal lateinit var Instance: JsWalletCore
+    lateinit var Instance: JsWalletCore
+        private set
 
     fun init(): Promise<JsWalletCore> =
         if (::Instance.isInitialized) {


### PR DESCRIPTION
## Description

- Kotlin doesn't have nullable constructors like Swift, so simply throw `IllegalArgumentException` if native constructor returns `null`
- Added `stringValuse` for enums with string value
- Use `interface` instead of `class/object` for safety in JS accessors
- Public getter for `WalletCore.Instance` in JS target
- Switch to Java 17 (new Android Studio requires it)
