### PR TITLE
added universal build support for macOS

### DIFF
--- a/tools/install-dependencies
+++ b/tools/install-dependencies
@@ -28,11 +28,19 @@ function download_dependencies() {
     ${BASE_DIR}/download-dependencies
 }
 
+function get_cmake_platform_options() {
+    local options=""
+    if [[ $(uname) == "Darwin" ]]; then
+        options="-DCMAKE_OSX_ARCHITECTURES='x86_64;arm64'"
+    fi
+    echo "$options"
+}
+
 function build_gtest() {
     # Build gtest
     GTEST_DIR="$ROOT/build/local/src/gtest"
     cd ${GTEST_DIR}/googletest-release-$GTEST_VERSION
-    $CMAKE -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX -H.
+    $CMAKE -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX -H. $(get_cmake_platform_options)
     $MAKE -j4
     $MAKE install
     $MAKE clean
@@ -42,7 +50,7 @@ function build_libcheck() {
     # Build Check
     CHECK_DIR="$ROOT/build/local/src/check"
     cd ${CHECK_DIR}/check-$CHECK_VERSION
-    $CMAKE -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX -H.
+    $CMAKE -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX -H. $(get_cmake_platform_options)
     $MAKE -j4
     $MAKE install
     $MAKE clean
@@ -53,7 +61,7 @@ function build_protobuf() {
     PROTOBUF_DIR="$ROOT/build/local/src/protobuf"
     cd ${PROTOBUF_DIR}/protobuf-$PROTOBUF_VERSION
 
-    $CMAKE -Scmake -B . -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_MODULE_COMPATIBLE=ON
+    $CMAKE -Scmake -B . -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_MODULE_COMPATIBLE=ON $(get_cmake_platform_options)
     $CMAKE --build . -j
     $CMAKE --install . --prefix $PREFIX
 
@@ -63,7 +71,7 @@ function build_protobuf() {
 
     # Protobuf plugins
     cd "$ROOT/protobuf-plugin"
-    $CMAKE . -Bbuild -DProtobuf_DIR=$PREFIX/lib/cmake/protobuf
+    $CMAKE . -Bbuild -DProtobuf_DIR=$PREFIX/lib/cmake/protobuf $(get_cmake_platform_options)
     $CMAKE --build build -j
     $CMAKE --install build --prefix $PREFIX
     $CMAKE --build build --target clean

--- a/tools/rust-bindgen
+++ b/tools/rust-bindgen
@@ -28,7 +28,13 @@ create_xc_framework() {
 
 cd rust
 
-if isTargetSpecified "native"; then
+if isTargetSpecified "native" && [[ $(uname) == "Darwin" ]]; then
+  echo "Generating Native target"
+  cargo build --target  x86_64-apple-darwin --target aarch64-apple-darwin --release --lib
+
+  lipo $BUILD_FOLDER/x86_64-apple-darwin/release/$TARGET_NAME $BUILD_FOLDER/aarch64-apple-darwin/release/$TARGET_NAME -create -output $BUILD_FOLDER/release/$TARGET_NAME
+
+else
   echo "Generating Native target"
   cargo build --release --lib
 fi


### PR DESCRIPTION
## Description

Added support for universal binary builds on macOS in the `install-dependencies` and `rust-bindgen` scripts.
1. In `install-dependencies`, a `get_cmake_platform_options` function was added to define `x86_64` and `arm64` architectures for Darwin (macOS) and return the necessary options for `CMAKE`.
2. `build_gtest/build_libcheck/build_protobuf` functions were updated to include platform compilation options, enabling correct dependency builds for universal binaries.
3. In `rust-bindgen`, logic was added to generate universal binaries when specifying `native` on Darwin (macOS). This performs builds for both `x86_64-apple-darwin` and `aarch64-apple-darwin`, followed by merging with `lipo`.

## How to test

1. Clone the repository and switch to the branch with changes.
2. Run `./bootstrap.sh native` to build the project with universal binaries.
3. Verify the generated binaries by running `lipo -info [path_to_binary]`, which should display both `x86_64` and `arm64` architectures.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] Created PR as a draft for initial review.
- [x] Added tests to cover changes as needed.
- [x] Updated documentation as needed.
- [x] Mentioned related Issue in the description if applicable.
