### PR TITLE
[Bitcoin]: Fix `TWAnySignerPlan` if `use_max_amount = true`

### DIFF
--- a/src/Bitcoin/TransactionBuilder.h
+++ b/src/Bitcoin/TransactionBuilder.h
@@ -30,11 +30,7 @@ public:
         Transaction tx;
         tx.lockTime = input.lockTime;
 
-        auto outputToAmount = input.amount;
-        if (plan.useMaxAmount) {
-            outputToAmount = plan.amount;
-        }
-        auto outputTo = prepareOutputWithScript(input.toAddress, outputToAmount, input.coinType);
+        auto outputTo = prepareOutputWithScript(input.toAddress, plan.amount, input.coinType);
         if (!outputTo.has_value()) { 
             return Result<Transaction, Common::Proto::SigningError>::failure(Common::Proto::Error_invalid_address);
         }

--- a/src/Bitcoin/TransactionPlan.h
+++ b/src/Bitcoin/TransactionPlan.h
@@ -41,9 +41,6 @@ struct TransactionPlan {
 
     Data outputOpReturn;
 
-    /// Check if we use max amount for output address
-    bool useMaxAmount = false;
-
     Common::Proto::SigningError error = Common::Proto::SigningError::OK;
 
     TransactionPlan() = default;

--- a/src/Decred/TransactionBuilder.h
+++ b/src/Decred/TransactionBuilder.h
@@ -29,18 +29,13 @@ struct TransactionBuilder {
     static Transaction build(const Bitcoin::TransactionPlan& plan, const Bitcoin::SigningInput& input) {
         auto coin = TWCoinTypeDecred;
 
-        auto outputToAmount = input.amount;
-        if (plan.useMaxAmount) {
-            outputToAmount = plan.amount;
-        }
-
         auto lockingScriptTo = Bitcoin::Script::lockScriptForAddress(input.toAddress, coin);
         if (lockingScriptTo.empty()) {
             return {};
         }
 
         Transaction tx;
-        tx.outputs.emplace_back(TransactionOutput(outputToAmount, /* version: */ 0, lockingScriptTo));
+        tx.outputs.emplace_back(TransactionOutput(plan.amount, /* version: */ 0, lockingScriptTo));
 
         if (plan.change > 0) {
             auto lockingScriptChange = Bitcoin::Script::lockScriptForAddress(input.changeAddress, coin);

--- a/src/Zen/TransactionBuilder.h
+++ b/src/Zen/TransactionBuilder.h
@@ -37,11 +37,7 @@ struct TransactionBuilder {
         auto blockHash = plan.preBlockHash;
         auto blockHeight = plan.preBlockHeight;
 
-        auto outputToAmount = input.amount;
-        if (plan.useMaxAmount) {
-            outputToAmount = plan.amount;
-        }
-        auto outputTo = prepareOutputWithScript(input.toAddress, outputToAmount, input.coinType, blockHash, blockHeight);
+        auto outputTo = prepareOutputWithScript(input.toAddress, plan.amount, input.coinType, blockHash, blockHeight);
         if (!outputTo.has_value()) { 
             return Result<Transaction, Common::Proto::SigningError>::failure(Common::Proto::Error_invalid_address);
         }

--- a/tests/chains/Bitcoin/TxComparisonHelper.cpp
+++ b/tests/chains/Bitcoin/TxComparisonHelper.cpp
@@ -43,6 +43,7 @@ UTXOs buildTestUTXOs(const std::vector<int64_t>& amounts) {
 
 SigningInput buildSigningInput(Amount amount, int byteFee, const UTXOs& utxos, bool useMaxAmount, enum TWCoinType coin, bool omitPrivateKey) {
     SigningInput input;
+    input.amount = amount;
     input.totalAmount = amount;
     input.byteFee = byteFee;
     input.useMaxAmount = useMaxAmount;

--- a/tests/chains/Zen/TransactionBuilderTests.cpp
+++ b/tests/chains/Zen/TransactionBuilderTests.cpp
@@ -66,7 +66,6 @@ TEST(ZenTransactionBuilder, Build) {
     ASSERT_EQ(plan.fee, 294);
     plan.preBlockHash = blockHash;
     plan.preBlockHeight = blockHeight;
-    plan.useMaxAmount = true;
 
     // plan1
     auto result = Zen::TransactionBuilder::build<Bitcoin::Transaction>(plan, input).payload();
@@ -75,7 +74,6 @@ TEST(ZenTransactionBuilder, Build) {
     ASSERT_EQ(result.outputs[0].value, plan.amount);
 
     // plan2
-    plan.useMaxAmount = false;
     result = Zen::TransactionBuilder::build<Bitcoin::Transaction>(plan, input).payload();
   
     ASSERT_EQ(result.outputs.size(), 4ul);


### PR DESCRIPTION
## Description

We inherited a bug https://github.com/trustwallet/wallet-core/issues/3273 from the DeFi wallet during https://github.com/trustwallet/wallet-core/pull/3225
This PR fixes the issue.

Please note that `use_max_amount = true` will lead to an error if [SigningInput::extra_outputs](https://github.com/trustwallet/wallet-core/blob/master/src/proto/Bitcoin.proto#L144) is not empty.

## How to test

Run C++ tests

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
