### PR TITLE
[THORSwaps] Prefix tokenID with symbol for tx's memo

### DIFF
--- a/src/THORChain/Swap.cpp
+++ b/src/THORChain/Swap.cpp
@@ -142,7 +142,7 @@ std::string SwapBuilder::buildMemo(bool shortened) noexcept {
     const auto& toChain = static_cast<Chain>(mToAsset.chain());
     const auto& toTokenId = mToAsset.token_id();
     const auto& toSymbol = mToAsset.symbol();
-    const auto toCoinToken = (!toTokenId.empty() && toTokenId != "0x0000000000000000000000000000000000000000") ? toTokenId : toSymbol;
+    const auto toCoinToken = (!toTokenId.empty() && toTokenId != "0x0000000000000000000000000000000000000000") ? toSymbol + "-" + toTokenId : toSymbol;
     std::stringstream memo;
     memo << prefix + ":" + chainName(toChain) + "." + toCoinToken + ":" + mToAddress;
 


### PR DESCRIPTION
## Description

WalletCore provides wrong memo for swaps where `toCoin`  is token. 

## How to test

THORChainSwapSwapInput: 
```
▿ WalletCore.TW_THORChainSwap_Proto_SwapInput:
from_asset {
  chain: BSC
  symbol: "BNB"
}
from_address: "0x121a38277e0ba795eDf8cB6bE7935A9773e1AC25"
to_asset {
  chain: BSC
  symbol: "USDT"
  token_id: "0x55d398326f99059fF775485246999027B3197955"
}
to_address: "0x121a38277e0ba795eDf8cB6bE7935A9773e1AC25"
vault_address: "0xddfc93bdf588d966b16a8214fce70e6e7fff6280"
router_address: "0xb30ec53f98ff5947ede720d32ac2da7e52a5f56b"
from_amount: "20000000000000000"
to_amount_limit: "0"
affiliate_fee_address: "v0"
affiliate_fee_rate_bp: "70"
expiration_time: 1714226686
stream_params {
  interval: "1"
  quantity: "0"
}
```

Memo: 
```
=:BSC.0x55d398326f99059fF775485246999027B3197955:0x121a38277e0ba795eDf8cB6bE7935A9773e1AC25:0/1/0:v0:70
```

Correct memo: 
https://bscscan.com/tx/0x4cae9e82365e6eb64616ad9be58f54b42d6f8aad630f9222e3ff98103acdbdfe

Wrong swap from WalletCore:
https://bscscan.com/tx/0x0b5ba3679c4176ee9572ac6e8e2482610a8a41d509b494c70fddd0f3c2137336
