### PR TITLE
Fix undefined symbol linker error by moving `sign` and `secureHash` t…

### DIFF
--- a/src/Harmony/Signer.cpp
+++ b/src/Harmony/Signer.cpp
@@ -297,14 +297,6 @@ CollectRewards Signer::buildUnsignedCollectRewards(const Proto::SigningInput &in
     return CollectRewards(delegatorAddr);
 }
 
-template <typename T>
-void Signer::sign(const PrivateKey& privateKey, const Data& hash, T& transaction) const noexcept {
-    auto tuple = sign(chainID, privateKey, hash);
-    transaction.r = std::get<0>(tuple);
-    transaction.s = std::get<1>(tuple);
-    transaction.v = std::get<2>(tuple);
-}
-
 Data Signer::rlpNoHash(const Transaction& transaction, const bool include_vrs) const noexcept {
     auto nonce = store(transaction.nonce);
     auto gasPrice = store(transaction.gasPrice);

--- a/src/Harmony/Signer.h
+++ b/src/Harmony/Signer.h
@@ -60,7 +60,12 @@ class Signer {
 
     /// Signs the given transaction.
     template <typename T>
-    void sign(const PrivateKey &privateKey, const Data &hash, T &transaction) const noexcept;
+    void sign(const PrivateKey &privateKey, const Data &hash, T &transaction) noexcept {
+        auto tuple = sign(chainID, privateKey, hash);
+        transaction.r = std::get<0>(tuple);
+        transaction.s = std::get<1>(tuple);
+        transaction.v = std::get<2>(tuple);
+    }
 
     /// Signs a hash with the given private key for the given chain identifier.
     ///

--- a/src/Waves/Address.cpp
+++ b/src/Waves/Address.cpp
@@ -15,11 +15,6 @@
 
 namespace TW::Waves {
 
-template <typename T>
-Data Address::secureHash(const T &data) {
-    return Hash::keccak256(Hash::blake2b(data, 32));
-}
-
 bool Address::isValid(const Data& decoded) {
     if (decoded.size() != Address::size) {
         return false;

--- a/src/Waves/Address.h
+++ b/src/Waves/Address.h
@@ -22,7 +22,9 @@ class Address : public Base58Address<26> {
     static const signed char testnet = 'T';
 
     template <typename T>
-    static Data secureHash(const T &data);
+    static Data secureHash(const T &data) {
+        return Hash::keccak256(Hash::blake2b(data, 32));
+    }
 
     /// Determines whether a string makes a valid address.
     static bool isValid(const std::string& string);


### PR DESCRIPTION
Move template definitions to .h file

## Description

Moved the definitions of template methods `Signer::sign` and `Address::secureHash` from `.cpp` to `.h` files to resolve linker errors due to missing template instantiations. This change ensures that the compiler has access to the full implementation of these templates in the translation units where they are used.

Error was fixed:

`Undefined symbols for architecture x86_64:
  "std::__1::vector<unsigned char, std::__1::allocator<unsigned char>> TW::Waves::Address::secureHash<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>(std::__1::vector<unsigned char, std::__1::allocator<unsigned char>> const&)", referenced from:
      TW::Waves::tests::WavesAddress_SecureHash_Test::TestBody() in AddressTests.cpp.o
  "void TW::Harmony::Signer::sign<TW::Harmony::Transaction>(TW::PrivateKey const&, std::__1::vector<unsigned char, std::__1::allocator<unsigned char>> const&, TW::Harmony::Transaction&) const", referenced from:
      TW::Harmony::HarmonySigner_SignAssumeLocalNet_Test::TestBody() in SignerTests.cpp.o
ld: symbol(s) not found for architecture x86_64
c++: error: linker command failed with exit code 1 (use -v to see invocation)`

## How to test

1. Run a full build of the project to ensure that the linker error is resolved and all components compile successfully.
2. Verify functionality by running existing tests for `Signer::sign` and `Address::secureHash`.
3. Check for any potential issues with symbol resolution across different platforms (e.g., macOS, Linux).

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Create pull request as draft initially, unless it's complete.
- [x] Add tests to cover changes as needed.
- [х] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.