### PR TITLE
chore: fix OS detection with `uname -s`

### DIFF
--- a/tools/android-release
+++ b/tools/android-release
@@ -8,7 +8,7 @@ set -e
 source $(dirname $0)/library
 version=$(wc_read_version  $1)
 
-if [[ `uname` == "Darwin" ]]; then
+if [[ $(uname -s) == "Darwin" ]]; then
     export BOOST_ROOT=$(brew --prefix boost)
 fi
 


### PR DESCRIPTION
## Description  
I noticed that the `uname` command in the script could return different values on different systems, leading to potential issues when detecting macOS. To ensure more reliable OS detection, I've updated the check to use `uname -s`, which provides the correct system name and accurately identifies macOS. This change will improve the script's compatibility across various platforms.

## How to test  
1. Run the script on different operating systems (e.g., macOS, Linux).
2. Ensure that the `uname -s` check correctly identifies macOS without issues on other systems.
3. Verify that the script runs successfully and builds/upload assets as expected.

## Types of changes  
- Bug fix (non-breaking change which fixes an issue)

## Checklist  
- [ ] Create pull request as draft initially, unless it's complete.  
- [ ] Add tests to cover changes as needed.  
- [ ] Update documentation as needed.  
- [ ] If there is a related Issue, mention it in the description.  
- [ ] I have read the [[guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria)](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.