### PR TITLE
Update registry.json

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -4814,5 +4814,36 @@
       "rpc": "https://docs.pactus.org/api/http",
       "documentation": "https://docs.pactus.org"
     }
+  },
+  {
+  "id": "alph",
+  "name": "Alph Network",
+  "coinId": 8738,
+  "symbol": "ALPH",
+  "decimals": 18,
+  "blockchain": "Ethereum",
+  "derivation": [
+    {
+      "path": "m/44'/60'/0'/0/0"
+    }
+  ],
+  "curve": "secp256k1",
+  "publicKeyType": "secp256k1Extended",
+  "chainId": "0x2222",
+  "addressHasher": "keccak256",
+  "explorer": {
+    "url": "https://explorer.alph.network",
+    "txPath": "/tx/",
+    "accountPath": "/address/",
+    "sampleTx": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    "sampleAccount": "0x720E1fa107A1Df39Db4E78A3633121ac36Bec132"
+  },
+  "info": {
+    "url": "https://alph.network",
+    "source": "https://github.com/alph-network",
+    "rpc": "https://rpc.alph.network",
+    "documentation": "https://docs.alph.network"
   }
+}
+
 ]


### PR DESCRIPTION
This commit adds support for Alph Network to the `registry.json` file. The necessary fields for the new blockchain have been added, including Coin ID, chain ID, RPC, and explorer URL.

- Added Alph Network with Coin ID 8738
- Set blockchain type as Ethereum
- Added RPC URL: https://rpc.alph.network
- Added explorer URL: https://explorer.alph.network

## Description

The registry.json file has been updated to include Alph Network as a supported blockchain in Wallet Core. This includes the necessary details for interacting with the Alph Network, including the Coin ID, chain ID, RPC URL, and explorer URL.

## How to test

1. Verify that the changes are correctly added to the `registry.json` file.
2. Ensure that Alph Network can be successfully integrated into Wallet Core with the added configurations.
3. Test that the new Coin ID (8738) works for generating addresses and interacting with the network.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] Create pull request as draft initially, unless it's complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
