### PR TITLE
[Security]: Generate random salt when creating/importing new wallet

### DIFF
--- a/src/Keystore/EncryptionParameters.h
+++ b/src/Keystore/EncryptionParameters.h
@@ -22,13 +22,13 @@ struct EncryptionParameters {
     static EncryptionParameters getPreset(enum TWStoredKeyEncryptionLevel preset, enum TWStoredKeyEncryption encryption = TWStoredKeyEncryptionAes128Ctr) {
         switch (preset) {
         case TWStoredKeyEncryptionLevelMinimal:
-            return EncryptionParameters(AESParameters::AESParametersFromEncryption(encryption), ScryptParameters::Minimal);
+            return { AESParameters::AESParametersFromEncryption(encryption), ScryptParameters::minimal() };
         case TWStoredKeyEncryptionLevelWeak:
         case TWStoredKeyEncryptionLevelDefault:
         default:
-            return EncryptionParameters(AESParameters::AESParametersFromEncryption(encryption), ScryptParameters::Weak);
+            return { AESParameters::AESParametersFromEncryption(encryption), ScryptParameters::weak() };
         case TWStoredKeyEncryptionLevelStandard:
-            return EncryptionParameters(AESParameters::AESParametersFromEncryption(encryption), ScryptParameters::Standard);
+            return { AESParameters::AESParametersFromEncryption(encryption), ScryptParameters::standard() };
         }
     }
 
@@ -54,7 +54,7 @@ struct EncryptionParameters {
     }
 
     /// Initializes with a JSON object.
-    EncryptionParameters(const nlohmann::json& json);
+    explicit EncryptionParameters(const nlohmann::json& json);
 
     /// Saves `this` as a JSON object.
     nlohmann::json json() const;
@@ -91,7 +91,7 @@ public:
     EncryptedPayload() = default;
 
     /// Initializes with standard values.
-    EncryptedPayload(const EncryptionParameters& params, const Data& encrypted, const Data& mac)
+    EncryptedPayload(EncryptionParameters  params, Data encrypted, Data mac)
         : params(std::move(params))
         , encrypted(std::move(encrypted))
         , _mac(std::move(mac)) {}
@@ -101,7 +101,7 @@ public:
     EncryptedPayload(const Data& password, const Data& data, const EncryptionParameters& params);
 
     /// Initializes with a JSON object.
-    EncryptedPayload(const nlohmann::json& json);
+    explicit EncryptedPayload(const nlohmann::json& json);
 
     /// Decrypts the payload with the given password.
     Data decrypt(const Data& password) const;

--- a/src/Keystore/ScryptParameters.cpp
+++ b/src/Keystore/ScryptParameters.cpp
@@ -11,13 +11,30 @@ using namespace TW;
 
 namespace TW::Keystore {
 
-ScryptParameters ScryptParameters::Minimal = ScryptParameters(Data(), minimalN, defaultR, minimalP, defaultDesiredKeyLength);
-ScryptParameters ScryptParameters::Weak = ScryptParameters(Data(), weakN, defaultR, weakP, defaultDesiredKeyLength);
-ScryptParameters ScryptParameters::Standard = ScryptParameters(Data(), standardN, defaultR, standardP, defaultDesiredKeyLength);
+namespace internal {
+
+Data randomSalt() {
+    Data salt(32);
+    random_buffer(salt.data(), salt.size());
+    return salt;
+}
+
+} // namespace internal
+
+ScryptParameters ScryptParameters::minimal() {
+    return { internal::randomSalt(), minimalN, defaultR, minimalP, defaultDesiredKeyLength };
+}
+
+ScryptParameters ScryptParameters::weak() {
+    return { internal::randomSalt(), weakN, defaultR, weakP, defaultDesiredKeyLength };
+}
+
+ScryptParameters ScryptParameters::standard() {
+    return { internal::randomSalt(), standardN, defaultR, standardP, defaultDesiredKeyLength };
+}
 
 ScryptParameters::ScryptParameters()
-    : salt(32) {
-    random_buffer(salt.data(), salt.size());
+    : salt(internal::randomSalt()) {
 }
 
 #pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"

--- a/src/Keystore/ScryptParameters.h
+++ b/src/Keystore/ScryptParameters.h
@@ -21,10 +21,6 @@ enum class ScryptValidationError {
 
 /// Scrypt function parameters.
 struct ScryptParameters {
-    static ScryptParameters Minimal;
-    static ScryptParameters Weak;
-    static ScryptParameters Standard;
-
     /// The N and P parameters of Scrypt encryption algorithm, using 256MB memory and
     /// taking approximately 1s CPU time on a modern processor.
     static const uint32_t standardN = 1 << 18;
@@ -59,13 +55,20 @@ struct ScryptParameters {
     /// Block size factor.
     uint32_t r = defaultR;
 
+    /// Generates Scrypt encryption parameters with the minimal sufficient level (4096), and with a random salt.
+    static ScryptParameters minimal();
+    /// Generates Scrypt encryption parameters with the weak sufficient level (16k), and with a random salt.
+    static ScryptParameters weak();
+    /// Generates Scrypt encryption parameters with the standard sufficient level (262k), and with a random salt.
+    static ScryptParameters standard();
+
     /// Initializes with default scrypt parameters and a random salt.
     ScryptParameters();
 
     /// Initializes `ScryptParameters` with all values.
     ///
     /// @throws ScryptValidationError if the parameters are invalid.
-    ScryptParameters(const Data& salt, uint32_t n, uint32_t r, uint32_t p, std::size_t desiredKeyLength)
+    ScryptParameters(Data salt, uint32_t n, uint32_t r, uint32_t p, std::size_t desiredKeyLength)
         : salt(std::move(salt)), desiredKeyLength(desiredKeyLength), n(n), p(p), r(r) {
         auto error = validate();
         if (error) {
@@ -79,7 +82,7 @@ struct ScryptParameters {
     std::optional<ScryptValidationError> validate() const;
 
     /// Initializes `ScryptParameters` with a JSON object.
-    ScryptParameters(const nlohmann::json& json);
+    explicit ScryptParameters(const nlohmann::json& json);
 
     /// Saves `this` as a JSON object.
     nlohmann::json json() const;


### PR DESCRIPTION
## Description

Starting from Nov 23, 2021 at https://github.com/trustwallet/wallet-core/commit/e11018827441c496bed0153ea8fa183558aa5a4b, WalletCore always uses empty salt for PrivateKey/Mnemonic encryption.
This PR changes the behaviour to always generate random salt on creating/importing new wallets.

## How to test

Run C++, iOS, Android tests

## Types of changes

* Remove `ScryptEncryption::Minimal`, `ScryptEncryption::Weak`, `ScryptEncryption::Standard` constants
* Add `ScryptEncryption::minimal()`, `ScryptEncryption::weak()`, `ScryptEncryption::standard()` constructors that always generate random salt

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
