### PR TITLE
chore(codeowners): Add onchain-corex-enabling team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,1 @@
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-
-* @satoshiotomakan @gupnik
-kotlin/ @JaimeToca @rkokhatskyi
+* @trustwallet/onchain-corex-enabling


### PR DESCRIPTION
This pull request updates the repository's code ownership configuration by assigning the entire repository to the `@trustwallet/onchain-corex-enabling` team, replacing the previous individual owners and Kotlin-specific owners.

- Repository ownership:
  * [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L1-R1): Replaced individual owners and language-specific owners with the `@trustwallet/onchain-corex-enabling` team for all files.