### PR TITLE
[ZetaChain]: Deposit BTC and call a smart contract in zEVM

### DIFF
--- a/src/Bitcoin/SigningInput.cpp
+++ b/src/Bitcoin/SigningInput.cpp
@@ -33,6 +33,9 @@ SigningInput::SigningInput(const Proto::SigningInput& input) {
         plan = TransactionPlan(input.plan());
     }
     outputOpReturn = data(input.output_op_return());
+    if (input.has_output_op_return_index()) {
+        outputOpReturnIndex = input.output_op_return_index().index();
+    }
     lockTime = input.lock_time();
     time = input.time();
 

--- a/src/Bitcoin/SigningInput.h
+++ b/src/Bitcoin/SigningInput.h
@@ -64,6 +64,10 @@ public:
 
     Data outputOpReturn;
 
+    // Optional index of the OP_RETURN output in the transaction.
+    // If not set, OP_RETURN output will be pushed as the latest output.
+    MaybeIndex outputOpReturnIndex;
+
     uint32_t lockTime = 0;
     uint32_t time = 0;
 

--- a/src/Bitcoin/TransactionBuilder.cpp
+++ b/src/Bitcoin/TransactionBuilder.cpp
@@ -85,6 +85,7 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
     if (input.outputOpReturn.size() > 0) {
         plan.outputOpReturn = input.outputOpReturn;
     }
+    plan.outputOpReturnIndex = input.outputOpReturnIndex;
 
     bool maxAmount = input.useMaxAmount;
     Amount totalAmount = input.amount + input.extraOutputsAmount;

--- a/src/proto/Bitcoin.proto
+++ b/src/proto/Bitcoin.proto
@@ -95,6 +95,11 @@ message OutputAddress {
     int64 amount = 2;
 }
 
+// Optional index of a corresponding output in the transaction.
+message OutputIndex {
+    uint32 index = 1;
+}
+
 // Input data necessary to create a signed transaction.
 message SigningInput {
     // Hash type to use when signing.
@@ -141,6 +146,10 @@ message SigningInput {
 
     // Optional zero-amount, OP_RETURN output
     bytes output_op_return = 13;
+
+    // Optional index of the OP_RETURN output in the transaction.
+    // If not set, OP_RETURN output will be pushed as the latest output.
+    OutputIndex output_op_return_index = 26;
 
     // Optional additional destination addresses, additional to first to_address output
     repeated OutputAddress extra_outputs = 14;
@@ -198,6 +207,10 @@ message TransactionPlan {
 
     // Optional zero-amount, OP_RETURN output
     bytes output_op_return = 8;
+
+    // Optional index of the OP_RETURN output in the transaction.
+    // If not set, OP_RETURN output will be pushed as the latest output.
+    OutputIndex output_op_return_index = 14;
 
     // zen & bitcoin diamond preblockhash
     bytes preblockhash = 9;

--- a/tests/chains/Bitcoin/TransactionPlanTests.cpp
+++ b/tests/chains/Bitcoin/TransactionPlanTests.cpp
@@ -715,6 +715,7 @@ TEST(TransactionPlan, OpReturn) {
     EXPECT_TRUE(verifyPlan(txPlan, {342101}, 300000, 205 * byteFee));
     EXPECT_EQ(txPlan.outputOpReturn.size(), 59ul);
     EXPECT_EQ(hex(txPlan.outputOpReturn), "535741503a54484f522e52554e453a74686f72317470657263616d6b6b7865633071306a6b366c74646e6c7176737732396775617038776d636c3a");
+    EXPECT_FALSE(txPlan.outputOpReturnIndex.has_value());
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
     EXPECT_EQ(feeCalculator.calculate(1, 2, byteFee), 174 * byteFee);


### PR DESCRIPTION
## Description

This PR introduces a `Proto::SigningInput::output_op_return_index` - an index of the OP_RETURN output in the transaction outputs list.

Currently, OP_RETURN is placed as the latest transaction output (after the P2WPKH and change outputs).
However, to interact with zEVM, OP_RETURN has to be the second output (after P2WPKH and before change outputs).

Documentation: https://www.zetachain.com/docs/developers/omnichain/bitcoin/#example-1-deposit-btc-into-an-account-in-zevm

## How to test

Run C++ tests

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
