### PR TITLE
docs: clarify language support for Android in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Trust Wallet Core is an open-source, cross-platform, mobile-focused library
 implementing low-level cryptographic wallet functionality for a high number of blockchains.
 It is a core part of the popular [Trust Wallet](https://trustwallet.com), and some other projects.
 Most of the code is C++ with a set of strict C interfaces, and idiomatic interfaces for supported languages:
-Swift for iOS and Java (Kotlin) for Android.
+Swift for iOS and Java or Kotlin for Android.
 
 [![iOS CI](https://github.com/trustwallet/wallet-core/actions/workflows/ios-ci.yml/badge.svg)](https://github.com/trustwallet/wallet-core/actions/workflows/ios-ci.yml)
 [![Android CI](https://github.com/trustwallet/wallet-core/actions/workflows/android-ci.yml/badge.svg)](https://github.com/trustwallet/wallet-core/actions/workflows/android-ci.yml)


### PR DESCRIPTION
## Description
- Updated the README.md to clarify the language support for the Android platforms. Changes "Java(Kotlin)" to "Java or Kotlin" for clearer and more accurate representation of the two supported languages

## How to test
- No testing needed for documentation changes. Simply review the updated README.md line

## Types of changes
- Documentation update