### PR TITLE
Use CMAKE_CURRENT_LIST_DIR

### DIFF
--- a/cmake/Protobuf.cmake
+++ b/cmake/Protobuf.cmake
@@ -4,8 +4,8 @@
 # terms governing use, modification, and redistribution, is contained in the
 # file LICENSE at the root of the source code distribution tree.
 
-set(protobuf_SOURCE_DIR ${CMAKE_SOURCE_DIR}/build/local/src/protobuf/protobuf-3.19.2)
-set(protobuf_source_dir ${CMAKE_SOURCE_DIR}/build/local/src/protobuf/protobuf-3.19.2)
+set(protobuf_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../build/local/src/protobuf/protobuf-3.19.2)
+set(protobuf_source_dir ${CMAKE_CURRENT_LIST_DIR}/../build/local/src/protobuf/protobuf-3.19.2)
 
 # sort + uniq -u
 # https://github.com/protocolbuffers/protobuf/blob/master/cmake/libprotobuf.cmake


### PR DESCRIPTION
Depending on CMAKE_CURRENT_SOURCE_DIR might cause all sorts of unintended consequences. For instance, this will break configuration when your project is included into another CMake managed project.

## Description

Use parent directory of Protobuf.cmake to ensure that CMake configuration process will be deterministic.

## How to test

Nothing should change from a casual user point of view so there is not much to test actually.
