### PR TITLE
fixed bootstrap.sh for macOS

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -16,7 +16,7 @@ fi
 
 echo "#### Installing system dependencies ... ####"
 if [[ $(uname) == "Darwin" ]]; then
-  tools/install-sys-dependencies-macos
+  tools/install-sys-dependencies-mac
 else
   tools/install-sys-dependencies-linux
 fi


### PR DESCRIPTION
## Description
./bootstrap.sh: line 19: tools/install-sys-dependencies-macos: No such file or directory
Correct name **install-sys-dependencies-mac**

## How to test
On macOs
_Call_
`./bootstrap.sh all`
## Checklist

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.
