### PR TITLE
chore(kucoin): Update KuCoin explorer

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -3847,7 +3847,7 @@
     "chainId": "321",
     "addressHasher": "keccak256",
     "explorer": {
-      "url": "https://explorer.kcc.io/en",
+      "url": "https://scan.kcc.io",
       "txPath": "/tx/",
       "accountPath": "/address/",
       "sampleTx": "0x2f0d79cd289a02f3181b68b9583a64c3809fe7387810b274275985c29d02c80d",

--- a/tests/chains/KuCoinCommunityChain/TWCoinTypeTests.cpp
+++ b/tests/chains/KuCoinCommunityChain/TWCoinTypeTests.cpp
@@ -25,8 +25,8 @@ TEST(TWKuCoinCommunityChainCoinType, TWCoinType) {
     ASSERT_EQ(0x0, TWCoinTypeP2shPrefix(TWCoinTypeKuCoinCommunityChain));
     ASSERT_EQ(0x0, TWCoinTypeStaticPrefix(TWCoinTypeKuCoinCommunityChain));
     assertStringsEqual(symbol, "KCS");
-    assertStringsEqual(txUrl, "https://explorer.kcc.io/en/tx/0x2f0d79cd289a02f3181b68b9583a64c3809fe7387810b274275985c29d02c80d");
-    assertStringsEqual(accUrl, "https://explorer.kcc.io/en/address/0x4446fc4eb47f2f6586f9faab68b3498f86c07521");
+    assertStringsEqual(txUrl, "https://scan.kcc.io/tx/0x2f0d79cd289a02f3181b68b9583a64c3809fe7387810b274275985c29d02c80d");
+    assertStringsEqual(accUrl, "https://scan.kcc.io/address/0x4446fc4eb47f2f6586f9faab68b3498f86c07521");
     assertStringsEqual(id, "kcc");
     assertStringsEqual(name, "KuCoin Community Chain");
 }


### PR DESCRIPTION
This pull request updates the KuCoin Community Chain explorer URLs to use the new domain. The change is reflected both in the chain registry configuration and the corresponding unit tests.

Explorer URL update:

* Changed the explorer URL for KuCoin Community Chain from `https://explorer.kcc.io/en` to `https://scan.kcc.io` in `registry.json`.

Test update:

* Updated test assertions in `TWCoinTypeTests.cpp` to match the new explorer URLs for transaction and account links.