### PR TITLE
Add DFK Chain (Avalanche Subnet) support

### DIFF
--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -115,6 +115,7 @@ enum TWCoinType {
     TWCoinTypeKuCoinCommunityChain = 10000321,
     TWCoinTypeBitcoinDiamond = 999,
     TWCoinTypeBoba = 10000288,
+    TWCoinTypeDfkchain = 10053935,
     TWCoinTypeSyscoin = 57,
     TWCoinTypeVerge = 77,
     TWCoinTypeZen = 121,

--- a/registry.json
+++ b/registry.json
@@ -3887,6 +3887,36 @@
     }
   },
   {
+    "id": "dfkchain",
+    "name": "DFK Chain",
+    "coinId": 10053935,
+    "symbol": "JEWEL",
+    "decimals": 18,
+    "blockchain": "Ethereum",
+    "derivation": [
+      {
+        "path": "m/44'/60'/0'/0/0"
+      }
+    ],
+    "curve": "secp256k1",
+    "publicKeyType": "secp256k1Extended",
+    "chainId": "53935",
+    "addressHasher": "keccak256",
+    "explorer": {
+      "url": "https://subnets.avax.network/defi-kingdoms",
+      "txPath": "/tx/",
+      "accountPath": "/address/",
+      "sampleTx": "0x92729e50d2a5a2da74f1f9d9bcd9533a3da9ffac396df5e05dd25957c2fb47a3",
+      "sampleAccount": "0xf57a8182a132d66513ab287e451768fda0fdfad5"
+    },
+    "info": {
+      "url": "https://defikingdoms.com",
+      "source": "https://github.com/DefiKingdoms",
+      "rpc": "https://subnets.avax.network/defi-kingdoms/dfk-chain/rpc",
+      "documentation": "https://docs.defikingdoms.com"
+    }
+  },
+  {
     "id": "metis",
     "name": "Metis",
     "coinId": 10001088,

--- a/rust/tw_tests/tests/coin_address_derivation_test.rs
+++ b/rust/tw_tests/tests/coin_address_derivation_test.rs
@@ -54,6 +54,7 @@ fn test_coin_address_derivation() {
             | CoinType::GoChain
             | CoinType::KavaEvm
             | CoinType::Kaia
+            | CoinType::Dfkchain
             | CoinType::KuCoinCommunityChain
             | CoinType::Meter
             | CoinType::Metis

--- a/tests/common/CoinAddressDerivationTests.cpp
+++ b/tests/common/CoinAddressDerivationTests.cpp
@@ -52,6 +52,7 @@ TEST(Coin, DeriveAddress) {
         case TWCoinTypeGoChain:
         case TWCoinTypeKavaEvm:
         case TWCoinTypeKaia:
+        case TWCoinTypeDfkchain:
         case TWCoinTypeKuCoinCommunityChain:
         case TWCoinTypeMeter:
         case TWCoinTypeMetis:


### PR DESCRIPTION
## Summary
Add native support for DFK Chain (DeFi Kingdoms Chain), an Avalanche subnet using JEWEL as its native currency.

## Chain Information
- **Chain ID**: 53935 (0xd2af)
- **Coin ID**: 10053935
- **Symbol**: JEWEL
- **Decimals**: 18
- **Network**: DFK Chain (Avalanche Subnet)
- **Website**: https://defikingdoms.com
- **Explorer**: https://subnets.avax.network/defi-kingdoms
- **RPC**: https://subnets.avax.network/defi-kingdoms/dfk-chain/rpc
- **Documentation**: https://docs.defikingdoms.com

## Changes Made
1. Added DFK Chain configuration to `registry.json` (line 3889)
2. Added `TWCoinTypeDfkchain = 10053935` to `include/TrustWalletCore/TWCoinType.h` (line 118)
3. Updated Rust derivation tests in `rust/tw_tests/tests/coin_address_derivation_test.rs`
4. Updated C++ derivation tests in `tests/common/CoinAddressDerivationTests.cpp`

## Technical Details
- **Blockchain Type**: Ethereum (EVM-compatible)
- **Derivation Path**: m/44'/60'/0'/0/0 (standard Ethereum)
- **Curve**: secp256k1
- **Public Key Type**: secp256k1Extended
- **Address Hasher**: keccak256

DFK Chain uses the same address derivation as Ethereum and other EVM-compatible chains already supported in Trust Wallet Core.

## Testing
- ✅ DFK Chain uses standard Ethereum derivation path (m/44'/60'/0'/0/0)
- ✅ Added to Ethereum-compatible test cases alongside Metis and Kaia
- ✅ RPC endpoint verified and accessible
- ✅ Explorer URLs confirmed working
- ✅ Sample transaction and address from live network

## Sample Data
- **Sample Transaction**: [0x92729e50...c2fb47a3](https://subnets.avax.network/defi-kingdoms/tx/0x92729e50d2a5a2da74f1f9d9bcd9533a3da9ffac396df5e05dd25957c2fb47a3)
- **Sample Account**: [0xf57a8182...fda0fdfad5](https://subnets.avax.network/defi-kingdoms/address/0xf57a8182a132d66513ab287e451768fda0fdfad5)

## References
- Similar EVM chain additions: #2307, #2157
- DFK Chain on ChainList: https://chainlist.org/chain/53935
- Trust Wallet EVM Chain Guide: https://developer.trustwallet.com/developer/wallet-core/newblockchain/newevmchain

## Checklist
- [x] Added chain to registry.json
- [x] Added coin type enum to TWCoinType.h
- [x] Updated Rust derivation tests
- [x] Updated C++ derivation tests
- [x] Verified RPC endpoint accessibility
- [x] Confirmed explorer URLs work
- [x] Used real sample data from live network

DFK Chain is a production blockchain with an active gaming ecosystem. Adding it to Trust Wallet Core will enable users to manage JEWEL and interact with DeFi Kingdoms directly from Trust Wallet.