### PR TITLE
Adds max output size constraint in pbkdf2 and scrypt

### DIFF
--- a/rust/tw_crypto/src/crypto_pbkdf2/error.rs
+++ b/rust/tw_crypto/src/crypto_pbkdf2/error.rs
@@ -1,0 +1,13 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+pub type Result<T> = core::result::Result<T, Error>;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Error {
+    /// Invalid output size
+    InvalidOutputSize,
+}

--- a/rust/tw_crypto/src/crypto_pbkdf2/mod.rs
+++ b/rust/tw_crypto/src/crypto_pbkdf2/mod.rs
@@ -4,18 +4,28 @@
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
 
+pub mod error;
+
+use error::Error;
+use error::Result;
 use pbkdf2::pbkdf2_hmac;
 use sha2::{Sha256, Sha512};
+
+const MAX_OUTPUT_SIZE: usize = 1024;
 
 pub fn pbkdf2_hmac_sha256(
     password: &[u8],
     salt: &[u8],
     iterations: u32,
     desired_len: usize,
-) -> Vec<u8> {
+) -> Result<Vec<u8>> {
+    if desired_len > MAX_OUTPUT_SIZE {
+        return Err(Error::InvalidOutputSize);
+    }
+
     let mut output = vec![0u8; desired_len];
     pbkdf2_hmac::<Sha256>(password, salt, iterations, &mut output);
-    output
+    Ok(output)
 }
 
 pub fn pbkdf2_hmac_512(
@@ -23,8 +33,12 @@ pub fn pbkdf2_hmac_512(
     salt: &[u8],
     iterations: u32,
     desired_len: usize,
-) -> Vec<u8> {
+) -> Result<Vec<u8>> {
+    if desired_len > MAX_OUTPUT_SIZE {
+        return Err(Error::InvalidOutputSize);
+    }
+
     let mut output = vec![0u8; desired_len];
     pbkdf2_hmac::<Sha512>(password, salt, iterations, &mut output);
-    output
+    Ok(output)
 }

--- a/rust/tw_crypto/src/crypto_scrypt/params.rs
+++ b/rust/tw_crypto/src/crypto_scrypt/params.rs
@@ -6,6 +6,8 @@
 
 use std::mem::size_of;
 
+const MAX_OUTPUT_SIZE: usize = 1024;
+
 #[derive(Clone, Copy, Debug)]
 pub struct InvalidParams;
 
@@ -35,6 +37,10 @@ impl Params {
     /// The only reason we should have rewritten the function is that it does unnecessary `log_n >= r * 16` check:
     /// https://github.com/RustCrypto/password-hashes/blob/a737bef1f992368f165face097d621bb1e76eba4/scrypt/src/params.rs#L67-L72
     pub fn check_params(&self) -> Result<(), InvalidParams> {
+        if self.desired_len > MAX_OUTPUT_SIZE {
+            return Err(InvalidParams);
+        }
+
         let log_n = self.try_log_n()?;
 
         let cond1 = (log_n as usize) < usize::BITS as usize;

--- a/rust/tw_crypto/src/ffi/crypto_pbkdf2.rs
+++ b/rust/tw_crypto/src/ffi/crypto_pbkdf2.rs
@@ -9,6 +9,7 @@
 use crate::crypto_pbkdf2::{pbkdf2_hmac_512, pbkdf2_hmac_sha256};
 use tw_macros::tw_ffi;
 use tw_memory::ffi::{tw_data::TWData, Nonnull, NullableMut, RawPtrTrait};
+use tw_misc::try_or_else;
 
 /// The PBKDF2 key derivation function.
 ///
@@ -32,7 +33,10 @@ pub unsafe extern "C" fn tw_pbkdf2_hmac_sha256(
         .map(|data| data.as_slice())
         .unwrap_or_default();
 
-    let output = pbkdf2_hmac_sha256(password, salt, iterations, dk_len);
+    let output = try_or_else!(
+        pbkdf2_hmac_sha256(password, salt, iterations, dk_len),
+        std::ptr::null_mut
+    );
     TWData::from(output).into_ptr()
 }
 
@@ -58,6 +62,9 @@ pub unsafe extern "C" fn tw_pbkdf2_hmac_sha512(
         .map(|data| data.as_slice())
         .unwrap_or_default();
 
-    let output = pbkdf2_hmac_512(password, salt, iterations, dk_len);
+    let output = try_or_else!(
+        pbkdf2_hmac_512(password, salt, iterations, dk_len),
+        std::ptr::null_mut
+    );
     TWData::from(output).into_ptr()
 }

--- a/rust/tw_crypto/tests/crypto_pbkdf2.rs
+++ b/rust/tw_crypto/tests/crypto_pbkdf2.rs
@@ -4,7 +4,7 @@
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
 
-use tw_crypto::crypto_pbkdf2::pbkdf2_hmac_sha256;
+use tw_crypto::crypto_pbkdf2::{error::Error, pbkdf2_hmac_512, pbkdf2_hmac_sha256};
 use tw_encoding::{base64, base64::STANDARD, hex};
 
 #[test]
@@ -12,13 +12,13 @@ fn test_pbkdf2_hmac_sha256() {
     let password = hex::decode("70617373776f7264").unwrap();
     let salt = hex::decode("73616C74").unwrap();
 
-    let data = pbkdf2_hmac_sha256(&password, &salt, 1, 20);
+    let data = pbkdf2_hmac_sha256(&password, &salt, 1, 20).unwrap();
     assert_eq!(
         hex::encode(&data, false),
         "120fb6cffcf8b32c43e7225256c4f837a86548c9"
     );
 
-    let data = pbkdf2_hmac_sha256(&password, &salt, 4096, 20);
+    let data = pbkdf2_hmac_sha256(&password, &salt, 4096, 20).unwrap();
     assert_eq!(
         hex::encode(&data, false),
         "c5e478d59288c841aa530db6845c4c8d962893a0"
@@ -26,9 +26,21 @@ fn test_pbkdf2_hmac_sha256() {
 
     let salt2 = base64::decode("kNHS+Mx//slRsmLF9396HQ==", STANDARD).unwrap();
 
-    let data = pbkdf2_hmac_sha256(&password, &salt2, 100, 32);
+    let data = pbkdf2_hmac_sha256(&password, &salt2, 100, 32).unwrap();
     assert_eq!(
         hex::encode(&data, false),
         "9cf33ebd3542c691fac6f61609a8d13355a0adf4d15eed77cc9d13f792b77c3a"
     );
+}
+
+#[test]
+fn test_pbkdf2_hmac_exceeds_max_output_size() {
+    let password = hex::decode("70617373776f7264").unwrap();
+    let salt = hex::decode("73616C74").unwrap();
+
+    let data = pbkdf2_hmac_sha256(&password, &salt, 1, 1025);
+    assert_eq!(data.err(), Some(Error::InvalidOutputSize));
+
+    let data = pbkdf2_hmac_512(&password, &salt, 1, 1025);
+    assert_eq!(data.err(), Some(Error::InvalidOutputSize));
 }

--- a/rust/tw_crypto/tests/crypto_scrypt.rs
+++ b/rust/tw_crypto/tests/crypto_scrypt.rs
@@ -42,3 +42,18 @@ fn test_scrypt_invalid_n() {
     };
     scrypt(&password, &salt, &params).unwrap_err();
 }
+
+#[test]
+fn test_scrypt_exceeds_max_output_size() {
+    let password = hex::decode("70617373776f7264").unwrap();
+    let salt =
+        hex::decode("80132842c6cde8f9d04582932ef92c3cad3ba6b41e1296ef681692372886db86").unwrap();
+
+    let params = Params {
+        n: 1 << 12,
+        r: 8,
+        p: 6,
+        desired_len: 1025,
+    };
+    scrypt(&password, &salt, &params).unwrap_err();
+}


### PR DESCRIPTION
## Description

This PR restricts the desired length to <= 1024 for both pbkdf2 and scrypt calculations.

## How to test

Rust Tests

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Create pull request as draft initially, unless its complete.
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
- [ ] If there is a related Issue, mention it in the description.

If you're adding a new blockchain

- [ ] I have read the [guidelines](https://developer.trustwallet.com/wallet-core/newblockchain#integration-criteria) for adding a new blockchain.
