### PR TITLE
fix(barz): Replace u32 parameters with i32

### DIFF
--- a/rust/tw_evm/src/ffi/barz.rs
+++ b/rust/tw_evm/src/ffi/barz.rs
@@ -41,10 +41,10 @@ pub unsafe extern "C" fn tw_barz_get_counterfactual_address(
 
 /// Returns the init code parameter of ERC-4337 User Operation
 ///
-/// \param factory The address of the factory contract.
+/// \param factory The address of the factory contract
 /// \param public_key Public key for the verification facet
-/// \param verification_facet The address of the verification facet.
-/// \param salt The salt of the init code.
+/// \param verification_facet The address of the verification facet
+/// \param salt The salt of the init code; Must be non-negative
 /// \return The init code.
 #[tw_ffi(ty = static_function, class = TWBarz, name = GetInitCode)]
 #[no_mangle]
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn tw_barz_get_init_code(
     factory: Nonnull<TWString>,
     public_key: NonnullMut<TWPublicKey>,
     verification_facet: Nonnull<TWString>,
-    salt: u32,
+    salt: i32,
 ) -> NullableMut<TWData> {
     let factory_address = try_or_else!(TWString::from_ptr_as_ref(factory), std::ptr::null_mut);
     let factory_address = try_or_else!(factory_address.as_str(), std::ptr::null_mut);
@@ -63,6 +63,8 @@ pub unsafe extern "C" fn tw_barz_get_init_code(
         std::ptr::null_mut
     );
     let verification_facet = try_or_else!(verification_facet.as_str(), std::ptr::null_mut);
+    let salt = try_or_else!(salt.try_into(), std::ptr::null_mut);
+
     let init_code = try_or_else!(
         get_init_code(
             factory_address,
@@ -117,18 +119,20 @@ pub unsafe extern "C" fn tw_barz_get_formatted_signature(
 ///
 /// \param msg_hash Original msgHash
 /// \param barzAddress The address of Barz wallet signing the message
-/// \param chainId The chainId of the network the verification will happen
+/// \param chainId The chainId of the network the verification will happen; Must be non-negative
 /// \return The final hash to be signed.
 #[tw_ffi(ty = static_function, class = TWBarz, name = GetPrefixedMsgHash)]
 #[no_mangle]
 pub unsafe extern "C" fn tw_barz_get_prefixed_msg_hash(
     msg_hash: Nonnull<TWData>,
     barz_address: Nonnull<TWString>,
-    chain_id: u32,
+    chain_id: i32,
 ) -> NullableMut<TWData> {
     let msg_hash = try_or_else!(TWData::from_ptr_as_ref(msg_hash), std::ptr::null_mut);
     let barz_address = try_or_else!(TWString::from_ptr_as_ref(barz_address), std::ptr::null_mut);
     let barz_address = try_or_else!(barz_address.as_str(), std::ptr::null_mut);
+    let chain_id = try_or_else!(chain_id.try_into(), std::ptr::null_mut);
+
     let prefixed_msg_hash = try_or_else!(
         get_prefixed_msg_hash(msg_hash.as_slice(), barz_address, chain_id),
         std::ptr::null_mut

--- a/rust/tw_macros/src/lib.rs
+++ b/rust/tw_macros/src/lib.rs
@@ -2,6 +2,7 @@ use proc_macro::TokenStream;
 
 mod code_gen;
 mod tw_ffi;
+mod utils;
 
 #[proc_macro_attribute]
 pub fn tw_ffi(attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/rust/tw_macros/src/tw_ffi.rs
+++ b/rust/tw_macros/src/tw_ffi.rs
@@ -12,6 +12,7 @@ use std::fs;
 use std::path::Path;
 
 use crate::code_gen::{TWArg, TWConfig, TWFunction};
+use crate::utils::is_uint;
 
 pub mod keywords {
     use syn::custom_keyword;
@@ -134,6 +135,13 @@ pub fn tw_ffi(attr: TokenStream2, item: TokenStream2) -> Result<TokenStream2> {
     };
 
     let class = args.class.unwrap().to_string();
+    // TODO add support for structs.
+    if func_args.iter().any(|arg| is_uint(&arg.ty)) {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "Unsigned integers are not supported within class methods. Consider using 'struct' or signed integers. See https://kotlinlang.org/docs/inline-classes.html#mangling"
+        ));
+    }
     let docs = func
         .attrs
         .iter()

--- a/rust/tw_macros/src/utils.rs
+++ b/rust/tw_macros/src/utils.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+
+pub fn is_uint(ty: &str) -> bool {
+    matches!(ty, "u8" | "u16" | "u32" | "u64" | "u128" | "usize")
+}


### PR DESCRIPTION
This pull request updates the FFI interface and macro code to improve type safety and prevent issues with unsigned integer types in FFI-exposed class methods. The main changes include switching FFI parameters from unsigned to signed integers in `barz.rs`, adding runtime checks for integer conversion, and introducing compile-time validation in the macro to block unsigned integer types in class methods. A new utility function is also added to help with type checking.

### FFI interface improvements

* Changed FFI parameter types from `u32` to `i32` for `salt` and `chain_id` in `tw_barz_get_init_code` and `tw_barz_get_prefixed_msg_hash` to enforce the use of signed integers and updated documentation comments to clarify non-negative requirements. [[1]](diffhunk://#diff-22b60354d54c6f63347aa155e4e544727eb6012b8ef3bb1dab1e7c138404d2c2L44-R55) [[2]](diffhunk://#diff-22b60354d54c6f63347aa155e4e544727eb6012b8ef3bb1dab1e7c138404d2c2L120-R135)
* Added runtime conversion checks using `try_into()` for `salt` and `chain_id` to ensure proper type handling and error safety at the FFI boundary. [[1]](diffhunk://#diff-22b60354d54c6f63347aa155e4e544727eb6012b8ef3bb1dab1e7c138404d2c2R66-R67) [[2]](diffhunk://#diff-22b60354d54c6f63347aa155e4e544727eb6012b8ef3bb1dab1e7c138404d2c2L120-R135)

### Macro and code generation validation

* Added a compile-time check in the `tw_ffi` macro to reject unsigned integer types in class methods, with a clear error message and documentation link for guidance.
* Introduced a new utility function `is_uint` in `utils.rs` to support type checking for unsigned integers.
* Updated imports to include the new utility module where needed. [[1]](diffhunk://#diff-afc3632b4dd6df7703dff3315a1edf73cac39fae645e1da2c264601e2dfee134R5) [[2]](diffhunk://#diff-ad816ae19fbdca5ce3734b6920039e39fa3fd7383a54fb805ff973ac0dec57cdR15)