### PR TITLE
fix(xrp): Fix Ripple.proto Kotlin compatibility

### DIFF
--- a/rust/tw_tests/tests/chains/ripple/ripple_sign.rs
+++ b/rust/tw_tests/tests/chains/ripple/ripple_sign.rs
@@ -10,7 +10,7 @@ use tw_proto::Ripple::Proto;
 use tw_proto::Ripple::Proto::mod_OperationPayment::OneOfamount_oneof as AmountType;
 use tw_proto::Ripple::Proto::mod_SigningInput::OneOfoperation_oneof as OperationType;
 
-const SELL_NFTOKEN_FLAG: u32 = 0x00000001;
+const SELL_NFTOKEN_FLAG: u64 = 0x00000001;
 
 #[test]
 fn test_ripple_sign_xrp_payment_0() {

--- a/src/proto/Ripple.proto
+++ b/src/proto/Ripple.proto
@@ -37,7 +37,8 @@ message OperationPayment {
     string destination = 3;
 
     // A Destination Tag
-    uint32 destination_tag = 4;
+    // It must fit uint32
+    uint64 destination_tag = 4;
 }
 
 // https://xrpl.org/escrowcreate.html
@@ -49,13 +50,16 @@ message OperationEscrowCreate {
     string destination = 2;
 
     // Destination Tag
-    uint32 destination_tag = 3;
+    // It must fit uint32
+    uint64 destination_tag = 3;
 
     // Escrow expire time
-    uint32 cancel_after = 4;
+    // It must fit uint32
+    uint64 cancel_after = 4;
 
     // Escrow release time
-    uint32 finish_after = 5;
+    // It must fit uint32
+    uint64 finish_after = 5;
 
     // Hex-encoded crypto condition
     // https://datatracker.ietf.org/doc/html/draft-thomas-crypto-conditions-02#section-8.1
@@ -86,13 +90,13 @@ message OperationEscrowFinish {
     string fulfillment = 4;
 }
 
-// https://xrpl.org/nftokenburn.html 
+// https://xrpl.org/nftokenburn.html
 message OperationNFTokenBurn {
     // Hex-encoded H256 NFTokenId
     string nftoken_id = 1;
 }
 
-// https://xrpl.org/nftokencreateoffer.html 
+// https://xrpl.org/nftokencreateoffer.html
 message OperationNFTokenCreateOffer {
     // Hex-encoded Hash256 NFTokenId
     string nftoken_id = 1;
@@ -101,13 +105,13 @@ message OperationNFTokenCreateOffer {
     string destination = 2;
 }
 
-// https://xrpl.org/nftokenacceptoffer.html 
+// https://xrpl.org/nftokenacceptoffer.html
 message OperationNFTokenAcceptOffer {
     // Hex-encoded Hash256 NFTokenOffer
     string sell_offer = 1;
 }
 
-// https://xrpl.org/nftokencanceloffer.html 
+// https://xrpl.org/nftokencanceloffer.html
 message OperationNFTokenCancelOffer {
     // Hex-encoded Vector256 NFTokenOffers
     repeated string token_offers = 1;
@@ -128,7 +132,8 @@ message SigningInput {
     string account = 4;
 
     // Transaction flags, optional
-    uint32 flags = 5;
+    // It must fit uint32
+    uint64 flags = 5;
 
     // The secret private key used for signing (32 bytes).
     bytes private_key = 6;
@@ -167,7 +172,8 @@ message SigningInput {
 
     // Arbitrary integer used to identify the reason for this payment, or a sender on whose behalf this transaction is made.
     // Conventionally, a refund should specify the initial payment's SourceTag as the refund payment's DestinationTag.
-    uint32 source_tag = 25;
+    // It must fit uint32.
+    uint64 source_tag = 25;
 }
 
 // Result containing the signed and encoded transaction.


### PR DESCRIPTION
## Description

Some parameters were changed from int64 to uint32 during the recent XRP Rust migration. However `protoc` generates Kotlin bindings with using signed integers only, so overflow happens on Kotlin side

## How to test

<!--- Please describe how reviewers can test your changes -->

## Change log

* Ripple.OperationPayment.destinationTag is now uint64
* Ripple.OperationEscrowCreate.destinationTag is now uint64
* Ripple.OperationEscrowCreate.cancelAfter is now uint64
* Ripple.OperationEscrowCreate.finishAfter is now uint64
* Ripple.SigningInput.flags is now uint64
* Ripple.SigningInput.sourceTag is now uint64

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
