### PR TITLE
fix(eip712): Fix cyclic message types handling

### DIFF
--- a/rust/tw_evm/src/message/eip712/eip712_message.rs
+++ b/rust/tw_evm/src/message/eip712/eip712_message.rs
@@ -406,6 +406,34 @@ mod tests {
     }
 
     #[test]
+    fn test_encode_type_cyclic_dependency() {
+        let custom_types = r#"{
+			"EIP712Domain": [
+				{ "name": "name", "type": "string" },
+				{ "name": "version", "type": "string" },
+				{ "name": "chainId", "type": "uint256" },
+				{ "name": "verifyingContract", "type": "address" }
+			],
+			"Person": [
+				{ "name": "name", "type": "string" },
+				{ "name": "wallet", "type": "address" },
+				{ "name": "mail", "type": "Mail" }
+			],
+			"Mail": [
+				{ "name": "from", "type": "Person" },
+				{ "name": "to", "type": "Person" },
+				{ "name": "contents", "type": "string" }
+			]
+		}"#;
+
+        let custom_types: CustomTypes = serde_json::from_str(custom_types).expect("alas error!");
+        assert_eq!(
+            "Mail(Person from,Person to,string contents)Person(string name,address wallet,Mail mail)",
+            encode_custom_type::encode_type(&custom_types, "Mail").expect("alas error!")
+        )
+    }
+
+    #[test]
     fn test_encode_type_hash() {
         let custom_types = r#"{
 			"EIP712Domain": [


### PR DESCRIPTION
This pull request improves the handling of custom type dependencies in the EIP-712 message encoding logic, specifically to correctly handle cyclic dependencies between types. It also updates the test coverage to ensure cycles are handled without causing infinite loops.

Dependency resolution fix:

* Fixed the logic in the `encode_custom_type` module to correctly detect and process custom type dependencies, ensuring that cyclic dependencies (such as between `Person` and `Mail`) do not cause infinite loops.

Test improvements:

* Updated the `test_build_dependencies` test to include a custom types definition with an intentional cyclic dependency between `Person` and `Mail`, verifying that the dependency builder can handle cycles safely.