### PR TITLE
[Polkadot]: Fix `Staking::Bond` and `Staking::BondAndNominate`

### DIFF
--- a/src/Polkadot/Extrinsic.cpp
+++ b/src/Polkadot/Extrinsic.cpp
@@ -15,7 +15,6 @@ static constexpr uint8_t sigTypeEd25519 = 0x00;
 static constexpr uint8_t extrinsicFormat = 4;
 static constexpr uint32_t multiAddrSpecVersion = 28;
 static constexpr uint32_t multiAddrSpecVersionKsm = 2028;
-static constexpr uint32_t stakingControllerSpecVersion = 9430;
 
 static const std::string balanceTransfer = "Balances.transfer";
 static const std::string utilityBatch = "Utility.batch_all";
@@ -78,21 +77,6 @@ bool Extrinsic::encodeRawAccount() const {
         return false;
     }
     return true;
-}
-
-Data Extrinsic::encodeStakingController(const Proto::Staking::Bond& bond) const {
-    if (bond.controller().empty()) {
-        return {};
-    }
-
-    bool polkadotOrKusama = network == static_cast<uint32_t>(TWSS58AddressTypePolkadot)
-                            || network == static_cast<uint32_t>(TWSS58AddressTypeKusama);
-    if (polkadotOrKusama && specVersion >= stakingControllerSpecVersion) {
-        return {};
-    }
-
-    auto controller = SS58Address(bond.controller(), network);
-    return encodeAccountId(controller.keyBytes(), encodeRawAccount());
 }
 
 Data Extrinsic::encodeEraNonceTip() const {
@@ -209,7 +193,10 @@ Data Extrinsic::encodeStakingCall(const Proto::Staking& staking) const {
         // call index
         append(data, getCallIndex(staking.bond().call_indices(), network, stakingBond));
         // controller
-        append(data, encodeStakingController(staking.bond()));
+        if (!staking.bond().controller().empty()) {
+            auto controller = SS58Address(staking.bond().controller(), network);
+            append(data, encodeAccountId(controller.keyBytes(), encodeRawAccount()));
+        }
         // value
         append(data, encodeCompact(value));
         // reward destination

--- a/src/Polkadot/Extrinsic.h
+++ b/src/Polkadot/Extrinsic.h
@@ -66,7 +66,6 @@ class Extrinsic {
 
   protected:
     bool encodeRawAccount() const;
-    Data encodeStakingController(const Proto::Staking::Bond& stakingBond) const;
     Data encodeBalanceCall(const Proto::Balance& balance) const;
     Data encodeTransfer(const Proto::Balance::Transfer& transfer) const;
     Data encodeAssetTransfer(const Proto::Balance::AssetTransfer& transfer) const;

--- a/src/Polkadot/Extrinsic.h
+++ b/src/Polkadot/Extrinsic.h
@@ -66,6 +66,7 @@ class Extrinsic {
 
   protected:
     bool encodeRawAccount() const;
+    Data encodeStakingController(const Proto::Staking::Bond& stakingBond) const;
     Data encodeBalanceCall(const Proto::Balance& balance) const;
     Data encodeTransfer(const Proto::Balance::Transfer& transfer) const;
     Data encodeAssetTransfer(const Proto::Balance::AssetTransfer& transfer) const;

--- a/src/proto/Polkadot.proto
+++ b/src/proto/Polkadot.proto
@@ -102,7 +102,7 @@ message Balance {
 message Staking {
     // Bond to a controller
     message Bond {
-        // controller ID
+        // controller ID (optional)
         string controller = 1;
 
         // amount (uint256, serialized little endian)
@@ -117,7 +117,7 @@ message Staking {
 
     // Bond to a controller, with nominators
     message BondAndNominate {
-        // controller ID
+        // controller ID (optional)
         string controller = 1;
 
         // amount (uint256, serialized little endian)

--- a/tests/chains/Polkadot/SignerTests.cpp
+++ b/tests/chains/Polkadot/SignerTests.cpp
@@ -626,4 +626,34 @@ TEST(PolkadotSigner, encodeTransaction_JoinIdentityAsKey) {
     ASSERT_EQ(hex(encoded), "c5018400d3b2f1c41b9b4522eb3e23329b81aca6cc0231167ecfa3580c5a71ff6d061054007f5adbb2749e2f0ace29b409c41dd717681495b1f22dc5358311646a9fb8af8a173fc47f1b19748fb56831c2128773e2976986685adee83c741ab49934d80006750000000705bb53000000000000");
 }
 
+TEST(PolkadotSigner, Kusama_SignBond_NoController) {
+    // tx on mainnet
+    // https://kusama.subscan.io/extrinsic/0x4e52e59b63910cbdb8c5430c2d100908934f473363c8994cddfd6d1501b017f5
+
+    Polkadot::Proto::SigningInput input;
+    input.set_network(ss58Prefix(TWCoinTypeKusama));
+    auto blockHash = parse_hex("beb02a3ee782f4bd60ffcfc3de473e3c5a00b2cf124dd302c559b0e77b4331eb");
+    auto vGenesisHash = parse_hex("b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe");
+    input.set_block_hash(std::string(blockHash.begin(), blockHash.end()));
+    input.set_genesis_hash(std::string(vGenesisHash.begin(), vGenesisHash.end()));
+    input.set_nonce(3UL);
+    input.set_spec_version(9430U);
+    input.set_transaction_version(23U);
+    input.set_private_key(privateKey.bytes.data(), privateKey.bytes.size());
+
+    auto* era = input.mutable_era();
+    era->set_block_number(18672490UL);
+    era->set_period(64UL);
+
+    auto* bond = input.mutable_staking_call()->mutable_bond();
+    auto value = store(uint256_t(120'000'000'000)); // 0.12
+    // Specify an invalid address that would lead to fail if `controller` address was used.
+    bond->set_controller("123");
+    bond->set_value(value.data(), value.size());
+    bond->set_reward_destination(Proto::RewardDestination::CONTROLLER);
+
+    auto output = Signer::sign(input);
+    ASSERT_EQ(hex(output.encoded()), "c101840088dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee00bc4d7a166bd1e7e2bfe9b53e81239c9e340d5a326f17c0a3d2768fcc127f20f4f85d888ecb90aa3ed9a0943f8ae8116b9a19747e563c8d8151dfe3b1b5deb40ca5020c0006000700b08ef01b02");
+}
+
 } // namespace TW::Polkadot::tests

--- a/tests/chains/Polkadot/SignerTests.cpp
+++ b/tests/chains/Polkadot/SignerTests.cpp
@@ -647,8 +647,6 @@ TEST(PolkadotSigner, Kusama_SignBond_NoController) {
 
     auto* bond = input.mutable_staking_call()->mutable_bond();
     auto value = store(uint256_t(120'000'000'000)); // 0.12
-    // Specify an invalid address that would lead to fail if `controller` address was used.
-    bond->set_controller("123");
     bond->set_value(value.data(), value.size());
     bond->set_reward_destination(Proto::RewardDestination::CONTROLLER);
 

--- a/tests/chains/Polkadot/SignerTests.cpp
+++ b/tests/chains/Polkadot/SignerTests.cpp
@@ -646,7 +646,7 @@ TEST(PolkadotSigner, Kusama_SignBond_NoController) {
     era->set_period(64UL);
 
     // Ignore `controller` as it was removed from the `Staking::bond` function at `spec_version = 9430`
-    // https://polkadot.subscan.io/runtime/Staking?version=9430
+    // https://kusama.subscan.io/runtime/Staking?version=9430
     auto* bond = input.mutable_staking_call()->mutable_bond();
     auto value = store(uint256_t(120'000'000'000)); // 0.12
     bond->set_value(value.data(), value.size());

--- a/tests/chains/Polkadot/SignerTests.cpp
+++ b/tests/chains/Polkadot/SignerTests.cpp
@@ -645,6 +645,8 @@ TEST(PolkadotSigner, Kusama_SignBond_NoController) {
     era->set_block_number(18672490UL);
     era->set_period(64UL);
 
+    // Ignore `controller` as it was removed from the `Staking::bond` function at `spec_version = 9430`
+    // https://polkadot.subscan.io/runtime/Staking?version=9430
     auto* bond = input.mutable_staking_call()->mutable_bond();
     auto value = store(uint256_t(120'000'000'000)); // 0.12
     bond->set_value(value.data(), value.size());


### PR DESCRIPTION
## Description

Don't set `controller` in `Staking::Bond` since `9430` runtime version.

## How to test

Run C++ tests

## Types of changes

`Bond::controller` is automatically ignored if `spec_version >= 9430` (for Kusama and Polkadot chains **only**) as the parameter was removed from the call.
Also `Bond::controller` can be omitted manually for custom Polkadot chains.

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
