### PR TITLE
Add CarrChain (Chain ID 7667) to registry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -2784,6 +2784,36 @@
       "documentation": "https://tezos.gitlab.io/tezos/api/rpc.html"
     }
   },
+{
+    "id": "carrchain",
+    "name": "CarrChain",
+    "coinId": 10007667,
+    "symbol": "CARR",
+    "decimals": 18,
+    "blockchain": "Ethereum",
+    "derivation": [
+      {
+        "path": "m/44'/60'/0'/0/0"
+      }
+    ],
+    "curve": "secp256k1",
+    "publicKeyType": "secp256k1Extended",
+    "chainId": "7667",
+    "addressHasher": "keccak256",
+    "explorer": {
+      "url": "https://carrscan.io",
+      "txPath": "/tx/",
+      "accountPath": "/address/",
+      "sampleTx": "",
+      "sampleAccount": ""
+    },
+    "info": {
+      "url": "https://carnomaly.io",
+      "source": "https://github.com/carnomaly",
+      "rpc": "https://rpc.carrchain.io",
+      "documentation": "https://carrscan.io"
+    }
+  },
   {
     "id": "cardano",
     "name": "Cardano",


### PR DESCRIPTION
## Description
This PR adds support for CarrChain, an EVM-compatible Layer 3 blockchain used by Carnomaly for automotive applications.

Chain details:
- Chain ID: 7667
- Coin ID: 10007667
- RPC: https://rpc.carrchain.io
- Explorer: https://carrscan.io
- Native token: CARR (18 decimals)
- Derivation path: m/44'/60'/0'/0/0 (standard Ethereum)

CarrChain is a production blockchain with over 100,000 vehicles on the platform.

## How to test
1. Verify registry.json follows the correct format for EVM chains
2. Confirm Chain ID 7667 is not already in use
3. Test that the RPC endpoint (https://rpc.carrchain.io) is accessible
4. Verify the explorer (https://carrscan.io) is functional

## Types of changes
* New feature (non-breaking change which adds functionality)

## Checklist
- [x] Create pull request as draft initially, unless its complete.
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
- [ ] If there is a related Issue, mention it in the description.

If you're adding a new blockchain
- [x] I have read the guidelines for adding a new blockchain.