### PR TITLE
[Aptos]: fix short address padding for aptos

### DIFF
--- a/src/Aptos/Address.h
+++ b/src/Aptos/Address.h
@@ -16,9 +16,9 @@
 
 namespace TW::Aptos {
 
-class Address : public Move::Address<Address, 32> {
+class Address : public Move::Address<Address, 32, true> {
 public:
-    using AptosAddress = Move::Address<Address, 32>;
+    using AptosAddress = Move::Address<Address, 32, true>;
     using AptosAddress::size;
     using AptosAddress::bytes;
 

--- a/tests/chains/Aptos/AddressTests.cpp
+++ b/tests/chains/Aptos/AddressTests.cpp
@@ -21,12 +21,15 @@ TEST(AptosAddress, Valid) {
     ASSERT_TRUE(Address::isValid("0xeeff357ea5c1a4e7bc11b2b17ff2dc2dcca69750bfef1e1ebcaccf8c8018175b"));
     ASSERT_TRUE(Address::isValid("eeff357ea5c1a4e7bc11b2b17ff2dc2dcca69750bfef1e1ebcaccf8c8018175b"));
     ASSERT_TRUE(Address::isValid("19aadeca9388e009d136245b9a67423f3eee242b03142849eb4f81a4a409e59c"));
+    ASSERT_TRUE(Address::isValid("777821c78442e17d82c3d7a371f42de7189e4248e529fe6eee6bca40ddbb"));
+    ASSERT_TRUE(Address::isValid("0x777821c78442e17d82c3d7a371f42de7189e4248e529fe6eee6bca40ddbb"));
+    ASSERT_TRUE(Address::isValid("eeff357ea5c1a4e7bc11b2b17ff2dc2dcca69750bfef1e1ebcaccf8c8018175"));   // too short -> automatically padded
 }
 
 TEST(AptosAddress, Invalid) {
     ASSERT_FALSE(Address::isValid("Seff357ea5c1a4e7bc11b2b17ff2dc2dcca69750bfef1e1ebcaccf8c8018175b"));  // Invalid hex character
     ASSERT_FALSE(Address::isValid("eeff357ea5c1a4e7bc11b2b17ff2dc2dcca69750bfef1e1ebcaccf8c8018175bb")); // Invalid length: too long
-    ASSERT_FALSE(Address::isValid("eeff357ea5c1a4e7bc11b2b17ff2dc2dcca69750bfef1e1ebcaccf8c8018175"));   // Invalid length: too short
+
 }
 
 TEST(AptosAddress, FromPrivateKey) {
@@ -44,6 +47,12 @@ TEST(AptosAddress, FromPublicKey) {
 TEST(AptosAddress, FromString) {
     auto address = Address("eeff357ea5c1a4e7bc11b2b17ff2dc2dcca69750bfef1e1ebcaccf8c8018175b");
     ASSERT_EQ(address.string(), "0xeeff357ea5c1a4e7bc11b2b17ff2dc2dcca69750bfef1e1ebcaccf8c8018175b");
+
+
+    address = Address("0x777821c78442e17d82c3d7a371f42de7189e4248e529fe6eee6bca40ddbb");
+    ASSERT_EQ(address.string(), "0x0000777821c78442e17d82c3d7a371f42de7189e4248e529fe6eee6bca40ddbb");
+    address = Address("777821c78442e17d82c3d7a371f42de7189e4248e529fe6eee6bca40ddbb");
+    ASSERT_EQ(address.string(), "0x0000777821c78442e17d82c3d7a371f42de7189e4248e529fe6eee6bca40ddbb");
 }
 
 TEST(AptosAddress, ShortString) {


### PR DESCRIPTION
## Description

Aptos short address need to be padded strictly: https://aptos.dev/concepts/accounts/#account-identifiers

```
Account identifiers
Currently, Aptos supports only a single, unified identifier for an account. Accounts on Aptos are universally represented as a 32-byte hex string. A hex string shorter than 32-bytes is also valid; in those scenarios, the hex string can be padded with leading zeroes, e.g., 0x1 => 0x0000000000000...01.
```