### PR TITLE
fix(ci): Use `iPhone 16` in ios-release

### DIFF
--- a/tools/ios-doc
+++ b/tools/ios-doc
@@ -9,7 +9,7 @@ pushd swift
 mkdir -p build && rm -rf build/*.doccarchive
 
 export DOCC_JSON_PRETTYPRINT="YES"
-xcodebuild -workspace TrustWalletCore.xcworkspace -derivedDataPath build/docsData -scheme WalletCore -destination 'platform=iOS Simulator,name=iPhone 14' -parallelizeTargets docbuild | xcbeautify
+xcodebuild -workspace TrustWalletCore.xcworkspace -derivedDataPath build/docsData -scheme WalletCore -destination 'platform=iOS Simulator,name=iPhone 16' -parallelizeTargets docbuild | xcbeautify
 
 pushd build
 


### PR DESCRIPTION
This pull request updates the iOS simulator device used for documentation builds in the `tools/ios-doc` script. The simulator target is changed from "iPhone 14" to "iPhone 16" to ensure compatibility with newer environments.

Build process update:

* Updated the `xcodebuild` command in `tools/ios-doc` to use the "iPhone 16" simulator instead of "iPhone 14" for generating documentation.