### PR TITLE
fix(random): Terminate process on failed reading random data (Native targets ONLY)

### DIFF
--- a/jni/cpp/Random.cpp
+++ b/jni/cpp/Random.cpp
@@ -35,8 +35,14 @@ void random_buffer(uint8_t *buf, size_t len) {
             std::terminate();
         }
 
-        randomData.read(reinterpret_cast<char*>(buf), len);
+        randomData.read(reinterpret_cast<char*>(buf), static_cast<std::streamsize>(len));
         randomData.close();
+
+        if (!randomData.good() || randomData.gcount() != static_cast<std::streamsize>(len)) {
+            // Critical: failed to read required amount of random data
+            std::terminate();
+        }
+
         return;
     }
 

--- a/trezor-crypto/crypto/rand.c
+++ b/trezor-crypto/crypto/rand.c
@@ -37,7 +37,7 @@ uint32_t __attribute__((weak)) random32(void) {
     }
 
     uint32_t result;
-    size_t readLen = read(randomData, &result, sizeof(result));
+    ssize_t readLen = read(randomData, &result, sizeof(result));
     close(randomData);
     if (readLen != sizeof(result)) {
         abort();  // Critical: failed to read random data
@@ -51,9 +51,9 @@ void __attribute__((weak)) random_buffer(uint8_t *buf, size_t len) {
     if (randomData < 0) {
         abort();  // Critical: cannot proceed without random source
     }
-    size_t readLen = read(randomData, buf, len);
+    ssize_t readLen = read(randomData, buf, len);
     close(randomData);
-    if (readLen != len) {
+    if (readLen != (ssize_t)len) {
         abort();  // Critical: failed to read random data
     }
 }


### PR DESCRIPTION
This pull request strengthens the handling of random number generation failures in both the C++ and C codebases by ensuring that the application terminates immediately if secure random data cannot be obtained. This avoids the risk of proceeding with uninitialized or insecure random values.

**Critical error handling improvements for random number generation:**

* Changed error handling in `jni/cpp/Random.cpp` so that failure to open `/dev/urandom` now calls `std::terminate()` instead of throwing an exception, ensuring the application does not proceed without a secure random source.
* In `trezor-crypto/crypto/rand.c`, replaced silent failures (returning 0 or returning early) with calls to `abort()` if `/dev/urandom` cannot be opened or if the read does not return the expected number of bytes, ensuring the process terminates on critical failure.
* Added `stdlib.h` include in `trezor-crypto/crypto/rand.c` to support the use of `abort()`.