### PR TITLE
fix: tron message signing

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/tron/TestTronMessageSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/tron/TestTronMessageSigner.kt
@@ -20,7 +20,7 @@ class TestTronMessageSigner {
         val privateKey = PrivateKey(data)
         val msg = "Hello World"
         val signature = TronMessageSigner.signMessage(privateKey, msg)
-        assertEquals("9bb6d11ec8a6a3fb686a8f55b123e7ec4e9746a26157f6f9e854dd72f5683b450397a7b0a9653865658de8f9243f877539882891bad30c7286c3bf5622b900471b", signature)
+        assertEquals("bc0753c070cc55693097df11bc11e1a7c4bd5e1a40b9dc94c75568e59bcc9d6b50a7873ef25b469e494490a54de37327b4bc7fc825c81a377b555e34fb7261ba1c", signature)
         val pubKey = privateKey.getPublicKey(CoinType.TRON)
         assertTrue(TronMessageSigner.verifyMessage(pubKey, msg, signature))
     }

--- a/src/Tron/MessageSigner.cpp
+++ b/src/Tron/MessageSigner.cpp
@@ -14,7 +14,7 @@ namespace TW::Tron {
 Data generateMessage(const std::string& message) {
     std::string prefix(1, MessageSigner::TronPrefix);
     std::stringstream ss;
-    ss << prefix << MessageSigner::MessagePrefix << message;
+    ss << prefix << MessageSigner::MessagePrefix << message.length() << message;
     Data signableMessage = Hash::keccak256(data(ss.str()));
     return signableMessage;
 }

--- a/src/Tron/MessageSigner.h
+++ b/src/Tron/MessageSigner.h
@@ -24,7 +24,7 @@ public:
     /// \param signature signature to verify the message against
     /// \return true if the message match the signature, false otherwise
     static bool verifyMessage(const PublicKey& publicKey, const std::string& message, const std::string& signature) noexcept;
-    static constexpr auto MessagePrefix = "TRON Signed Message:\n32";
+    static constexpr auto MessagePrefix = "TRON Signed Message:\n";
     static constexpr std::uint8_t TronPrefix{0x19};
 };
 

--- a/swift/Tests/Blockchains/TronTests.swift
+++ b/swift/Tests/Blockchains/TronTests.swift
@@ -79,7 +79,7 @@ class TronTests: XCTestCase {
         let privateKey = PrivateKey(data: Data(hexString: "75065f100e38d3f3b4c5c4235834ba8216de62272a4f03532c44b31a5734360a")!)!
         let msg = "Hello World"
         let signature = TronMessageSigner.signMessage(privateKey: privateKey, message: msg)
-        XCTAssertEqual(signature, "9bb6d11ec8a6a3fb686a8f55b123e7ec4e9746a26157f6f9e854dd72f5683b450397a7b0a9653865658de8f9243f877539882891bad30c7286c3bf5622b900471b")
+        XCTAssertEqual(signature, "bc0753c070cc55693097df11bc11e1a7c4bd5e1a40b9dc94c75568e59bcc9d6b50a7873ef25b469e494490a54de37327b4bc7fc825c81a377b555e34fb7261ba1c")
         let pubKey = privateKey.getPublicKey(coinType: .tron)
         XCTAssertTrue(TronMessageSigner.verifyMessage(pubKey: pubKey, message: msg, signature: signature))
     }

--- a/tests/chains/Tron/TronMessageSignerTests.cpp
+++ b/tests/chains/Tron/TronMessageSignerTests.cpp
@@ -15,9 +15,16 @@ namespace TW::Tron {
         PrivateKey tronKey(parse_hex("75065f100e38d3f3b4c5c4235834ba8216de62272a4f03532c44b31a5734360a"));
         auto msg = "Hello World";
         auto signature = Tron::MessageSigner::signMessage(tronKey, msg);
-        ASSERT_EQ(signature, "9bb6d11ec8a6a3fb686a8f55b123e7ec4e9746a26157f6f9e854dd72f5683b450397a7b0a9653865658de8f9243f877539882891bad30c7286c3bf5622b900471b");
         auto pubKey = tronKey.getPublicKey(TWPublicKeyTypeSECP256k1Extended);
+
+        ASSERT_EQ(signature, "bc0753c070cc55693097df11bc11e1a7c4bd5e1a40b9dc94c75568e59bcc9d6b50a7873ef25b469e494490a54de37327b4bc7fc825c81a377b555e34fb7261ba1c");
         ASSERT_TRUE(Tron::MessageSigner::verifyMessage(pubKey, msg, signature));
+
+        auto msg2 = "A much longer message to test the signing and verification process";
+        auto signature2 = Tron::MessageSigner::signMessage(tronKey, msg2);
+
+        ASSERT_EQ(signature2, "93aee5f753cf889e0749c74dd0c5996cce889883ae079e09ede462e16d65d06a4f43d1ed2745e9f3c1690695628269bd58f057a4a93953cc50e66b4a05bc0f451b");
+        ASSERT_TRUE(Tron::MessageSigner::verifyMessage(pubKey, msg2, signature2));
     }
     
     TEST(TWTronMessageSigner, SignAndVerifyLegacy) {
@@ -27,7 +34,12 @@ namespace TW::Tron {
         
         const auto pubKey = WRAP(TWPublicKey, TWPrivateKeyGetPublicKey(privateKey.get(), TWCoinTypeTron));
         const auto signature = WRAPS(TWTronMessageSignerSignMessage(privateKey.get(), message.get()));
-        EXPECT_EQ(std::string(TWStringUTF8Bytes(signature.get())), "9bb6d11ec8a6a3fb686a8f55b123e7ec4e9746a26157f6f9e854dd72f5683b450397a7b0a9653865658de8f9243f877539882891bad30c7286c3bf5622b900471b");
+        EXPECT_EQ(std::string(TWStringUTF8Bytes(signature.get())), "bc0753c070cc55693097df11bc11e1a7c4bd5e1a40b9dc94c75568e59bcc9d6b50a7873ef25b469e494490a54de37327b4bc7fc825c81a377b555e34fb7261ba1c");
         EXPECT_TRUE(TWTronMessageSignerVerifyMessage(pubKey.get(), message.get(), signature.get()));
+
+        const auto message2 = STRING("A much longer message to test the signing and verification process");
+        const auto signature2 = WRAPS(TWTronMessageSignerSignMessage(privateKey.get(), message2.get()));
+        EXPECT_EQ(std::string(TWStringUTF8Bytes(signature2.get())), "93aee5f753cf889e0749c74dd0c5996cce889883ae079e09ede462e16d65d06a4f43d1ed2745e9f3c1690695628269bd58f057a4a93953cc50e66b4a05bc0f451b");
+        EXPECT_TRUE(TWTronMessageSignerVerifyMessage(pubKey.get(), message2.get(), signature2.get()));
     }
 }


### PR DESCRIPTION
Fixes #4325
## Description
- Use message length instead of constant number.
- Added new test case with different message length

## How to test
Tests included. Signing a Tron message and verifying the address is recoverable
<!--- Please describe how reviewers can test your changes -->

## Types of changes
- Bug fix

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
