### PR TITLE
fix: Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install some basics
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y \
         wget \
         curl \
@@ -23,7 +24,7 @@ RUN apt-get update \
         libtool autoconf pkg-config \
         ninja-build \
         ruby-full \
-        clang-14 \
+        clang \
         llvm-14 \
         libc++-dev libc++abi-dev \
         cmake \
@@ -47,6 +48,9 @@ RUN cargo install --force cbindgen \
 
 COPY . /wallet-core
 WORKDIR /wallet-core
+
+# Clean CMakeCache before CMake execution
+RUN rm -rf /wallet-core/protobuf-plugin/build/CMakeCache.txt
 
 # Install dependencies
 RUN tools/install-dependencies


### PR DESCRIPTION
## Description

Fixed the Dockerfile, which previously failed to build and run tests correctly inside the Docker container. The changes ensure that the Docker environment is properly set up to handle both tasks without errors.

## How to test

Build the Docker image using the command `docker build -t wallet-core-dev .` and verify that it completes without errors.
`docker run -i -t wallet-core-dev /bin/bash`
`./tools/build-and-test`

## Types of changes

- *Bug fix* 


## Checklist


- [x] Create pull request as draft initially, unless its complete.
- [ ] Add tests to cover changes as needed.
- [x] Update documentation as needed. (There is another PR in developer repo https://github.com/trustwallet/developer/pull/358 )
- [ ] If there is a related Issue, mention it in the description.
