### PR TITLE
Fixes ios package issue with auto-generated C++ header files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,10 +36,12 @@ swift/wallet-core/
 codegen-v2/bindings/
 
 src/Generated/*.cpp
-include/Generated/TrustWalletCore/*.h
 include/TrustWalletCore/TWHRP.h
 include/TrustWalletCore/TW*Proto.h
 include/TrustWalletCore/TWEthereumChainID.h
+
+# Generated
+include/TrustWalletCore/TWTONAddressConverter.h
 
 # Wasm
 emsdk/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,6 @@ endif ()
 target_include_directories(TrustWalletCore
         PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/Generated>
         $<INSTALL_INTERFACE:include>
         PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src

--- a/codegen-v2/src/codegen/cpp/code_gen.rs
+++ b/codegen-v2/src/codegen/cpp/code_gen.rs
@@ -8,7 +8,7 @@ use crate::Error::BadFormat;
 use crate::Result;
 
 static IN_DIR: &str = "../rust/bindings/";
-static HEADER_OUT_DIR: &str = "../include/Generated/TrustWalletCore/";
+static HEADER_OUT_DIR: &str = "../include/TrustWalletCore/";
 static SOURCE_OUT_DIR: &str = "../src/Generated/";
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -72,14 +72,14 @@ fn generate_header_guard(file: &mut std::fs::File) -> Result<()> {
 }
 
 fn generate_header_includes(file: &mut std::fs::File, info: &TWConfig) -> Result<()> {
-    writeln!(file, "#include <TrustWalletCore/TWBase.h>")?;
+    writeln!(file, "#include \"TWBase.h\"")?;
 
     // Include headers based on argument types
     let mut included_headers = std::collections::HashSet::new();
     for func in &info.static_functions {
         for arg in &func.args {
             if arg.ty.contains("TWString") && included_headers.insert("TWString.h") {
-                writeln!(file, "#include <TrustWalletCore/TWString.h>")?;
+                writeln!(file, "#include \"TWString.h\"")?;
             }
             // Additional type checks can be added here in the future
         }
@@ -160,7 +160,7 @@ pub fn generate_header(info: &TWConfig) -> Result<()> {
 fn generate_source_includes(file: &mut std::fs::File, info: &TWConfig) -> Result<()> {
     writeln!(
         file,
-        "#include <Generated/TrustWalletCore/{}.h>",
+        "#include <TrustWalletCore/{}.h>",
         info.class
     )?;
     writeln!(file, "#include \"rust/Wrapper.h\"")?;

--- a/codegen/bin/codegen
+++ b/codegen/bin/codegen
@@ -15,7 +15,6 @@ Encoding.default_internal = Encoding::UTF_8
 options = OpenStruct.new
 # default input / output path
 options.input = "#{CurrentDir}/../../include/TrustWalletCore"
-options.input_generated = "#{CurrentDir}/../../include/Generated/TrustWalletCore"
 options.output = "#{CurrentDir}/../../"
 options.swift = true
 options.java = true
@@ -63,17 +62,15 @@ end.parse!
 
 entities = []
 files = []
-[options.input, options.input_generated].each do |input_dir|
-  Dir.foreach(input_dir) do |item|
-    next if ['.', '..', '.DS_Store'].include?(item)
+Dir.foreach(options.input) do |item|
+  next if ['.', '..', '.DS_Store'].include?(item)
 
-    file_path = File.expand_path(File.join(input_dir, item))
-    entity = Parser.new(path: file_path).parse
-    next if entity.nil?
+  file_path = File.expand_path(File.join(options.input, item))
+  entity = Parser.new(path: file_path).parse
+  next if entity.nil?
 
-    entities << entity
-    files << File.basename(item, '.h').sub(/^TW/, '')
-  end
+  entities << entity
+  files << File.basename(item, '.h').sub(/^TW/, '')
 end
 
 generator = CodeGenerator.new(entities: entities, files: files, output_folder: options.output)

--- a/kotlin/wallet-core-kotlin/build.gradle.kts
+++ b/kotlin/wallet-core-kotlin/build.gradle.kts
@@ -103,10 +103,8 @@ kotlin {
                 includeDirs(
                     rootDir.parentFile.resolve("include"),
                     rootDir.parentFile.resolve("include/TrustWalletCore"),
-                    rootDir.parentFile.resolve("include/Generated/TrustWalletCore")
                 )
-                headers(rootDir.parentFile.resolve("include/Generated/TrustWalletCore").listFiles()!! +
-                       rootDir.parentFile.resolve("include/TrustWalletCore").listFiles()!!)
+                headers(rootDir.parentFile.resolve("include/TrustWalletCore").listFiles()!!)
             }
         }
     }

--- a/tests/chains/TheOpenNetwork/TWTONAddressConverterTests.cpp
+++ b/tests/chains/TheOpenNetwork/TWTONAddressConverterTests.cpp
@@ -4,7 +4,7 @@
 
 #include "TestUtilities.h"
 
-#include "TrustWalletCore/TWTONAddressConverter.h"
+#include <TrustWalletCore/TWTONAddressConverter.h>
 
 namespace TW::TheOpenNetwork::tests {
 


### PR DESCRIPTION
## Description

This PR changes the automatic FFI generation to save the created header file in `include/TrustWalletCore`. This ensures that  the downstream packages are able to find the headers correctly.

## How to test

The existing tests continue to work.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
