### PR TITLE
[TON]: Do not require password at `TWStoredKeyUpdateAddress`

### DIFF
--- a/include/TrustWalletCore/TWStoredKey.h
+++ b/include/TrustWalletCore/TWStoredKey.h
@@ -295,16 +295,15 @@ TWData* _Nullable TWStoredKeyExportJSON(struct TWStoredKey* _Nonnull key);
 TW_EXPORT_METHOD
 bool TWStoredKeyFixAddresses(struct TWStoredKey* _Nonnull key, TWData* _Nonnull password);
 
-/// Re-derives address and public key for the specified chain.
-/// It can be used to update the address if the default address format for the given chain has been changed.
-/// This method needs the encryption password to re-write address.
+/// Re-derives address for the account(s) associated with the given coin.
+/// This method can be used if address format has been changed.
+/// In case of multiple accounts, all of them will be updated.
 ///
 /// \param key Non-null pointer to a stored key
-/// \param password Non-null block of data, password of the stored key
-/// \param coin Coin type for which to update the address and public key
-/// \return `false` if the password is incorrect or there is no data for the specified chain, true otherwise.
+/// \param coin Account(s) coin type to be updated
+/// \return `false` if there are no accounts associated with the given coin, true otherwise
 TW_EXPORT_METHOD
-bool TWStoredKeyUpdateAddress(struct TWStoredKey* _Nonnull key, TWData* _Nonnull password, enum TWCoinType coin);
+bool TWStoredKeyUpdateAddress(struct TWStoredKey* _Nonnull key, enum TWCoinType coin);
 
 /// Retrieve stored key encoding parameters, as JSON string.
 ///

--- a/src/Keystore/StoredKey.h
+++ b/src/Keystore/StoredKey.h
@@ -144,11 +144,11 @@ public:
     /// the encryption password to re-derive addresses from private keys.
     void fixAddresses(const Data& password);
 
-    /// Re-derives address and public key for the specified chain.
+    /// Re-derives address for the account(s) associated with the given coin.
     ///
-    /// Use when address format for the given chain has been changed. This method needs
-    /// the encryption password to re-derive addresses from private keys.
-    bool updateAddress(TWCoinType coin, const Data& password);
+    /// This method can be used if address format has been changed.
+    /// In case of multiple accounts, all of them will be updated.
+    bool updateAddress(TWCoinType coin);
 
 private:
     /// Default constructor, private

--- a/src/interface/TWStoredKey.cpp
+++ b/src/interface/TWStoredKey.cpp
@@ -224,10 +224,9 @@ bool TWStoredKeyFixAddresses(struct TWStoredKey* _Nonnull key, TWData* _Nonnull 
     }
 }
 
-bool TWStoredKeyUpdateAddress(struct TWStoredKey* _Nonnull key, TWData* _Nonnull password, enum TWCoinType coin) {
+bool TWStoredKeyUpdateAddress(struct TWStoredKey* _Nonnull key, enum TWCoinType coin) {
     try {
-        const auto passwordData = TW::data(TWDataBytes(password), TWDataSize(password));
-        return key->impl.updateAddress(coin, passwordData);
+        return key->impl.updateAddress(coin);
     } catch (...) {
         return false;
     }

--- a/tests/interface/TWStoredKeyTests.cpp
+++ b/tests/interface/TWStoredKeyTests.cpp
@@ -305,7 +305,7 @@ TEST(TWStoredKey, UpdateAddressWithMnemonic) {
 
     // Last step - update TON account address.
     // Expect to have a non-bounceable address in the end.
-    ASSERT_TRUE(TWStoredKeyUpdateAddress(key.get(), password.get(), TWCoinTypeTON));
+    ASSERT_TRUE(TWStoredKeyUpdateAddress(key.get(), TWCoinTypeTON));
     const auto tonAccount = WRAP(TWAccount, TWStoredKeyAccountForCoin(key.get(), TWCoinTypeTON, nullptr));
     assertStringsEqual(WRAPS(TWAccountAddress(tonAccount.get())), newAddress);
 }
@@ -338,29 +338,18 @@ TEST(TWStoredKey, UpdateAddressWithPrivateKey) {
 
     // Last step - update Ethereum account address.
     // Expect to have a checksummed address in the end.
-    ASSERT_TRUE(TWStoredKeyUpdateAddress(key.get(), password.get(), TWCoinTypeEthereum));
+    ASSERT_TRUE(TWStoredKeyUpdateAddress(key.get(), TWCoinTypeEthereum));
     const auto ethAccount = WRAP(TWAccount, TWStoredKeyAccountForCoin(key.get(), TWCoinTypeEthereum, nullptr));
     assertStringsEqual(WRAPS(TWAccountAddress(ethAccount.get())), newAddress);
 }
 
-TEST(TWStoredKey, updateAddressInvalidPassword) {
-    const auto keyName = STRING("key");
-    const string passwordString = "password";
-    const string invalidPasswordString = "invalid password";
-    const auto password = WRAPD(TWDataCreateWithBytes((const uint8_t*)passwordString.c_str(), passwordString.size()));
-    const auto invalidPassword = WRAPD(TWDataCreateWithBytes((const uint8_t*)invalidPasswordString.c_str(), invalidPasswordString.size()));
-
-    auto key = createAStoredKey(TWCoinTypeBitcoin, password.get());
-    ASSERT_FALSE(TWStoredKeyUpdateAddress(key.get(), invalidPassword.get(), TWCoinTypeBitcoin));
-}
-
-TEST(TWStoredKey, updateAddressUnknownAccount) {
+TEST(TWStoredKey, updateAddressNoAssociatedAccounts) {
     const auto keyName = STRING("key");
     const string passwordString = "password";
     const auto password = WRAPD(TWDataCreateWithBytes((const uint8_t*)passwordString.c_str(), passwordString.size()));
 
     auto key = createAStoredKey(TWCoinTypeBitcoin, password.get());
-    ASSERT_FALSE(TWStoredKeyUpdateAddress(key.get(), password.get(), TWCoinTypeEthereum));
+    ASSERT_FALSE(TWStoredKeyUpdateAddress(key.get(), TWCoinTypeEthereum));
 }
 
 TEST(TWStoredKey, importInvalidKey) {


### PR DESCRIPTION
## Description

We can use stored account public key to re-derive account address. No need to require a password to decrypt wallet/privateKey.

## How to test

Run C++ tests

## Types of changes

Remove `TWData* password` parameter from the `TWStoredKeyUpdateAddress` function

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
