### PR TITLE
feat(bitcoin): Increase OP_RETURN size limit to match Bitcoin Core v30

### DIFF
--- a/rust/frameworks/tw_utxo/src/script/standard_script/conditions.rs
+++ b/rust/frameworks/tw_utxo/src/script/standard_script/conditions.rs
@@ -110,7 +110,8 @@ pub fn new_p2tr_script_path(pubkey: &H264, merkle_root: &H256) -> Script {
 }
 
 pub fn new_op_return(data: &[u8]) -> Script {
-    let mut s = Script::with_capacity(83);
+    // Capacity: 1 (OP_RETURN) + 3 (max push opcode for 10000 bytes is OP_PUSHDATA2 + 2 bytes) + data.len()
+    let mut s = Script::with_capacity(4 + data.len());
     s.push(OP_RETURN);
     s.push_slice(data);
     s

--- a/src/Bitcoin/Script.h
+++ b/src/Bitcoin/Script.h
@@ -20,8 +20,10 @@ namespace TW::Bitcoin {
 
 class Script {
   public:
-    // Maximum length for OP_RETURN data
-    static const size_t MaxOpReturnLength = 80;
+    // Maximum length for OP_RETURN data.
+    // Bitcoin Core v30 increased the default -datacarriersize from 83 to 10000 bytes.
+    // This constant represents the maximum payload data size (not including OP_RETURN and push opcodes).
+    static const size_t MaxOpReturnLength = 10000;
 
     /// Script raw bytes.
     Data bytes;
@@ -122,7 +124,7 @@ class Script {
     /// Builds a V1 pay-to-witness-program script, P2TR (from a 32-byte Schnorr public key).
     static Script buildPayToV1WitnessProgram(const Data& publicKey);
 
-    /// Builds an OP_RETURN script with given data. Returns empty script on error, if data is too long (>80).
+    /// Builds an OP_RETURN script with given data. Returns empty script on error, if data is too long (>10000).
     static Script buildOpReturnScript(const Data& data);
 
     /// Builds a appropriate lock script for the given


### PR DESCRIPTION
## Summary

- Updates the OP_RETURN size limit from 80 bytes to 10,000 bytes to match Bitcoin Core v30's new default `-datacarriersize`
- Extends the `pushDataLength()` function in C++ to support `OP_PUSHDATA2` for data larger than 255 bytes
- Removes the outdated 83-byte assertion that was blocking larger OP_RETURN scripts
- Adds comprehensive tests for various OP_RETURN data sizes (100, 255, 256, 1000, 10000 bytes)

## Background

Bitcoin Core v30 increased the default `-datacarriersize` from 83 to 10,000 bytes. Transactions with OP_RETURN outputs larger than 80 bytes that are valid under Bitcoin Core 30 were failing to build in wallet-core due to hardcoded limits.

## Changes

**C++ Code:**
- `src/Bitcoin/Script.h`: Updated `MaxOpReturnLength` from 80 to 10000
- `src/Bitcoin/Script.cpp`: Extended `pushDataLength()` to handle sizes > 255 bytes using `OP_PUSHDATA2`, removed 83-byte assertion

**Rust Code:**
- `rust/frameworks/tw_utxo/src/transaction/standard_transaction/builder/output.rs`: Updated `OP_RETURN_DATA_LIMIT` from 80 to 10000
- `rust/frameworks/tw_utxo/src/script/standard_script/conditions.rs`: Updated capacity hint in `new_op_return()`

**Tests:**
- `tests/chains/Bitcoin/BitcoinScriptTests.cpp`: Added tests for 100, 255, 256, 1000, and 10000 byte OP_RETURN data
- Rust tests added in `output.rs` for the same size ranges

## Test plan

- [x] Unit tests added for C++ `buildOpReturnScript()` with various data sizes
- [x] Unit tests added for Rust `OutputBuilder::op_return()` with various data sizes
- [x] Tests verify correct opcode selection (OP_PUSHBYTES_N, OP_PUSHDATA1, OP_PUSHDATA2)
- [x] Tests verify rejection of data > 10000 bytes

Fixes #4548

---

Generated with [Claude Code](https://claude.com/claude-code)