### PR TITLE
feat(stable-account): Add `TWDerivationSmartChainStableAccount` derivation

### DIFF
--- a/codegen/bin/coins
+++ b/codegen/bin/coins
@@ -26,6 +26,10 @@ def self.camel_case(id)
   id[0].upcase + id[1..].downcase
 end
 
+def self.upper_camel_case(id)
+  id.split('_').map { |w| w.capitalize }.join
+end
+
 def self.coin_img(coin)
   "<img src=\"https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/#{coin}/info/logo.png\" width=\"32\" />"
 end

--- a/codegen/lib/derivation.rb
+++ b/codegen/lib/derivation.rb
@@ -14,7 +14,7 @@ end
 # Returns a string of `<Coin><Derivation>` if derivation's name is specified, otherwise returns `Default`.
 def derivation_enum_name_no_prefix(deriv, coin)
   return "Default" if deriv['name'].nil?
-  format_name(coin['name']) + camel_case(deriv['name'])
+  format_name(coin['name']) + upper_camel_case(deriv['name'])
 end
 
 # Returns a string of `TWDerivation<Coin><Derivation>` if derivation's name is specified, otherwise returns `TWDerivationDefault`.

--- a/include/TrustWalletCore/TWDerivation.h
+++ b/include/TrustWalletCore/TWDerivation.h
@@ -27,6 +27,7 @@ enum TWDerivation {
     TWDerivationBitcoinTaproot = 8,
     TWDerivationPactusMainnet = 9,
     TWDerivationPactusTestnet = 10,
+    TWDerivationSmartChainStableAccount = 11,
     // end_of_derivation_enum - USED TO GENERATE CODE
 };
 

--- a/registry.json
+++ b/registry.json
@@ -3090,6 +3090,11 @@
     "derivation": [
       {
         "path": "m/44'/60'/0'/0/0"
+      },
+      {
+        "name": "stable_account",
+        "path": "m/44'/60'/9172'/3604/9999",
+        "description": "TrustWallet's specific derivation path for Stable Account wallets"
       }
     ],
     "curve": "secp256k1",

--- a/rust/tw_coin_registry/src/tw_derivation.rs
+++ b/rust/tw_coin_registry/src/tw_derivation.rs
@@ -20,6 +20,7 @@ pub enum TWDerivation {
     BitcoinTaproot = 8,
     PactusMainnet = 9,
     PactusTestnet = 10,
+    SmartChainStableAccount = 11,
     // end_of_derivation_enum - USED TO GENERATE CODE
     #[default]
     Default = 0,
@@ -36,6 +37,7 @@ impl From<TWDerivation> for Derivation {
             TWDerivation::BitcoinTaproot => Derivation::Taproot,
             TWDerivation::PactusMainnet => Derivation::Default,
             TWDerivation::PactusTestnet => Derivation::Testnet,
+            TWDerivation::SmartChainStableAccount => Derivation::Default,
         }
     }
 }


### PR DESCRIPTION
This pull request adds support for a new "Stable Account" derivation path for Smart Chain wallets, updating both the registry and relevant enums across the codebase. Additionally, it refines the naming logic for derivations to ensure consistency.

**Smart Chain Stable Account Derivation Support:**

* Added a new derivation entry for Smart Chain called `"stable_account"` with a specific path and description in `registry.json`.
* Introduced `TWDerivationSmartChainStableAccount = 11` to the `TWDerivation` enum in both the C header (`TWDerivation.h`) and Rust source (`tw_derivation.rs`). [[1]](diffhunk://#diff-d55147dcd7c76d64514e4e382a18b1daa0c2a68ac603243d3de6c72f6c497f92R30) [[2]](diffhunk://#diff-7a371b753884165e4fd0f7a3bbbbf90f4357e5807681ea366f1f7a6471b7b482R23)
* Updated Rust's `From<TWDerivation> for Derivation` implementation to map `SmartChainStableAccount` to the default derivation logic.

**Naming Consistency:**

* Changed the derivation name formatting in `derivation_enum_name_no_prefix` to use `upper_camel_case` instead of `camel_case` for improved consistency.