### PR TITLE
security(scrypt): Force Scrypt parameters to have all n, p, r values

### DIFF
--- a/src/Keystore/ScryptParameters.cpp
+++ b/src/Keystore/ScryptParameters.cpp
@@ -22,14 +22,12 @@ Data randomSalt() {
 
 } // namespace internal
 
-constexpr size_t gMaxInputSize = 1024;
-
 std::string toString(const ScryptValidationError error) {
     switch (error) {
     case ScryptValidationError::desiredKeyLengthTooLarge:
             return "Desired key length is too large";
-    case ScryptValidationError::saltLengthTooLarge:
-        return "Salt length is too large";
+    case ScryptValidationError::invalidSaltLength:
+        return "Salt length is invalid";
     case ScryptValidationError::blockSizeTooLarge:
             return "Block size (r * p) is too large";
     case ScryptValidationError::invalidCostFactor:
@@ -63,8 +61,8 @@ std::optional<ScryptValidationError> ScryptParameters::validate() const {
     if (desiredKeyLength > ((1ULL << 32) - 1) * 32) { // depending on size_t size on platform, may be always false
         return ScryptValidationError::desiredKeyLengthTooLarge;
     }
-    if (salt.size() > gMaxInputSize) {
-        return ScryptValidationError::saltLengthTooLarge;
+    if (salt.size() < minSaltLength || salt.size() > maxSaltLength) {
+        return ScryptValidationError::invalidSaltLength;
     }
     if (static_cast<uint64_t>(r) * static_cast<uint64_t>(p) >= (1 << 30)) {
         return ScryptValidationError::blockSizeTooLarge;

--- a/src/Keystore/ScryptParameters.h
+++ b/src/Keystore/ScryptParameters.h
@@ -14,7 +14,7 @@ namespace TW::Keystore {
 
 enum class ScryptValidationError {
     desiredKeyLengthTooLarge,
-    saltLengthTooLarge,
+    invalidSaltLength,
     blockSizeTooLarge,
     invalidCostFactor,
     overflow,
@@ -42,6 +42,11 @@ struct ScryptParameters {
 
     /// Default desired key length of Scrypt encryption algorithm.
     static const std::size_t defaultDesiredKeyLength = 32;
+
+    /// Minimum and maximum salt length for Scrypt encryption algorithm.
+    /// https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-132.pdf
+    static const std::size_t minSaltLength = 16;
+    static const std::size_t maxSaltLength = 1024;
 
     /// Random salt.
     Data salt;


### PR DESCRIPTION
This pull request updates the construction logic for `ScryptParameters` to improve validation and error handling when parsing JSON input. Now, the constructor checks for the presence of all required scrypt parameters and validates them, throwing clear exceptions if any are missing or invalid.

**Improvements to input validation and error handling:**

* Updated the `ScryptParameters` constructor in `src/Keystore/ScryptParameters.cpp` to:
  - Require the presence of all three scrypt parameters (`n`, `p`, and `r`) in the input JSON, throwing an exception if any are missing.
  - Immediately validate the parameters after parsing and throw a detailed exception if validation fails.