### PR TITLE
[ICP]: Update derivation path to be compatible with other wallets

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
@@ -150,7 +150,7 @@ class CoinAddressDerivationTests {
         NOBLE -> assertEquals("noble142j9u5eaduzd7faumygud6ruhdwme98qc8l3wa", address)
         ROOTSTOCK -> assertEquals("0xA2D7065F94F838a3aB9C04D67B312056846424Df", address)
         SEI -> assertEquals("sei142j9u5eaduzd7faumygud6ruhdwme98qagm0sj", address)
-        INTERNETCOMPUTER -> assertEquals("b9a13d974ee9db036d5abc5b66ace23e513cb5676f3996626c7717c339a3ee87", address)
+        INTERNETCOMPUTER -> assertEquals("6f8e568160a3c8362789848dc0fa52891964473c045cc25208a305fb35b7c4ab", address)
         TIA -> assertEquals("celestia142j9u5eaduzd7faumygud6ruhdwme98qpwmfv7", address)
         NATIVEZETACHAIN -> assertEquals("zeta13u6g7vqgw074mgmf2ze2cadzvkz9snlwywj304", address)
         DYDX -> assertEquals("dydx142j9u5eaduzd7faumygud6ruhdwme98qeayaky", address)

--- a/kotlin/wallet-core-kotlin/src/commonTest/kotlin/com/trustwallet/core/test/CoinAddressDerivationTests.kt
+++ b/kotlin/wallet-core-kotlin/src/commonTest/kotlin/com/trustwallet/core/test/CoinAddressDerivationTests.kt
@@ -143,7 +143,7 @@ class CoinAddressDerivationTests {
         Noble -> "noble142j9u5eaduzd7faumygud6ruhdwme98qc8l3wa"
         Rootstock -> "0xA2D7065F94F838a3aB9C04D67B312056846424Df"
         Sei -> "sei142j9u5eaduzd7faumygud6ruhdwme98qagm0sj"
-        InternetComputer -> "b9a13d974ee9db036d5abc5b66ace23e513cb5676f3996626c7717c339a3ee87"
+        InternetComputer -> "6f8e568160a3c8362789848dc0fa52891964473c045cc25208a305fb35b7c4ab"
         Tia -> "celestia142j9u5eaduzd7faumygud6ruhdwme98qpwmfv7"
         NativeZetaChain -> "zeta13u6g7vqgw074mgmf2ze2cadzvkz9snlwywj304"
         Dydx -> "dydx142j9u5eaduzd7faumygud6ruhdwme98qeayaky"

--- a/registry.json
+++ b/registry.json
@@ -4578,7 +4578,7 @@
     "blockchain": "InternetComputer",
     "derivation": [
       {
-        "path": "m/44'/223'/1'/0/0",
+        "path": "m/44'/223'/0'/0/0",
         "xpub": "xpub",
         "xpriv": "xpriv"
       }

--- a/swift/Tests/CoinAddressDerivationTests.swift
+++ b/swift/Tests/CoinAddressDerivationTests.swift
@@ -385,7 +385,7 @@ class CoinAddressDerivationTests: XCTestCase {
                     let expectedResult = "sei142j9u5eaduzd7faumygud6ruhdwme98qagm0sj"
                     assertCoinDerivation(coin, expectedResult, derivedAddress, address)
                 case .internetComputer:
-                    let expectedResult = "b9a13d974ee9db036d5abc5b66ace23e513cb5676f3996626c7717c339a3ee87"
+                    let expectedResult = "6f8e568160a3c8362789848dc0fa52891964473c045cc25208a305fb35b7c4ab"
                     assertCoinDerivation(coin, expectedResult, derivedAddress, address)
                 case .tia:
                     let expectedResult = "celestia142j9u5eaduzd7faumygud6ruhdwme98qpwmfv7"


### PR DESCRIPTION
## Description

Update derivation path from `m/44'/223'/1'/0/0` to `m/44'/223'/0'/0/0` for `InternetComputer` to be compatible with other wallets.

