### PR TITLE
fix(waves): Fix potential size_t to uint16_t incorrect cast

### DIFF
--- a/src/Waves/BinaryCoding.h
+++ b/src/Waves/BinaryCoding.h
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <vector>
+#include <limits>
 
 #include "../BinaryCoding.h"
 


### PR DESCRIPTION
This pull request introduces an important validation to the `encodeDynamicLengthBytes` function in `src/Waves/BinaryCoding.h`, ensuring that encoded data does not exceed the maximum allowed length.

Validation improvements:

* Added a check in `encodeDynamicLengthBytes` to throw an exception if the `data` size exceeds the `uint16_t` maximum, preventing oversized data from being encoded.