### PR TITLE
Update rexml version to 3.3.9

### DIFF
--- a/swift/Gemfile.lock
+++ b/swift/Gemfile.lock
@@ -203,7 +203,7 @@ GEM
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
+      rexml (~> 3.3.9)
     xcpretty (0.3.0)
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.1)


### PR DESCRIPTION
This report details CVE-2024-43398, a Denial of Service (DoS) vulnerability affecting the REXML library in Ruby. This vulnerability arises when parsing XML documents containing deeply nested elements with numerous identical local attribute names, leading to excessive resource consumption and slow processing, potentially causing application crashes. The vulnerability was discovered and reported on August 22, 2024, and impacts REXML versions older than 3.3.6 
 
.