### PR TITLE
Fix ios-xcframework-release script adding missing quotes in Package file body.

### DIFF
--- a/tools/ios-xcframework-release
+++ b/tools/ios-xcframework-release
@@ -58,12 +58,12 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WalletCore",
-            url: ${core_download_url},
+            url: "${core_download_url}",
             checksum: "${core_hash}"
         ),
         .binaryTarget(
             name: "SwiftProtobuf",
-            url: ${protobuf_download_url},
+            url: "${protobuf_download_url}",
             checksum: "${protobuf_hash}"
         )
     ]


### PR DESCRIPTION
## Description

On each release (eg https://github.com/trustwallet/wallet-core/releases/tag/4.2.10), an up-to-date `Package.swift` file is added. Due to a bug in `ios-xcframework-release`, it is invalid due to missing quotes in the file urls of both frameworks.
This PR fixes `ios-xcframework-release` script adding missing quotes in the Package file body.

## How to test

<!--- Please describe how reviewers can test your changes -->

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Create pull request as draft initially, unless its complete.
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
- [ ] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [X] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
