### PR TITLE
fix(random): Fix random implementation for native target

### DIFF
--- a/WalletCore.podspec
+++ b/WalletCore.podspec
@@ -129,7 +129,7 @@ Pod::Spec.new do |s|
       'trezor-crypto/crypto/monero',
       'trezor-crypto/crypto/tests',
       'trezor-crypto/crypto/tools',
-      'trezor-crypto/crypto/rand.c',
+      'src/Random.cpp',
       'swift/Sources/Generated/WalletCore.h'
 
     ss.public_header_files =

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+//
+// Originally from Trezor Crypto:
+// Copyright (c) 2013-2014 Tomas Dzetkulic
+// Copyright (c) 2013-2014 Pavol Rusnak
+
+#include <TrezorCrypto/rand.h>
+
+#include <fcntl.h>
+#include <stdexcept>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+extern "C" {
+
+// Weak implementations that can be overridden by platform-specific versions:
+// - wasm/src/Random.cpp (for WebAssembly builds)
+// - jni/cpp/Random.cpp (for Android/JNI builds)
+// - swift/Sources/SecRandom.m (for iOS/Swift builds)
+
+uint32_t __attribute__((weak)) random32(void) {
+    int randomData = open("/dev/urandom", O_RDONLY);
+    if (randomData < 0) {
+        throw std::runtime_error("Random device not available");
+    }
+
+    uint32_t result;
+    if (read(randomData, &result, sizeof(result)) < 0) {
+        close(randomData);
+        throw std::runtime_error("Failed to read random data");
+    }
+
+    close(randomData);
+    return result;
+}
+
+void __attribute__((weak)) random_buffer(uint8_t *buf, size_t len) {
+    int randomData = open("/dev/urandom", O_RDONLY);
+    if (randomData < 0) {
+        throw std::runtime_error("Random device not available");
+    }
+    if (read(randomData, buf, len) < 0) {
+        close(randomData);
+        throw std::runtime_error("Failed to read random data");
+    }
+    close(randomData);
+}
+
+} // extern "C"

--- a/swift/common-xcframework.yml
+++ b/swift/common-xcframework.yml
@@ -62,7 +62,6 @@ targets:
       - trezor-crypto/crypto/ecdsa.c
       - trezor-crypto/crypto/curves.c
       - trezor-crypto/crypto/secp256k1.c
-      - trezor-crypto/crypto/rand.c
       - trezor-crypto/crypto/hmac.c
       - trezor-crypto/crypto/bip32.c
       - trezor-crypto/crypto/bip39.c

--- a/swift/project.yml
+++ b/swift/project.yml
@@ -80,7 +80,6 @@ targets:
       - trezor-crypto/crypto/ecdsa.c
       - trezor-crypto/crypto/curves.c
       - trezor-crypto/crypto/secp256k1.c
-      - trezor-crypto/crypto/rand.c
       - trezor-crypto/crypto/hmac.c
       - trezor-crypto/crypto/bip32.c
       - trezor-crypto/crypto/bip39.c

--- a/trezor-crypto/CMakeLists.txt
+++ b/trezor-crypto/CMakeLists.txt
@@ -26,7 +26,7 @@ set(TW_WARNING_FLAGS
 set(CMAKE_C_STANDARD 11)
 
 add_library(TrezorCrypto
-    crypto/bignum.c crypto/ecdsa.c crypto/curves.c crypto/secp256k1.c crypto/rand.c crypto/hmac.c crypto/bip32.c crypto/bip39.c crypto/slip39.c crypto/pbkdf2.c crypto/base58.c crypto/base32.c
+    crypto/bignum.c crypto/ecdsa.c crypto/curves.c crypto/secp256k1.c crypto/hmac.c crypto/bip32.c crypto/bip39.c crypto/slip39.c crypto/pbkdf2.c crypto/base58.c crypto/base32.c
     crypto/address.c
     crypto/script.c
     crypto/ripemd160.c

--- a/trezor-crypto/crypto/tests/CMakeLists.txt
+++ b/trezor-crypto/crypto/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ enable_testing()
 find_library(check PATH ${CMAKE_SOURCE_DIR}/build/local/lib/pkgconfig NO_DEFAULT_PATH)
 
 # Test executable
-add_executable(TrezorCryptoTests test_check.c)
+add_executable(TrezorCryptoTests test_check.c testing_rand.c)
 target_link_libraries(TrezorCryptoTests TrezorCrypto check)
 target_link_directories(TrezorCryptoTests PRIVATE ${PREFIX}/lib)
 target_include_directories(TrezorCryptoTests PRIVATE ${CMAKE_SOURCE_DIR}/src ${PREFIX}/include)

--- a/trezor-crypto/crypto/tests/testing_rand.c
+++ b/trezor-crypto/crypto/tests/testing_rand.c
@@ -1,0 +1,64 @@
+/**
+* Copyright (c) 2013-2014 Tomas Dzetkulic
+ * Copyright (c) 2013-2014 Pavol Rusnak
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// The file provides weak implementations of random32() and random_buffer()
+// that are used in TrezorCryptoTests ONLY.
+// For production code, platform-specific implementations should be provided
+// that override these weak definitions.
+// For example: `src/Random.cpp`, `wasm/src/Random.cpp`,
+// `jni/cpp/Random.cpp`, `swift/Sources/SecRandom.m`.
+
+#include <TrezorCrypto/rand.h>
+
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+// [wallet-core]
+uint32_t __attribute__((weak)) random32(void) {
+    int randomData = open("/dev/urandom", O_RDONLY);
+    if (randomData < 0) {
+        return 0;
+    }
+
+    uint32_t result;
+    if (read(randomData, &result, sizeof(result)) < 0) {
+        return 0;
+    }
+
+    close(randomData);
+
+    return result;
+}
+
+void __attribute__((weak)) random_buffer(uint8_t *buf, size_t len) {
+    int randomData = open("/dev/urandom", O_RDONLY);
+    if (randomData < 0) {
+        return;
+    }
+    if (read(randomData, buf, len) < 0) {
+        return;
+    }
+    close(randomData);
+}


### PR DESCRIPTION
This pull request refactors how random number generation is implemented and linked in the project. The main change is moving the weak implementations of `random32` and `random_buffer` out of the core TrezorCrypto library and into platform-specific or test-specific files. This allows for easier overriding of these functions on different platforms and ensures that production code uses the correct source of randomness.

Key changes include:

**Random Number Generation Refactor:**

* Removed `trezor-crypto/crypto/rand.c` from the TrezorCrypto core library and build files, and replaced it with a new C++ implementation in `src/Random.cpp` that provides weak definitions of `random32` and `random_buffer` for production use.

* Added a new file, `trezor-crypto/crypto/tests/testing_rand.c`, which provides weak implementations of `random32` and `random_buffer` specifically for use in tests, ensuring that test builds have their own isolated random source.

These changes improve modularity and make it easier to provide secure, platform-specific randomness in different build environments.