### PR TITLE
Add Fitochain (chainId 1233) to Trust Wallet

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -4859,33 +4859,35 @@
     "blockchain": "Polymesh",
     "derivation": [
       {
-        "path": "m/44'/595'/0'/0'/0'"
+            "path": "m/44'/595'/0'/0'/0'"
+      }
+    ]
+  },
+  {
+    "id": "fitochain",
+    "name": "Fitochain",
+    "coinId": 1233,
+    "symbol": "FITO",
+    "decimals": 18,
+    "blockchain": "Fitochain",
+    "derivation": [
+      {
+        "path": "m/44'/1233'/0'/0/0"
       }
     ],
-  {
-  "id": "fitochain",
-  "name": "Fitochain",
-  "coinId": 1233,
-  "symbol": "FITO",
-  "decimals": 18,
-  "blockchain": "Fitochain",
-  "derivation": [
-    {
-      "path": "m/44'/1233'/0'/0/0"
-    }
-  ],
-  "curve": "secp256k1",
-  "publicKeyType": "secp256k1",
-  "explorer": {
-    "url": "https://explorer.fitochain.com",
-    "txPath": "/tx/{txHash}",
-    "accountPath": "/address/{address}"
-  },
-  "info": {
-    "url": "https://fitochain.com",
-    "source": "https://github.com/donholmes805", 
-    "rpc": "https://rpc.fitochain.com",
-    "documentation": "https://fitochain.com/docs"
+    "curve": "secp256k1",
+    "publicKeyType": "secp256k1",
+    "explorer": {
+      "url": "https://explorer.fitochain.com",
+      "txPath": "/tx/{txHash}",
+      "accountPath": "/address/{address}"
+    },
+    "info": {
+      "url": "https://fitochain.com",
+      "source": "https://github.com/donholmes805",
+      "rpc": "https://rpc.fitochain.com",
+      "documentation": "https://fitochain.com/docs"
+    },
+    "logoURI": "ipfs://bafkreifb3rymsc4nerl4ikh54seyhpqwnio5bdxrp3aapb6dt3wrtgl57y"
   }
-}
 ]


### PR DESCRIPTION
This PR adds support for the Fitochain blockchain:

- Name: Fitochain
- Chain ID: 1233
- Consensus: Proof-of-Stake
- Symbol: FITO
- Explorer: https://explorer.fitochain.com
- RPC: https://rpc.fitochain.com

This will allow Trust Wallet to recognize and support Fitochain natively.
