### PR TITLE
Migrates `scrypt.c` to Rust

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "digest 0.10.6",
+ "digest 0.10.7",
  "itertools",
  "num-bigint",
  "num-traits",
@@ -101,7 +101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std",
- "digest 0.10.6",
+ "digest 0.10.7",
  "num-bigint",
 ]
 
@@ -267,7 +267,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -516,7 +516,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.6",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -600,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.3",
  "const-oid",
@@ -617,7 +617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a48e5d537b8a30c0b023116d981b16334be1485af7ca68db3a2b7024cbc957fd"
 dependencies = [
  "der",
- "digest 0.10.6",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -637,7 +637,7 @@ checksum = "75c71eaa367f2e5d556414a8eea812bc62985c879748d6403edabd9cb03f16e7"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.6",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -739,7 +739,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343cfc165f92a988fd60292f7a0bfde4352a5a0beff9fbec29251ca4e9676e4d"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -807,7 +807,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1120,6 +1120,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,7 +1341,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1493,18 +1503,18 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1513,7 +1523,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -1523,7 +1533,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "rand_core",
 ]
 
@@ -2037,7 +2047,7 @@ dependencies = [
  "arbitrary 1.3.0",
  "blake-hash",
  "blake2b-ref",
- "digest 0.10.6",
+ "digest 0.10.7",
  "groestl",
  "hmac",
  "ripemd",
@@ -2076,7 +2086,7 @@ dependencies = [
  "crypto_box",
  "curve25519-dalek",
  "der",
- "digest 0.10.6",
+ "digest 0.10.7",
  "ecdsa",
  "k256",
  "lazy_static",
@@ -2097,6 +2107,18 @@ dependencies = [
  "tw_memory",
  "tw_misc",
  "zeroize",
+]
+
+[[package]]
+name = "tw_keystore"
+version = "0.1.0"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+ "tw_encoding",
+ "tw_memory",
+ "tw_misc",
 ]
 
 [[package]]
@@ -2519,6 +2541,7 @@ dependencies = [
  "tw_ethereum",
  "tw_hash",
  "tw_keypair",
+ "tw_keystore",
  "tw_macros",
  "tw_memory",
  "tw_misc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "tw_evm",
     "tw_hash",
     "tw_keypair",
+    "tw_keystore",
     "tw_macros",
     "tw_memory",
     "tw_misc",

--- a/rust/tw_keystore/Cargo.toml
+++ b/rust/tw_keystore/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "tw_keystore"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+pbkdf2 = "0.12.2"
+salsa20 = "0.10.2"
+sha2 = "0.10.8"
+tw_encoding = { path = "../tw_encoding" }
+tw_memory = { path = "../tw_memory" }
+tw_misc = { path = "../tw_misc" }

--- a/rust/tw_keystore/fuzz/.gitignore
+++ b/rust/tw_keystore/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target
+corpus
+artifacts
+coverage
+Cargo.lock

--- a/rust/tw_keystore/fuzz/Cargo.toml
+++ b/rust/tw_keystore/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "tw_keystore-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
+
+[dependencies.tw_keystore]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "crypto_scrypt"
+path = "fuzz_targets/crypto_scrypt.rs"
+test = false
+doc = false

--- a/rust/tw_keystore/fuzz/fuzz_targets/crypto_scrypt.rs
+++ b/rust/tw_keystore/fuzz/fuzz_targets/crypto_scrypt.rs
@@ -1,0 +1,36 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#![no_main]
+
+use libfuzzer_sys::{arbitrary, fuzz_target};
+use tw_keystore::crypto_scrypt::{params::Params, scrypt};
+
+#[derive(arbitrary::Arbitrary, Debug)]
+struct ScryptInput<'a> {
+    password: &'a [u8],
+    salt: &'a [u8],
+    log_n: u8,
+    r: u32,
+    p: u32,
+    desired_len: usize,
+}
+
+fuzz_target!(|input: ScryptInput<'_>| {
+    // Greater r, p parameters make `scrypt` incredibly slow.
+    if input.r > 16 || input.p > 16 {
+        return;
+    }
+
+    let params = Params {
+        log_n: input.log_n,
+        r: input.r,
+        p: input.p,
+        desired_len: input.desired_len,
+    };
+
+    let _ = scrypt(input.password, input.salt, &params);
+});

--- a/rust/tw_keystore/src/crypto_scrypt/mod.rs
+++ b/rust/tw_keystore/src/crypto_scrypt/mod.rs
@@ -1,0 +1,42 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+use crate::crypto_scrypt::params::{InvalidParams, Params};
+use pbkdf2::pbkdf2_hmac;
+use sha2::Sha256;
+
+pub mod params;
+mod romix;
+
+/// The scrypt key derivation function.
+/// Original: https://github.com/RustCrypto/password-hashes/blob/a737bef1f992368f165face097d621bb1e76eba4/scrypt/src/lib.rs#L89
+///
+/// The only reason we should have rewritten the function is that it does unnecessary `log_n >= r * 16` check:
+/// https://github.com/RustCrypto/password-hashes/blob/a737bef1f992368f165face097d621bb1e76eba4/scrypt/src/params.rs#L67-L72
+pub fn scrypt(password: &[u8], salt: &[u8], params: &Params) -> Result<Vec<u8>, InvalidParams> {
+    params.check_params()?;
+
+    // The checks in the `Params::check_params` guarantee
+    // that the following is safe:
+    let n = params.n as usize;
+    let r128 = (params.r as usize) * 128;
+    let pr128 = (params.p as usize) * r128;
+    let nr128 = n * r128;
+
+    let mut b = vec![0u8; pr128];
+    pbkdf2_hmac::<Sha256>(password, salt, 1, &mut b);
+
+    let mut v = vec![0u8; nr128];
+    let mut t = vec![0u8; r128];
+
+    for chunk in &mut b.chunks_mut(r128) {
+        romix::scrypt_ro_mix(chunk, &mut v, &mut t, n);
+    }
+
+    let mut output = vec![0u8; params.desired_len];
+    pbkdf2_hmac::<Sha256>(password, &b, 1, &mut output);
+    Ok(output)
+}

--- a/rust/tw_keystore/src/crypto_scrypt/params.rs
+++ b/rust/tw_keystore/src/crypto_scrypt/params.rs
@@ -1,0 +1,94 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+use std::mem::size_of;
+
+#[derive(Clone, Copy, Debug)]
+pub struct InvalidParams;
+
+pub struct Params {
+    /// Scrypt parameter `N`: CPU/memory cost.
+    /// Must be a power of 2.
+    pub n: u32,
+    /// Scrypt parameter `r`: block size.
+    pub r: u32,
+    /// Scrypt parameter `p`: parallelism.
+    pub p: u32,
+    /// Scrypt parameter `Key length`.
+    pub desired_len: usize,
+}
+
+impl Params {
+    /// Create a new instance of [`Params`].
+    ///
+    /// # Conditions
+    /// - `log_n` must be less than `64`
+    /// - `r` must be greater than `0` and less than or equal to `4294967295`
+    /// - `p` must be greater than `0` and less than `4294967295`
+    /// - `desired_len` must be greater than `9` and less than or equal to `64`
+    ///
+    /// Original: https://github.com/RustCrypto/password-hashes/blob/a737bef1f992368f165face097d621bb1e76eba4/scrypt/src/params.rs#L44
+    ///
+    /// The only reason we should have rewritten the function is that it does unnecessary `log_n >= r * 16` check:
+    /// https://github.com/RustCrypto/password-hashes/blob/a737bef1f992368f165face097d621bb1e76eba4/scrypt/src/params.rs#L67-L72
+    pub fn check_params(&self) -> Result<(), InvalidParams> {
+        let log_n = self.try_log_n()?;
+
+        let cond1 = (log_n as usize) < usize::BITS as usize;
+        let cond2 = size_of::<usize>() >= size_of::<u32>();
+        let cond3 = self.r <= usize::MAX as u32 && self.p < usize::MAX as u32;
+        let cond4 = (10..=64).contains(&self.desired_len);
+        if !(self.r > 0 && self.p > 0 && cond1 && (cond2 || cond3) && cond4) {
+            return Err(InvalidParams);
+        }
+
+        let r = self.r as usize;
+        let p = self.p as usize;
+        let n = self.n as usize;
+
+        // check that r * 128 doesn't overflow
+        let r128 = r.checked_mul(128).ok_or(InvalidParams)?;
+
+        // check that n * r * 128 doesn't overflow
+        r128.checked_mul(n).ok_or(InvalidParams)?;
+
+        // check that p * r * 128 doesn't overflow
+        r128.checked_mul(p).ok_or(InvalidParams)?;
+
+        // This check required by Scrypt:
+        // check: p <= ((2^32-1) * 32) / (128 * r)
+        // It takes a bit of re-arranging to get the check above into this form,
+        // but it is indeed the same.
+        if r * p >= 0x4000_0000 {
+            return Err(InvalidParams);
+        }
+
+        // The following checks are copied from C++:
+        // https://github.com/trustwallet/wallet-core/blob/b530432921d7a9709428b0162673e0ab72de1c3d/src/Keystore/ScryptParameters.cpp#L27-L42
+
+        if (n & (n - 1)) != 0 || n < 2 {
+            // Invalid cost factor.
+            return Err(InvalidParams);
+        }
+
+        let max_r = u32::MAX as usize / 128_usize / p;
+        let max_n = u32::MAX as usize / 128 / r;
+        if r > max_r || n > max_n {
+            return Err(InvalidParams);
+        }
+
+        Ok(())
+    }
+
+    fn try_log_n(&self) -> Result<u8, InvalidParams> {
+        let log_n = self.n.checked_ilog2().ok_or(InvalidParams)?;
+        // `Params::n` must be equal to 2^log_n.
+        if 1 << log_n != self.n {
+            return Err(InvalidParams);
+        }
+        log_n.try_into().map_err(|_| InvalidParams)
+    }
+}

--- a/rust/tw_keystore/src/crypto_scrypt/romix.rs
+++ b/rust/tw_keystore/src/crypto_scrypt/romix.rs
@@ -1,0 +1,81 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+//! Original: https://github.com/RustCrypto/password-hashes/blob/master/scrypt/src/romix.rs
+/// Execute the ROMix operation in-place.
+/// b - the data to operate on
+/// v - a temporary variable to store the vector V
+/// t - a temporary variable to store the result of the xor
+/// n - the scrypt parameter N
+#[allow(clippy::many_single_char_names)]
+pub(crate) fn scrypt_ro_mix(b: &mut [u8], v: &mut [u8], t: &mut [u8], n: usize) {
+    fn integerify(x: &[u8], n: usize) -> usize {
+        // n is a power of 2, so n - 1 gives us a bitmask that we can use to perform a calculation
+        // mod n using a simple bitwise and.
+        let mask = n - 1;
+        // This cast is safe since we're going to get the value mod n (which is a power of 2), so we
+        // don't have to care about truncating any of the high bits off
+        //let result = (LittleEndian::read_u32(&x[x.len() - 64..x.len() - 60]) as usize) & mask;
+        let t = u32::from_le_bytes(x[x.len() - 64..x.len() - 60].try_into().unwrap());
+        (t as usize) & mask
+    }
+
+    let len = b.len();
+
+    for chunk in v.chunks_mut(len) {
+        chunk.copy_from_slice(b);
+        scrypt_block_mix(chunk, b);
+    }
+
+    for _ in 0..n {
+        let j = integerify(b, n);
+        xor(b, &v[j * len..(j + 1) * len], t);
+        scrypt_block_mix(t, b);
+    }
+}
+
+/// Execute the BlockMix operation
+/// input - the input vector. The length must be a multiple of 128.
+/// output - the output vector. Must be the same length as input.
+fn scrypt_block_mix(input: &[u8], output: &mut [u8]) {
+    use salsa20::{
+        cipher::{typenum::U4, StreamCipherCore},
+        SalsaCore,
+    };
+
+    type Salsa20_8 = SalsaCore<U4>;
+
+    let mut x = [0u8; 64];
+    x.copy_from_slice(&input[input.len() - 64..]);
+
+    let mut t = [0u8; 64];
+
+    for (i, chunk) in input.chunks(64).enumerate() {
+        xor(&x, chunk, &mut t);
+
+        let mut t2 = [0u32; 16];
+
+        for (c, b) in t.chunks_exact(4).zip(t2.iter_mut()) {
+            *b = u32::from_le_bytes(c.try_into().unwrap());
+        }
+
+        Salsa20_8::from_raw_state(t2).write_keystream_block((&mut x).into());
+
+        let pos = if i % 2 == 0 {
+            (i / 2) * 64
+        } else {
+            (i / 2) * 64 + input.len() / 2
+        };
+
+        output[pos..pos + 64].copy_from_slice(&x);
+    }
+}
+
+fn xor(x: &[u8], y: &[u8], output: &mut [u8]) {
+    for ((out, &x_i), &y_i) in output.iter_mut().zip(x.iter()).zip(y.iter()) {
+        *out = x_i ^ y_i;
+    }
+}

--- a/rust/tw_keystore/src/ffi/crypto_scrypt.rs
+++ b/rust/tw_keystore/src/ffi/crypto_scrypt.rs
@@ -1,0 +1,70 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#![allow(clippy::missing_safety_doc)]
+
+use crate::crypto_scrypt::params::Params;
+use crate::crypto_scrypt::scrypt;
+use tw_memory::ffi::c_byte_array::{CByteArray, CByteArrayResult};
+use tw_memory::ffi::c_byte_array_ref::CByteArrayRef;
+use tw_memory::ffi::c_result::ErrorCode;
+use tw_misc::try_or_else;
+
+#[repr(C)]
+pub enum ScryptError {
+    Ok = 0,
+    InvalidParams = 1,
+}
+
+impl From<ScryptError> for ErrorCode {
+    fn from(error: ScryptError) -> Self {
+        error as ErrorCode
+    }
+}
+
+/// The scrypt key derivation function.
+///
+/// \param password *nullable* byte array.
+/// \param password_len the length of the `password` array.
+/// \param salt *nullable* byte array.
+/// \param salt_len the length of the `salt` array.
+/// \param n scrypt parameter `N`: CPU/memory cost.
+/// \param r scrypt parameter `r`: block size.
+/// \param p scrypt parameter `p`: parallelism.
+/// \param desired_len scrypt parameter `Key length`.
+/// \return C-compatible byte array.
+#[no_mangle]
+pub unsafe extern "C" fn crypto_scrypt(
+    password: *const u8,
+    password_len: usize,
+    salt: *const u8,
+    salt_len: usize,
+    n: u32,
+    r: u32,
+    p: u32,
+    desired_len: usize,
+) -> CByteArrayResult {
+    let password_ref = CByteArrayRef::new(password, password_len);
+    let password = try_or_else!(password_ref.as_slice(), || CByteArrayResult::error(
+        ScryptError::InvalidParams
+    ));
+
+    let salt_ref = CByteArrayRef::new(salt, salt_len);
+    let salt = try_or_else!(salt_ref.as_slice(), || CByteArrayResult::error(
+        ScryptError::InvalidParams
+    ));
+
+    let params = Params {
+        n,
+        r,
+        p,
+        desired_len,
+    };
+    scrypt(password, salt, &params)
+        .map(CByteArray::from)
+        .map_err(|_| ScryptError::InvalidParams)
+        .into()
+}

--- a/rust/tw_keystore/src/ffi/mod.rs
+++ b/rust/tw_keystore/src/ffi/mod.rs
@@ -1,0 +1,7 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+pub mod crypto_scrypt;

--- a/rust/tw_keystore/src/lib.rs
+++ b/rust/tw_keystore/src/lib.rs
@@ -1,0 +1,8 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+pub mod crypto_scrypt;
+pub mod ffi;

--- a/rust/tw_keystore/tests/crypto_scrypt.rs
+++ b/rust/tw_keystore/tests/crypto_scrypt.rs
@@ -1,0 +1,44 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+use tw_encoding::hex;
+use tw_keystore::crypto_scrypt::params::Params;
+use tw_keystore::crypto_scrypt::scrypt;
+
+#[test]
+fn test_scrypt() {
+    let password = hex::decode("70617373776f7264").unwrap();
+    let salt =
+        hex::decode("80132842c6cde8f9d04582932ef92c3cad3ba6b41e1296ef681692372886db86").unwrap();
+
+    let params = Params {
+        n: 1 << 12,
+        r: 8,
+        p: 6,
+        desired_len: 32,
+    };
+    let res = scrypt(&password, &salt, &params).unwrap();
+    assert_eq!(
+        hex::encode(&res, false),
+        "1217705511f43b7d2faea767a156a9946c579b3436ba27252a73278a7162cedc"
+    );
+}
+
+#[test]
+fn test_scrypt_invalid_n() {
+    let password = hex::decode("70617373776f7264").unwrap();
+    let salt =
+        hex::decode("80132842c6cde8f9d04582932ef92c3cad3ba6b41e1296ef681692372886db86").unwrap();
+
+    let params = Params {
+        // Must be a power of 2.
+        n: (1 << 12) + 1,
+        r: 8,
+        p: 6,
+        desired_len: 32,
+    };
+    scrypt(&password, &salt, &params).unwrap_err();
+}

--- a/rust/tw_keystore/tests/crypto_scrypt_ffi.rs
+++ b/rust/tw_keystore/tests/crypto_scrypt_ffi.rs
@@ -1,0 +1,36 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+use tw_encoding::hex;
+use tw_keystore::ffi::crypto_scrypt::crypto_scrypt;
+use tw_memory::ffi::c_byte_array::CByteArray;
+
+#[test]
+fn test_crypto_scrypt_ffi_null_salt() {
+    let password = hex::decode("70617373776f7264").unwrap();
+    let password = CByteArray::from(password);
+
+    let salt = CByteArray::null();
+
+    let res = unsafe {
+        crypto_scrypt(
+            password.data(),
+            password.size(),
+            salt.data(),
+            salt.size(),
+            16384,
+            8,
+            4,
+            32,
+        )
+    }
+    .unwrap();
+    let data = unsafe { res.into_vec() };
+    assert_eq!(
+        hex::encode(&data, false),
+        "004f57df809101216a343d6215879a9a7f1d7e2c04ef2845b4494cf5f10181a1"
+    );
+}

--- a/rust/wallet_core_rs/Cargo.toml
+++ b/rust/wallet_core_rs/Cargo.toml
@@ -21,6 +21,7 @@ any-coin = ["tw_any_coin"]
 bitcoin = ["tw_bitcoin", "tw_coin_registry"]
 ethereum = ["tw_ethereum", "tw_coin_registry"]
 keypair = ["tw_keypair"]
+keystore = ["tw_keystore"]
 solana = ["tw_solana"]
 ton = ["tw_ton"]
 utils = [
@@ -41,6 +42,7 @@ tw_encoding = { path = "../tw_encoding", optional = true }
 tw_ethereum = { path = "../chains/tw_ethereum", optional = true }
 tw_hash = { path = "../tw_hash", optional = true }
 tw_keypair = { path = "../tw_keypair", optional = true }
+tw_keystore = { path = "../tw_keystore", optional = true }
 tw_memory = { path = "../tw_memory", optional = true }
 tw_number = { path = "../tw_number", optional = true }
 tw_macros = { path = "../tw_macros" }

--- a/rust/wallet_core_rs/cbindgen.toml
+++ b/rust/wallet_core_rs/cbindgen.toml
@@ -11,6 +11,7 @@ extra_bindings = [
     "tw_encoding",
     "tw_hash",
     "tw_keypair",
+    "tw_keystore",
     "tw_memory",
 ]
 include = [
@@ -18,5 +19,6 @@ include = [
     "tw_encoding",
     "tw_hash",
     "tw_keypair",
+    "tw_keystore",
     "tw_memory",
 ]

--- a/rust/wallet_core_rs/src/lib.rs
+++ b/rust/wallet_core_rs/src/lib.rs
@@ -12,6 +12,8 @@ pub extern crate tw_encoding;
 pub extern crate tw_hash;
 #[cfg(feature = "keypair")]
 pub extern crate tw_keypair;
+#[cfg(feature = "keystore")]
+pub extern crate tw_keystore;
 #[cfg(feature = "utils")]
 pub extern crate tw_memory;
 


### PR DESCRIPTION
## Description

Taken from https://github.com/trustwallet/wallet-core/pull/3489

## How to test

Run C++, Rust, iOS, Android, WASM tests

## Types of changes

Add `crypto_scrypt` FFI function in Rust that is inspired by [RustCrypto/scrypt](https://crates.io/crates/scrypt) and using [RustCrypto/pbkdf2](https://crates.io/crates/pbkdf2) (most likely not audited) and [RustCrypto/salsa20](https://crates.io/crates/salsa20) (not audited, has a usage warning).

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [x] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
