### PR TITLE
Add Maven Central (Sonatype) publishing support for Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,10 @@
 buildscript {
     ext.kotlin_version = '2.1.0'
+    ext.isSigningEnabled = {
+        def signingKey = System.getenv("MVN_SIGNING_KEY")
+        def signingPassphrase = System.getenv("MVN_SIGNING_PASSPHRASE")
+        return signingKey != null && !signingKey.isEmpty() && signingPassphrase != null && !signingPassphrase.isEmpty()
+    }
     repositories {
         google()
         mavenCentral()
@@ -7,6 +12,28 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.8.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+plugins {
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
+}
+
+group = 'com.trustwallet'
+
+nexusPublishing {
+    packageGroup = 'com.trustwallet'
+    repositories {
+        sonatype {
+            nexusUrl = uri('https://ossrh-staging-api.central.sonatype.com/service/local/')
+            snapshotRepositoryUrl = uri('https://central.sonatype.com/repository/maven-snapshots/')
+            username = System.getenv('SONATYPE_USERNAME')
+            password = System.getenv('SONATYPE_PASSWORD')
+            def profileId = System.getenv('SONATYPE_STAGING_PROFILE_ID')
+            if (profileId) {
+                stagingProfileId = profileId
+            }
+        }
     }
 }
 

--- a/android/wallet-core-proto/build.gradle
+++ b/android/wallet-core-proto/build.gradle
@@ -8,6 +8,7 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 
     withSourcesJar()
+    withJavadocJar()
 
     sourceSets {
         main.java.srcDirs += '../../jni/proto'

--- a/android/wallet-core-proto/maven-push.gradle
+++ b/android/wallet-core-proto/maven-push.gradle
@@ -1,9 +1,38 @@
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 publishing {
     publications {
         release(MavenPublication) {
             from components.java
+
+            groupId = 'com.trustwallet.walletcore'
+            artifactId = 'proto'
+            version = project.findProperty('version') ?: '0.0.0'
+
+            pom {
+                name = 'WalletCoreProto'
+                description = POM_DESCRIPTION
+                url = POM_URL
+                licenses {
+                    license {
+                        name = POM_LICENCE_NAME
+                        url = POM_LICENCE_URL
+                        distribution = POM_LICENCE_DIST
+                    }
+                }
+                scm {
+                    url = POM_SCM_URL
+                    connection = POM_SCM_CONNECTION
+                    developerConnection = POM_SCM_DEV_CONNECTION
+                }
+                developers {
+                    developer {
+                        id = POM_DEVELOPER_ID
+                        name = POM_DEVELOPER_NAME
+                    }
+                }
+            }
         }
     }
 
@@ -17,5 +46,12 @@ publishing {
             }
         }
         mavenLocal()
+    }
+}
+
+if (rootProject.ext.isSigningEnabled()) {
+    signing {
+        useInMemoryPgpKeys(System.getenv("MVN_SIGNING_KEY"), System.getenv("MVN_SIGNING_PASSPHRASE"))
+        sign publishing.publications.release
     }
 }

--- a/android/wallet-core/build.gradle
+++ b/android/wallet-core/build.gradle
@@ -44,6 +44,7 @@ android {
     publishing {
         singleVariant('release') {
             withSourcesJar()
+            withJavadocJar()
         }
     }
     lint {

--- a/android/wallet-core/maven-push.gradle
+++ b/android/wallet-core/maven-push.gradle
@@ -1,10 +1,39 @@
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 publishing {
     publications {
         release(MavenPublication) {
             afterEvaluate {
                 from components.release
+            }
+
+            groupId = GROUP
+            artifactId = POM_ARTIFACT_ID
+            version = project.findProperty('version') ?: VERSION_NAME
+
+            pom {
+                name = POM_NAME
+                description = POM_DESCRIPTION
+                url = POM_URL
+                licenses {
+                    license {
+                        name = POM_LICENCE_NAME
+                        url = POM_LICENCE_URL
+                        distribution = POM_LICENCE_DIST
+                    }
+                }
+                scm {
+                    url = POM_SCM_URL
+                    connection = POM_SCM_CONNECTION
+                    developerConnection = POM_SCM_DEV_CONNECTION
+                }
+                developers {
+                    developer {
+                        id = POM_DEVELOPER_ID
+                        name = POM_DEVELOPER_NAME
+                    }
+                }
             }
         }
     }
@@ -19,5 +48,12 @@ publishing {
             }
         }
         mavenLocal()
+    }
+}
+
+if (rootProject.ext.isSigningEnabled()) {
+    signing {
+        useInMemoryPgpKeys(System.getenv("MVN_SIGNING_KEY"), System.getenv("MVN_SIGNING_PASSPHRASE"))
+        sign publishing.publications.release
     }
 }

--- a/tools/android-release
+++ b/tools/android-release
@@ -2,45 +2,80 @@
 #
 # This script uploads android build to repositories defined in maven-push.gradle
 # It also builds and uploads Kotlin docs
+#
+# Usage:
+#   tools/android-release [version] [--target local|sonatype|gpr|all]
+#
 
 set -e
 
 source $(dirname $0)/library
-version=$(wc_read_version  $1)
+
+# Parse arguments
+version=""
+target="all"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --target)
+            target="$2"
+            shift 2
+            ;;
+        *)
+            version="$1"
+            shift
+            ;;
+    esac
+done
+
+version=$(wc_read_version "$version")
 
 if [[ $(uname -s) == "Darwin" ]]; then
     export BOOST_ROOT=$(brew --prefix boost)
 fi
 
-echo "Building $version"
+echo "Building $version (target: $target)"
 
 export ANDROID_HOME="$HOME/Library/Android/sdk"
 pushd android
 ./gradlew clean build assembleRelease -Pversion="$version"
 
-echo "Publishing to Maven Local..."
-./gradlew publishAllPublicationsToMavenLocalRepository -Pversion="$version"
+if [[ "$target" == "local" || "$target" == "all" ]]; then
+    echo "Publishing to Maven Local..."
+    ./gradlew publishAllPublicationsToMavenLocalRepository -Pversion="$version"
 
-echo ""
-echo "Published artifacts in Maven Local (~/.m2/repository/com/trustwallet):"
-find ~/.m2/repository/com/trustwallet -type f -name "*.pom" -o -name "*.jar" -o -name "*.aar" -o -name "*.klib" 2>/dev/null | grep "$version" | sort || echo "No artifacts found"
+    echo ""
+    echo "Published artifacts in Maven Local (~/.m2/repository/com/trustwallet):"
+    find ~/.m2/repository/com/trustwallet -type f -name "*.pom" -o -name "*.jar" -o -name "*.aar" -o -name "*.klib" 2>/dev/null | grep "$version" | sort || echo "No artifacts found"
+fi
 
-echo "Publishing to GitHub Packages..."
-./gradlew publishAllPublicationsToGitHubPackagesRepository -Pversion="$version" || echo "Warning: GitHub Packages publishing failed"
+if [[ "$target" == "sonatype" || "$target" == "all" ]]; then
+    echo "Publishing to Maven Central (Sonatype)..."
+    if [ -n "${SONATYPE_USERNAME:-}" ] && [ -n "${SONATYPE_PASSWORD:-}" ] && [ -n "${MVN_SIGNING_KEY:-}" ]; then
+        ./gradlew publishAllPublicationsToSonatypeRepository -Pversion="$version"
+        echo "Artifacts staged on Sonatype. Visit https://central.sonatype.com to verify and release."
+    else
+        echo "Skipping Sonatype: SONATYPE_USERNAME, SONATYPE_PASSWORD, and MVN_SIGNING_KEY must be set"
+    fi
+fi
 
+if [[ "$target" == "gpr" || "$target" == "all" ]]; then
+    echo "Publishing to GitHub Packages..."
+    ./gradlew publishAllPublicationsToGitHubPackagesRepository -Pversion="$version" || echo "Warning: GitHub Packages publishing failed"
+fi
 
 echo "Android build uploaded"
 popd # android
 
-echo "Building docs..."
-tools/kotlin-doc
+if [[ "$target" == "all" ]]; then
+    echo "Building docs..."
+    tools/kotlin-doc
 
-pushd build/dokka
+    pushd build/dokka
 
-filename=kdoc.zip
-echo "Upload asset $filename"
-download_url=$(wc_upload_asset ${version} ${filename})
-echo "download_url is $download_url"
+    filename=kdoc.zip
+    echo "Upload asset $filename"
+    download_url=$(wc_upload_asset ${version} ${filename})
+    echo "download_url is $download_url"
 
-popd # build/dokka
-
+    popd # build/dokka
+fi


### PR DESCRIPTION
## Summary

  Add Sonatype (Maven Central) as a publish target for Android artifacts, inspired by https://github.com/trustwallet/wallet-core/pull/4641

  Closes #4612 (Javadoc for Android artifacts)
  Closes #4613 (POM metadata)
  Closes #4614 (Artifact signing)

  ### Why we need this

  1. GitHub Packages (GPR) requires a GitHub token to download — not ideal for public libraries
  2. F-Droid and WalletScrutiny do not recommend GPR for reproducible builds
  3. Maven Central packages are publicly downloadable without authentication and widely adopted

  ### Changes

  - Add `gradle-nexus-publish-plugin` to `android/build.gradle` with Sonatype Central config
  - Add POM metadata and conditional PGP signing to `wallet-core` and `wallet-core-proto`
  - Add Javadoc JARs to `wallet-core` and `wallet-core-proto` (required by Maven Central)
  - Add `--target` flag to `tools/android-release` for testing individual targets (`local`, `sonatype`,
  `gpr`, `all`)

  ### Usage

  ```bash
  # Publish to Maven Central (staging only, release manually):
  tools/android-release 4.1.0 --target sonatype

  # Publish to all targets:
  tools/android-release 4.1.0
```
### Setup

  Before publishing to Sonatype:
  1. Verify com.trustwallet namespace is claimed in [Central Portal Namespaces](https://central.sonatype.com/publishing/namespaces)
  2. Set environment variables:
    - `SONATYPE_USERNAME` / `SONATYPE_PASSWORD` — [Generate a token](https://central.sonatype.com/account)
    - `MVN_SIGNING_KEY` / `MVN_SIGNING_PASSPHRASE` — [Set up GPG signing](https://central.sonatype.org/publish/requirements/gpg/)

### Notes

  Sonatype publishing could not be fully tested locally (requires credentials), but follows the same
  pattern used to publish Gemstone to Maven Central: https://central.sonatype.com/artifact/com.gemwallet.gemstone/gemstone, there is no public release workflows in wallet core, so we only updated the script

### Test
`tools/android-release 0.0.1-test --target local`  # verify Gradle config compiles and artifacts appear
  in ~/.m2

@sergei-boiko-trustwallet @10gic @alex-kobozev-tw could you guys take a look?

Thanks