### PR TITLE
[Eth/Eip712]: Fix `bytes` hashing

### DIFF
--- a/rust/tw_evm/src/message/eip712/eip712_message.rs
+++ b/rust/tw_evm/src/message/eip712/eip712_message.rs
@@ -176,7 +176,8 @@ fn encode_bytes(value: &Json) -> MessageSigningResult<Data> {
         .decode_hex()
         .map_err(|_| MessageSigningError::InvalidParameterValue)?;
     let hash = keccak256(&bytes);
-    Ok(encode_tokens(&[Token::Bytes(hash)]))
+    let checked_bytes = NonEmptyBytes::new(hash).expect("`hash` must not be empty");
+    Ok(encode_tokens(&[Token::FixedBytes(checked_bytes)]))
 }
 
 fn encode_array(

--- a/rust/tw_evm/tests/data/eip712_different_bytes.json
+++ b/rust/tw_evm/tests/data/eip712_different_bytes.json
@@ -1,0 +1,58 @@
+{
+    "types": {
+        "EIP712Domain": [
+            {
+                "name": "name",
+                "type": "string"
+            },
+            {
+                "name": "version",
+                "type": "string"
+            },
+            {
+                "name": "verifyingContract",
+                "type": "address"
+            }
+        ],
+        "BytesTest": [
+            {
+                "name": "data_long",
+                "type": "bytes"
+            },
+            {
+                "name": "data_short",
+                "type": "bytes"
+            },
+            {
+                "name": "fix_data32",
+                "type": "bytes32"
+            },
+            {
+                "name": "fix_data32_short",
+                "type": "bytes32"
+            },
+            {
+                "name": "fix_data16",
+                "type": "bytes16"
+            },
+            {
+                "name": "fix_data16_short",
+                "type": "bytes16"
+            }
+        ]
+    },
+    "domain": {
+        "name": "Test",
+        "version": "0.0.0",
+        "verifyingContract": "0xb8d6eb2c8236ba373b40adfad4decb8e05ac9230"
+    },
+    "primaryType": "BytesTest",
+    "message": {
+        "data_long": "0xcb5a7173d109f8a59c23109189056c862d843808d00bac069e9b76ca7217d845a94d0ad600000000000000000000000000000000000000000000000000000000000000a07c1a7062fbf633885ae02e0919ec07020a96aa20bf9c79554d2ddcd013113c64579837cd54cb5f05c65c46c04fac9abe54f839a74fa3cc1c47fc9048db037a84000000000000000000000000000000000000000000000000000000000000001b0000000000000000000000000000000000000000000000000000000000000035697066733a2f2f516d61414e35575832525851385852374b5158475a6f726931517461597972356e3547537471456a71706a4e71640000000000000000000000",
+        "data_short": "0xcb5a71",
+        "fix_data32": "0xcb5a7173d109f8a59c23109189056c862d843808d00bac069e9b76ca7217d845",
+        "fix_data32_short": "0xcb5a71",
+        "fix_data16": "0xcb5a7173d109f8a59c23109189056c86",
+        "fix_data16_short": "0xcb5a71"
+    }
+}

--- a/rust/tw_evm/tests/data/eip712_long_bytes.json
+++ b/rust/tw_evm/tests/data/eip712_long_bytes.json
@@ -1,0 +1,63 @@
+{
+    "types": {
+        "EIP712Domain": [
+            {
+                "name": "name",
+                "type": "string"
+            },
+            {
+                "name": "version",
+                "type": "string"
+            },
+            {
+                "name": "verifyingContract",
+                "type": "address"
+            }
+        ],
+        "ForwardRequest": [
+            {
+                "name": "info",
+                "type": "string"
+            },
+            {
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "name": "value",
+                "type": "uint256"
+            },
+            {
+                "name": "gas",
+                "type": "uint256"
+            },
+            {
+                "name": "nonce",
+                "type": "uint256"
+            },
+            {
+                "name": "data",
+                "type": "bytes"
+            }
+        ]
+    },
+    "domain": {
+        "name": "MinimalForwarder",
+        "version": "0.0.2",
+        "verifyingContract": "0x65CDf66C6FDDCD0a43042F237Aa871414b724f4d"
+    },
+    "primaryType": "ForwardRequest",
+    "message": {
+        "info": "Please sign this message, so OwnerChip can send this transaction on your behalf.",
+        "from": "0xff7abfb4ad52ba6ec9af37955365a7691c8167b9",
+        "to": "0xb8d6eb2c8236ba373b40adfad4decb8e05ac9230",
+        "value": 0,
+        "gas": 500000,
+        "nonce": 228,
+        "data": "0xcb5a7173d109f8a59c23109189056c862d843808d00bac069e9b76ca7217d845a94d0ad600000000000000000000000000000000000000000000000000000000000000a07c1a7062fbf633885ae02e0919ec07020a96aa20bf9c79554d2ddcd013113c64579837cd54cb5f05c65c46c04fac9abe54f839a74fa3cc1c47fc9048db037a84000000000000000000000000000000000000000000000000000000000000001b0000000000000000000000000000000000000000000000000000000000000035697066733a2f2f516d61414e35575832525851385852374b5158475a6f726931517461597972356e3547537471456a71706a4e71640000000000000000000000"
+    }
+}

--- a/rust/tw_evm/tests/message_signer.rs
+++ b/rust/tw_evm/tests/message_signer.rs
@@ -20,6 +20,8 @@ const EIP712_UNEQUAL_ARRAY_LEN: &str = include_str!("data/eip712_unequal_array_l
 const EIP712_WITH_CHAIN_ID_STR: &str = include_str!("data/eip712_with_chain_id_string.json");
 const EIP712_GREENFIELD: &str = include_str!("data/eip712_greenfield.json");
 const EIP712_FIXED_BYTES: &str = include_str!("data/eip712_fixed_bytes.json");
+const EIP712_LONG_BYTES: &str = include_str!("data/eip712_long_bytes.json");
+const EIP712_DIFFERENT_BYTES: &str = include_str!("data/eip712_different_bytes.json");
 
 struct SignVerifyTestInput {
     private_key: &'static str,
@@ -275,5 +277,27 @@ fn test_message_signer_sign_verify_eip712_fixed_bytes() {
         msg_type: Proto::MessageType::MessageType_typed,
         chain_id: None,
         signature: "7ee9b54fedf355e40fa86bbe23e63b318ef797bd8fdbc5bb714edbace042d4cb60111912218234e856f2cf300b3b47c91383b98e263ecf69c6c10193fef6c9581b",
+    });
+}
+
+#[test]
+fn test_message_signer_sign_verify_eip712_long_bytes() {
+    test_message_signer_sign_verify(SignVerifyTestInput {
+        private_key: "6f96f3aa7e8052170f1864f72a9a53606ee9c0d185188266cab895512a4bcf84",
+        msg: EIP712_LONG_BYTES,
+        msg_type: Proto::MessageType::MessageType_typed,
+        chain_id: None,
+        signature: "3f78f5860dc9c38d3bf68fd0759c0e4963f104ba6c7fa44e915ed41a1575dbd50d6fd946919e6cfa7eecb869a5d90658b16b1d7b79ec6380acd1841fc21c77f71c",
+    });
+}
+
+#[test]
+fn test_message_signer_sign_verify_eip712_different_bytes() {
+    test_message_signer_sign_verify(SignVerifyTestInput {
+        private_key: "6f96f3aa7e8052170f1864f72a9a53606ee9c0d185188266cab895512a4bcf84",
+        msg: EIP712_DIFFERENT_BYTES,
+        msg_type: Proto::MessageType::MessageType_typed,
+        chain_id: None,
+        signature: "48dc667cd8a53beb58ea6b1745f98c21b12e1a57587ce28bae07689dba3600d40cef2685dc8a68028d38f3e63289891868ecdf05e8affc275fee3001e51d6c581c",
     });
 }

--- a/rust/tw_misc/src/lib.rs
+++ b/rust/tw_misc/src/lib.rs
@@ -5,6 +5,7 @@
 // file LICENSE at the root of the source code distribution tree.
 
 pub mod macros;
+#[cfg(feature = "serde")]
 pub mod serde;
 #[cfg(feature = "test-utils")]
 pub mod test_utils;

--- a/samples/kmp/shared/build.gradle.kts
+++ b/samples/kmp/shared/build.gradle.kts
@@ -35,7 +35,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation("com.trustwallet:wallet-core-kotlin:4.0.10")
+                implementation("com.trustwallet:wallet-core-kotlin:4.0.13")
             }
         }
         val commonTest by getting {


### PR DESCRIPTION
## Description

This PR fixes a bug with hashing `bytes` properties in EIP712.
At this moment, any `bytes` value will be hashed and then serialized with a two length prefixes that is incorrect.

As the result, the output EIP712 message signature is invalid.

For example, there is a byte array `0xcb5a7173d109f8a59c23109189056c862d843808d00bac069e9b76ca7217d845a94d0ad600000000000000000000000000000000000000000000000000000000000000a07c1a7062fbf633885ae02e0919ec07020a96aa20bf9c79554d2ddcd013113c64579837cd54cb5f05c65c46c04fac9abe54f839a74fa3cc1c47fc9048db037a84000000000000000000000000000000000000000000000000000000000000001b0000000000000000000000000000000000000000000000000000000000000035697066733a2f2f516d61414e35575832525851385852374b5158475a6f726931517461597972356e3547537471456a71706a4e71640000000000000000000000`
which is hashed as `9e0ebc6a4cbbc0f378d10ed3a59be0dad43314be0bef2c2c0f4df6254375206a`.

In the current implementation, the final property hash will be `000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000209e0ebc6a4cbbc0f378d10ed3a59be0dad43314be0bef2c2c0f4df6254375206a` , but expected to be `9e0ebc6a4cbbc0f378d10ed3a59be0dad43314be0bef2c2c0f4df6254375206a`.

## How to test

Run Rust tests.

Both new tests have been checked via Metamask's `eth_sign_typedData_v4` call.

## Types of changes

Bug fix.

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
