### PR TITLE
fix(data): Allocate empty array on `tw_data_create_with_bytes` if data is NULL

### DIFF
--- a/rust/tw_keypair/src/ffi/asn.rs
+++ b/rust/tw_keypair/src/ffi/asn.rs
@@ -32,9 +32,7 @@ pub unsafe extern "C" fn ecdsa_signature_from_asn_der(
     encoded_len: usize,
 ) -> CByteArrayResult {
     let encoded_ref = CByteArrayRef::new(encoded, encoded_len);
-    let Some(encoded) = encoded_ref.to_vec() else {
-        return CByteArrayResult::error(CKeyPairError::InvalidSignature);
-    };
+    let encoded = encoded_ref.to_vec();
 
     der::Signature::from_bytes(encoded.as_slice())
         .map(|sign| CByteArray::from(sign.to_vec()))

--- a/rust/tw_keypair/src/ffi/privkey.rs
+++ b/rust/tw_keypair/src/ffi/privkey.rs
@@ -33,7 +33,7 @@ pub unsafe extern "C" fn tw_private_key_create_with_data(
     input_len: usize,
 ) -> *mut TWPrivateKey {
     let bytes_ref = CByteArrayRef::new(input, input_len);
-    let bytes = try_or_else!(bytes_ref.to_vec(), std::ptr::null_mut);
+    let bytes = bytes_ref.to_vec();
 
     PrivateKey::new(bytes)
         .map(|private| TWPrivateKey(private).into_ptr())
@@ -85,7 +85,7 @@ pub unsafe extern "C" fn tw_private_key_is_valid(
     curve: u32,
 ) -> bool {
     let curve = try_or_false!(Curve::from_raw(curve));
-    let priv_key_slice = try_or_false!(CByteArrayRef::new(key, key_len).as_slice());
+    let priv_key_slice = CByteArrayRef::new(key, key_len).as_slice();
     PrivateKey::is_valid(priv_key_slice, curve)
 }
 
@@ -105,10 +105,7 @@ pub unsafe extern "C" fn tw_private_key_sign(
 ) -> CByteArray {
     let curve = try_or_else!(Curve::from_raw(curve), CByteArray::default);
     let private = try_or_else!(TWPrivateKey::from_ptr_as_ref(key), CByteArray::default);
-    let message_to_sign = try_or_else!(
-        CByteArrayRef::new(message, message_len).as_slice(),
-        CByteArray::default
-    );
+    let message_to_sign = CByteArrayRef::new(message, message_len).as_slice();
 
     // Return an empty signature if an error occurs.
     let sig = private.0.sign(message_to_sign, curve).unwrap_or_default();

--- a/rust/tw_keypair/src/ffi/pubkey.rs
+++ b/rust/tw_keypair/src/ffi/pubkey.rs
@@ -34,7 +34,7 @@ pub unsafe extern "C" fn tw_public_key_create_with_data(
     ty: u32,
 ) -> *mut TWPublicKey {
     let bytes_ref = CByteArrayRef::new(input, input_len);
-    let bytes = try_or_else!(bytes_ref.to_vec(), std::ptr::null_mut);
+    let bytes = bytes_ref.to_vec();
     let ty = try_or_else!(PublicKeyType::from_raw(ty), std::ptr::null_mut);
     PublicKey::new(bytes, ty)
         .map(|public| TWPublicKey(public).into_ptr())
@@ -67,8 +67,8 @@ pub unsafe extern "C" fn tw_public_key_verify(
     msg_len: usize,
 ) -> bool {
     let public = try_or_false!(TWPublicKey::from_ptr_as_ref(key));
-    let sig = try_or_false!(CByteArrayRef::new(sig, sig_len).as_slice());
-    let msg = try_or_false!(CByteArrayRef::new(msg, msg_len).as_slice());
+    let sig = CByteArrayRef::new(sig, sig_len).as_slice();
+    let msg = CByteArrayRef::new(msg, msg_len).as_slice();
     public.0.verify(sig, msg)
 }
 

--- a/rust/tw_memory/src/ffi/c_byte_array_ref.rs
+++ b/rust/tw_memory/src/ffi/c_byte_array_ref.rs
@@ -22,8 +22,8 @@ impl CByteArrayRef {
     /// # Safety
     ///
     /// The inner data must be valid.
-    pub unsafe fn to_vec(&self) -> Option<Vec<u8>> {
-        self.as_slice().map(|data| data.to_vec())
+    pub unsafe fn to_vec(&self) -> Vec<u8> {
+        self.as_slice().to_vec()
     }
 
     /// Returns a slice.
@@ -32,10 +32,10 @@ impl CByteArrayRef {
     /// # Safety
     ///
     /// The inner data must be valid.
-    pub unsafe fn as_slice(&self) -> Option<&'static [u8]> {
+    pub unsafe fn as_slice(&self) -> &'static [u8] {
         if self.data.is_null() {
-            return None;
+            return &[];
         }
-        Some(std::slice::from_raw_parts(self.data, self.size))
+        std::slice::from_raw_parts(self.data, self.size)
     }
 }

--- a/rust/tw_memory/src/ffi/tw_data.rs
+++ b/rust/tw_memory/src/ffi/tw_data.rs
@@ -20,8 +20,8 @@ impl TWData {
     }
 
     /// Creates a `TWData` from a raw byte array.
-    pub unsafe fn from_raw_data(bytes: *const u8, size: usize) -> Option<TWData> {
-        CByteArrayRef::new(bytes, size).to_vec().map(TWData)
+    pub unsafe fn from_raw_data(bytes: *const u8, size: usize) -> TWData {
+        TWData(CByteArrayRef::new(bytes, size).to_vec())
     }
 
     /// Converts `TWData` into `Data` without additional allocation.
@@ -65,9 +65,7 @@ impl RawPtrTrait for TWData {}
 /// \return Non-null filled block of data.
 #[no_mangle]
 pub unsafe extern "C" fn tw_data_create_with_bytes(bytes: *const u8, size: usize) -> *mut TWData {
-    TWData::from_raw_data(bytes, size)
-        .map(|data| data.into_ptr())
-        .unwrap_or_else(std::ptr::null_mut)
+    TWData::from_raw_data(bytes, size).into_ptr()
 }
 
 /// Deletes a block of data created with a `TWDataCreate*` method.

--- a/rust/tw_memory/src/ffi/tw_string.rs
+++ b/rust/tw_memory/src/ffi/tw_string.rs
@@ -16,9 +16,7 @@ pub struct TWString(CString);
 
 impl TWString {
     pub unsafe fn is_utf8_string(bytes: *const u8, size: usize) -> bool {
-        let Some(bytes) = CByteArrayRef::new(bytes, size).to_vec() else {
-            return false;
-        };
+        let bytes = CByteArrayRef::new(bytes, size).to_vec();
         String::from_utf8(bytes).is_ok()
     }
 

--- a/tests/chains/Ethereum/BarzTests.cpp
+++ b/tests/chains/Ethereum/BarzTests.cpp
@@ -423,6 +423,24 @@ TEST(Barz, SignAuthorization) {
     }
 }
 
+TEST(Barz, SignAuthorizationZeroNonce) {
+    {
+        const auto chainId = store(uint256_t(1));
+        const auto contractAddress = "0xB91aaa96B138A1B1D94c9df4628187132c5F2bf1";
+        const Data nonce;
+        const auto privateKey = "0x947dd69af402e7f48da1b845dfc1df6be593d01a0d8274bd03ec56712e7164e8";
+
+        const auto signedAuthorization = WRAPS(TWBarzSignAuthorization(WRAPD(TWDataCreateWithBytes(chainId.data(), chainId.size())).get(), STRING(contractAddress).get(), WRAPD(TWDataCreateWithBytes(nonce.data(), nonce.size())).get(), STRING(privateKey).get()));
+        auto json = nlohmann::json::parse(std::string(TWStringUTF8Bytes(signedAuthorization.get())));
+        ASSERT_EQ(json["chainId"], hexEncoded(chainId));
+        ASSERT_EQ(json["address"], contractAddress);
+        ASSERT_EQ(json["nonce"], "0x00");
+        ASSERT_EQ(json["yParity"], hexEncoded(store(uint256_t(0))));
+        ASSERT_EQ(json["r"], "0x2269a34ea41b8898fb28196c3548836e2df0efe5968574be1cefc0355af11c24");
+        ASSERT_EQ(json["s"], "0x601b4443deafb48303d4f4a580505485e3fa7f516472675227494a88e9d0a5b5");
+    }
+}
+
 TEST(Barz, GetEncodedHash) {
     {
         const auto chainId = store(uint256_t(31337), 32);

--- a/tests/common/DataTests.cpp
+++ b/tests/common/DataTests.cpp
@@ -92,3 +92,13 @@ TEST(DataTests, hasPrefix) {
     const Data prefix23 = parse_hex("bb");
     EXPECT_FALSE(has_prefix(data, prefix23));
 }
+
+TEST(DataTests, rustEmptyArray) {
+    Data empty;
+    EXPECT_EQ(empty.size(), 0ul);
+    EXPECT_EQ(empty.data(), nullptr);
+    auto* rustPtr = Rust::tw_data_create_with_bytes(empty.data(), empty.size());
+    EXPECT_NE(rustPtr, nullptr);
+    EXPECT_EQ(Rust::tw_data_size(rustPtr), 0);
+    Rust::tw_data_delete(rustPtr);
+}


### PR DESCRIPTION
This pull request refactors memory handling in the Rust FFI layer to simplify error handling and improve API consistency. The main change is that methods like `CByteArrayRef::to_vec()` and `CByteArrayRef::as_slice()` now always return a value (empty if pointer is NULL), instead of an `Option`. Additionally, a new test is added for Ethereum Barz authorization with an empty-array representation of zero nonce.

### Memory API refactoring

* [`rust/tw_memory/src/ffi/c_byte_array_ref.rs`](diffhunk://#diff-1b997197f87eefd2c000261fbca414d8e9baea7c87fb79e44d2b5c22bbca0dcbL25-R26): Changed `CByteArrayRef::to_vec()` and `CByteArrayRef::as_slice()` to always return a value (empty on invalid input), removing `Option` from their signatures. [[1]](diffhunk://#diff-1b997197f87eefd2c000261fbca414d8e9baea7c87fb79e44d2b5c22bbca0dcbL25-R26) [[2]](diffhunk://#diff-1b997197f87eefd2c000261fbca414d8e9baea7c87fb79e44d2b5c22bbca0dcbL35-R39)
* [`rust/tw_memory/src/ffi/tw_data.rs`](diffhunk://#diff-1887252784ac6ba54082cdf13b132e35f750fd7bcb93e1cd7b25976865be00aaL23-R24): Updated `TWData::from_raw_data()` to always return a `TWData` and refactored `tw_data_create_with_bytes()` to remove error handling for null pointers. [[1]](diffhunk://#diff-1887252784ac6ba54082cdf13b132e35f750fd7bcb93e1cd7b25976865be00aaL23-R24) [[2]](diffhunk://#diff-1887252784ac6ba54082cdf13b132e35f750fd7bcb93e1cd7b25976865be00aaL68-R68)
* [`rust/tw_memory/src/ffi/tw_string.rs`](diffhunk://#diff-87ad852bca7bede860d237e15f8774ffd8cbae4ab7da6e763bc7744c187066d3L19-R19): Simplified `TWString::is_utf8_string()` to remove error handling for invalid input.

### FFI function simplification

* `rust/tw_keypair/src/ffi/privkey.rs`, `rust/tw_keypair/src/ffi/pubkey.rs`, `rust/tw_keypair/src/ffi/asn.rs`: Removed error-handling macros (`try_or_else!`, `try_or_false!`) from FFI functions, relying on the new memory API to return empty values on invalid input instead. [[1]](diffhunk://#diff-3d15808a32e4d2829e341a8f6f40ef140a480c124fc75d0e39c7aef5a9ff45cfL36-R36) [[2]](diffhunk://#diff-3d15808a32e4d2829e341a8f6f40ef140a480c124fc75d0e39c7aef5a9ff45cfL88-R88) [[3]](diffhunk://#diff-3d15808a32e4d2829e341a8f6f40ef140a480c124fc75d0e39c7aef5a9ff45cfL108-R108) [[4]](diffhunk://#diff-2de37651a6becfe2deb797cd3c84315f6c65c556eb010ae68afa7b3729eb9a92L37-R37) [[5]](diffhunk://#diff-2de37651a6becfe2deb797cd3c84315f6c65c556eb010ae68afa7b3729eb9a92L70-R71) [[6]](diffhunk://#diff-5d8330fa98e0da920aa2ed9778d3dccb82f6c8fd5237187e69e5e1c8e3edd6e4L35-R35)

### Testing improvements

* [`tests/chains/Ethereum/BarzTests.cpp`](diffhunk://#diff-bea784b364c46fd4a4715ee5853c31a360be55c41d89c564efc4ea67ed718b8eR426-R443): Added a new test case for signing Ethereum Barz authorization with a zero nonce to verify correct handling of empty nonce input.