### PR TITLE
[Aeternity]: Catch all exceptions on `TWAnyAddressIsValid`

### DIFF
--- a/tests/chains/Aeternity/AddressTests.cpp
+++ b/tests/chains/Aeternity/AddressTests.cpp
@@ -2,9 +2,9 @@
 //
 // Copyright © 2017 Trust Wallet.
 
+#include <TrustWalletCore/TWAnyAddress.h>
 #include <Aeternity/Address.h>
 #include <HexCoding.h>
-#include <PrivateKey.h>
 #include <gtest/gtest.h>
 
 namespace TW::Aeternity::tests {
@@ -20,6 +20,7 @@ TEST(AeternityAddress, FromString) {
     auto address = Address("ak_2p5878zbFhxnrm7meL7TmqwtvBaqcBddyp5eGzZbovZ5FeVfcw");
     ASSERT_EQ(address.string(), "ak_2p5878zbFhxnrm7meL7TmqwtvBaqcBddyp5eGzZbovZ5FeVfcw");
     ASSERT_ANY_THROW(Address("invalid"));
+    ASSERT_ANY_THROW(Address("behave@wallet"));
 }
 
 } // namespace TW::Aeternity::tests

--- a/tests/chains/Aeternity/TWAnyAddressTests.cpp
+++ b/tests/chains/Aeternity/TWAnyAddressTests.cpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+
+#include <TrustWalletCore/TWAnyAddress.h>
+#include <gtest/gtest.h>
+#include <TestUtilities.h>
+
+namespace TW::Aeternity::tests {
+
+// `TWAnyAddressIsValid` must catch exceptions and return false.
+TEST(AeternityAddress, IsValid) {
+    ASSERT_FALSE(TWAnyAddressIsValid(STRING("invalid").get(), TWCoinTypeAeternity));
+    ASSERT_FALSE(TWAnyAddressIsValid(STRING("behave@wallet").get(), TWCoinTypeAeternity));
+    ASSERT_FALSE(TWAnyAddressIsValid(STRING("a").get(), TWCoinTypeAeternity));
+}
+
+} // namespace TW::Aeternity::tests


### PR DESCRIPTION
## Description

`AnyAddress.isValid` throws an exception for Aeternity coin when using FIO handles.
We should catch all exceptions and return false in case of using invalid addresses.

## How to test

Run C++ tests

## Types of changes

Add try-catch blocks to `TWAnyAddressIsValid`, `TWAnyAddressIsValidBech32` and `TWAnyAddressIsValidSS58`

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
