### PR TITLE
[Security]: Rename `ExpandedSecretKey::sign_with_pubkey` to `dangerous_sign_with_pubkey`

### DIFF
--- a/rust/tw_keypair/src/ed25519/keypair.rs
+++ b/rust/tw_keypair/src/ed25519/keypair.rs
@@ -33,7 +33,7 @@ impl<H: Hasher512> SigningKeyTrait for KeyPair<H> {
     type Signature = Signature;
 
     fn sign(&self, message: Self::SigningMessage) -> KeyPairResult<Self::Signature> {
-        self.private().sign_with_public_key(self.public(), &message)
+        self.private().sign(message)
     }
 }
 

--- a/rust/tw_keypair/src/ed25519/modifications/cardano/extended_keypair.rs
+++ b/rust/tw_keypair/src/ed25519/modifications/cardano/extended_keypair.rs
@@ -35,8 +35,10 @@ impl<H: Hasher512> SigningKeyTrait for ExtendedKeyPair<H> {
     type Signature = Signature;
 
     fn sign(&self, message: Self::SigningMessage) -> KeyPairResult<Self::Signature> {
-        self.private()
-            .sign_with_public_key(self.public(), message.as_slice())
+        unsafe {
+            self.private()
+                .sign_with_public_key(self.public(), message.as_slice())
+        }
     }
 }
 

--- a/rust/tw_keypair/src/ed25519/modifications/cardano/extended_keypair.rs
+++ b/rust/tw_keypair/src/ed25519/modifications/cardano/extended_keypair.rs
@@ -35,10 +35,7 @@ impl<H: Hasher512> SigningKeyTrait for ExtendedKeyPair<H> {
     type Signature = Signature;
 
     fn sign(&self, message: Self::SigningMessage) -> KeyPairResult<Self::Signature> {
-        unsafe {
-            self.private()
-                .sign_with_public_key(self.public(), message.as_slice())
-        }
+        self.private().sign(message)
     }
 }
 

--- a/rust/tw_keypair/src/ed25519/modifications/cardano/extended_private.rs
+++ b/rust/tw_keypair/src/ed25519/modifications/cardano/extended_private.rs
@@ -45,7 +45,13 @@ impl<H: Hasher512> ExtendedPrivateKey<H> {
     }
 
     /// `ed25519` signing uses a public key associated with the private key.
-    pub(crate) fn sign_with_public_key(
+    ///
+    /// # Unsafe
+    ///
+    /// Ensure that the public key is always correctly paired with the private key,
+    /// preventing scenarios where an arbitrary public key could be introduced into the signing process.
+    /// Security report: https://github.com/trustwallet/wallet-core/security/advisories/GHSA-7g72-jxww-q9vq
+    pub(crate) unsafe fn sign_with_public_key(
         &self,
         public: &ExtendedPublicKey<H>,
         message: &[u8],
@@ -61,7 +67,7 @@ impl<H: Hasher512> SigningKeyTrait for ExtendedPrivateKey<H> {
     type Signature = Signature;
 
     fn sign(&self, message: Self::SigningMessage) -> KeyPairResult<Self::Signature> {
-        self.sign_with_public_key(&self.public(), message.as_slice())
+        unsafe { self.sign_with_public_key(&self.public(), message.as_slice()) }
     }
 }
 

--- a/rust/tw_keypair/src/ed25519/private.rs
+++ b/rust/tw_keypair/src/ed25519/private.rs
@@ -43,8 +43,10 @@ impl<H: Hasher512> PrivateKey<H> {
         public: &PublicKey<H>,
         message: &[u8],
     ) -> KeyPairResult<Signature> {
-        self.expanded_key
-            .sign_with_pubkey(public.to_bytes(), message)
+        unsafe {
+            self.expanded_key
+                .sign_with_pubkey(public.to_bytes(), message)
+        }
     }
 }
 

--- a/rust/tw_keypair/src/ed25519/private.rs
+++ b/rust/tw_keypair/src/ed25519/private.rs
@@ -36,18 +36,6 @@ impl<H: Hasher512> PrivateKey<H> {
     pub fn public(&self) -> PublicKey<H> {
         PublicKey::with_expanded_secret(&self.expanded_key)
     }
-
-    /// `ed25519` signing uses a public key associated with the private key.
-    pub(crate) fn sign_with_public_key(
-        &self,
-        public: &PublicKey<H>,
-        message: &[u8],
-    ) -> KeyPairResult<Signature> {
-        unsafe {
-            self.expanded_key
-                .sign_with_pubkey(public.to_bytes(), message)
-        }
-    }
 }
 
 impl<H: Hasher512> SigningKeyTrait for PrivateKey<H> {
@@ -55,7 +43,8 @@ impl<H: Hasher512> SigningKeyTrait for PrivateKey<H> {
     type Signature = Signature;
 
     fn sign(&self, message: Self::SigningMessage) -> KeyPairResult<Self::Signature> {
-        self.sign_with_public_key(&self.public(), &message)
+        self.expanded_key
+            .dangerous_sign_with_pubkey(self.public().to_bytes(), &message)
     }
 }
 

--- a/rust/tw_keypair/src/ed25519/secret.rs
+++ b/rust/tw_keypair/src/ed25519/secret.rs
@@ -69,8 +69,14 @@ impl<H: Hasher512> ExpandedSecretKey<H> {
     /// Signs a message with this `ExpandedSecretKey`.
     /// Source: https://github.com/dalek-cryptography/ed25519-dalek/blob/1.0.1/src/secret.rs#L389-L412
     /// Ported: https://github.com/trustwallet/wallet-core/blob/423f0e34725f69c0a9d535e1a32534c99682edea/trezor-crypto/crypto/ed25519-donna/ed25519.c#L97-L130
+    ///
+    /// # Unsafe
+    ///
+    /// Ensure that the public key is always correctly paired with the private key,
+    /// preventing scenarios where an arbitrary public key could be introduced into the signing process.
+    /// Security report: https://github.com/trustwallet/wallet-core/security/advisories/GHSA-7g72-jxww-q9vq
     #[allow(non_snake_case)]
-    pub(crate) fn sign_with_pubkey(
+    pub(crate) unsafe fn sign_with_pubkey(
         &self,
         pubkey: H256,
         message: &[u8],
@@ -122,7 +128,7 @@ mod tests {
         let message = hex::decode("f0").unwrap();
 
         // Anyway, the result signature has an expected value.
-        let sign = secret_key.sign_with_pubkey(public, &message).unwrap();
+        let sign = unsafe { secret_key.sign_with_pubkey(public, &message).unwrap() };
         let expected = H512::from("ed55bce14a845a275e7a3a7242420ed1eeaba79dc3141bebf42ca0d12169e209a6e56b6981a336f711ae3aaea8d063b72b0e79a8808311d08cb42cabfdd0450d");
         assert_eq!(sign.to_bytes(), expected);
     }

--- a/rust/tw_keypair/src/ed25519/secret.rs
+++ b/rust/tw_keypair/src/ed25519/secret.rs
@@ -70,13 +70,13 @@ impl<H: Hasher512> ExpandedSecretKey<H> {
     /// Source: https://github.com/dalek-cryptography/ed25519-dalek/blob/1.0.1/src/secret.rs#L389-L412
     /// Ported: https://github.com/trustwallet/wallet-core/blob/423f0e34725f69c0a9d535e1a32534c99682edea/trezor-crypto/crypto/ed25519-donna/ed25519.c#L97-L130
     ///
-    /// # Unsafe
+    /// # Important
     ///
     /// Ensure that the public key is always correctly paired with the private key,
     /// preventing scenarios where an arbitrary public key could be introduced into the signing process.
     /// Security report: https://github.com/trustwallet/wallet-core/security/advisories/GHSA-7g72-jxww-q9vq
     #[allow(non_snake_case)]
-    pub(crate) unsafe fn sign_with_pubkey(
+    pub(crate) fn dangerous_sign_with_pubkey(
         &self,
         pubkey: H256,
         message: &[u8],
@@ -128,7 +128,9 @@ mod tests {
         let message = hex::decode("f0").unwrap();
 
         // Anyway, the result signature has an expected value.
-        let sign = unsafe { secret_key.sign_with_pubkey(public, &message).unwrap() };
+        let sign = secret_key
+            .dangerous_sign_with_pubkey(public, &message)
+            .unwrap();
         let expected = H512::from("ed55bce14a845a275e7a3a7242420ed1eeaba79dc3141bebf42ca0d12169e209a6e56b6981a336f711ae3aaea8d063b72b0e79a8808311d08cb42cabfdd0450d");
         assert_eq!(sign.to_bytes(), expected);
     }


### PR DESCRIPTION
## Description

The function sign_with_pubkey used in tw_keypair/src/ed25519 is vulnerable to Chalkias attack, this vulnerability allows an attacker to use the signing function with arbitrary public keys leading to the extraction of the private key.
This PR makes `ExpandedSecretKey::sign_with_pubkey` unsafe to require maintainers to pay extra attention when using it.

Ref: https://github.com/trustwallet/wallet-core/security/advisories/GHSA-7g72-jxww-q9vq

## How to test

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
