### PR TITLE
[Bitcoin]: Add support for Taproot address generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ codegen-v2/bindings/
 src/Generated/*.cpp
 include/TrustWalletCore/TWHRP.h
 include/TrustWalletCore/TW*Proto.h
-include/TrustWalletCore/TWDerivation.h
 include/TrustWalletCore/TWEthereumChainID.h
 
 # Wasm

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/TestCoinType.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/TestCoinType.kt
@@ -54,6 +54,8 @@ class TestCoinType {
         assertEquals(res, "m/84'/0'/0'/0/0")
         res = CoinType.createFromValue(CoinType.BITCOIN.value()).derivationPathWithDerivation(Derivation.BITCOINLEGACY).toString()
         assertEquals(res, "m/44'/0'/0'/0/0")
+        res = CoinType.createFromValue(CoinType.BITCOIN.value()).derivationPathWithDerivation(Derivation.BITCOINTAPROOT).toString()
+        assertEquals(res, "m/86'/0'/0'/0/0")
         res = CoinType.createFromValue(CoinType.SOLANA.value()).derivationPathWithDerivation(Derivation.SOLANASOLANA).toString()
         assertEquals(res, "m/44'/501'/0'/0'")
     }

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestAnyAddress.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestAnyAddress.kt
@@ -58,6 +58,9 @@ class TestAnyAddress {
 
         val address2 = AnyAddress(pubkey, coin, Derivation.BITCOINLEGACY)
         assertEquals(address2.description(), "1JvRfEQFv5q5qy9uTSAezH7kVQf4hqnHXx")
+
+        val address3 = AnyAddress(pubkey, coin, Derivation.BITCOINTAPROOT)
+        assertEquals(address3.description(), "bc1pnncpg8s7gu7t6xmmzxqarcj8ydthmaz8gr4m76eephjfprs53maswgel0w")
     }
 
     @Test

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestHDWallet.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/utils/TestHDWallet.kt
@@ -121,6 +121,9 @@ class TestHDWallet {
 
         val key3 = wallet.getKeyDerivation(coin, Derivation.BITCOINTESTNET)
         assertEquals(key3.data().toHex(), "0xca5845e1b43e3adf577b7f110b60596479425695005a594c88f9901c3afe864f")
+
+        val key4 = wallet.getKeyDerivation(coin, Derivation.BITCOINTAPROOT)
+        assertEquals(key4.data().toHex(), "0xa2c4d6df786f118f20330affd65d248ffdc0750ae9cbc729d27c640302afd030")
     }
 
     @Test
@@ -145,6 +148,9 @@ class TestHDWallet {
 
         val address3 = wallet.getAddressDerivation(coin, Derivation.BITCOINTESTNET)
         assertEquals(address3, "tb1qwgpxgwn33z3ke9s7q65l976pseh4edrzfmyvl0")
+
+        val address4 = wallet.getAddressDerivation(coin, Derivation.BITCOINTAPROOT)
+        assertEquals(address4, "bc1pgqks0cynn93ymve4x0jq3u7hne77908nlysp289hc44yc4cmy0hslyckrz")
     }
 
     @Test

--- a/codegen/bin/coins
+++ b/codegen/bin/coins
@@ -4,6 +4,10 @@ require 'erb'
 require 'fileutils'
 require 'json'
 
+CurrentDir = File.dirname(__FILE__)
+$LOAD_PATH.unshift(File.join(CurrentDir, '..', 'lib'))
+require 'derivation'
+
 # Transforms a coin name to a C++ name
 def self.format_name(n)
   formatted = n
@@ -18,22 +22,8 @@ def self.coin_name(coin)
   coin['displayName'] || coin['name']
 end
 
-def self.derivation_path(coin)
-  coin['derivation'][0]['path']
-end
-
 def self.camel_case(id)
   id[0].upcase + id[1..].downcase
-end
-
-def self.derivation_name(deriv)
-  return "" if deriv['name'].nil?
-  deriv['name'].downcase
-end
-
-def self.derivation_enum_name(deriv, coin)
-  return "TWDerivationDefault" if deriv['name'].nil?
-  "TWDerivation" + format_name(coin['name']) + camel_case(deriv['name'])
 end
 
 def self.coin_img(coin)
@@ -55,13 +45,15 @@ coins = JSON.parse(json_string).sort_by { |x| x['coinId'] }
 enum_count = 0
 
 erbs = [
-  {'template' => 'TWDerivation.h.erb', 'folder' => 'include/TrustWalletCore', 'file' => 'TWDerivation.h'},
   {'template' => 'CoinInfoData.cpp.erb', 'folder' => 'src/Generated', 'file' => 'CoinInfoData.cpp'},
   {'template' => 'registry.md.erb', 'folder' => 'docs', 'file' => 'registry.md'},
   {'template' => 'hrp.cpp.erb', 'folder' => 'src/Generated', 'file' => 'TWHRP.cpp'},
   {'template' => 'hrp.h.erb', 'folder' => 'include/TrustWalletCore', 'file' => 'TWHRP.h'},
   {'template' => 'TWEthereumChainID.h.erb', 'folder' => 'include/TrustWalletCore', 'file' => 'TWEthereumChainID.h'}
 ]
+
+# Update coins derivations if changed.
+update_derivation_enum(coins)
 
 FileUtils.mkdir_p File.join('src', 'Generated')
 erbs.each do |erb|

--- a/codegen/lib/coin_skeleton_gen.rb
+++ b/codegen/lib/coin_skeleton_gen.rb
@@ -7,6 +7,7 @@ require 'json'
 require 'entity_decl'
 require 'code_generator'
 require 'coin_test_gen'
+require 'file_editor'
 
 # Coin template generation
 
@@ -68,26 +69,6 @@ def insert_coin_entry(coin)
     insert_target_line(target_file, target_line, "// end_of_coin_dipatcher_declarations_marker_do_not_modify\n")
     target_line = "        case TWBlockchain#{entryName}: entry = &#{entryName}DP; break;" + $flag_comment + "\n"
     insert_target_line(target_file, target_line, "        // end_of_coin_dipatcher_switch_marker_do_not_modify\n")
-end
-
-def self.insert_target_line(target_file, target_line, original_line)
-    lines = File.readlines(target_file)
-    index = lines.index(target_line)
-    if !index.nil?
-        puts "Line is already present, file: #{target_file}  line: #{target_line}"
-        return true
-    end
-    index = lines.index(original_line)
-    if index.nil?
-        puts "WARNING: Could not find line! file: #{target_file}  line: #{original_line}"
-        return false
-    end
-    lines.insert(index, target_line)
-    File.open(target_file, "w+") do |f|
-        f.puts(lines)
-    end
-    puts "Updated file: #{target_file}  new line: #{target_line}"
-    return true
 end
 
 def generate_blockchain_files(coin)

--- a/codegen/lib/derivation.rb
+++ b/codegen/lib/derivation.rb
@@ -3,6 +3,7 @@
 require 'file_editor'
 
 $derivation_file = "include/TrustWalletCore/TWDerivation.h"
+$derivation_file_rust = "rust/tw_coin_registry/src/tw_derivation.rs"
 
 # Returns a derivation name if specified.
 def derivation_name(deriv)
@@ -10,22 +11,27 @@ def derivation_name(deriv)
   deriv['name'].downcase
 end
 
+# Returns a string of `<Coin><Derivation>` if derivation's name is specified, otherwise returns `Default`.
+def derivation_enum_name_no_prefix(deriv, coin)
+  return "Default" if deriv['name'].nil?
+  format_name(coin['name']) + camel_case(deriv['name'])
+end
+
+# Returns a string of `TWDerivation<Coin><Derivation>` if derivation's name is specified, otherwise returns `TWDerivationDefault`.
+def derivation_enum_name(deriv, coin)
+  return "TWDerivation" + derivation_enum_name_no_prefix(deriv, coin)
+end
+
 # Returns a derivation path.
 def derivation_path(coin)
   coin['derivation'][0]['path']
 end
 
-# Returns a `TWDerivation<X>` if derivation's name is specified, otherwise returns `TWDerivationDefault`
-def derivation_enum_name(deriv, coin)
-  return "TWDerivationDefault" if deriv['name'].nil?
-  "TWDerivation" + format_name(coin['name']) + camel_case(deriv['name'])
-end
-
 # Get the last `TWDerivation` enum variant ID.
-def get_last_derivation()
+def get_last_derivation(file_path)
   last_derivation_id = nil
 
-  File.open($derivation_file, "r") do |file|
+  File.open(file_path, "r") do |file|
     file.each_line do |line|
       # Match lines that define a TWDerivation enum value
       if line =~ /TWDerivation\w+\s*=\s*(\d+),/
@@ -38,8 +44,8 @@ def get_last_derivation()
 end
 
 # Returns whether the TWDerivation enum contains the given `derivation` variant.
-def find_derivation(derivation)
-  File.open($derivation_file, "r") do |file|
+def find_derivation(file_path, derivation)
+  File.open(file_path, "r") do |file|
     file.each_line do |line|
       return true if line.include?(derivation)
     end
@@ -48,10 +54,9 @@ def find_derivation(derivation)
 end
 
 # Insert a new `TWDerivation<X> = N,` to the end of the enum.
-def insert_derivation(derivation)
-  new_derivation_id = get_last_derivation() + 1
-  target_line = "    #{derivation} = #{new_derivation_id},"
-  insert_target_line($derivation_file, target_line, "};\n")
+def insert_derivation(file_path, derivation, derivation_id)
+  target_line = "    #{derivation} = #{derivation_id},"
+  insert_target_line(file_path, target_line, "    // end_of_derivation_enum - USED TO GENERATE CODE\n")
 end
 
 # Update TWDerivation enum variants if new derivation appeared.
@@ -59,8 +64,12 @@ def update_derivation_enum(coins)
   coins.each do |coin|
     coin['derivation'].each_with_index do |deriv, index|
       deriv_name = derivation_enum_name(deriv, coin)
-      if !find_derivation(deriv_name)
-        insert_derivation(deriv_name)
+      if !find_derivation($derivation_file, deriv_name)
+        new_derivation_id = get_last_derivation($derivation_file) + 1
+        insert_derivation($derivation_file, deriv_name, new_derivation_id)
+
+        rust_deriv_name = derivation_enum_name_no_prefix(deriv, coin)
+        insert_derivation($derivation_file_rust, rust_deriv_name, new_derivation_id)
       end
     end
   end

--- a/codegen/lib/derivation.rb
+++ b/codegen/lib/derivation.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'file_editor'
+
+$derivation_file = "include/TrustWalletCore/TWDerivation.h"
+
+# Returns a derivation name if specified.
+def derivation_name(deriv)
+  return "" if deriv['name'].nil?
+  deriv['name'].downcase
+end
+
+# Returns a derivation path.
+def derivation_path(coin)
+  coin['derivation'][0]['path']
+end
+
+# Returns a `TWDerivation<X>` if derivation's name is specified, otherwise returns `TWDerivationDefault`
+def derivation_enum_name(deriv, coin)
+  return "TWDerivationDefault" if deriv['name'].nil?
+  "TWDerivation" + format_name(coin['name']) + camel_case(deriv['name'])
+end
+
+# Get the last `TWDerivation` enum variant ID.
+def get_last_derivation()
+  last_derivation_id = nil
+
+  File.open($derivation_file, "r") do |file|
+    file.each_line do |line|
+      # Match lines that define a TWDerivation enum value
+      if line =~ /TWDerivation\w+\s*=\s*(\d+),/
+        last_derivation_id = $1.to_i
+      end
+    end
+  end
+
+  last_derivation_id
+end
+
+# Returns whether the TWDerivation enum contains the given `derivation` variant.
+def find_derivation(derivation)
+  File.open($derivation_file, "r") do |file|
+    file.each_line do |line|
+      return true if line.include?(derivation)
+    end
+  end
+  return false
+end
+
+# Insert a new `TWDerivation<X> = N,` to the end of the enum.
+def insert_derivation(derivation)
+  new_derivation_id = get_last_derivation() + 1
+  target_line = "    #{derivation} = #{new_derivation_id},"
+  insert_target_line($derivation_file, target_line, "};\n")
+end
+
+# Update TWDerivation enum variants if new derivation appeared.
+def update_derivation_enum(coins)
+  coins.each do |coin|
+    coin['derivation'].each_with_index do |deriv, index|
+      deriv_name = derivation_enum_name(deriv, coin)
+      if !find_derivation(deriv_name)
+        insert_derivation(deriv_name)
+      end
+    end
+  end
+end

--- a/codegen/lib/file_editor.rb
+++ b/codegen/lib/file_editor.rb
@@ -1,0 +1,19 @@
+def insert_target_line(target_file, target_line, original_line)
+  lines = File.readlines(target_file)
+  index = lines.index(target_line)
+  if !index.nil?
+      puts "Line is already present, file: #{target_file}  line: #{target_line}"
+      return true
+  end
+  index = lines.index(original_line)
+  if index.nil?
+      puts "WARNING: Could not find line! file: #{target_file}  line: #{original_line}"
+      return false
+  end
+  lines.insert(index, target_line)
+  File.open(target_file, "w+") do |f|
+      f.puts(lines)
+  end
+  puts "Updated file: #{target_file}  new line: #{target_line}"
+  return true
+end

--- a/include/TrustWalletCore/TWDerivation.h
+++ b/include/TrustWalletCore/TWDerivation.h
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+//
+// This is a GENERATED FILE from \registry.json, changes made here WILL BE LOST.
+//
+
+#pragma once
+
+#include "TWBase.h"
+
+TW_EXTERN_C_BEGIN
+
+/// Non-default coin address derivation names (default, unnamed derivations are not included).
+TW_EXPORT_ENUM()
+enum TWDerivation {
+    TWDerivationDefault = 0, // default, for any coin
+    TWDerivationCustom = 1, // custom, for any coin
+    TWDerivationBitcoinSegwit = 2,
+    TWDerivationBitcoinLegacy = 3,
+    TWDerivationBitcoinTestnet = 4,
+    TWDerivationLitecoinLegacy = 5,
+    TWDerivationSolanaSolana = 6,
+    TWDerivationStratisSegwit = 7,
+    TWDerivationBitcoinTaproot = 8,
+};
+
+TW_EXTERN_C_END

--- a/include/TrustWalletCore/TWDerivation.h
+++ b/include/TrustWalletCore/TWDerivation.h
@@ -12,6 +12,8 @@
 TW_EXTERN_C_BEGIN
 
 /// Non-default coin address derivation names (default, unnamed derivations are not included).
+/// Note the enum variant must be sync with `TWDerivation` enum in Rust:
+/// https://github.com/trustwallet/wallet-core/blob/master/rust/tw_coin_registry/src/tw_derivation.rs
 TW_EXPORT_ENUM()
 enum TWDerivation {
     TWDerivationDefault = 0, // default, for any coin
@@ -23,6 +25,7 @@ enum TWDerivation {
     TWDerivationSolanaSolana = 6,
     TWDerivationStratisSegwit = 7,
     TWDerivationBitcoinTaproot = 8,
+    // end_of_derivation_enum - USED TO GENERATE CODE
 };
 
 TW_EXTERN_C_END

--- a/include/TrustWalletCore/TWPurpose.h
+++ b/include/TrustWalletCore/TWPurpose.h
@@ -18,6 +18,7 @@ enum TWPurpose {
     TWPurposeBIP44 = 44,
     TWPurposeBIP49 = 49, // Derivation scheme for P2WPKH-nested-in-P2SH
     TWPurposeBIP84 = 84, // Derivation scheme for P2WPKH
+    TWPurposeBIP86 = 86, // Derivation scheme for P2TR
     TWPurposeBIP1852 = 1852, // Derivation scheme used by Cardano-Shelley
 };
 

--- a/registry.json
+++ b/registry.json
@@ -24,6 +24,12 @@
         "path": "m/84'/1'/0'/0/0",
         "xpub": "zpub",
         "xprv": "zprv"
+      },
+      {
+        "name": "taproot",
+        "path": "m/86'/0'/0'/0/0",
+        "xpub": "zpub",
+        "xprv": "zprv"
       }
     ],
     "curve": "secp256k1",

--- a/rust/frameworks/tw_utxo/src/address/derivation.rs
+++ b/rust/frameworks/tw_utxo/src/address/derivation.rs
@@ -6,10 +6,12 @@ use tw_coin_entry::coin_context::CoinContext;
 use tw_coin_entry::derivation::{ChildIndex, Derivation};
 
 pub const SEGWIT_DERIVATION_PATH_TYPE: ChildIndex = ChildIndex::Hardened(84);
+pub const TAPROOT_DERIVATION_PATH_TYPE: ChildIndex = ChildIndex::Hardened(86);
 
 pub enum BitcoinDerivation {
     Legacy,
     Segwit,
+    Taproot,
 }
 
 impl BitcoinDerivation {
@@ -23,6 +25,7 @@ impl BitcoinDerivation {
             Derivation::Default | Derivation::Testnet => (),
             Derivation::Segwit => return BitcoinDerivation::Segwit,
             Derivation::Legacy => return BitcoinDerivation::Legacy,
+            Derivation::Taproot => return BitcoinDerivation::Taproot,
         }
 
         let Some(default_derivation) = coin.derivations().first() else {
@@ -32,8 +35,12 @@ impl BitcoinDerivation {
 
         match default_derivation.name {
             Derivation::Segwit => BitcoinDerivation::Segwit,
+            Derivation::Taproot => BitcoinDerivation::Taproot,
             Derivation::Default if derivation_path_type == Some(SEGWIT_DERIVATION_PATH_TYPE) => {
                 BitcoinDerivation::Segwit
+            },
+            Derivation::Default if derivation_path_type == Some(TAPROOT_DERIVATION_PATH_TYPE) => {
+                BitcoinDerivation::Taproot
             },
             Derivation::Default | Derivation::Legacy | Derivation::Testnet => {
                 BitcoinDerivation::Legacy
@@ -47,6 +54,13 @@ impl BitcoinDerivation {
         coin.derivations().iter().any(|der| {
             der.name == Derivation::Segwit
                 || der.path.path().first().copied() == Some(SEGWIT_DERIVATION_PATH_TYPE)
+        })
+    }
+
+    pub fn tw_supports_taproot(coin: &dyn CoinContext) -> bool {
+        coin.derivations().iter().any(|der| {
+            der.name == Derivation::Taproot
+                || der.path.path().first().copied() == Some(TAPROOT_DERIVATION_PATH_TYPE)
         })
     }
 }

--- a/rust/frameworks/tw_utxo/src/address/standard_bitcoin.rs
+++ b/rust/frameworks/tw_utxo/src/address/standard_bitcoin.rs
@@ -82,8 +82,10 @@ impl StandardBitcoinAddress {
             if let Ok(segwit) = SegwitAddress::from_str_with_coin_and_prefix(coin, s, None) {
                 return Ok(StandardBitcoinAddress::Segwit(segwit));
             }
+        }
 
-            // TODO use `BitcoinDerivation::tw_supports_taproot` based on `registry.json`.
+        // Try to parse a Taproot address if the coin supports it.
+        if BitcoinDerivation::tw_supports_taproot(coin) {
             if let Ok(taproot) = TaprootAddress::from_str_with_coin_and_prefix(coin, s, None) {
                 return Ok(StandardBitcoinAddress::Taproot(taproot));
             }
@@ -126,6 +128,11 @@ impl StandardBitcoinAddress {
             BitcoinDerivation::Segwit => {
                 SegwitAddress::p2wpkh_with_coin_and_prefix(coin, public_key, None)
                     .map(StandardBitcoinAddress::Segwit)
+            },
+            BitcoinDerivation::Taproot => {
+                let no_merkle_root = None;
+                TaprootAddress::p2tr_with_coin_and_prefix(coin, public_key, None, no_merkle_root)
+                    .map(StandardBitcoinAddress::Taproot)
             },
         }
     }

--- a/rust/tw_any_coin/src/test_utils/address_utils.rs
+++ b/rust/tw_any_coin/src/test_utils/address_utils.rs
@@ -30,6 +30,15 @@ impl WithDestructor for TWAnyAddress {
 }
 
 pub fn test_address_derive(coin: CoinType, private_key: &str, address: &str) {
+    test_address_derive_with_derivation(coin, private_key, address, TWDerivation::Default)
+}
+
+pub fn test_address_derive_with_derivation(
+    coin: CoinType,
+    private_key: &str,
+    address: &str,
+    derivation: TWDerivation,
+) {
     let coin_item = get_coin_item(coin).unwrap();
 
     let private_key = TWPrivateKeyHelper::with_hex(private_key);
@@ -41,7 +50,7 @@ pub fn test_address_derive(coin: CoinType, private_key: &str, address: &str) {
         tw_any_address_create_with_public_key_derivation(
             public_key.ptr(),
             coin as u32,
-            TWDerivation::Default as u32,
+            derivation as u32,
         )
     });
 

--- a/rust/tw_coin_entry/src/derivation.rs
+++ b/rust/tw_coin_entry/src/derivation.rs
@@ -23,6 +23,7 @@ pub enum Derivation {
     Segwit,
     Legacy,
     Testnet,
+    Taproot,
     /// Default derivation.
     #[default]
     #[serde(other)]

--- a/rust/tw_coin_registry/src/tw_derivation.rs
+++ b/rust/tw_coin_registry/src/tw_derivation.rs
@@ -16,7 +16,9 @@ pub enum TWDerivation {
     BitcoinTestnet = 4,
     LitecoinLegacy = 5,
     SolanaSolana = 6,
-    /// Default derivation.
+    StratisSegwit = 7,
+    BitcoinTaproot = 8,
+    // end_of_derivation_enum - USED TO GENERATE CODE
     #[default]
     Default = 0,
 }
@@ -25,10 +27,11 @@ impl From<TWDerivation> for Derivation {
     fn from(derivation: TWDerivation) -> Self {
         match derivation {
             TWDerivation::Default | TWDerivation::Custom => Derivation::Default,
-            TWDerivation::BitcoinSegwit => Derivation::Segwit,
+            TWDerivation::BitcoinSegwit | TWDerivation::StratisSegwit => Derivation::Segwit,
             TWDerivation::BitcoinLegacy | TWDerivation::LitecoinLegacy => Derivation::Legacy,
             TWDerivation::BitcoinTestnet => Derivation::Testnet,
             TWDerivation::SolanaSolana => Derivation::Default,
+            TWDerivation::BitcoinTaproot => Derivation::Taproot,
         }
     }
 }

--- a/rust/tw_tests/tests/chains/bitcoin/bitcoin_address.rs
+++ b/rust/tw_tests/tests/chains/bitcoin/bitcoin_address.rs
@@ -5,12 +5,57 @@
 use tw_any_coin::test_utils::address_utils::{
     test_address_base58_is_valid, test_address_bech32_is_valid,
     test_address_create_base58_with_public_key, test_address_create_bech32_with_public_key,
-    test_address_get_data, test_address_invalid, test_address_normalization, test_address_valid,
-    AddressBase58IsValid, AddressBech32IsValid, AddressCreateBase58WithPublicKey,
-    AddressCreateBech32WithPublicKey,
+    test_address_derive, test_address_derive_with_derivation, test_address_get_data,
+    test_address_invalid, test_address_normalization, test_address_valid, AddressBase58IsValid,
+    AddressBech32IsValid, AddressCreateBase58WithPublicKey, AddressCreateBech32WithPublicKey,
 };
 use tw_coin_registry::coin_type::CoinType;
+use tw_coin_registry::tw_derivation::TWDerivation;
 use tw_keypair::tw::PublicKeyType;
+
+#[test]
+fn test_bitcoin_address_derive() {
+    // Segwit address by default.
+    test_address_derive(
+        CoinType::Bitcoin,
+        "a26b7ffda8ad29cf3aba066cc43ce255cb13b3fba5fa9b638f4685333e3670fd",
+        "bc1qj7uu67l9zkajuhx976d8fvj2ylc29gnq3kjm3r",
+    );
+    // Explicit Legacy address.
+    test_address_derive_with_derivation(
+        CoinType::Bitcoin,
+        "a8212108f1f2a42b18b642c2dbe6e388e75de89ca7be9b6f7648bab06cdedabf",
+        "1JspsmYcHGLjRDavb62hodTb7BW8GGia7v",
+        TWDerivation::BitcoinLegacy,
+    );
+    // Explicit Segwit address.
+    test_address_derive_with_derivation(
+        CoinType::Bitcoin,
+        "a26b7ffda8ad29cf3aba066cc43ce255cb13b3fba5fa9b638f4685333e3670fd",
+        "bc1qj7uu67l9zkajuhx976d8fvj2ylc29gnq3kjm3r",
+        TWDerivation::BitcoinSegwit,
+    );
+
+    // Explicit Taproot addresses.
+    test_address_derive_with_derivation(
+        CoinType::Bitcoin,
+        "e5bbc9cab0ff9ec86889bcd84d79ca484b017763614cd4fa3bf4aa49ad9d55a9",
+        "bc1pkup60ng64cthqujp38l57y0eewkyqy35s86tmqjcc5yzgmz9l2gscz37tx",
+        TWDerivation::BitcoinTaproot,
+    );
+    test_address_derive_with_derivation(
+        CoinType::Bitcoin,
+        "ae39965b1e73944763eb8ddaeb126d9cbde772a5c141e3ad5791f8e7f094a089",
+        "bc1plvzy756f4t2p32n29jy9vrqcrj46g5yka7u7e89tkeufx5urgyss38y98d",
+        TWDerivation::BitcoinTaproot,
+    );
+    test_address_derive_with_derivation(
+        CoinType::Bitcoin,
+        "e0721275d0f94bf4d0f59bf0bef42179f680e38dfb306e1d0e3c13ab1d797d20",
+        "bc1puu933ez5v6w99w9dqsmwdeajpnrvknc65tlnrdx3xhxwd954mudsa39gum",
+        TWDerivation::BitcoinTaproot,
+    );
+}
 
 #[test]
 fn test_bitcoin_address_normalization() {

--- a/src/Bitcoin/Entry.cpp
+++ b/src/Bitcoin/Entry.cpp
@@ -12,6 +12,8 @@
 
 namespace TW::Bitcoin {
 
+const EntryV2 bitcoinV2Dispatcher;
+
 bool Entry::validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const {
     auto* base58Prefix = std::get_if<Base58Prefix>(&addressPrefix);
     auto* hrp = std::get_if<Bech32Prefix>(&addressPrefix);
@@ -85,6 +87,9 @@ std::string Entry::deriveAddress(TWCoinType coin, const PublicKey& publicKey, TW
 
         case TWDerivationBitcoinTestnet:
             return SegwitAddress::createTestnetFromPublicKey(publicKey).string();
+
+        case TWDerivationBitcoinTaproot:
+            return bitcoinV2Dispatcher.deriveAddress(coin, publicKey, derivation, addressPrefix);
 
         case TWDerivationBitcoinSegwit:
         case TWDerivationDefault:

--- a/src/Bitcoin/Entry.h
+++ b/src/Bitcoin/Entry.h
@@ -4,9 +4,15 @@
 
 #pragma once
 
-#include "../CoinEntry.h"
+#include "rust/RustCoinEntry.h"
 
 namespace TW::Bitcoin {
+
+/// A helper Bitcoin Entry migrated to Rust partly used in some cases,
+/// for example, in Taproot address generation.
+/// TODO remove when `Bitcoin` is migrated to Rust completely.
+class EntryV2: public Rust::RustCoinEntry {
+};
 
 /// Bitcoin entry dispatcher.
 /// Note: do not put the implementation here (no matter how simple), to avoid having coin-specific

--- a/swift/Tests/AnyAddressTests.swift
+++ b/swift/Tests/AnyAddressTests.swift
@@ -40,6 +40,9 @@ class AnyAddressTests: XCTestCase {
 
         let address2 = AnyAddress(publicKey: pubkey, coin: coin, derivation: .bitcoinLegacy)
         XCTAssertEqual(address2.description, "1JvRfEQFv5q5qy9uTSAezH7kVQf4hqnHXx")
+        
+        let address3 = AnyAddress(publicKey: pubkey, coin: coin, derivation: .bitcoinTaproot)
+        XCTAssertEqual(address3.description, "bc1pnncpg8s7gu7t6xmmzxqarcj8ydthmaz8gr4m76eephjfprs53maswgel0w")
     }
 
     func testCreateBech32WithPublicKey() {

--- a/swift/Tests/CoinTypeTests.swift
+++ b/swift/Tests/CoinTypeTests.swift
@@ -32,6 +32,7 @@ class CoinTypeTests: XCTestCase {
     func testCoinDerivation() {
         XCTAssertEqual(CoinType.bitcoin.derivationPath(), "m/84'/0'/0'/0/0")
         XCTAssertEqual(CoinType.bitcoin.derivationPathWithDerivation(derivation: Derivation.bitcoinLegacy), "m/44'/0'/0'/0/0")
+        XCTAssertEqual(CoinType.bitcoin.derivationPathWithDerivation(derivation: Derivation.bitcoinTaproot), "m/86'/0'/0'/0/0")
         XCTAssertEqual(CoinType.solana.derivationPathWithDerivation(derivation: Derivation.solanaSolana), "m/44'/501'/0'/0'")
     }
 

--- a/swift/Tests/HDWalletTests.swift
+++ b/swift/Tests/HDWalletTests.swift
@@ -100,6 +100,9 @@ class HDWalletTests: XCTestCase {
 
         let key3 = wallet.getKeyDerivation(coin: coin, derivation: .bitcoinTestnet)
         XCTAssertEqual(key3.data.hexString, "ca5845e1b43e3adf577b7f110b60596479425695005a594c88f9901c3afe864f")
+        
+        let key4 = wallet.getKeyDerivation(coin: coin, derivation: .bitcoinTaproot)
+        XCTAssertEqual(key4.data.hexString, "a2c4d6df786f118f20330affd65d248ffdc0750ae9cbc729d27c640302afd030")
     }
 
     func testGetAddressForCoin() {
@@ -122,6 +125,9 @@ class HDWalletTests: XCTestCase {
 
         let address3 = wallet.getAddressDerivation(coin: coin, derivation: .bitcoinTestnet)
         XCTAssertEqual(address3, "tb1qwgpxgwn33z3ke9s7q65l976pseh4edrzfmyvl0")
+        
+        let address4 = wallet.getAddressDerivation(coin: coin, derivation: .bitcoinTaproot)
+        XCTAssertEqual(address4, "bc1pgqks0cynn93ymve4x0jq3u7hne77908nlysp289hc44yc4cmy0hslyckrz")
     }
 
     func testDerive() {

--- a/swift/Tests/Keystore/KeyStoreTests.swift
+++ b/swift/Tests/Keystore/KeyStoreTests.swift
@@ -437,6 +437,10 @@ class KeyStoreTests: XCTestCase {
         let btc2 = try wallet.getAccount(password: password, coin: .bitcoin, derivation: .bitcoinLegacy)
         XCTAssertEqual(btc2.address, "1NyRyFewhZcWMa9XCj3bBxSXPXyoSg8dKz")
         XCTAssertEqual(btc2.extendedPublicKey, "xpub6CR52eaUuVb4kXAVyHC2i5ZuqJ37oWNPZFtjXaazFPXZD45DwWBYEBLdrF7fmCR9pgBuCA9Q57zZfyJjDUBDNtWkhWuGHNYKLgDHpqrHsxV")
+        
+        let btc3 = try wallet.getAccount(password: password, coin: .bitcoin, derivation: .bitcoinTaproot)
+        XCTAssertEqual(btc3.address, "bc1pyqkqf20fmmwmcxf98tv6k63e2sgnjy4zne6d0r32vxwm3au0hnksq6ec57")
+        XCTAssertEqual(btc3.extendedPublicKey, "zpub6qNRYbLLXquaD1GKxHZWDs3moUFQfP4iqXiDPCd8aD3oNHZkCAusAw5raKQEWV8BkXBTXhWBkgZTxzjjnQ5cRjWa6LNcjmrVVNdUKvbKTgm")
 
         let solana1 = try wallet.getAccount(password: password, coin: .solana, derivation: .default)
         XCTAssertEqual(solana1.address, "HiipoCKL8hX2RVmJTz3vaLy34hS2zLhWWMkUWtw85TmZ")

--- a/tests/chains/Bitcoin/TWAnyAddressTests.cpp
+++ b/tests/chains/Bitcoin/TWAnyAddressTests.cpp
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+
+#include <TrustWalletCore/TWAnyAddress.h>
+#include <TrustWalletCore/TWPrivateKey.h>
+#include <TrustWalletCore/TWPublicKey.h>
+#include "Hash.h"
+#include "PublicKey.h"
+
+#include "TestUtilities.h"
+#include <gtest/gtest.h>
+
+namespace TW::Bitcoin::tests {
+
+void testBitcoinAddressFromPublicKeyDerivation(const char* privateKey, TWDerivation derivation, const char* expectedAddr) {
+    const auto data = DATA(privateKey);
+    const auto privkey = WRAP(TWPrivateKey, TWPrivateKeyCreateWithData(data.get()));
+    const auto pubkey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeyByType(privkey.get(), TWPublicKeyTypeSECP256k1));
+    const auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithPublicKeyDerivation(pubkey.get(), TWCoinTypeBitcoin, derivation));
+    const auto addrDescription = WRAPS(TWAnyAddressDescription(addr.get()));
+    assertStringsEqual(addrDescription, expectedAddr);
+}
+
+TEST(TWBitcoinAnyAddress, CreateFromPublicKey) {
+    testBitcoinAddressFromPublicKeyDerivation(
+        "a26b7ffda8ad29cf3aba066cc43ce255cb13b3fba5fa9b638f4685333e3670fd",
+        TWDerivationDefault,
+        "bc1qj7uu67l9zkajuhx976d8fvj2ylc29gnq3kjm3r"
+    );
+}
+
+TEST(TWBitcoinAnyAddress, CreateFromPublicKeyWithDerivationLegacy) {
+    testBitcoinAddressFromPublicKeyDerivation(
+        "a8212108f1f2a42b18b642c2dbe6e388e75de89ca7be9b6f7648bab06cdedabf",
+        TWDerivationBitcoinLegacy,
+        "1JspsmYcHGLjRDavb62hodTb7BW8GGia7v"
+    );
+}
+
+TEST(TWBitcoinAnyAddress, CreateFromPublicKeyWithDerivationTaproot) {
+    testBitcoinAddressFromPublicKeyDerivation(
+        "e5bbc9cab0ff9ec86889bcd84d79ca484b017763614cd4fa3bf4aa49ad9d55a9",
+        TWDerivationBitcoinTaproot,
+        "bc1pkup60ng64cthqujp38l57y0eewkyqy35s86tmqjcc5yzgmz9l2gscz37tx"
+    );
+    testBitcoinAddressFromPublicKeyDerivation(
+        "ae39965b1e73944763eb8ddaeb126d9cbde772a5c141e3ad5791f8e7f094a089",
+        TWDerivationBitcoinTaproot,
+        "bc1plvzy756f4t2p32n29jy9vrqcrj46g5yka7u7e89tkeufx5urgyss38y98d"
+    );
+    testBitcoinAddressFromPublicKeyDerivation(
+        "e0721275d0f94bf4d0f59bf0bef42179f680e38dfb306e1d0e3c13ab1d797d20",
+        TWDerivationBitcoinTaproot,
+        "bc1puu933ez5v6w99w9dqsmwdeajpnrvknc65tlnrdx3xhxwd954mudsa39gum"
+    );
+}
+
+} // namespace TW::Bitcoin::tests

--- a/tests/chains/Bitcoin/TWBitcoinSigningTests.cpp
+++ b/tests/chains/Bitcoin/TWBitcoinSigningTests.cpp
@@ -693,7 +693,7 @@ TEST(BitcoinSigning, SignDepositBtcToZetaChain) {
     ANY_PLAN(signingInput, plan, TWCoinTypeBitcoin);
     EXPECT_EQ(plan.error(), Common::Proto::SigningError::OK);
     EXPECT_TRUE(plan.has_output_op_return_index());
-    EXPECT_EQ(plan.output_op_return_index().index(), 1);
+    EXPECT_EQ(plan.output_op_return_index().index(), 1u);
 
     *signingInput.mutable_plan() = plan;
     ANY_SIGN(signingInput, TWCoinTypeBitcoin);

--- a/tests/common/Keystore/DerivationPathTests.cpp
+++ b/tests/common/Keystore/DerivationPathTests.cpp
@@ -82,6 +82,8 @@ TEST(Derivation, alternativeDerivation) {
     EXPECT_EQ(std::string(TW::derivationName(TWCoinTypeBitcoin, TWDerivationBitcoinSegwit)), "segwit");
     EXPECT_EQ(TW::derivationPath(TWCoinTypeBitcoin, TWDerivationBitcoinLegacy).string(), "m/44'/0'/0'/0/0");
     EXPECT_EQ(std::string(TW::derivationName(TWCoinTypeBitcoin, TWDerivationBitcoinLegacy)), "legacy");
+    EXPECT_EQ(TW::derivationPath(TWCoinTypeBitcoin, TWDerivationBitcoinTaproot).string(), "m/86'/0'/0'/0/0");
+    EXPECT_EQ(std::string(TW::derivationName(TWCoinTypeBitcoin, TWDerivationBitcoinTaproot)), "taproot");
 
     EXPECT_EQ(TW::derivationPath(TWCoinTypeLitecoin, TWDerivationDefault).string(), "m/84'/2'/0'/0/0");
     EXPECT_EQ(TW::derivationPath(TWCoinTypeLitecoin, TWDerivationLitecoinLegacy).string(), "m/44'/2'/0'/0/0");

--- a/tests/interface/TWHDWalletTests.cpp
+++ b/tests/interface/TWHDWalletTests.cpp
@@ -156,6 +156,13 @@ TEST(HDWallet, GetKeyDerivation) {
         auto publicKeyData = WRAPD(TWPublicKeyData(publicKey.get()));
         assertHexEqual(publicKeyData, "0240ebf906b948281289405317a5eb9a98045af8a8ab5311b2e3060cfb66c507a1");
     }
+    {
+        auto key = WRAP(TWPrivateKey, TWHDWalletGetKeyDerivation(wallet.get(), TWCoinTypeBitcoin, TWDerivationBitcoinTaproot));
+        assertHexEqual(WRAPD(TWPrivateKeyData(key.get())), "a2c4d6df786f118f20330affd65d248ffdc0750ae9cbc729d27c640302afd030");
+        auto publicKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKeySecp256k1(key.get(), true));
+        auto publicKeyData = WRAPD(TWPublicKeyData(publicKey.get()));
+        assertHexEqual(publicKeyData, "026acc6c37789625ecd5ad4ebb7631249dfb9ebc3f82386f187325f54881557b9f");
+    }
 }
 
 TEST(HDWallet, DeriveAddressBitcoin) {
@@ -366,11 +373,15 @@ TEST(HDWallet, ExtendedKeysCustomAccount) {
 
     auto zprv0 = WRAPS(TWHDWalletGetExtendedPrivateKeyAccount(wallet.get(), TWPurposeBIP84, TWCoinTypeBitcoin, TWDerivationBitcoinSegwit, TWHDVersionZPRV, 0));
     assertStringsEqual(zprv0, "zprvAdG4iTXWBoARxkkzNpNh8r6Qag3irQB8PzEMkAFeTRXxHpbF9z4QgEvBRmfvqWvGp42t42nvgGpNgYSJA9iefm1yYNZKEm7z6qUWCroSQnE");
+    auto zprvTaproot = WRAPS(TWHDWalletGetExtendedPrivateKeyAccount(wallet.get(), TWPurposeBIP86, TWCoinTypeBitcoin, TWDerivationBitcoinTaproot, TWHDVersionZPRV, 0));
+    assertStringsEqual(zprvTaproot, "zprvAcMMthTpHWStuMM6r6wLFq5uiZhLN8sZCYyTCQLEF5XWgMtAgobYEqc95nLcWB43pCvLjbEu5HCEa8D5MjxcUdLdaeyQfojS5zpovJT6Swy");
     auto zprv1 = WRAPS(TWHDWalletGetExtendedPrivateKeyAccount(wallet.get(), TWPurposeBIP84, TWCoinTypeBitcoin, TWDerivationBitcoinSegwit, TWHDVersionZPRV, 1));
     assertStringsEqual(zprv1, "zprvAdG4iTXWBoAS2cCGuaGevCvH54GCunrvLJb2hoWCSuE3D9LS42XVg3c6sPm64w6VMq3w18vJf8nF3cBA2kUMkyWHsq6enWVXivzw42UrVHG");
 
     auto zpub0 = WRAPS(TWHDWalletGetExtendedPublicKeyAccount(wallet.get(), TWPurposeBIP84, TWCoinTypeBitcoin, TWDerivationBitcoinSegwit, TWHDVersionZPUB, 0));
     assertStringsEqual(zpub0, "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs");
+    auto zpubTaproot = WRAPS(TWHDWalletGetExtendedPublicKeyAccount(wallet.get(), TWPurposeBIP86, TWCoinTypeBitcoin, TWDerivationBitcoinTaproot, TWHDVersionZPUB, 0));
+    assertStringsEqual(zpubTaproot, "zpub6qLiJCzi7t1C7qRZx8ULcy2eGbXpmbbQZmu3znjqoR4VZADKELunndvcw4iSVaGx2KhviLLXuB3vcyGcdd2q8XXBQJc5T5qrtorRowa1zfs");
     auto zpub1 = WRAPS(TWHDWalletGetExtendedPublicKeyAccount(wallet.get(), TWPurposeBIP84, TWCoinTypeBitcoin, TWDerivationBitcoinSegwit, TWHDVersionZPUB, 1));
     assertStringsEqual(zpub1, "zpub6rFR7y4Q2AijF6Gk1bofHLs1d66hKFamhXWdWBup1Em25wfabZqkDqvaieV63fDQFaYmaatCG7jVNUpUiM2hAMo6SAVHcrUpSnHDpNzucB7");
 }

--- a/tests/interface/TWStoredKeyTests.cpp
+++ b/tests/interface/TWStoredKeyTests.cpp
@@ -204,6 +204,10 @@ TEST(TWStoredKey, addressAddDerivation) {
     EXPECT_EQ(string(TWStringUTF8Bytes(accountAddress2.get())), "1NyRyFewhZcWMa9XCj3bBxSXPXyoSg8dKz");
 
     EXPECT_EQ(TWStoredKeyAccountCount(key.get()), 2ul);
+
+    const auto accountCoin3 = WRAP(TWAccount, TWStoredKeyAccountForCoinDerivation(key.get(), coin, TWDerivationBitcoinTaproot, wallet.get()));
+    const auto accountAddress3 = WRAPS(TWAccountAddress(accountCoin3.get()));
+    EXPECT_EQ(string(TWStringUTF8Bytes(accountAddress3.get())), "bc1pyqkqf20fmmwmcxf98tv6k63e2sgnjy4zne6d0r32vxwm3au0hnksq6ec57");
 }
 
 TEST(TWStoredKey, exportJSON) {


### PR DESCRIPTION
## Description

This PR adds support for P2TR key-path address generation through.
Please note that by default (`TWDerivationDefault`) is a Native Segwit (P2WPKH).
To generate P2TR address, specify `TWDerivationBitcoinTaproot`.

For example,

```kt
val wallet = HDWallet(words, password)

val address = wallet.getAddressDerivation(CoinType.BITCOIN, Derivation.BITCOINTAPROOT)
assertEquals(address, "bc1pgqks0cynn93ymve4x0jq3u7hne77908nlysp289hc44yc4cmy0hslyckrz")
```

## How to test

<!--- Please describe how reviewers can test your changes -->

## Types of changes

* Refactored `codegen` tool, so new derivations added to registry.json are now appended to the end of the  `TWDerivation` enum on each `./tools/generate-files` command. This is required to avoid changing the order of existing derivations.

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
