### PR TITLE
[Binance]: Add `cosmos-sdk/MsgSideChainStakeMigration` message type

### DIFF
--- a/rust/chains/tw_binance/src/transaction/message/mod.rs
+++ b/rust/chains/tw_binance/src/transaction/message/mod.rs
@@ -41,6 +41,7 @@ pub enum BinanceMessageEnum {
     SideDelegateOrder(side_chain_delegate::SideDelegateOrder),
     SideRedelegateOrder(side_chain_delegate::SideRedelegateOrder),
     SideUndelegateOrder(side_chain_delegate::SideUndelegateOrder),
+    StakeMigrationOrder(side_chain_delegate::StakeMigrationOrder),
     TimeLockOrder(time_lock_order::TimeLockOrder),
     TimeRelockOrder(time_lock_order::TimeRelockOrder),
     TimeUnlockOrder(time_lock_order::TimeUnlockOrder),
@@ -133,6 +134,10 @@ impl TWBinanceProto for BinanceMessageEnum {
                 time_lock_order::TimeUnlockOrder::from_tw_proto(coin, order)
                     .map(BinanceMessageEnum::TimeUnlockOrder)
             },
+            BinanceMessageProto::side_stake_migration_order(ref order) => {
+                side_chain_delegate::StakeMigrationOrder::from_tw_proto(coin, order)
+                    .map(BinanceMessageEnum::StakeMigrationOrder)
+            },
             BinanceMessageProto::None => Err(SigningError(SigningErrorType::Error_invalid_params)),
         }
     }
@@ -158,6 +163,9 @@ impl TWBinanceProto for BinanceMessageEnum {
             },
             BinanceMessageEnum::SideUndelegateOrder(m) => {
                 BinanceMessageProto::side_undelegate_order(m.to_tw_proto())
+            },
+            BinanceMessageEnum::StakeMigrationOrder(m) => {
+                BinanceMessageProto::side_stake_migration_order(m.to_tw_proto())
             },
             BinanceMessageEnum::TimeLockOrder(m) => {
                 BinanceMessageProto::time_lock_order(m.to_tw_proto())
@@ -207,6 +215,7 @@ impl<'a> AsRef<dyn BinanceMessage + 'a> for BinanceMessageEnum {
             BinanceMessageEnum::SideDelegateOrder(m) => m,
             BinanceMessageEnum::SideRedelegateOrder(m) => m,
             BinanceMessageEnum::SideUndelegateOrder(m) => m,
+            BinanceMessageEnum::StakeMigrationOrder(m) => m,
             BinanceMessageEnum::TimeLockOrder(m) => m,
             BinanceMessageEnum::TimeRelockOrder(m) => m,
             BinanceMessageEnum::TimeUnlockOrder(m) => m,

--- a/rust/chains/tw_binance/src/transaction/message/side_chain_delegate.rs
+++ b/rust/chains/tw_binance/src/transaction/message/side_chain_delegate.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use tw_coin_entry::coin_context::CoinContext;
 use tw_coin_entry::coin_entry::CoinAddress;
 use tw_coin_entry::error::{SigningError, SigningErrorType, SigningResult};
+use tw_evm::address::Address as EthereumAddress;
 use tw_memory::Data;
 use tw_misc::serde::Typed;
 use tw_proto::Binance::Proto;
@@ -204,3 +205,72 @@ impl TWBinanceProto for SideUndelegateOrder {
         }
     }
 }
+
+pub type StakeMigrationOrder = Typed<StakeMigrationOrderValue>;
+
+/// https://github.com/bnb-chain/bnc-cosmos-sdk/blob/cf3ab19af300ccd6a6381287c3fae6bf6ac12f5e/x/stake/types/stake_migration.go#L29-L35
+#[derive(Deserialize, Serialize)]
+pub struct StakeMigrationOrderValue {
+    #[serde(serialize_with = "Token::serialize_with_string_amount")]
+    pub amount: Token,
+    pub delegator_addr: EthereumAddress,
+    pub refund_addr: BinanceAddress,
+    pub validator_dst_addr: EthereumAddress,
+    pub validator_src_addr: BinanceAddress,
+}
+
+impl StakeMigrationOrderValue {
+    /// cbindgen:ignore
+    /// https://github.com/bnb-chain/javascript-sdk/blob/442286ac2923fdfd7cb4fb2299f722ec263c714c/src/types/tx/stdTx.ts#L68
+    pub const PREFIX: [u8; 4] = [0x38, 0x58, 0x91, 0x96];
+    /// cbindgen:ignore
+    pub const MESSAGE_TYPE: &'static str = "cosmos-sdk/MsgSideChainStakeMigration";
+}
+
+impl BinanceMessage for StakeMigrationOrder {
+    fn to_amino_protobuf(&self) -> SigningResult<Data> {
+        Ok(AminoEncoder::new(&StakeMigrationOrderValue::PREFIX)
+            .extend_with_msg(&self.to_tw_proto())?
+            .encode())
+    }
+}
+
+impl TWBinanceProto for StakeMigrationOrder {
+    type Proto<'a> = Proto::SideChainStakeMigration<'a>;
+
+    fn from_tw_proto(coin: &dyn CoinContext, msg: &Self::Proto<'_>) -> SigningResult<Self> {
+        let delegator_addr = EthereumAddress::try_from(msg.delegator_addr.as_ref())?;
+        let refund_addr = BinanceAddress::from_key_hash_with_coin(coin, msg.refund_addr.to_vec())?;
+        let validator_dst_addr = EthereumAddress::try_from(msg.validator_dst_addr.as_ref())?;
+        let validator_src_addr =
+            BinanceAddress::new_validator_addr(msg.validator_src_addr.to_vec())?;
+
+        let amount = msg
+            .amount
+            .as_ref()
+            .ok_or(SigningError(SigningErrorType::Error_invalid_params))?;
+
+        let value = StakeMigrationOrderValue {
+            amount: Token::from_tw_proto(amount),
+            delegator_addr,
+            refund_addr,
+            validator_dst_addr,
+            validator_src_addr,
+        };
+        Ok(Typed {
+            ty: StakeMigrationOrderValue::MESSAGE_TYPE.to_string(),
+            value,
+        })
+    }
+
+    fn to_tw_proto(&self) -> Self::Proto<'static> {
+        Proto::SideChainStakeMigration {
+            delegator_addr: self.value.delegator_addr.data().into(),
+            validator_src_addr: self.value.validator_src_addr.data().into(),
+            validator_dst_addr: self.value.validator_dst_addr.data().into(),
+            refund_addr: self.value.refund_addr.data().into(),
+            amount: Some(self.value.amount.to_tw_proto()),
+        }
+    }
+}
+

--- a/rust/chains/tw_binance/src/transaction/message/side_chain_delegate.rs
+++ b/rust/chains/tw_binance/src/transaction/message/side_chain_delegate.rs
@@ -273,4 +273,3 @@ impl TWBinanceProto for StakeMigrationOrder {
         }
     }
 }
-

--- a/rust/tw_any_coin/tests/chains/binance/mod.rs
+++ b/rust/tw_any_coin/tests/chains/binance/mod.rs
@@ -17,6 +17,9 @@ const ACCOUNT_15_PRIVATE_KEY: &str =
     "eeba3f6f2db26ced519a3d4c43afff101db957a21d54d25dc7fd235c404d7a5d";
 const ACCOUNT_16_PRIVATE_KEY: &str =
     "851fab89c14f4bbec0cc06f5e445ec065efc641068d78b308c67217d9bd5c88a";
+/// tbnb1rr74uvz8rcvl5dqn43jkwdufx5aksp4zwzszvs
+const ACCOUNT_91147_PRIVATE_KEY: &str =
+    "56b1253d944956c7f5b7668892509a44290f1fd149edecbe4fd44f69ba04b84c";
 
 fn make_token(denom: &str, amount: i64) -> Proto::mod_SendOrder::Token {
     Proto::mod_SendOrder::Token {

--- a/rust/tw_evm/src/address.rs
+++ b/rust/tw_evm/src/address.rs
@@ -110,6 +110,15 @@ impl FromStr for Address {
     }
 }
 
+impl<'a> TryFrom<&'a [u8]> for Address {
+    type Error = AddressError;
+
+    fn try_from(bytes: &'a [u8]) -> Result<Self, Self::Error> {
+        let bytes = H160::try_from(bytes).map_err(|_| AddressError::InvalidInput)?;
+        Ok(Address { bytes })
+    }
+}
+
 impl EvmAddress for Address {}
 
 /// Implement `str` -> `PrivateKey` conversion for test purposes.

--- a/src/proto/Binance.proto
+++ b/src/proto/Binance.proto
@@ -282,6 +282,16 @@ message SideChainUndelegate {
 	string chain_id = 4;
 }
 
+// Message for BNB Beacon Chain -> BSC Stake Migration.
+// https://github.com/bnb-chain/javascript-sdk/blob/26f6db8b67326e6214e74203ff90c89777b592a1/src/types/msg/stake/stakeMigrationMsg.ts#L13-L18
+message SideChainStakeMigration {
+    bytes validator_src_addr = 1;
+    bytes validator_dst_addr = 2;
+    bytes delegator_addr = 3;
+    bytes refund_addr = 4;
+    SendOrder.Token amount = 5;
+}
+
 // Message for TimeLock order
 message TimeLockOrder {
     // owner address
@@ -369,6 +379,7 @@ message SigningInput {
         TimeLockOrder time_lock_order = 24;
         TimeRelockOrder time_relock_order = 25;
         TimeUnlockOrder time_unlock_order = 26;
+        SideChainStakeMigration side_stake_migration_order = 27;
     }
 }
 


### PR DESCRIPTION
## Description

Add `cosmos-sdk/MsgSideChainStakeMigration` message type to allow BNB Beacon Chain users to migrate their stake amounts on Binance Smart Chain in one transaction.

https://github.com/bnb-chain/bnc-cosmos-sdk/blob/master/x/stake/types/stake_migration.go#L29-L35

Additional info
JS SDK sample : https://github.com/bnb-chain/javascript-sdk/pull/408/files

## How to test

Run Rust tests

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
