### PR TITLE
add chain bty

### DIFF
--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -186,6 +186,7 @@ enum TWCoinType {
     TWCoinTypeBlast = 81457,
     TWCoinTypeBounceBit = 6001,
     TWCoinTypeZkLinkNova = 810180,
+    TWCoinTypeBitYuan = 13107,
     // end_of_tw_coin_type_marker_do_not_modify
 };
 

--- a/registry.json
+++ b/registry.json
@@ -4781,5 +4781,36 @@
       "rpc": "https://rpc.zklink.io",
       "documentation": "https://docs.zklink.io"
     }
+  },
+  {
+    "id": "bityuan",
+    "name": "BitYuan",
+    "displayName": "BitYuan Mainnet",
+    "coinId": 13107,
+    "symbol": "BTY",
+    "decimals": 18,
+    "blockchain": "BitYuan",
+    "derivation": [
+      {
+        "path": "m/44'/60'/0'/0/0"
+      }
+    ],
+    "curve": "secp256k1",
+    "publicKeyType": "secp256k1Extended",
+    "chainId": "2999",
+    "addressHasher": "keccak256",
+    "explorer": {
+      "url": "https://mainnet.bityuan.com",
+      "txPath": "/tx/",
+      "accountPath": "/address/",
+      "sampleTx": "0x08e67624a7a9fbec2af3ab37dac17b15a1facf56dd3806d7d84e95abb333a468",
+      "sampleAccount": "0x944880ad48b7e351513857701b39be968fd18d5b"
+    },
+    "info": {
+      "url": "https://bityuan.com/",
+      "source": "https://github.com/bityuan/bityuan",
+      "rpc": "https://mainnet.bityuan.com/eth",
+      "documentation": "https://eth.wiki/json-rpc/API"
+    }
   }
 ]

--- a/rust/tw_any_coin/tests/coin_address_derivation_test.rs
+++ b/rust/tw_any_coin/tests/coin_address_derivation_test.rs
@@ -91,6 +91,7 @@ fn test_coin_address_derivation() {
             | CoinType::Blast
             | CoinType::BounceBit
             | CoinType::ZkLinkNova
+            | CoinType::BitYuan
             // end_of_evm_address_derivation_tests_marker_do_not_modify
                 => "0xAc1ec44E4f0ca7D172B7803f6836De87Fb72b309",
             CoinType::Bitcoin => "bc1qten42eesehw0ktddcp0fws7d3ycsqez3f7d5yt",

--- a/tests/chains/BitYuan/TWCoinTypeTests.cpp
+++ b/tests/chains/BitYuan/TWCoinTypeTests.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+
+#include "TestUtilities.h"
+#include <TrustWalletCore/TWCoinTypeConfiguration.h>
+#include <gtest/gtest.h>
+
+TEST(TWBitYuanCoinType, TWCoinType) {
+    const auto coin = TWCoinTypeBitYuan;
+    const auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(coin));
+    const auto id = WRAPS(TWCoinTypeConfigurationGetID(coin));
+    const auto name = WRAPS(TWCoinTypeConfigurationGetName(coin));
+    const auto txId = WRAPS(TWStringCreateWithUTF8Bytes("0x08e67624a7a9fbec2af3ab37dac17b15a1facf56dd3806d7d84e95abb333a468"));
+    const auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(coin, txId.get()));
+    const auto accId = WRAPS(TWStringCreateWithUTF8Bytes("0x944880ad48b7e351513857701b39be968fd18d5b"));
+    const auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(coin, accId.get()));
+
+    assertStringsEqual(id, "bityuan");
+    assertStringsEqual(name, "BitYuan Mainnet");
+    assertStringsEqual(symbol, "BTY");
+    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(coin), 18);
+    ASSERT_EQ(TWCoinTypeBlockchain(coin), TWBlockchainBitYuan);
+    ASSERT_EQ(TWCoinTypeP2pkhPrefix(coin), 0);
+    ASSERT_EQ(TWCoinTypeP2shPrefix(coin), 0);
+    ASSERT_EQ(TWCoinTypeStaticPrefix(coin), 0);
+    assertStringsEqual(txUrl, "https://mainnet.bityuan.com/tx/0x08e67624a7a9fbec2af3ab37dac17b15a1facf56dd3806d7d84e95abb333a468");
+    assertStringsEqual(accUrl, "https://mainnet.bityuan.com/address/0x944880ad48b7e351513857701b39be968fd18d5b");
+}

--- a/tests/common/CoinAddressDerivationTests.cpp
+++ b/tests/common/CoinAddressDerivationTests.cpp
@@ -89,6 +89,7 @@ TEST(Coin, DeriveAddress) {
         case TWCoinTypeBlast:
         case TWCoinTypeBounceBit:
         case TWCoinTypeZkLinkNova:
+        case TWCoinTypeBitYuan:
             // end_of_evm_address_derivation_tests_marker_do_not_modify
             EXPECT_EQ(address, "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F");
             break;


### PR DESCRIPTION
## Description

BITYUAN is a decentralized blockchain, which aims to build the strongest parachain alliance link to the world and an integrated ecosystem with global quality projects.
Bityuan (BTY) is a simple, stable, and highly expandable public chain network. The research and development of the Bityuan blockchain is based on the Chain33 bottom architecture and Bityuan is the world's first public chain project with a multi-chain (parachain) architecture that has been implemented. Multiple public chains can be developed on the Bityuan blockchain in parallel to expand performance and improve security.

## How to test
## Types of changes
## Checklist

- [ ] Create pull request as draft initially, unless its complete.
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
- [ ] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
