### PR TITLE
Fix TrezorCrypto CMake build

### DIFF
--- a/trezor-crypto/CMakeLists.txt
+++ b/trezor-crypto/CMakeLists.txt
@@ -23,6 +23,8 @@ set(TW_WARNING_FLAGS
     -Wno-missing-braces
 )
 
+set(CMAKE_C_STANDARD 11)
+
 add_library(TrezorCrypto
     crypto/bignum.c crypto/ecdsa.c crypto/curves.c crypto/secp256k1.c crypto/rand.c crypto/hmac.c crypto/bip32.c crypto/bip39.c crypto/slip39.c crypto/pbkdf2.c crypto/base58.c crypto/base32.c
     crypto/address.c


### PR DESCRIPTION
The [`_Static_assert` requires C11](https://en.cppreference.com/w/c/language/_Static_assert), which is not correctly set on CMake.