### PR TITLE
switch back to codegen version 1 for Swift bindings

### DIFF
--- a/codegen/bin/codegen
+++ b/codegen/bin/codegen
@@ -16,7 +16,7 @@ options = OpenStruct.new
 # default input / output path
 options.input = "#{CurrentDir}/../../include/TrustWalletCore"
 options.output = "#{CurrentDir}/../../"
-options.swift = false
+options.swift = true
 options.java = true
 options.jni_h = true
 options.jni_c = true

--- a/tools/generate-files
+++ b/tools/generate-files
@@ -49,14 +49,6 @@ codegen/bin/coins
 # Generate interface code, Swift bindings excluded.
 codegen/bin/codegen
 
-# Generate Swift bindings with codegen-v2. This is a transitionary process 
-# and will eventually deprecate the current codegen/ entirely.
-cd codegen-v2/
-cargo run -- swift
-cp -R bindings/ ../swift/Sources/Generated/
-cp src/codegen/swift/templates/WalletCore.h ../swift/Sources/Generated/
-cd ..
-
 # Convert doxygen comments to appropriate format
 tools/doxygen_convert_comments
 


### PR DESCRIPTION
Opening this regarding: https://github.com/trustwallet/wallet-core/discussions/3166

Imo, given that we're not fully done yet with version 2 (including the processing of `registry.json`), we should just revert `master` to version 1 and not have to tell users to deal with version 2 as of now. The released tags `3.1.33` and `3.1.34` can still be tested and verified regarding the correctness of the Swift codegen-v2 generation.