### PR TITLE
fix(scrypt):  Fix scrypt JSON parsing for p and r

### DIFF
--- a/src/Keystore/ScryptParameters.cpp
+++ b/src/Keystore/ScryptParameters.cpp
@@ -75,9 +75,9 @@ ScryptParameters::ScryptParameters(const nlohmann::json& json) {
     desiredKeyLength = json[CodingKeys::SP::desiredKeyLength];
     if (json.count(CodingKeys::SP::n) != 0)
         n = json[CodingKeys::SP::n];
-    if (json.count(CodingKeys::SP::n) != 0)
+    if (json.count(CodingKeys::SP::p) != 0)
         p = json[CodingKeys::SP::p];
-    if (json.count(CodingKeys::SP::n) != 0)
+    if (json.count(CodingKeys::SP::r) != 0)
         r = json[CodingKeys::SP::r];
 }
 


### PR DESCRIPTION
## Description

Fixed the JSON parsing copy-paste bug so p and r are only read when their own keys are present, preventing defaults from being silently used. Updated logic in `src/Keystore/ScryptParameters.cpp` to check `CodingKeys::SP::p` and `CodingKeys::SP::r` instead of `CodingKeys::SP::n`.
