### PR TITLE
feat(FIO): Add support for "remaddress" action type

### DIFF
--- a/src/FIO/Action.cpp
+++ b/src/FIO/Action.cpp
@@ -41,7 +41,7 @@ void Action::serialize(Data& out) const {
     append(out, 0); // 00
 }
 
-void AddPubAddressData::serialize(Data& out) const {
+void PubAddressActionData::serialize(Data& out) const {
     encodeString(fioAddress, out);
     addresses.serialize(out);
     encode64LE(fee, out);

--- a/src/FIO/Action.h
+++ b/src/FIO/Action.h
@@ -81,8 +81,11 @@ public:
     void serialize(Data& out) const;
 };
 
-/// AddPubAddress action data part.
-class AddPubAddressData {
+/// A public address action data part.
+/// Can be used for `addaddress`, `remaddress` actions.
+/// https://dev.fio.net/reference/add_pub_address
+/// https://dev.fio.net/reference/remove_pub_address
+class PubAddressActionData {
 public:
     std::string fioAddress;
     PublicAddresses addresses;
@@ -90,7 +93,7 @@ public:
     std::string tpid;
     std::string actor;
 
-    AddPubAddressData(const std::string& fioAddress, const std::vector<PublicAddress>& addresses,
+    PubAddressActionData(const std::string& fioAddress, const std::vector<PublicAddress>& addresses,
         uint64_t fee, const std::string& tpid, const std::string& actor) :
         fioAddress(fioAddress), addresses(addresses),
         fee(fee), tpid(tpid), actor(actor) {}

--- a/src/FIO/Signer.cpp
+++ b/src/FIO/Signer.cpp
@@ -23,9 +23,11 @@ using namespace std;
 
 Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) noexcept {
     FIO::Proto::SigningOutput output;
-    try {    
+    try {
+        const string actionName = TransactionBuilder::actionName(input);
         const string json = TransactionBuilder::sign(input);
         output.set_json(json);
+        output.set_action_name(actionName);
     } catch(const std::exception& e) {
         output.set_error(Common::Proto::Error_internal);
     }

--- a/src/FIO/TransactionBuilder.h
+++ b/src/FIO/TransactionBuilder.h
@@ -64,6 +64,20 @@ public:
         const std::vector<std::pair<std::string, std::string>>& pubAddresses,
         const ChainParams& chainParams, uint64_t fee, const std::string& walletTpId, uint32_t expiryTime);
 
+    /// Create a signed `remaddress` transaction, returned as json string (double quote delimited), suitable for remove_pub_address RPC call
+    /// @address The owners' FIO address
+    /// @privateKey The private key matching the address, needed for signing.
+    /// @fioName The FIO name already registered to the owner. Ex.: "dmitry@trust"
+    /// @addressess List of public addresses to be registered, ex. {{"BTC", "bc1qv...7v"},{"BNB", "bnb1ts3...9s"}}
+    /// @chainParams Current parameters from the FIO chain, must be obtained recently using get_info and get_block calls.
+    /// @fee Max fee to spend, can be obtained using get_fee API.
+    /// @walletTpId The FIO name of the originating wallet (project-wide constant)
+    /// @expiryTime Expiry for this message, can be 0, then it is taken from current time with default expiry
+    /// Note: fee is usually 0 for remove_pub_address.
+    static std::string createRemovePubAddress(const Address& address, const PrivateKey& privateKey, const std::string& fioName,
+        const std::vector<std::pair<std::string, std::string>>& pubAddresses,
+        const ChainParams& chainParams, uint64_t fee, const std::string& walletTpId, uint32_t expiryTime);
+
     /// Create a signed TransferTokens transaction, returned as json string (double quote delimited), suitable for transfer_tokens_pub_key RPC call
     /// @address The owners' FIO address
     /// @privateKey The private key matching the address, needed for signing.
@@ -131,8 +145,17 @@ private:
     static Transaction buildUnsignedRegisterFioAddress(const Address& address, const std::string& fioName,
         const ChainParams& chainParams, uint64_t fee, const std::string& walletTpId, uint32_t expiryTime);
 
-    static Transaction buildUnsignedAddPubAddress(const Address& address, const std::string& fioName,
-        const std::vector<std::pair<std::string, std::string>>& pubAddresses,
+    /// Builds an unsigned transaction to perform an action over public addresses, e.g. adding or removing public addresses.
+    /// @apiName The action API name, ex. "addaddress", "remaddress".
+    /// @address The owners' FIO address.
+    /// @fioName The FIO name already registered to the owner. Ex.: "dmitry@trust"
+    /// @pubAddresses List of public addresses to be registered, ex. {{"BTC", "bc1qv...7v"},{"BNB", "bnb1ts3...9s"}}
+    /// @chainParams Current parameters from the FIO chain, must be obtained recently using get_info and get_block calls.
+    /// @fee Max fee to spend, can be obtained using get_fee API.
+    /// @walletTpId The FIO name of the originating wallet (project-wide constant)
+    /// @expiryTime Expiry for this message, can be 0, then it is taken from current time with default expiry
+    static Transaction buildUnsignedPubAddressAction(const std::string& apiName, const Address& address,
+        const std::string& fioName, const std::vector<std::pair<std::string, std::string>>& pubAddresses,
         const ChainParams& chainParams, uint64_t fee, const std::string& walletTpId, uint32_t expiryTime);
 
     static Transaction buildUnsignedTransfer(const Address& address, const std::string& payeePublicKey, uint64_t amount,

--- a/src/FIO/TransactionBuilder.h
+++ b/src/FIO/TransactionBuilder.h
@@ -38,6 +38,9 @@ public:
     /// Generic transaction signer: Build a signed transaction, in Json, from the specific SigningInput messages.
     static std::string sign(Proto::SigningInput in);
 
+    /// Returns an action name according to the given signing input.
+    static std::string actionName(const Proto::SigningInput& input);
+
     /// Create a signed RegisterFioAddress transaction, returned as json string (double quote delimited), suitable for register_fio_address RPC call
     /// @address The owners' FIO address. Ex.: "FIO6m1fMdTpRkRBnedvYshXCxLFiC5suRU8KDfx8xxtXp2hntxpnf"
     /// @privateKey The private key matching the address, needed for signing.

--- a/src/proto/FIO.proto
+++ b/src/proto/FIO.proto
@@ -64,6 +64,19 @@ message Action {
         uint64 fee = 3;        
     }
 
+    // Action for removing public chain addresses from a FIO name; remove_pub_address
+    // Note: actor is not needed, computed from private key
+    message RemovePubAddress {
+        // The FIO name already registered to the owner. Ex.: "alice@trust"
+        string fio_address = 1;
+
+        // List of public addresses to be unregistered, ex. {{"BTC", "bc1qv...7v"},{"BNB", "bnb1ts3...9s"}}
+        repeated PublicAddress public_addresses = 2;
+
+        // Max fee to spend, can be obtained using get_fee API.
+        uint64 fee = 3;
+    }
+
     // Action for transferring FIO coins; transfer_tokens_pub_key
     // Note: actor is not needed, computed from private key
     message Transfer {
@@ -116,6 +129,7 @@ message Action {
         Transfer transfer_message = 3;
         RenewFioAddress renew_fio_address_message = 4;
         NewFundsRequest new_funds_request_message = 5;
+        RemovePubAddress remove_pub_address_message = 6;
     }
 }
 

--- a/src/proto/FIO.proto
+++ b/src/proto/FIO.proto
@@ -176,4 +176,7 @@ message SigningOutput {
 
     // error code description
     string error_message = 3;
+
+    // Performed action name, ex. "addaddress", "remaddress", "trnsfiopubky" etc.
+    string action_name = 4;
 }

--- a/tests/chains/FIO/SignerTests.cpp
+++ b/tests/chains/FIO/SignerTests.cpp
@@ -103,6 +103,7 @@ TEST(FIOSigner, compile) {
         Proto::SigningOutput result = Signer::compile(input, signature);
         EXPECT_EQ(R"({"compression":"none","packed_context_free_data":"","packed_trx":"b0ae295e50c3400a6dee00000000010000980ad20ca85be0e1d195ba85e7cd01102b2f46fca756b200000000a8ed32325d3546494f37754d5a6f6565693548745841443234433479436b70575762663234626a597472524e6a57646d474358485a63637775694500ca9a3b0000000080b2e60e00000000102b2f46fca756b20e726577617264734077616c6c657400","signatures":["SIG_K1_K9VRCnvaTYN7vgcoVKVXgyJTdKUGV8hLXgFLoEbvqAcFxy7DXQ1rSnAfEuabi4ATkgmvnpaSBdVFN7TBtM1wrbZYqeJQw9"]})"
         , result.json());
+        EXPECT_EQ(result.action_name(), "trnsfiopubky");
 }
 
 } // namespace TW::FIO::tests

--- a/tests/chains/FIO/TWFIOTests.cpp
+++ b/tests/chains/FIO/TWFIOTests.cpp
@@ -37,6 +37,7 @@ TEST(TWFIO, Address) {
 }
 
 const Data gChainId = parse_hex("4e46572250454b796d7296eec9e8896327ea82dd40f2cd74cf1b1d8ba90bcd77");
+const Data gChainIdMainnet = parse_hex("21dcae42c0182200e93f954a074011f9048a7624c6fe81d3c9541a614a88bd1c");
 // 5KEDWtAUJcFX6Vz38WXsAQAv2geNqT7UaZC8gYu9kTuryr3qkri FIO6m1fMdTpRkRBnedvYshXCxLFiC5suRU8KDfx8xxtXp2hntxpnf
 const PrivateKey privKeyBA = PrivateKey(parse_hex("ba0828d5734b65e3bcc2c51c93dfc26dd71bd666cc0273adee77d73d9a322035"));
 const PublicKey pubKey6M = privKeyBA.getPublicKey(TWPublicKeyTypeSECP256k1);
@@ -85,6 +86,31 @@ TEST(TWFIO, AddPubAddress) {
     ANY_SIGN(input, TWCoinTypeFIO);
     EXPECT_EQ(Common::Proto::OK, output.error());
     EXPECT_EQ(R"({"compression":"none","packed_context_free_data":"","packed_trx":"15c2285e2d2d23622eff0000000001003056372503a85b0000c6eaa664523201102b2f46fca756b200000000a8ed3232c9010f6164616d4066696f746573746e65740303425443034254432a626331717679343037347267676b647232707a773576706e6e3632656730736d7a6c787770373064377603455448034554482a30786365356342366339324461333762624261393142643430443443394434443732344133613846353103424e4203424e422a626e6231747333646735346170776c76723968757076326e306a366534367135347a6e6e75736a6b39730000000000000000102b2f46fca756b20e726577617264734077616c6c657400","signatures":["SIG_K1_K3zimaMKU8cBhVRPw46KM2u7uQWaAKXrnoeYZ7MEbp6sVJcDQmQR2RtdavpUPwkAnYUkd8NqLun8H48tcxZBcTUgkiPGVJ"]})", output.json());
+}
+
+TEST(TWFIO, RemovePubAddress) {
+    auto privateKey = parse_hex("93083dc4d9e8f613a57e3a862a1fa5d665c5e90141a8428990c945d1c2b56491");
+
+    Proto::SigningInput input;
+    input.set_expiry(1713269931);
+    input.mutable_chain_params()->set_chain_id(string(gChainIdMainnet.begin(), gChainIdMainnet.end()));
+    input.mutable_chain_params()->set_head_block_number(256054093);
+    input.mutable_chain_params()->set_ref_block_prefix(2438027034);
+    input.set_private_key(string(privateKey.begin(), privateKey.end()));
+    input.set_tpid("trust@fiomembers");
+    auto action = input.mutable_action()->mutable_remove_pub_address_message();
+    action->set_fio_address("sergeitrust@wallet");
+    action->add_public_addresses();
+    action->mutable_public_addresses(0)->set_coin_symbol("BTC");
+    action->mutable_public_addresses(0)->set_address("bc1q68caps3gqt2c9qxtnkhmzf3whxenrs9cav4wlm");
+    action->set_fee(4878336459);
+
+    Proto::SigningOutput output;
+    ANY_SIGN(input, TWCoinTypeFIO);
+    EXPECT_EQ(Common::Proto::OK, output.error());
+    std::cout << output.json() << std::endl;
+    // Successfully broadcasted: https://fio.bloks.io/transaction/0bb6da24a3ea9e3ee57906de1cfa8bad18709acd64bf30908713dd61c54cfaea
+    EXPECT_EQ(R"({"compression":"none","packed_context_free_data":"","packed_trx":"ab6c1e664d131a5751910000000001003056372503a85b0000c6eaa664a4ba01b038b9d6c13372f700000000a8ed3232681273657267656974727573744077616c6c65740103425443034254432a62633171363863617073336771743263397178746e6b686d7a6633776878656e72733963617634776c6dcb81c52201000000b038b9d6c13372f71074727573744066696f6d656d6265727300","signatures":["SIG_K1_K3cKHXCFYYB9aLFc9qk2idmWgEA4Q9192fECc3cF7MYHXkw9kZamdeHv3qbVoifG9oS8h6nVAJwJvj5YcnhHmnd3u89ND7"]})", output.json());
 }
 
 TEST(TWFIO, Transfer) {

--- a/tests/chains/FIO/TWFIOTests.cpp
+++ b/tests/chains/FIO/TWFIOTests.cpp
@@ -59,6 +59,7 @@ TEST(TWFIO, RegisterFioAddress) {
     ANY_SIGN(input, TWCoinTypeFIO);
     EXPECT_EQ(Common::Proto::OK, output.error());
     EXPECT_EQ(R"({"compression":"none","packed_context_free_data":"","packed_trx":"3f99295ec99b904215ff0000000001003056372503a85b0000c6eaa66498ba01102b2f46fca756b200000000a8ed3232650f6164616d4066696f746573746e65743546494f366d31664d645470526b52426e6564765973685843784c4669433573755255384b44667838787874587032686e7478706e6600f2052a01000000102b2f46fca756b20e726577617264734077616c6c657400","signatures":["SIG_K1_K19ugLriG3ApYgjJCRDsy21p9xgsjbDtqBuZrmAEix9XYzndR1kNbJ6fXCngMJMAhxUHfwHAsPnh58otXiJZkazaM1EkS5"]})", output.json());
+    EXPECT_EQ(output.action_name(), "regaddress");
 }
 
 TEST(TWFIO, AddPubAddress) {
@@ -86,6 +87,7 @@ TEST(TWFIO, AddPubAddress) {
     ANY_SIGN(input, TWCoinTypeFIO);
     EXPECT_EQ(Common::Proto::OK, output.error());
     EXPECT_EQ(R"({"compression":"none","packed_context_free_data":"","packed_trx":"15c2285e2d2d23622eff0000000001003056372503a85b0000c6eaa664523201102b2f46fca756b200000000a8ed3232c9010f6164616d4066696f746573746e65740303425443034254432a626331717679343037347267676b647232707a773576706e6e3632656730736d7a6c787770373064377603455448034554482a30786365356342366339324461333762624261393142643430443443394434443732344133613846353103424e4203424e422a626e6231747333646735346170776c76723968757076326e306a366534367135347a6e6e75736a6b39730000000000000000102b2f46fca756b20e726577617264734077616c6c657400","signatures":["SIG_K1_K3zimaMKU8cBhVRPw46KM2u7uQWaAKXrnoeYZ7MEbp6sVJcDQmQR2RtdavpUPwkAnYUkd8NqLun8H48tcxZBcTUgkiPGVJ"]})", output.json());
+    EXPECT_EQ(output.action_name(), "addaddress");
 }
 
 TEST(TWFIO, RemovePubAddress) {
@@ -111,6 +113,7 @@ TEST(TWFIO, RemovePubAddress) {
     std::cout << output.json() << std::endl;
     // Successfully broadcasted: https://fio.bloks.io/transaction/0bb6da24a3ea9e3ee57906de1cfa8bad18709acd64bf30908713dd61c54cfaea
     EXPECT_EQ(R"({"compression":"none","packed_context_free_data":"","packed_trx":"ab6c1e664d131a5751910000000001003056372503a85b0000c6eaa664a4ba01b038b9d6c13372f700000000a8ed3232681273657267656974727573744077616c6c65740103425443034254432a62633171363863617073336771743263397178746e6b686d7a6633776878656e72733963617634776c6dcb81c52201000000b038b9d6c13372f71074727573744066696f6d656d6265727300","signatures":["SIG_K1_K3cKHXCFYYB9aLFc9qk2idmWgEA4Q9192fECc3cF7MYHXkw9kZamdeHv3qbVoifG9oS8h6nVAJwJvj5YcnhHmnd3u89ND7"]})", output.json());
+    EXPECT_EQ(output.action_name(), "remaddress");
 }
 
 TEST(TWFIO, Transfer) {
@@ -129,6 +132,7 @@ TEST(TWFIO, Transfer) {
     ANY_SIGN(input, TWCoinTypeFIO);
     EXPECT_EQ(Common::Proto::OK, output.error());
     EXPECT_EQ(R"({"compression":"none","packed_context_free_data":"","packed_trx":"b0ae295e50c3400a6dee00000000010000980ad20ca85be0e1d195ba85e7cd01102b2f46fca756b200000000a8ed32325d3546494f37754d5a6f6565693548745841443234433479436b70575762663234626a597472524e6a57646d474358485a63637775694500ca9a3b0000000080b2e60e00000000102b2f46fca756b20e726577617264734077616c6c657400","signatures":["SIG_K1_K9VRCnvaTYN7vgcoVKVXgyJTdKUGV8hLXgFLoEbvqAcFxy7DXQ1rSnAfEuabi4ATkgmvnpaSBdVFN7TBtM1wrbZYqeJQw9"]})", output.json());
+    EXPECT_EQ(output.action_name(), "trnsfiopubky");
 }
 
 TEST(TWFIO, RenewFioAddress) {
@@ -147,6 +151,7 @@ TEST(TWFIO, RenewFioAddress) {
     ANY_SIGN(input, TWCoinTypeFIO);
     EXPECT_EQ(Common::Proto::OK, output.error());
     EXPECT_EQ(R"({"compression":"none","packed_context_free_data":"","packed_trx":"289b295ec99b904215ff0000000001003056372503a85b80b1ba2919aea6ba01102b2f46fca756b200000000a8ed32322f0f6e69636b4066696f746573746e6574005ed0b200000000102b2f46fca756b20e726577617264734077616c6c657400","signatures":["SIG_K1_Jxz7oCJ7Z4ECsxqb2utqBcyP3zPQCeQCBws9wWQjyptUKoWVk2AyCVEqtdMHJwqtLniio5Z7npMnaZB8E4pa2G75P9uGkb"]})", output.json());
+    EXPECT_EQ(output.action_name(), "renewaddress");
 }
 
 TEST(TWFIO, NewFundsRequest) {
@@ -175,6 +180,7 @@ TEST(TWFIO, NewFundsRequest) {
     EXPECT_EQ(
         R"({"compression":"none","packed_context_free_data":"","packed_trx":"289b295ec99b904215ff000000000100403ed4aa0ba85b00acba384dbdb89a01102b2f46fca756b200000000a8ed32328802106d6172696f4066696f746573746)",
         output.json().substr(0, 195));
+    EXPECT_EQ(output.action_name(), "newfundsreq");
 }
 
 } // namespace TW::FIO::TWFIOTests

--- a/tests/chains/FIO/TransactionBuilderTests.cpp
+++ b/tests/chains/FIO/TransactionBuilderTests.cpp
@@ -468,6 +468,7 @@ TEST(FIOTransactionBuilder, buildSigningOutput) {
 
         EXPECT_EQ(R"({"compression":"none","packed_context_free_data":"","packed_trx":"3f99295ec99b904215ff0000000001003056372503a85b0000c6eaa66498ba01102b2f46fca756b200000000a8ed3232650f6164616d4066696f746573746e65743546494f366d31664d645470526b52426e6564765973685843784c4669433573755255384b44667838787874587032686e7478706e6600f2052a01000000102b2f46fca756b20e726577617264734077616c6c657400","signatures":["SIG_K1_K19ugLriG3ApYgjJCRDsy21p9xgsjbDtqBuZrmAEix9XYzndR1kNbJ6fXCngMJMAhxUHfwHAsPnh58otXiJZkazaM1EkS5"]})"
         , result.json());
+        EXPECT_EQ(result.action_name(), "regaddress");
 
     }   
     {
@@ -506,6 +507,7 @@ TEST(FIOTransactionBuilder, buildSigningOutput) {
         Proto::SigningOutput result = TransactionBuilder::buildSigningOutput(input, signature);
         EXPECT_EQ(R"({"compression":"none","packed_context_free_data":"","packed_trx":"15c2285e2d2d23622eff0000000001003056372503a85b0000c6eaa664523201102b2f46fca756b200000000a8ed3232c9010f6164616d4066696f746573746e65740303425443034254432a626331717679343037347267676b647232707a773576706e6e3632656730736d7a6c787770373064377603455448034554482a30786365356342366339324461333762624261393142643430443443394434443732344133613846353103424e4203424e422a626e6231747333646735346170776c76723968757076326e306a366534367135347a6e6e75736a6b39730000000000000000102b2f46fca756b20e726577617264734077616c6c657400","signatures":["SIG_K1_K3zimaMKU8cBhVRPw46KM2u7uQWaAKXrnoeYZ7MEbp6sVJcDQmQR2RtdavpUPwkAnYUkd8NqLun8H48tcxZBcTUgkiPGVJ"]})"
         , result.json());
+        EXPECT_EQ(result.action_name(), "addaddress");
     }
     {
         // Test transfer_message
@@ -530,6 +532,7 @@ TEST(FIOTransactionBuilder, buildSigningOutput) {
         Proto::SigningOutput result = TransactionBuilder::buildSigningOutput(input, signature);
         EXPECT_EQ(R"({"compression":"none","packed_context_free_data":"","packed_trx":"b0ae295e50c3400a6dee00000000010000980ad20ca85be0e1d195ba85e7cd01102b2f46fca756b200000000a8ed32325d3546494f37754d5a6f6565693548745841443234433479436b70575762663234626a597472524e6a57646d474358485a63637775694500ca9a3b0000000080b2e60e00000000102b2f46fca756b20e726577617264734077616c6c657400","signatures":["SIG_K1_K9VRCnvaTYN7vgcoVKVXgyJTdKUGV8hLXgFLoEbvqAcFxy7DXQ1rSnAfEuabi4ATkgmvnpaSBdVFN7TBtM1wrbZYqeJQw9"]})"
         , result.json());
+        EXPECT_EQ(result.action_name(), "trnsfiopubky");
     }
     {   
         // Test renew_fio_address_message
@@ -553,6 +556,7 @@ TEST(FIOTransactionBuilder, buildSigningOutput) {
         Proto::SigningOutput result = TransactionBuilder::buildSigningOutput(input, signature);
         EXPECT_EQ(R"({"compression":"none","packed_context_free_data":"","packed_trx":"289b295ec99b904215ff0000000001003056372503a85b80b1ba2919aea6ba01102b2f46fca756b200000000a8ed32322f0f6e69636b4066696f746573746e6574005ed0b200000000102b2f46fca756b20e726577617264734077616c6c657400","signatures":["SIG_K1_Jxz7oCJ7Z4ECsxqb2utqBcyP3zPQCeQCBws9wWQjyptUKoWVk2AyCVEqtdMHJwqtLniio5Z7npMnaZB8E4pa2G75P9uGkb"]})"
         , result.json());
+        EXPECT_EQ(result.action_name(), "renewaddress");
     }
 }
 

--- a/tests/chains/FIO/TransactionBuilderTests.cpp
+++ b/tests/chains/FIO/TransactionBuilderTests.cpp
@@ -145,7 +145,7 @@ TEST(FIOTransaction, ActionRegisterFioAddressInternal) {
 }
 
 TEST(FIOTransaction, ActionAddPubAddressInternal) {
-    AddPubAddressData aadata("adam@fiotestnet", {{"BTC", "BTC", "bc1qvy4074rggkdr2pzw5vpnn62eg0smzlxwp70d7v"}, {"ETH", "ETH", "0xce5cB6c92Da37bbBa91Bd40D4C9D4D724A3a8F51"}, {"BNB", "BNB", "bnb1ts3dg54apwlvr9hupv2n0j6e46q54znnusjk9s"}},
+    PubAddressActionData aadata("adam@fiotestnet", {{"BTC", "BTC", "bc1qvy4074rggkdr2pzw5vpnn62eg0smzlxwp70d7v"}, {"ETH", "ETH", "0xce5cB6c92Da37bbBa91Bd40D4C9D4D724A3a8F51"}, {"BNB", "BNB", "bnb1ts3dg54apwlvr9hupv2n0j6e46q54znnusjk9s"}},
                              0, "rewards@wallet", "qdfejz2a5wpl");
     Data ser1;
     aadata.serialize(ser1);

--- a/tests/chains/FIO/TransactionCompilerTests.cpp
+++ b/tests/chains/FIO/TransactionCompilerTests.cpp
@@ -85,7 +85,8 @@ TEST(FIOCompiler, CompileWithSignatures) {
 
         TW::FIO::Proto::SigningOutput output;
         ASSERT_TRUE(output.ParseFromArray(outputData.data(), (int)outputData.size()));
-        EXPECT_EQ(ExpectedTx, output.json());    
+        EXPECT_EQ(ExpectedTx, output.json());
+        EXPECT_EQ(output.action_name(), "trnsfiopubky");
     }
     { // Double check: check if simple signature process gives the same result. Note that private
       // keys were not used anywhere up to this point.


### PR DESCRIPTION
## Description

Currently, WC does not support removing address action for FIO blockchain.

Sample from the SDK
https://github.com/fioprotocol/fiosdk_typescript-examples/blob/f4eacd0b7f279f74a1787385a1dc96a4f7c7d9e4/fio.address-remaddress.js#L19

Endpoint to broadcast
https://dev.fio.net/reference/remove_pub_address

## How to test

Run C++ tests

## Types of changes

* Add `Proto::Action::RemovePubAddress` message type.
* Add `Proto::SigningOutput::action_name` field to make the WalletKit easier to broadcast transactions.

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
