### PR TITLE
[Cosmos]: Add ability to sign direct with `TxBody` bytes only

### DIFF
--- a/rust/tw_cosmos_sdk/src/modules/compiler/tw_compiler.rs
+++ b/rust/tw_cosmos_sdk/src/modules/compiler/tw_compiler.rs
@@ -62,7 +62,7 @@ impl<Context: CosmosContext> TWTransactionCompiler<Context> {
         input: Proto::SigningInput<'_>,
     ) -> SigningResult<CompilerProto::PreSigningOutput<'static>> {
         let tx_hasher = TxBuilder::<Context>::tx_hasher_from_proto(&input);
-        let preimage = match TxBuilder::<Context>::try_sign_direct_args(&input) {
+        let preimage = match TxBuilder::<Context>::try_sign_direct_args(coin, &input) {
             // If there was a `SignDirect` message in the signing input, generate the tx preimage directly.
             Ok(Some(sign_direct_args)) => {
                 ProtobufPreimager::<Context>::preimage_hash_direct(&sign_direct_args, tx_hasher)?
@@ -128,7 +128,7 @@ impl<Context: CosmosContext> TWTransactionCompiler<Context> {
         let params = TxBuilder::<Context>::public_key_params_from_proto(&input);
         let public_key = Context::PublicKey::from_bytes(coin, &public_key, params)?;
 
-        let signed_tx_raw = match TxBuilder::<Context>::try_sign_direct_args(&input) {
+        let signed_tx_raw = match TxBuilder::<Context>::try_sign_direct_args(coin, &input) {
             // If there was a `SignDirect` message in the signing input, generate the `TxRaw` directly.
             Ok(Some(sign_direct_args)) => ProtobufSerializer::<Context>::build_direct_signed_tx(
                 &sign_direct_args,

--- a/src/proto/Cosmos.proto
+++ b/src/proto/Cosmos.proto
@@ -240,8 +240,10 @@ message Message {
     // For signing an already serialized transaction. Account number and chain ID must be set outside.
     message SignDirect {
         // The prepared serialized TxBody
+        // Required
         bytes body_bytes = 1;
         // The prepared serialized AuthInfo
+        // Optional. If not provided, will be generated from `SigningInput` parameters.
         bytes auth_info_bytes = 2;
     }
 


### PR DESCRIPTION
## Description

Add ability to sign direct with `TxBody` bytes only.
In other words, generate `AuthInfo` from `SigningInput` parameters if `SignDirect.auth_info_bytes` not provided.

## How to test

Run Rust tests

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
