### PR TITLE
chore(actions): Use TW actions proxy

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: macos-latest-large
     if: github.event.pull_request.draft == false
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: trustwallet/github-actions-proxy/actions/checkout@main
 
     - name: Set up JDK 17
-      uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+      uses: trustwallet/github-actions-proxy/actions/setup-java@main
       with:
         java-version: '17'
         distribution: 'temurin'
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+      uses: trustwallet/github-actions-proxy/actions/gradle-build-action@main
       with:
         gradle-version: 8.10.2
 
@@ -33,7 +33,7 @@ jobs:
         tools/install-sys-dependencies-mac
 
     - name: Cache Rust
-      uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      uses: trustwallet/github-actions-proxy/actions/rust-cache@main
       with:
         workspaces: |
           rust
@@ -47,7 +47,7 @@ jobs:
 
     - name: Cache internal dependencies
       id: internal_cache
-      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+      uses: trustwallet/github-actions-proxy/actions/cache@main
       with:
         path: build/local
         key: ${{ runner.os }}-${{ runner.arch }}-internal-${{ hashFiles('tools/install-dependencies') }}-${{ hashFiles('tools/dependencies-version') }}
@@ -69,7 +69,7 @@ jobs:
         popd
 
     - name: Run tests
-      uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b # v2.35.0
+      uses: trustwallet/github-actions-proxy/actions/android-emulator-runner@main
       with:
         api-level: 30
         target: google_apis

--- a/.github/workflows/codegen-v2.yml
+++ b/.github/workflows/codegen-v2.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: trustwallet/github-actions-proxy/actions/checkout@main
       - name: Install system dependencies
         run: |
           tools/install-sys-dependencies-linux
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@65101d47ea8028ed0c98a1cdea8dd9182e9b5133 # v0.0.8
+        uses: trustwallet/github-actions-proxy/actions/sccache-action@main
 
       - name: Install Rust dependencies
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,13 +13,13 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: trustwallet/github-actions-proxy/actions/checkout@main
       - name: Lint Dockerfile
         run: |
           curl -L https://github.com/hadolint/hadolint/releases/download/v1.17.6/hadolint-Linux-x86_64 -o hadolint && chmod +x hadolint
           ./hadolint Dockerfile
       - name: Build Dockerfile
-        uses: docker/build-push-action@92e71463491f2d026a477188b8ad3a0fdd9d672c # v1.1.0
+        uses: trustwallet/github-actions-proxy/actions/build-push-action@main
         with:
           repository: trustwallet/wallet-core
           tags: latest

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: trustwallet/github-actions-proxy/actions/checkout@main
     - name: Install system dependencies
       run: |
         tools/install-sys-dependencies-linux
         tools/install-rust-dependencies
     - name: Cache internal dependencies
       id: internal_cache
-      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+      uses: trustwallet/github-actions-proxy/actions/cache@main
       with:
         path: build/local
         key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('tools/install-sys-dependencies-linux') }}-internal-${{ hashFiles('tools/install-dependencies') }}-${{ hashFiles('tools/dependencies-version') }}
@@ -35,7 +35,7 @@ jobs:
       if: steps.internal_cache.outputs.cache-hit != 'true'
 
     - name: Cache Rust
-      uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      uses: trustwallet/github-actions-proxy/actions/rust-cache@main
       with:
         workspaces: |
           rust
@@ -48,7 +48,7 @@ jobs:
         CXX: /usr/bin/clang++
 
     - name: Setup Dart
-      uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.1
+      uses: trustwallet/github-actions-proxy/actions/setup-dart@main
       with:
         sdk: '3.8.1'
         cache: true

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: macos-15-xlarge
     if: github.event.pull_request.draft == false
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: trustwallet/github-actions-proxy/actions/checkout@main
 
     - name: Install system dependencies
       run: |
         tools/install-sys-dependencies-mac
 
     - name: Cache Rust
-      uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      uses: trustwallet/github-actions-proxy/actions/rust-cache@main
       with:
         workspaces: |
           rust
@@ -33,7 +33,7 @@ jobs:
 
     - name: Cache internal dependencies
       id: internal_cache
-      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+      uses: trustwallet/github-actions-proxy/actions/cache@main
       with:
         path: build/local
         key: ${{ runner.os }}-${{ runner.arch }}-internal-${{ hashFiles('tools/install-dependencies') }}-${{ hashFiles('tools/dependencies-version') }}

--- a/.github/workflows/kotlin-ci.yml
+++ b/.github/workflows/kotlin-ci.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: macos-latest-xlarge
     if: github.event.pull_request.draft == false
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: trustwallet/github-actions-proxy/actions/checkout@main
 
     - name: Set up JDK 17
-      uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+      uses: trustwallet/github-actions-proxy/actions/setup-java@main
       with:
         java-version: '17'
         distribution: 'temurin'
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+      uses: trustwallet/github-actions-proxy/actions/gradle-build-action@main
       with:
         gradle-version: 8.10.2
 
@@ -33,7 +33,7 @@ jobs:
         tools/install-sys-dependencies-mac
 
     - name: Cache Rust
-      uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      uses: trustwallet/github-actions-proxy/actions/rust-cache@main
       with:
         workspaces: |
           rust
@@ -50,7 +50,7 @@ jobs:
 
     - name: Cache internal dependencies
       id: internal_cache
-      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+      uses: trustwallet/github-actions-proxy/actions/cache@main
       with:
         path: build/local
         key: ${{ runner.os }}-${{ runner.arch }}-internal-${{ hashFiles('tools/install-dependencies') }}-${{ hashFiles('tools/dependencies-version') }}

--- a/.github/workflows/kotlin-sample-ci.yml
+++ b/.github/workflows/kotlin-sample-ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: macos-14-xlarge
     if: github.event.pull_request.draft == false
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: trustwallet/github-actions-proxy/actions/checkout@main
 
     - name: Set up JDK 17
-      uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+      uses: trustwallet/github-actions-proxy/actions/setup-java@main
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/linux-ci-sonarcloud.yml
+++ b/.github/workflows/linux-ci-sonarcloud.yml
@@ -17,10 +17,10 @@ jobs:
     if: false
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: trustwallet/github-actions-proxy/actions/checkout@main
 
       - name: Set up JDK 17
-        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        uses: trustwallet/github-actions-proxy/actions/setup-java@main
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -32,7 +32,7 @@ jobs:
 
       - name: Cache internal dependencies
         id: internal_cache
-        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        uses: trustwallet/github-actions-proxy/actions/cache@main
         with:
           path: build/local
           key: ${{ runner.os }}-${{ runner.arch }}-internal-${{ hashFiles('tools/install-dependencies') }}-${{ hashFiles('tools/dependencies-version') }}

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: trustwallet/github-actions-proxy/actions/checkout@main
     - name: Install system dependencies
       run: |
         tools/install-sys-dependencies-linux
         tools/install-rust-dependencies
     - name: Cache internal dependencies
       id: internal_cache
-      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+      uses: trustwallet/github-actions-proxy/actions/cache@main
       with:
         path: build/local
         key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('tools/install-sys-dependencies-linux') }}-internal-${{ hashFiles('tools/install-dependencies') }}-${{ hashFiles('tools/dependencies-version') }}
@@ -35,7 +35,7 @@ jobs:
       if: steps.internal_cache.outputs.cache-hit != 'true'
 
     - name: Cache Rust
-      uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      uses: trustwallet/github-actions-proxy/actions/rust-cache@main
       with:
         workspaces: |
           rust

--- a/.github/workflows/linux-sampleapp-ci.yml
+++ b/.github/workflows/linux-sampleapp-ci.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: trustwallet/github-actions-proxy/actions/checkout@main
     - name: Install system dependencies
       run: |
         tools/install-sys-dependencies-linux
         tools/install-rust-dependencies
     - name: Cache internal dependencies
       id: internal_cache
-      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+      uses: trustwallet/github-actions-proxy/actions/cache@main
       with:
         path: build/local
         key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('tools/install-sys-dependencies-linux') }}-internal-${{ hashFiles('tools/install-dependencies') }}-${{ hashFiles('tools/dependencies-version') }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,16 +23,16 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: trustwallet/github-actions-proxy/actions/checkout@main
       - name: Install system dependencies
         run: |
           tools/install-sys-dependencies-linux
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@65101d47ea8028ed0c98a1cdea8dd9182e9b5133 # v0.0.8
+        uses: trustwallet/github-actions-proxy/actions/sccache-action@main
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        uses: trustwallet/github-actions-proxy/actions/rust-cache@main
         with:
           workspaces: |
             rust
@@ -56,16 +56,16 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: trustwallet/github-actions-proxy/actions/checkout@main
       - name: Install system dependencies
         run: |
           tools/install-sys-dependencies-linux
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@65101d47ea8028ed0c98a1cdea8dd9182e9b5133 # v0.0.8
+        uses: trustwallet/github-actions-proxy/actions/sccache-action@main
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        uses: trustwallet/github-actions-proxy/actions/rust-cache@main
         with:
           workspaces: |
             rust
@@ -87,16 +87,16 @@ jobs:
     runs-on: macos-latest-xlarge
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: trustwallet/github-actions-proxy/actions/checkout@main
       - name: Install system dependencies
         run: |
           tools/install-sys-dependencies-mac
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@65101d47ea8028ed0c98a1cdea8dd9182e9b5133 # v0.0.8
+        uses: trustwallet/github-actions-proxy/actions/sccache-action@main
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        uses: trustwallet/github-actions-proxy/actions/rust-cache@main
         with:
           workspaces: |
             rust
@@ -118,7 +118,7 @@ jobs:
           ./tools/release-size measure-rust > release-report.json
 
       - name: Upload release report
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: trustwallet/github-actions-proxy/actions/upload-artifact@main
         with:
           name: release_report
           path: release-report.json
@@ -142,7 +142,7 @@ jobs:
 
       - name: Create or Update Comment
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: trustwallet/github-actions-proxy/actions/github-script@main
         with:
           script: |
             const script = require('./tools/gh-create-or-update-comment.js');
@@ -152,15 +152,15 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: trustwallet/github-actions-proxy/actions/checkout@main
         with:
           submodules: true
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@65101d47ea8028ed0c98a1cdea8dd9182e9b5133 # v0.0.8
+        uses: trustwallet/github-actions-proxy/actions/sccache-action@main
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        uses: trustwallet/github-actions-proxy/actions/rust-cache@main
         with:
           workspaces: |
             rust
@@ -218,16 +218,16 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: trustwallet/github-actions-proxy/actions/checkout@main
       - name: Install system dependencies
         run: |
           tools/install-sys-dependencies-linux
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@65101d47ea8028ed0c98a1cdea8dd9182e9b5133 # v0.0.8
+        uses: trustwallet/github-actions-proxy/actions/sccache-action@main
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        uses: trustwallet/github-actions-proxy/actions/rust-cache@main
         with:
           workspaces: |
             rust

--- a/.github/workflows/wasm-ci.yml
+++ b/.github/workflows/wasm-ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: trustwallet/github-actions-proxy/actions/checkout@main
 
     - name: Install system dependencies
       run: |
@@ -26,7 +26,7 @@ jobs:
 
     - name: Cache internal dependencies
       id: internal_cache
-      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+      uses: trustwallet/github-actions-proxy/actions/cache@main
       with:
         path: build/local
         key: ${{ runner.os }}-${{ runner.arch }}-internal-${{ hashFiles('tools/install-dependencies') }}-${{ hashFiles('tools/dependencies-version') }}


### PR DESCRIPTION
This pull request updates all GitHub Actions workflow files to use custom proxied actions from the `trustwallet/github-actions-proxy` repository instead of direct third-party actions. This change centralizes control over CI/CD dependencies, improves security, and makes it easier to manage and update action versions across the organization.

The most important changes are:

**Migration to TrustWallet Proxy Actions:**

* All instances of commonly used actions such as `checkout`, `setup-java`, `setup-dart`, `gradle-build-action`, `rust-cache`, `cache`, `build-push-action`, `sccache-action`, `upload-artifact`, and `github-script` have been replaced with their equivalents from `trustwallet/github-actions-proxy` across all workflow files, including Android, iOS, Kotlin, Flutter, Linux, Docker, Rust, WASM, and codegen workflows.

**Security and Maintainability Improvements:**

* Direct references to third-party actions with specific commit SHAs have been removed, reducing the risk of supply chain attacks and making it easier to update actions in the future.
* Centralized action management allows for organization-wide updates and auditing of CI/CD dependencies.

**Consistency Across CI/CD Workflows:**

* All workflows now use the same proxy pattern, ensuring a consistent approach to dependency management for all platforms and environments (Android, iOS, Linux, macOS, Docker, WASM, etc.).

**No Functional Changes to Build/Test Steps:**

* The actual build, test, and artifact upload steps remain unchanged in terms of logic; only the source of the GitHub Actions has been updated.

**Preparation for Future Updates:**

* By using the proxy, future updates to action versions or patches can be made centrally in the proxy repository, reducing maintenance overhead for individual workflow files.

Let me know if you have any questions about how these changes affect our CI/CD pipeline or how to work with the new proxy actions!