### PR TITLE
[Greenfield]: Add support for Delegate and Undelegate messages

### DIFF
--- a/src/Greenfield/Constants.h
+++ b/src/Greenfield/Constants.h
@@ -15,5 +15,7 @@ static constexpr auto* TIMEOUT_HEIGHT_STR = "0";
 static constexpr auto* FEE_GRANTER = "";
 static constexpr auto* MSG_SEND_TYPE = "/cosmos.bank.v1beta1.MsgSend";
 static constexpr auto* MSG_TRANSFER_OUT_TYPE = "/greenfield.bridge.MsgTransferOut";
+static constexpr auto* MSG_DELEGATE_TYPE = "/cosmos.staking.v1beta1.MsgDelegate";
+static constexpr auto* MSG_UNDELEGATE_TYPE = "/cosmos.staking.v1beta1.MsgUndelegate";
 
 } // namespace TW::Greenfield

--- a/src/Greenfield/ProtobufSerialization.cpp
+++ b/src/Greenfield/ProtobufSerialization.cpp
@@ -11,6 +11,7 @@
 #include "Cosmos/Protobuf/bank_tx.pb.h"
 #include "Cosmos/Protobuf/greenfield_ethsecp256k1.pb.h"
 #include "Cosmos/Protobuf/greenfield_tx.pb.h"
+#include "Cosmos/Protobuf/staking_tx.pb.h"
 #include "Cosmos/Protobuf/tx.pb.h"
 #include "PrivateKey.h"
 
@@ -69,6 +70,28 @@ static SigningResult<Any> convertMessage(const Proto::Message& msg) {
             *msgTransferOut.mutable_amount() = convertCoin(transferOut.amount());
 
             any.PackFrom(msgTransferOut, ProtobufAnyNamespacePrefix);
+            break;
+        }
+        case Proto::Message::kStakeMessage: {
+            const auto& stake = msg.stake_message();
+
+            auto msgDelegate = cosmos::staking::v1beta1::MsgDelegate();
+            msgDelegate.set_delegator_address(stake.delegator_address());
+            msgDelegate.set_validator_address(stake.validator_address());
+            *msgDelegate.mutable_amount() = convertCoin(stake.amount());
+
+            any.PackFrom(msgDelegate, ProtobufAnyNamespacePrefix);
+            break;
+        }
+        case Proto::Message::kUnstakeMessage: {
+            const auto& stake = msg.unstake_message();
+
+            auto msgDelegate = cosmos::staking::v1beta1::MsgUndelegate();
+            msgDelegate.set_delegator_address(stake.delegator_address());
+            msgDelegate.set_validator_address(stake.validator_address());
+            *msgDelegate.mutable_amount() = convertCoin(stake.amount());
+
+            any.PackFrom(msgDelegate, ProtobufAnyNamespacePrefix);
             break;
         }
         default: {

--- a/src/Greenfield/SignerEip712.h
+++ b/src/Greenfield/SignerEip712.h
@@ -42,6 +42,12 @@ struct SignerEip712 {
     /// Packs the `MsgTransferOut` Tx input in a EIP712 object.
     static json wrapMsgTransferOutToTypedData(const Proto::SigningInput& input, const Proto::Message_BridgeTransferOut& msgTransferOut);
 
+    /// Packs the `MsgDelegate` Tx input in a EIP712 object.
+    static json wrapMsgDelegateToTypedData(const Proto::SigningInput& input, const Proto::Message_Delegate& msgDelegate);
+
+    /// Packs the `MsgUndelegate` Tx input in a EIP712 object.
+    static json wrapMsgUndelegateToTypedData(const Proto::SigningInput& input, const Proto::Message_Undelegate& msgUndelegate);
+
     /// Prepares the given `signature` to make it Ethereum compatible.
     static void prepareSignature(Data& signature);
 };

--- a/src/proto/Greenfield.proto
+++ b/src/proto/Greenfield.proto
@@ -51,10 +51,28 @@ message Message {
         string type_prefix = 4;
     }
 
+    // cosmos-sdk/MsgDelegate
+    message Delegate {
+        string delegator_address = 1;
+        string validator_address = 2;
+        Amount amount = 3;
+        string type_prefix = 4;
+    }
+
+    // cosmos-sdk/MsgUndelegate to unstake
+    message Undelegate {
+        string delegator_address = 1;
+        string validator_address = 2;
+        Amount amount = 3;
+        string type_prefix = 4;
+    }
+
     // The payload message
     oneof message_oneof {
         Send send_coins_message = 1;
         BridgeTransferOut bridge_transfer_out = 2;
+        Delegate stake_message = 3;
+        Undelegate unstake_message = 4;
     }
 }
 


### PR DESCRIPTION
## Description

Add support for `MsgDelegate` and `MsgUndelegate`.

## TODO

- [ ] Broadcast valid transactions and fix the `GreenfieldSigner.SignMsgDelegate` test.
There is a properly generated, signed and encoded transaction that failed during the execution: https://greenfieldscan.com/tx/EC8C246841DAAEC9445557073B538E011C48AD9F479B1549E5F000CB4BF57E2D
The problems seems to be in the incorrect validator address.
- [ ] Add the `GreenfieldSigner.SignMsgUndelegate` C++ test.
- [ ] Add Android, Swift tests

## How to test

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
- [ ] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
