### PR TITLE
feat(monad): Update block explorer

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -4929,7 +4929,7 @@
     "chainId": "143",
     "addressHasher": "keccak256",
     "explorer": {
-      "url": "http://monvision.io",
+      "url": "https://monvision.io",
       "txPath": "/tx/",
       "accountPath": "/address/",
       "sampleTx": "0x8394f9f01bc2ae2cc93e19170bf80c303210f6f4198e5ec3cc99b0cba04962b6",

--- a/tests/chains/Monad/TWCoinTypeTests.cpp
+++ b/tests/chains/Monad/TWCoinTypeTests.cpp
@@ -24,6 +24,6 @@ TEST(TWMonadCoinType, TWCoinType) {
     ASSERT_EQ(TWCoinTypeP2pkhPrefix(coin), 0);
     ASSERT_EQ(TWCoinTypeP2shPrefix(coin), 0);
     ASSERT_EQ(TWCoinTypeStaticPrefix(coin), 0);
-    assertStringsEqual(txUrl, "http://monvision.io/tx/0x8394f9f01bc2ae2cc93e19170bf80c303210f6f4198e5ec3cc99b0cba04962b6");
-    assertStringsEqual(accUrl, "http://monvision.io/address/0x6ab69B482987b0BA1f1c96BDbDC192a80CB09132");
+    assertStringsEqual(txUrl, "https://monvision.io/tx/0x8394f9f01bc2ae2cc93e19170bf80c303210f6f4198e5ec3cc99b0cba04962b6");
+    assertStringsEqual(accUrl, "https://monvision.io/address/0x6ab69B482987b0BA1f1c96BDbDC192a80CB09132");
 }


### PR DESCRIPTION
This pull request updates the Monad chain explorer URLs to reflect the recent change in their official explorer domain. Both the registry configuration and the related unit tests have been updated to use the new `monvision.io` domain.

Explorer URL updates:

* Updated the `explorer.url` field for Monad in `registry.json` from `https://monadexplorer.com` to `https://monvision.io`.
* Updated the expected explorer URLs in `tests/chains/Monad/TWCoinTypeTests.cpp` to use `https://monvision.io` instead of `https://monadexplorer.com`.