### PR TITLE
[kmp]: Fix kmp  by updating WC to 3.1.38

### DIFF
--- a/samples/kmp/shared/build.gradle.kts
+++ b/samples/kmp/shared/build.gradle.kts
@@ -35,7 +35,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation("com.trustwallet:wallet-core-kotlin:3.1.36")
+                implementation("com.trustwallet:wallet-core-kotlin:3.1.38")
             }
         }
         val commonTest by getting {


### PR DESCRIPTION
## Description

Fixes Kotlin Multiplatform CI