### PR TITLE
fix(MultiversX): Added `cstdint` to headers

### DIFF
--- a/src/MultiversX/Transaction.h
+++ b/src/MultiversX/Transaction.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace TW::MultiversX {

--- a/src/MultiversX/TransactionFactoryConfig.h
+++ b/src/MultiversX/TransactionFactoryConfig.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace TW::MultiversX {


### PR DESCRIPTION
Newer versions of the C++ standard library (both LLVM's `libc++` and GNU's `libstdc++` excluded `cstdint` inclusion on `string`, breaking compilations of the project.

This PR adds `cstdint` inclusion manually to the affected files.