### PR TITLE
Allows extension to import a wallet with private key

### DIFF
--- a/wasm/src/keystore/default-impl.ts
+++ b/wasm/src/keystore/default-impl.ts
@@ -139,11 +139,9 @@ export class Default implements Types.IKeyStore {
   ): Promise<PrivateKey> {
     return this.load(id).then((wallet) => {
       let storedKey = this.mapStoredKey(wallet);
-      let hdWallet = storedKey.wallet(Buffer.from(password));
       let coin = (this.core.CoinType as any).values["" + account.coin];
-      let privateKey = hdWallet.getKey(coin, account.derivationPath);
+      let privateKey = storedKey.privateKey(coin, Buffer.from(password));
       storedKey.delete();
-      hdWallet.delete();
       return privateKey;
     });
   }

--- a/wasm/src/keystore/types.ts
+++ b/wasm/src/keystore/types.ts
@@ -6,7 +6,7 @@ import { CoinType, Derivation, PrivateKey, StoredKeyEncryption } from "../wallet
 
 export enum WalletType {
   Mnemonic = "mnemonic",
-  PrivateKey = "privateKey",
+  PrivateKey = "private-key",
   WatchOnly = "watchOnly",
   Hardware = "hardware",
 }

--- a/wasm/tests/KeyStore.test.ts
+++ b/wasm/tests/KeyStore.test.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+
+import "mocha";
+import { assert } from "chai";
+import { Buffer } from "buffer";
+import { KeyStore } from "../dist";
+
+describe("KeyStore", () => {
+  it("test get key", async () => {
+    const { CoinType, StoredKeyEncryption, HexCoding } = globalThis.core;
+    const mnemonic = globalThis.mnemonic as string;
+    const password = globalThis.password as string;
+
+    const storage = new KeyStore.FileSystemStorage("/tmp");
+    const keystore = new KeyStore.Default(globalThis.core, storage);
+
+    var wallet = await keystore.import(mnemonic, "Coolw", password, [
+      CoinType.bitcoin,
+    ], StoredKeyEncryption.aes128Ctr);
+
+    const account = wallet.activeAccounts[0];
+    const key = await keystore.getKey(wallet.id, password, account);
+
+    assert.equal(
+      HexCoding.encode(key.data()),
+      "0xd2568511baea8dc347f14c4e0479eb8ebe29eb5f664ed796e755896250ffd11f"
+    );
+
+    const inputPrivateKey = Buffer.from("9cdb5cab19aec3bd0fcd614c5f185e7a1d97634d4225730eba22497dc89a716c", "hex");
+    wallet = await keystore.importKey(inputPrivateKey, "Coolw", password, CoinType.bitcoin, StoredKeyEncryption.aes128Ctr);
+
+    const account2 = wallet.activeAccounts[0];
+    const key2 = await keystore.getKey(wallet.id, password, account2);
+
+    assert.equal(
+      HexCoding.encode(key2.data()),
+      "0x9cdb5cab19aec3bd0fcd614c5f185e7a1d97634d4225730eba22497dc89a716c"
+    );
+  }).timeout(10000);
+
+  it("test export", async () => {
+    const { CoinType, StoredKeyEncryption, HexCoding } = globalThis.core;
+    const mnemonic = globalThis.mnemonic as string;
+    const password = globalThis.password as string;
+    
+    const storage = new KeyStore.FileSystemStorage("/tmp");
+    const keystore = new KeyStore.Default(globalThis.core, storage);
+
+    var wallet = await keystore.import(mnemonic, "Coolw", password, [
+      CoinType.bitcoin,
+    ], StoredKeyEncryption.aes128Ctr);
+    
+    const exported = await keystore.export(wallet.id, password);
+    assert.equal(exported, mnemonic);
+
+    const inputPrivateKey = Buffer.from("9cdb5cab19aec3bd0fcd614c5f185e7a1d97634d4225730eba22497dc89a716c", "hex");
+    wallet = await keystore.importKey(inputPrivateKey, "Coolw", password, CoinType.bitcoin, StoredKeyEncryption.aes128Ctr);
+
+    const exported2 = await keystore.export(wallet.id, password);
+    assert.equal(HexCoding.encode(exported2), "0x9cdb5cab19aec3bd0fcd614c5f185e7a1d97634d4225730eba22497dc89a716c");
+  }).timeout(10000);
+});


### PR DESCRIPTION
## Description

This PR fixes `KeyStore.getKey` and `KeyStore.export` for wasm to allow the browser extension to import a wallet with a private key.

## How to test

Added wasm tests

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

Bug fix (non-breaking change which fixes an issue) 

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
