### PR TITLE
chore(aptos): Deprecate `register_token` in Rust

### DIFF
--- a/rust/chains/tw_aptos/src/aptos_move_packages.rs
+++ b/rust/chains/tw_aptos/src/aptos_move_packages.rs
@@ -192,22 +192,6 @@ pub fn token_transfers_claim_script(
     )))
 }
 
-pub fn managed_coin_register(coin_type: TypeTag) -> TransactionPayload {
-    TransactionPayload::EntryFunction(EntryFunction::new(
-        ModuleId::new(
-            AccountAddress::new([
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 1,
-            ]),
-            ident_str!("managed_coin").to_owned(),
-        ),
-        ident_str!("register").to_owned(),
-        vec![coin_type],
-        vec![],
-        json!([]),
-    ))
-}
-
 pub fn fungible_asset_transfer(
     metadata_address: AccountAddress,
     to: AccountAddress,

--- a/rust/chains/tw_aptos/src/transaction_builder.rs
+++ b/rust/chains/tw_aptos/src/transaction_builder.rs
@@ -5,9 +5,8 @@
 use crate::address::from_account_error;
 use crate::aptos_move_packages::{
     aptos_account_create_account, aptos_account_transfer, aptos_account_transfer_coins,
-    coin_transfer, fungible_asset_transfer, managed_coin_register,
-    token_transfers_cancel_offer_script, token_transfers_claim_script,
-    token_transfers_offer_script,
+    coin_transfer, fungible_asset_transfer, token_transfers_cancel_offer_script,
+    token_transfers_claim_script, token_transfers_offer_script,
 };
 use crate::constants::{GAS_UNIT_PRICE, MAX_GAS_AMOUNT};
 use crate::liquid_staking::{
@@ -124,13 +123,6 @@ impl TransactionFactory {
             OneOftransaction_payload::nft_message(nft_message) => {
                 factory.nft_ops(NftOperation::try_from(nft_message)?)
             },
-            OneOftransaction_payload::register_token(register_token) => {
-                let function = register_token
-                    .function
-                    .or_tw_err(SigningErrorType::Error_invalid_params)
-                    .context("'ManagedTokensRegisterMessage::function' is not set")?;
-                Ok(factory.register_token(convert_proto_struct_tag_to_type_tag(function)?))
-            },
             OneOftransaction_payload::liquid_staking_message(msg) => {
                 factory.liquid_staking_ops(LiquidStakingOperation::try_from(msg)?)
             },
@@ -198,10 +190,6 @@ impl TransactionFactory {
 
     pub fn create_user_account(&self, to: AccountAddress) -> SigningResult<TransactionBuilder> {
         Ok(self.payload(aptos_account_create_account(to)?))
-    }
-
-    pub fn register_token(&self, coin_type: TypeTag) -> TransactionBuilder {
-        self.payload(managed_coin_register(coin_type))
     }
 
     pub fn nft_ops(&self, operation: NftOperation) -> SigningResult<TransactionBuilder> {

--- a/rust/chains/tw_aptos/tests/signer.rs
+++ b/rust/chains/tw_aptos/tests/signer.rs
@@ -122,17 +122,6 @@ fn setup_proto_transaction<'a>(
                 panic!("Unsupported arguments")
             }
         },
-        "register_token" => {
-            if let OpsDetails::RegisterToken(register_token) = ops_details.unwrap() {
-                Proto::mod_SigningInput::OneOftransaction_payload::register_token(
-                    Proto::ManagedTokensRegisterMessage {
-                        function: Some(convert_type_tag_to_struct_tag(register_token.coin_type)),
-                    },
-                )
-            } else {
-                panic!("Unsupported arguments")
-            }
-        },
         "liquid_staking_ops" => {
             if let OpsDetails::LiquidStakingOps(liquid_staking_ops) = ops_details.unwrap() {
                 Proto::mod_SigningInput::OneOftransaction_payload::liquid_staking_message(

--- a/src/proto/Aptos.proto
+++ b/src/proto/Aptos.proto
@@ -57,12 +57,6 @@ message FungibleAssetTransferMessage {
   uint64 amount = 3;
 }
 
-// Necessary fields to process a ManagedTokensRegisterMessage
-message ManagedTokensRegisterMessage {
-  // token function to register, e.g BTC: 0x43417434fd869edee76cca2a4d2301e528a1551b1d719b75c350c3c97d15b8b9::coins::BTC
-  StructTag function = 1;
-}
-
 // Necessary fields to process a CreateAccountMessage
 message CreateAccountMessage {
   // auth account address to create
@@ -171,7 +165,6 @@ message SigningInput {
     TokenTransferMessage token_transfer = 10;
     CreateAccountMessage create_account = 11;
     NftMessage nft_message = 12;
-    ManagedTokensRegisterMessage register_token = 13;
     LiquidStaking liquid_staking_message = 14;
     TokenTransferCoinsMessage token_transfer_coins = 15;
     FungibleAssetTransferMessage fungible_asset_transfer = 16;


### PR DESCRIPTION
This pull request removes support for the "managed coin register" functionality from the Aptos transaction builder and related code. The main changes include deleting the code for creating and handling managed coin registration transactions, as well as removing the associated Protobuf message and test logic.

Removed managed coin registration functionality:

* Deleted the `managed_coin_register` function from `aptos_move_packages.rs`, which built the transaction payload for registering a managed coin.
* Removed the `register_token` branch and method from `TransactionFactory` in `transaction_builder.rs`, eliminating support for building these transactions. [[1]](diffhunk://#diff-1cc6b0fe5189695b04981a7c0531df5d98e96773bcc7c3a4dbbb7326908ca27fL127-L133) [[2]](diffhunk://#diff-1cc6b0fe5189695b04981a7c0531df5d98e96773bcc7c3a4dbbb7326908ca27fL203-L206)
* Removed the import of `managed_coin_register` from `transaction_builder.rs`.

Protobuf and test cleanup:

* Deleted the `ManagedTokensRegisterMessage` message and its usage from `Aptos.proto`, and removed the corresponding field from the `SigningInput` message. [[1]](diffhunk://#diff-882dfa5ab20aca1790d90e32c96108f0b26228fe64b997ca5867b914ee1c6d65L60-L65) [[2]](diffhunk://#diff-882dfa5ab20aca1790d90e32c96108f0b26228fe64b997ca5867b914ee1c6d65L174)
* Removed test logic for the `register_token` operation from `signer.rs`.