### PR TITLE
[WalletConnect/Solana]: Add support for WalletConnect signing requests

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/solana/TestSolanaWalletConnectSigning.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/solana/TestSolanaWalletConnectSigning.kt
@@ -1,0 +1,52 @@
+package com.trustwallet.core.app.blockchains.solana
+
+import com.google.protobuf.ByteString
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import wallet.core.java.AnySigner
+import wallet.core.jni.Base58
+import wallet.core.jni.CoinType.SOLANA
+import wallet.core.jni.WalletConnectRequest
+import wallet.core.jni.proto.Common.SigningError
+import wallet.core.jni.proto.Solana.Encoding
+import wallet.core.jni.proto.Solana.SigningOutput
+import wallet.core.jni.proto.WalletConnect
+
+class TestSolanaWalletConnectSigning {
+
+    init {
+        System.loadLibrary("TrustWalletCore")
+    }
+
+    @Test
+    fun testSignSolanaTransactionFromWalletConnectRequest() {
+        // Step 1: Parse a signing request received through WalletConnect.
+
+        val parsingInput = WalletConnect.ParseRequestInput.newBuilder().apply {
+            method = WalletConnect.Method.SolanaSignTransaction
+            payload = "{\"transaction\":\"AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDZsL1CMnFVcrMn7JtiOiN1U4hC7WovOVof2DX51xM0H/GizyJTHgrBanCf8bGbrFNTn0x3pCGq30hKbywSTr6AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAgIAAQwCAAAAKgAAAAAAAAA=\"}"
+        }.build()
+
+        val parsingOutputBytes = WalletConnectRequest.parse(SOLANA, parsingInput.toByteArray())
+        val parsingOutput = WalletConnect.ParseRequestOutput.parseFrom(parsingOutputBytes)
+
+        assertEquals(parsingOutput.error, SigningError.OK)
+
+        // Step 2: Set missing fields.
+
+        val signingInput = parsingOutput.solana.toBuilder().apply {
+            privateKey = ByteString.copyFrom(Base58.decodeNoCheck("A7psj2GW7ZMdY4E5hJq14KMeYg7HFjULSsWSrTXZLvYr"))
+            txEncoding = Encoding.Base64
+        }.build()
+
+        // Step 3: Sign the transaction.
+
+        val output = AnySigner.sign(signingInput, SOLANA, SigningOutput.parser())
+
+        assertEquals(output.error, SigningError.OK)
+        assertEquals(output.encoded, "AQPWaOi7dMdmQpXi8HyQQKwiqIftrg1igGQxGtZeT50ksn4wAnyH4DtDrkkuE0fqgx80LTp4LwNN9a440SrmoA8BAAEDZsL1CMnFVcrMn7JtiOiN1U4hC7WovOVof2DX51xM0H/GizyJTHgrBanCf8bGbrFNTn0x3pCGq30hKbywSTr6AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAgIAAQwCAAAAKgAAAAAAAAA=")
+
+        assertEquals(output.getSignatures(0).pubkey, "7v91N7iZ9mNicL8WfG6cgSCKyRXydQjLh6UYBWwm6y1Q")
+        assertEquals(output.getSignatures(0).signature, "5T6uZBHnHFd8uWErDBTFRVkbKuhbcm94K5MJ2beTYDruzqv4FjS7EMKvC94ZfxNAiWUXZ6bZxS3WXUbhJwYNPWn")
+    }
+}

--- a/rust/chains/tw_solana/Cargo.toml
+++ b/rust/chains/tw_solana/Cargo.toml
@@ -7,12 +7,10 @@ edition = "2021"
 bincode = "1.3.3"
 lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 tw_coin_entry = { path = "../../tw_coin_entry" }
 tw_encoding = { path = "../../tw_encoding" }
 tw_hash = { path = "../../tw_hash" }
 tw_keypair = { path = "../../tw_keypair" }
 tw_memory = { path = "../../tw_memory" }
 tw_proto = { path = "../../tw_proto" }
-
-[dev-dependencies]
-serde_json = "1.0"

--- a/rust/chains/tw_solana/src/blockhash.rs
+++ b/rust/chains/tw_solana/src/blockhash.rs
@@ -3,33 +3,29 @@
 // Copyright © 2017 Trust Wallet.
 
 use crate::SOLANA_ALPHABET;
+use serde::Deserialize;
 use std::fmt;
 use std::str::FromStr;
-use tw_encoding::{base58, EncodingError};
+use tw_encoding::base58::{self, as_base58_bitcoin};
+use tw_encoding::EncodingError;
 use tw_hash::H256;
 
-#[derive(Clone, Copy)]
-pub struct Blockhash {
-    bytes: H256,
-}
+#[derive(Clone, Copy, Default, Deserialize)]
+pub struct Blockhash(#[serde(with = "as_base58_bitcoin")] H256);
 
 impl Blockhash {
     pub fn with_bytes(bytes: H256) -> Blockhash {
-        Blockhash { bytes }
+        Blockhash(bytes)
     }
 
     pub fn to_bytes(&self) -> H256 {
-        self.bytes
+        self.0
     }
 }
 
 impl fmt::Display for Blockhash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            base58::encode(self.bytes.as_slice(), &SOLANA_ALPHABET)
-        )
+        write!(f, "{}", base58::encode(self.0.as_slice(), &SOLANA_ALPHABET))
     }
 }
 
@@ -39,6 +35,6 @@ impl FromStr for Blockhash {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let bytes = base58::decode(s, &SOLANA_ALPHABET)?;
         let bytes = H256::try_from(bytes.as_slice()).map_err(|_| EncodingError::InvalidInput)?;
-        Ok(Blockhash { bytes })
+        Ok(Blockhash(bytes))
     }
 }

--- a/rust/chains/tw_solana/src/compiler.rs
+++ b/rust/chains/tw_solana/src/compiler.rs
@@ -4,6 +4,7 @@
 
 use crate::address::SolanaAddress;
 use crate::modules::message_builder::MessageBuilder;
+use crate::modules::proto_builder::ProtoBuilder;
 use crate::modules::tx_signer::TxSigner;
 use crate::SOLANA_ALPHABET;
 use std::borrow::Cow;
@@ -104,6 +105,7 @@ impl SolanaCompiler {
         Ok(Proto::SigningOutput {
             encoded: Cow::from(signed_encoded),
             unsigned_tx: Cow::from(unsigned_encoded),
+            signatures: ProtoBuilder::build_signatures(&signed_tx),
             ..Proto::SigningOutput::default()
         })
     }

--- a/rust/chains/tw_solana/src/entry.rs
+++ b/rust/chains/tw_solana/src/entry.rs
@@ -5,6 +5,7 @@
 use crate::address::SolanaAddress;
 use crate::compiler::SolanaCompiler;
 use crate::modules::transaction_decoder::SolanaTransactionDecoder;
+use crate::modules::wallet_connect::connector::SolanaWalletConnector;
 use crate::signer::SolanaSigner;
 use std::str::FromStr;
 use tw_coin_entry::coin_context::CoinContext;
@@ -14,7 +15,6 @@ use tw_coin_entry::error::AddressResult;
 use tw_coin_entry::modules::json_signer::NoJsonSigner;
 use tw_coin_entry::modules::message_signer::NoMessageSigner;
 use tw_coin_entry::modules::plan_builder::NoPlanBuilder;
-use tw_coin_entry::modules::wallet_connector::NoWalletConnector;
 use tw_coin_entry::prefix::NoPrefix;
 use tw_keypair::tw::PublicKey;
 use tw_proto::Solana::Proto;
@@ -32,7 +32,7 @@ impl CoinEntry for SolanaEntry {
     type JsonSigner = NoJsonSigner;
     type PlanBuilder = NoPlanBuilder;
     type MessageSigner = NoMessageSigner;
-    type WalletConnector = NoWalletConnector;
+    type WalletConnector = SolanaWalletConnector;
     type TransactionDecoder = SolanaTransactionDecoder;
 
     #[inline]
@@ -88,6 +88,11 @@ impl CoinEntry for SolanaEntry {
         public_keys: Vec<PublicKeyBytes>,
     ) -> Self::SigningOutput {
         SolanaCompiler::compile(coin, input, signatures, public_keys)
+    }
+
+    #[inline]
+    fn wallet_connector(&self) -> Option<Self::WalletConnector> {
+        Some(SolanaWalletConnector)
     }
 
     #[inline]

--- a/rust/chains/tw_solana/src/modules/message_builder.rs
+++ b/rust/chains/tw_solana/src/modules/message_builder.rs
@@ -15,7 +15,7 @@ use crate::modules::instruction_builder::token_instruction::TokenInstructionBuil
 use crate::modules::instruction_builder::InstructionBuilder;
 use crate::modules::PubkeySignatureMap;
 use crate::transaction::versioned::VersionedMessage;
-use crate::transaction::{legacy, v0, CompiledInstruction, MessageHeader};
+use crate::transaction::{legacy, v0, CompiledInstruction, MessageHeader, Signature};
 use std::borrow::Cow;
 use std::str::FromStr;
 use tw_coin_entry::error::{AddressResult, SigningError, SigningErrorType, SigningResult};
@@ -501,8 +501,9 @@ impl RawMessageBuilder {
         let mut key_signs = PubkeySignatureMap::with_capacity(raw_message.signatures.len());
         for entry in raw_message.signatures.iter() {
             let pubkey = SolanaAddress::from_str(entry.pubkey.as_ref())?;
-            let signature = ed25519::Signature::try_from(entry.signature.as_ref())?;
-            key_signs.insert(pubkey, signature);
+            let signature = Signature::from_str(entry.signature.as_ref())?;
+            let ed25519_signature = ed25519::Signature::try_from(signature.0.as_slice())?;
+            key_signs.insert(pubkey, ed25519_signature);
         }
         Ok(key_signs)
     }

--- a/rust/chains/tw_solana/src/modules/mod.rs
+++ b/rust/chains/tw_solana/src/modules/mod.rs
@@ -14,5 +14,6 @@ pub mod proto_builder;
 pub mod transaction_decoder;
 pub mod tx_signer;
 pub mod utils;
+pub mod wallet_connect;
 
 pub type PubkeySignatureMap = HashMap<SolanaAddress, ed25519::Signature>;

--- a/rust/chains/tw_solana/src/modules/proto_builder.rs
+++ b/rust/chains/tw_solana/src/modules/proto_builder.rs
@@ -80,19 +80,15 @@ impl ProtoBuilder {
             .collect()
     }
 
-    fn build_signatures(
-        tx: &VersionedTransaction,
-    ) -> Vec<Proto::mod_RawMessage::PubkeySignature<'static>> {
+    pub fn build_signatures(tx: &VersionedTransaction) -> Vec<Proto::PubkeySignature<'static>> {
         tx.message
             .account_keys()
             .iter()
             .zip(tx.signatures.iter())
-            .map(
-                |(pubkey, signature)| Proto::mod_RawMessage::PubkeySignature {
-                    pubkey: Cow::from(pubkey.to_string()),
-                    signature: Cow::from(signature.0.to_vec()),
-                },
-            )
+            .map(|(pubkey, signature)| Proto::PubkeySignature {
+                pubkey: Cow::from(pubkey.to_string()),
+                signature: Cow::from(signature.to_string()),
+            })
             .collect()
     }
 }

--- a/rust/chains/tw_solana/src/modules/utils.rs
+++ b/rust/chains/tw_solana/src/modules/utils.rs
@@ -2,6 +2,7 @@
 //
 // Copyright © 2017 Trust Wallet.
 
+use crate::modules::proto_builder::ProtoBuilder;
 use crate::modules::tx_signer::TxSigner;
 use crate::modules::PubkeySignatureMap;
 use crate::transaction::versioned::VersionedTransaction;
@@ -70,6 +71,7 @@ impl SolanaTransaction {
         Ok(Proto::SigningOutput {
             encoded: Cow::from(signed_encoded),
             unsigned_tx: Cow::from(unsigned_encoded),
+            signatures: ProtoBuilder::build_signatures(&signed_tx),
             ..Proto::SigningOutput::default()
         })
     }

--- a/rust/chains/tw_solana/src/modules/wallet_connect/connector.rs
+++ b/rust/chains/tw_solana/src/modules/wallet_connect/connector.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+
+use crate::modules::proto_builder::ProtoBuilder;
+use crate::modules::wallet_connect::request::SignTransactionRequest;
+use crate::transaction::versioned::VersionedTransaction;
+use tw_coin_entry::coin_context::CoinContext;
+use tw_coin_entry::error::{SigningError, SigningErrorType, SigningResult};
+use tw_coin_entry::modules::wallet_connector::WalletConnector;
+use tw_coin_entry::signing_output_error;
+use tw_proto::Solana::Proto;
+use tw_proto::WalletConnect::Proto::{
+    self as WCProto, mod_ParseRequestOutput::OneOfsigning_input_oneof as SigningInputEnum,
+};
+
+pub struct SolanaWalletConnector;
+
+impl WalletConnector for SolanaWalletConnector {
+    fn parse_request(
+        &self,
+        coin: &dyn CoinContext,
+        request: WCProto::ParseRequestInput<'_>,
+    ) -> WCProto::ParseRequestOutput<'static> {
+        Self::parse_request_impl(coin, request)
+            .unwrap_or_else(|e| signing_output_error!(WCProto::ParseRequestOutput, e))
+    }
+}
+
+impl SolanaWalletConnector {
+    fn parse_request_impl(
+        coin: &dyn CoinContext,
+        request: WCProto::ParseRequestInput<'_>,
+    ) -> SigningResult<WCProto::ParseRequestOutput<'static>> {
+        match request.method {
+            WCProto::Method::SolanaSignTransaction => {
+                Self::parse_sign_transaction_request(coin, request)
+            },
+            _ => Err(SigningError(SigningErrorType::Error_not_supported)),
+        }
+    }
+
+    pub fn parse_sign_transaction_request(
+        _coin: &dyn CoinContext,
+        request: WCProto::ParseRequestInput<'_>,
+    ) -> SigningResult<WCProto::ParseRequestOutput<'static>> {
+        let sign_req: SignTransactionRequest = serde_json::from_str(&request.payload)
+            .map_err(|_| SigningError(SigningErrorType::Error_input_parse))?;
+        let transaction: VersionedTransaction = bincode::deserialize(&sign_req.transaction.0)
+            .map_err(|_| SigningError(SigningErrorType::Error_input_parse))?;
+
+        let signing_input = Proto::SigningInput {
+            raw_message: Some(ProtoBuilder::build_from_tx(&transaction)?),
+            ..Proto::SigningInput::default()
+        };
+
+        Ok(WCProto::ParseRequestOutput {
+            signing_input_oneof: SigningInputEnum::solana(signing_input),
+            ..WCProto::ParseRequestOutput::default()
+        })
+    }
+}

--- a/rust/chains/tw_solana/src/modules/wallet_connect/mod.rs
+++ b/rust/chains/tw_solana/src/modules/wallet_connect/mod.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+
+pub mod connector;
+pub mod request;

--- a/rust/chains/tw_solana/src/modules/wallet_connect/request.rs
+++ b/rust/chains/tw_solana/src/modules/wallet_connect/request.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+
+use serde::Deserialize;
+use tw_encoding::base64::Base64Encoded;
+
+/// `solana_signTransaction` request payload without legacy fields.
+/// https://docs.walletconnect.com/advanced/rpc-reference/solana-rpc#solana_signtransaction
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignTransactionRequest {
+    pub transaction: Base64Encoded,
+}

--- a/rust/chains/tw_solana/src/signer.rs
+++ b/rust/chains/tw_solana/src/signer.rs
@@ -3,6 +3,7 @@
 // Copyright © 2017 Trust Wallet.
 
 use crate::modules::message_builder::MessageBuilder;
+use crate::modules::proto_builder::ProtoBuilder;
 use crate::modules::tx_signer::TxSigner;
 use crate::SOLANA_ALPHABET;
 use std::borrow::Cow;
@@ -51,6 +52,7 @@ impl SolanaSigner {
         Ok(Proto::SigningOutput {
             encoded: Cow::from(encoded_tx),
             unsigned_tx: Cow::from(encoded_unsigned),
+            signatures: ProtoBuilder::build_signatures(&signed_tx),
             ..Proto::SigningOutput::default()
         })
     }

--- a/rust/tw_any_coin/tests/chains/solana/mod.rs
+++ b/rust/tw_any_coin/tests/chains/solana/mod.rs
@@ -6,3 +6,4 @@ mod solana_address;
 mod solana_compile;
 mod solana_sign;
 mod solana_transaction;
+mod solana_wallet_connect;

--- a/rust/tw_any_coin/tests/chains/solana/solana_transaction.rs
+++ b/rust/tw_any_coin/tests/chains/solana/solana_transaction.rs
@@ -7,7 +7,6 @@ use tw_any_coin::test_utils::sign_utils::{AnySignerHelper, CompilerHelper, PreIm
 use tw_any_coin::test_utils::transaction_decode_utils::TransactionDecoderHelper;
 use tw_coin_registry::coin_type::CoinType;
 use tw_encoding::base58::Alphabet;
-use tw_encoding::hex::DecodeHex;
 use tw_encoding::{base58, base64};
 use tw_proto::Common::Proto::SigningError;
 use tw_proto::Solana::Proto;
@@ -150,15 +149,10 @@ fn test_solana_decode_transaction() {
         ],
     };
     let expected = Proto::RawMessage {
-        signatures: vec![
-            raw_message::PubkeySignature {
-                pubkey: "AHy6YZA8BsHgQfVkk7MbwpAN94iyN7Nf1zN4nPqUN32Q".into(),
-                signature: "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-                    .decode_hex()
-                    .unwrap()
-                    .into()
-            }
-        ],
+        signatures: vec![Proto::PubkeySignature {
+            pubkey: "AHy6YZA8BsHgQfVkk7MbwpAN94iyN7Nf1zN4nPqUN32Q".into(),
+            signature: "1111111111111111111111111111111111111111111111111111111111111111".into(),
+        }],
         message: MessageType::v0(expected_msg),
     };
 
@@ -178,13 +172,13 @@ fn test_solana_decode_transaction_update_blockhash_and_sign_with_external_fee_pa
     let mut decoded_tx = output.transaction.unwrap();
 
     let expected_signatures = vec![
-        raw_message::PubkeySignature {
+        Proto::PubkeySignature {
             pubkey: FEE_PAYER_PUBLIC_KEY.into(),
-            signature: b58(PREV_FEE_PAYER_SIGNATURE),
+            signature: PREV_FEE_PAYER_SIGNATURE.into(),
         },
-        raw_message::PubkeySignature {
+        Proto::PubkeySignature {
             pubkey: SENDER_PUBLIC_KEY.into(),
-            signature: b58(PREV_SENDER_SIGNATURE),
+            signature: PREV_SENDER_SIGNATURE.into(),
         },
     ];
     assert_eq!(decoded_tx.signatures, expected_signatures);
@@ -226,20 +220,20 @@ fn test_solana_decode_transaction_update_blockhash_and_sign_with_external_fee_pa
     let mut decoded_tx = output.transaction.unwrap();
 
     let expected_signatures = vec![
-        raw_message::PubkeySignature {
+        Proto::PubkeySignature {
             pubkey: FEE_PAYER_PUBLIC_KEY.into(),
-            signature: b58(PREV_FEE_PAYER_SIGNATURE),
+            signature: PREV_FEE_PAYER_SIGNATURE.into(),
         },
-        raw_message::PubkeySignature {
+        Proto::PubkeySignature {
             pubkey: SENDER_PUBLIC_KEY.into(),
-            signature: b58(PREV_SENDER_SIGNATURE),
+            signature: PREV_SENDER_SIGNATURE.into(),
         },
     ];
     assert_eq!(decoded_tx.signatures, expected_signatures);
 
     // Step 2. Update the recent-blockhash and external fee payer signature.
 
-    decoded_tx.signatures[0].signature = b58(NEW_FEE_PAYER_SIGNATURE);
+    decoded_tx.signatures[0].signature = NEW_FEE_PAYER_SIGNATURE.into();
 
     check_and_update_recent_blockhash(&mut decoded_tx, PREV_RECENT_BLOCKHASH, NEW_RECENT_BLOCKHASH);
 

--- a/rust/tw_any_coin/tests/chains/solana/solana_wallet_connect.rs
+++ b/rust/tw_any_coin/tests/chains/solana/solana_wallet_connect.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+
+use serde_json::json;
+use std::borrow::Cow;
+use tw_any_coin::test_utils::sign_utils::AnySignerHelper;
+use tw_any_coin::test_utils::wallet_connect_utils::WalletConnectRequestHelper;
+use tw_coin_registry::coin_type::CoinType;
+use tw_encoding::base58;
+use tw_encoding::base58::Alphabet;
+use tw_proto::Common::Proto::SigningError;
+use tw_proto::Solana::Proto;
+use tw_proto::WalletConnect::Proto as WCProto;
+
+fn b58(s: &str) -> Cow<'static, [u8]> {
+    base58::decode(s, Alphabet::BITCOIN).unwrap().into()
+}
+
+fn pubkey_signature(pubkey: &str, signature: &str) -> Proto::PubkeySignature<'static> {
+    Proto::PubkeySignature {
+        pubkey: pubkey.to_string().into(),
+        signature: signature.to_string().into(),
+    }
+}
+
+#[test]
+fn test_solana_sign_wallet_connect_case_1() {
+    let tx_encoded_to_sign = "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDZsL1CMnFVcrMn7JtiOiN1U4hC7WovOVof2DX51xM0H/GizyJTHgrBanCf8bGbrFNTn0x3pCGq30hKbywSTr6AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAgIAAQwCAAAAKgAAAAAAAAA=";
+    let tx_encoded_signed = "AQPWaOi7dMdmQpXi8HyQQKwiqIftrg1igGQxGtZeT50ksn4wAnyH4DtDrkkuE0fqgx80LTp4LwNN9a440SrmoA8BAAEDZsL1CMnFVcrMn7JtiOiN1U4hC7WovOVof2DX51xM0H/GizyJTHgrBanCf8bGbrFNTn0x3pCGq30hKbywSTr6AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAgIAAQwCAAAAKgAAAAAAAAA=";
+
+    let request_params = json!({
+        "transaction": tx_encoded_to_sign
+    });
+    let input = WCProto::ParseRequestInput {
+        protocol: WCProto::Protocol::V2,
+        method: WCProto::Method::SolanaSignTransaction,
+        payload: request_params.to_string().into(),
+    };
+
+    let mut parser = WalletConnectRequestHelper::default();
+    let parsing_output = parser.parse(CoinType::Solana, &input);
+
+    let mut signing_input = match parsing_output.signing_input_oneof {
+        WCProto::mod_ParseRequestOutput::OneOfsigning_input_oneof::solana(input) => input,
+        _ => unreachable!(),
+    };
+
+    // Set missing private key.
+    signing_input.private_key = b58("A7psj2GW7ZMdY4E5hJq14KMeYg7HFjULSsWSrTXZLvYr");
+    signing_input.tx_encoding = Proto::Encoding::Base64;
+
+    let mut signer = AnySignerHelper::<Proto::SigningOutput>::default();
+    let signing_output = signer.sign(CoinType::Solana, signing_input);
+
+    assert_eq!(signing_output.error, SigningError::OK);
+    assert_eq!(signing_output.encoded, tx_encoded_signed);
+    let expected_signatures = vec![pubkey_signature(
+        "7v91N7iZ9mNicL8WfG6cgSCKyRXydQjLh6UYBWwm6y1Q",
+        "5T6uZBHnHFd8uWErDBTFRVkbKuhbcm94K5MJ2beTYDruzqv4FjS7EMKvC94ZfxNAiWUXZ6bZxS3WXUbhJwYNPWn",
+    )];
+    assert_eq!(signing_output.signatures, expected_signatures);
+}
+
+#[test]
+fn test_solana_sign_wallet_connect_with_external_fee_payer() {
+    let tx_encoded_to_sign = "AgVnzLgdHFLYfmSR0mp/npPzRqaabwMYqy8dj7ohDQsDQ0NzDH7V06lqN+LrTpfLgT7smx+rgrU4+c991xODzQMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAGCssq8Im1alV3N7wXGODL8jLPWwLhTuCqfGZ1Iz9fb5tXlMOJD6jUvASrKmdtLK/qXNyJns2Vqcvlk+nfJYdZaFqUGMlXapwAxr2PwiP0cVc/cXJIjeEKqE2/Y8U6ILrnF0haJP+0BwRhu21/HIt1jGstyQAp1VG1/U6s2C1l4wIgwjHcAvSCmA99mRXB7PUzdAkdOMBgtJSH+cXZMuB37XY7RCyzkSFX8TqTPQE0KC0DK1/+zQGi2/G3eQYI3wAupwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKkGp9UXGSxcUSGMyUw9SvF/WNruCJuh/UTj29mKAAAAAIyXJY9OJInxuz0QKRSODYMLWhOZ2v8QhASOe9jb6fhZzipDMbzjZw5uqL7f9ZCMbZH4M6Maf96sFpeMJhoYAdUCCQcAAgQFBgcIAAcEAwUCAQoMoA8AAAAAAAAG";
+    // https://explorer.solana.com/tx/7GZGFT2VA4dpJBBwjiMqj1o8yChDvoCsqnQ7xz4GxY513W3efxRqbB8y7g4tH2GEGQRx4vCkKipG1sMaDEen1A2?cluster=devnet
+    let tx_encoded_signed = "AgVnzLgdHFLYfmSR0mp/npPzRqaabwMYqy8dj7ohDQsDQ0NzDH7V06lqN+LrTpfLgT7smx+rgrU4+c991xODzQOK74uU+ESOWD5RtUxJNbGRG7mOvDBTpGhZhlRRWEsR6D/hpQc0r8kzuXMUK3OptIklCXmLKjptzYUcCAlwTUsOAgAGCssq8Im1alV3N7wXGODL8jLPWwLhTuCqfGZ1Iz9fb5tXlMOJD6jUvASrKmdtLK/qXNyJns2Vqcvlk+nfJYdZaFqUGMlXapwAxr2PwiP0cVc/cXJIjeEKqE2/Y8U6ILrnF0haJP+0BwRhu21/HIt1jGstyQAp1VG1/U6s2C1l4wIgwjHcAvSCmA99mRXB7PUzdAkdOMBgtJSH+cXZMuB37XY7RCyzkSFX8TqTPQE0KC0DK1/+zQGi2/G3eQYI3wAupwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKkGp9UXGSxcUSGMyUw9SvF/WNruCJuh/UTj29mKAAAAAIyXJY9OJInxuz0QKRSODYMLWhOZ2v8QhASOe9jb6fhZzipDMbzjZw5uqL7f9ZCMbZH4M6Maf96sFpeMJhoYAdUCCQcAAgQFBgcIAAcEAwUCAQoMoA8AAAAAAAAG";
+
+    let request_params = json!({
+        "transaction": tx_encoded_to_sign
+    });
+    let input = WCProto::ParseRequestInput {
+        protocol: WCProto::Protocol::V2,
+        method: WCProto::Method::SolanaSignTransaction,
+        payload: request_params.to_string().into(),
+    };
+
+    let mut parser = WalletConnectRequestHelper::default();
+    let parsing_output = parser.parse(CoinType::Solana, &input);
+
+    let mut signing_input = match parsing_output.signing_input_oneof {
+        WCProto::mod_ParseRequestOutput::OneOfsigning_input_oneof::solana(input) => input,
+        _ => unreachable!(),
+    };
+
+    // Set missing private key.
+    signing_input.private_key = b58("9YtuoD4sH4h88CVM8DSnkfoAaLY7YeGC2TarDJ8eyMS5");
+    signing_input.tx_encoding = Proto::Encoding::Base64;
+
+    let mut signer = AnySignerHelper::<Proto::SigningOutput>::default();
+    let signing_output = signer.sign(CoinType::Solana, signing_input);
+
+    assert_eq!(signing_output.error, SigningError::OK);
+    assert_eq!(signing_output.encoded, tx_encoded_signed);
+
+    let expected_signatures = vec![
+        pubkey_signature(
+            "Eg5jqooyG6ySaXKbQUu4Lpvu2SqUPZrNkM4zXs9iUDLJ",
+            "7GZGFT2VA4dpJBBwjiMqj1o8yChDvoCsqnQ7xz4GxY513W3efxRqbB8y7g4tH2GEGQRx4vCkKipG1sMaDEen1A2",
+        ),
+        pubkey_signature(
+            "B1iGmDJdvmxyUiYM8UEo2Uw2D58EmUrw4KyLYMmrhf8V",
+            "3n7RHTCBAtnFVuDn5eRbyQB24h6AqajJi5nGMPrfnUVFUDh2Cb8AoaJ7mVtjnv73V4HaJCzSwCLAj3zcGEaFftWZ"
+        )
+    ];
+    assert_eq!(signing_output.signatures, expected_signatures);
+}

--- a/rust/tw_encoding/src/base58.rs
+++ b/rust/tw_encoding/src/base58.rs
@@ -23,6 +23,32 @@ pub fn decode(input: &str, alphabet: &Alphabet) -> EncodingResult<Vec<u8>> {
         .map_err(EncodingError::from)
 }
 
+pub mod as_base58_bitcoin {
+    use super::*;
+    use serde::de::Error;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    /// Serializes the `value` as base58.
+    pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: AsRef<[u8]>,
+        S: Serializer,
+    {
+        encode(value.as_ref(), Alphabet::BITCOIN).serialize(serializer)
+    }
+
+    /// Serializes the `value` as base58.
+    pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: for<'a> TryFrom<&'a [u8]>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let data = decode(&s, Alphabet::BITCOIN).map_err(|e| Error::custom(format!("{e:?}")))?;
+        T::try_from(&data).map_err(|_| Error::custom("Unexpected bytes length"))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/tw_encoding/src/base64.rs
+++ b/rust/tw_encoding/src/base64.rs
@@ -3,7 +3,8 @@
 // Copyright © 2017 Trust Wallet.
 
 use crate::{EncodingError, EncodingResult};
-use serde::{Serialize, Serializer};
+use serde::de::Error as DeError;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tw_memory::Data;
 
 pub fn encode(data: &[u8], is_url: bool) -> String {
@@ -33,5 +34,18 @@ impl Serialize for Base64Encoded {
     {
         let is_url = false;
         serializer.serialize_str(&encode(&self.0, is_url))
+    }
+}
+
+impl<'de> Deserialize<'de> for Base64Encoded {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let is_url = false;
+        decode(&s, is_url)
+            .map(Base64Encoded)
+            .map_err(|e| DeError::custom(format!("{e:?}")))
     }
 }

--- a/src/proto/Solana.proto
+++ b/src/proto/Solana.proto
@@ -150,12 +150,13 @@ message AdvanceNonceAccount {
     string nonce_account = 1;
 }
 
-message RawMessage {
-    message PubkeySignature {
-        string pubkey = 1;
-        bytes signature = 2;
-    }
+message PubkeySignature {
+    string pubkey = 1;
+    // base58 encoded signature.
+    string signature = 2;
+}
 
+message RawMessage {
     message MessageHeader {
         uint32 num_required_signatures = 1;
         uint32 num_readonly_signed_accounts = 2;
@@ -164,14 +165,14 @@ message RawMessage {
 
     message Instruction {
         uint32 program_id = 1;
-        repeated uint32 accounts = 2 [packed=true];
+        repeated uint32 accounts = 2 [packed = true];
         bytes program_data = 3;
     }
 
     message MessageAddressTableLookup {
         string account_key = 1;
-        repeated uint32 writable_indexes = 2 [packed=true];
-        repeated uint32 readonly_indexes = 3 [packed=true];
+        repeated uint32 writable_indexes = 2 [packed = true];
+        repeated uint32 readonly_indexes = 3 [packed = true];
     }
 
     message MessageLegacy {
@@ -269,6 +270,9 @@ message SigningOutput {
 
     // The encoded message. Can be used to estimate a transaction fee required to execute the message.
     string unsigned_tx = 4;
+
+    // Transaction signatures (may include external signatures).
+    repeated PubkeySignature signatures = 5;
 }
 
 /// Transaction pre-signing output

--- a/src/proto/WalletConnect.proto
+++ b/src/proto/WalletConnect.proto
@@ -5,6 +5,7 @@ option java_package = "wallet.core.jni.proto";
 
 import "Binance.proto";
 import "Common.proto";
+import "Solana.proto";
 
 // The transaction protocol may differ from version to version.
 enum Protocol {
@@ -16,6 +17,8 @@ enum Method {
     Unknown = 0;
     // cosmos_signAmino
     CosmosSignAmino = 1;
+    // solana_signTransaction
+    SolanaSignTransaction = 2;
 }
 
 message ParseRequestInput {
@@ -40,5 +43,6 @@ message ParseRequestOutput {
     // Prepared unsigned transaction input, on the source chain. Some fields must be completed, and it has to be signed.
     oneof signing_input_oneof {
         Binance.Proto.SigningInput binance = 3;
+        Solana.Proto.SigningInput solana = 4;
     }
 }

--- a/tests/chains/Solana/TWSolanaTransaction.cpp
+++ b/tests/chains/Solana/TWSolanaTransaction.cpp
@@ -59,12 +59,12 @@ TEST(TWSolanaTransaction, DecodeUpdateBlockhashAndSign) {
     ASSERT_TRUE(decodeOutput.transaction().has_legacy());
     // Previous fee payer signature.
     EXPECT_EQ(
-        Base58::encode(data(decodeOutput.transaction().signatures(0).signature())),
+        decodeOutput.transaction().signatures(0).signature(),
         "3KbvREZUat76wgWMtnJfWbJL74Vzh4U2eabVJa3Z3bb2fPtW8AREP5pbmRwUrxZCESbTomWpL41PeKDcPGbojsej"
     );
     // Previous sender signature.
     EXPECT_EQ(
-        Base58::encode(data(decodeOutput.transaction().signatures(1).signature())),
+        decodeOutput.transaction().signatures(1).signature(),
         "37UT8U6DdqaWqV6yQuHcRN3JpMefDgVna8LJJPmmDNKYMwmefEgvcreSg9AqSsT7cU2rMBNyDktEtDU19ZqqZvML"
     );
 

--- a/tests/chains/Solana/TWWalletConnectSolana.cpp
+++ b/tests/chains/Solana/TWWalletConnectSolana.cpp
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+
+#include "Base58.h"
+#include "proto/Solana.pb.h"
+#include "proto/WalletConnect.pb.h"
+#include "Coin.h"
+#include <TrustWalletCore/TWAnySigner.h>
+#include <TrustWalletCore/TWWalletConnectRequest.h>
+
+#include "TestUtilities.h"
+#include <gtest/gtest.h>
+
+namespace TW::Solana {
+
+TEST(TWWalletConnectSolana, Transfer) {
+    auto private_key = Base58::decode("A7psj2GW7ZMdY4E5hJq14KMeYg7HFjULSsWSrTXZLvYr");
+    const auto payload = R"({"transaction":"AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDZsL1CMnFVcrMn7JtiOiN1U4hC7WovOVof2DX51xM0H/GizyJTHgrBanCf8bGbrFNTn0x3pCGq30hKbywSTr6AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAgIAAQwCAAAAKgAAAAAAAAA="})";
+
+    WalletConnect::Proto::ParseRequestInput parsingInput;
+    parsingInput.set_method(WalletConnect::Proto::Method::SolanaSignTransaction);
+    parsingInput.set_payload(payload);
+
+    const auto parsinginputData = parsingInput.SerializeAsString();
+    const auto parsingInputDataPtr = WRAPD(TWDataCreateWithBytes(reinterpret_cast<const uint8_t *>(parsinginputData.c_str()), parsinginputData.size()));
+
+    const auto outputDataPtr = WRAPD(TWWalletConnectRequestParse(TWCoinTypeSolana, parsingInputDataPtr.get()));
+
+    WalletConnect::Proto::ParseRequestOutput parsingOutput;
+    parsingOutput.ParseFromArray(
+        TWDataBytes(outputDataPtr.get()),
+        static_cast<int>(TWDataSize(outputDataPtr.get()))
+    );
+
+    EXPECT_EQ(parsingOutput.error(), Common::Proto::SigningError::OK);
+
+    // Step 2: Set missing fields.
+    ASSERT_TRUE(parsingOutput.has_solana());
+    Proto::SigningInput signingInput = parsingOutput.solana();
+
+    signingInput.set_private_key(private_key.data(), private_key.size());
+    signingInput.set_tx_encoding(Proto::Encoding::Base64);
+
+    Proto::SigningOutput output;
+    ANY_SIGN(signingInput, TWCoinTypeSolana);
+
+    EXPECT_EQ(output.error(), Common::Proto::SigningError::OK);
+    EXPECT_EQ(output.encoded(), "AQPWaOi7dMdmQpXi8HyQQKwiqIftrg1igGQxGtZeT50ksn4wAnyH4DtDrkkuE0fqgx80LTp4LwNN9a440SrmoA8BAAEDZsL1CMnFVcrMn7JtiOiN1U4hC7WovOVof2DX51xM0H/GizyJTHgrBanCf8bGbrFNTn0x3pCGq30hKbywSTr6AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAgIAAQwCAAAAKgAAAAAAAAA=");
+}
+
+} // namespace TW::Binance


### PR DESCRIPTION
## How to use

1. Parse the received signing request by using `WalletConnectRequest.parse` method.
2. Adjust fee, add a `privateKey` to the result `Proto::SigningInput` message.
3. Generate and sign a transaction by using `AnySigner.sign` method.
4. Generate a WalletConnect JSON response with the result signature.

## How to test

Run Rust, C++, Android, iOS tests

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
