### PR TITLE
Add Defi Oracle Meta Mainnet (Chain 138) to wallet-core

### DIFF
--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -192,6 +192,7 @@ enum TWCoinType {
     TWCoinTypePlasma = 9745,
     TWCoinTypeMonad = 10143,
     TWCoinTypeMegaETH = 4326,
+    TWCoinTypeDefiOracleMetaMainnet = 10000138,
     // end_of_tw_coin_type_marker_do_not_modify
 };
 

--- a/registry.json
+++ b/registry.json
@@ -322,6 +322,36 @@
     }
   },
   {
+    "id": "dfiometa",
+    "name": "Defi Oracle Meta Mainnet",
+    "coinId": 10000138,
+    "symbol": "ETH",
+    "decimals": 18,
+    "blockchain": "Ethereum",
+    "derivation": [
+      {
+        "path": "m/44'/60'/0'/0/0"
+      }
+    ],
+    "curve": "secp256k1",
+    "publicKeyType": "secp256k1Extended",
+    "chainId": "138",
+    "addressHasher": "keccak256",
+    "explorer": {
+      "url": "https://explorer.d-bis.org",
+      "txPath": "/tx/",
+      "accountPath": "/address/",
+      "sampleTx": "0xbc36c6050ea6b6f484009a1fcd8f8c6c2c2bd629661bc75fa5e84829c662a604",
+      "sampleAccount": "0x4A666F96fC8764181194447A7dFdb7d471b301C8"
+    },
+    "info": {
+      "url": "https://d-bis.org",
+      "source": "https://gitea.d-bis.org/d-bis",
+      "rpc": "https://rpc-http-pub.d-bis.org",
+      "documentation": "https://d-bis.org"
+    }
+  },
+  {
     "id": "syscoin",
     "name": "Syscoin",
     "coinId": 57,

--- a/rust/tw_tests/tests/coin_address_derivation_test.rs
+++ b/rust/tw_tests/tests/coin_address_derivation_test.rs
@@ -95,6 +95,7 @@ fn test_coin_address_derivation() {
             | CoinType::Plasma
             | CoinType::Monad
             | CoinType::MegaETH
+            | CoinType::DefiOracleMetaMainnet
             // end_of_evm_address_derivation_tests_marker_do_not_modify
                 => "0xAc1ec44E4f0ca7D172B7803f6836De87Fb72b309",
             CoinType::Bitcoin => "bc1qten42eesehw0ktddcp0fws7d3ycsqez3f7d5yt",

--- a/tests/chains/DefiOracleMetaMainnet/TWCoinTypeTests.cpp
+++ b/tests/chains/DefiOracleMetaMainnet/TWCoinTypeTests.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+
+#include "TestUtilities.h"
+#include <TrustWalletCore/TWCoinTypeConfiguration.h>
+#include <gtest/gtest.h>
+
+TEST(TWDefiOracleMetaMainnetCoinType, TWCoinType) {
+    const auto coin = TWCoinTypeDefiOracleMetaMainnet;
+    const auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(coin));
+    const auto id = WRAPS(TWCoinTypeConfigurationGetID(coin));
+    const auto name = WRAPS(TWCoinTypeConfigurationGetName(coin));
+    const auto txId = WRAPS(TWStringCreateWithUTF8Bytes("0xbc36c6050ea6b6f484009a1fcd8f8c6c2c2bd629661bc75fa5e84829c662a604"));
+    const auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(coin, txId.get()));
+    const auto accId = WRAPS(TWStringCreateWithUTF8Bytes("0x4A666F96fC8764181194447A7dFdb7d471b301C8"));
+    const auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(coin, accId.get()));
+
+    assertStringsEqual(id, "dfiometa");
+    assertStringsEqual(name, "Defi Oracle Meta Mainnet");
+    assertStringsEqual(symbol, "ETH");
+    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(coin), 18);
+    ASSERT_EQ(TWCoinTypeBlockchain(coin), TWBlockchainEthereum);
+    ASSERT_EQ(TWCoinTypeP2pkhPrefix(coin), 0);
+    ASSERT_EQ(TWCoinTypeP2shPrefix(coin), 0);
+    ASSERT_EQ(TWCoinTypeStaticPrefix(coin), 0);
+    assertStringsEqual(txUrl, "https://explorer.d-bis.org/tx/0xbc36c6050ea6b6f484009a1fcd8f8c6c2c2bd629661bc75fa5e84829c662a604");
+    assertStringsEqual(accUrl, "https://explorer.d-bis.org/address/0x4A666F96fC8764181194447A7dFdb7d471b301C8");
+}

--- a/tests/common/CoinAddressDerivationTests.cpp
+++ b/tests/common/CoinAddressDerivationTests.cpp
@@ -93,6 +93,7 @@ TEST(Coin, DeriveAddress) {
         case TWCoinTypePlasma:
         case TWCoinTypeMonad:
         case TWCoinTypeMegaETH:
+        case TWCoinTypeDefiOracleMetaMainnet:
             // end_of_evm_address_derivation_tests_marker_do_not_modify
             EXPECT_EQ(address, "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F");
             break;


### PR DESCRIPTION
### Summary
Adds **Defi Oracle Meta Mainnet** (Chain ID 138) to the wallet-core registry and generated code so Trust Wallet can support the chain in its built-in list.

### Chain details
- **Registry id:** `dfiometa`
- **Name:** Defi Oracle Meta Mainnet
- **Chain ID:** 138
- **Coin ID:** 10000138 (10000000 + chainId; no SLIP-44 for 138)
- **Symbol:** ETH
- **Decimals:** 18
- **Derivation:** `m/44'/60'/0'/0/0` (standard EVM)
- **Explorer:** https://explorer.d-bis.org
- **Public RPC:** https://rpc-http-pub.d-bis.org
- **Info:** https://d-bis.org

### Changes
- **registry.json:** New entry for `dfiometa` with explorer, sample tx/account, and public RPC.
- **Codegen:** Ran `cargo run -- new-evmchain dfiometa` from `codegen-v2`; updated:
  - `include/TrustWalletCore/TWCoinType.h`
  - `rust/tw_tests/tests/coin_address_derivation_test.rs`
  - `tests/common/CoinAddressDerivationTests.cpp`
  - **New:** `tests/chains/DefiOracleMetaMainnet/TWCoinTypeTests.cpp`

### Verification
- `cargo test --all` in `codegen-v2` — passed
- `cargo check --tests` in `rust` — passed

### References
- Explorer: https://explorer.d-bis.org

Made with [Cursor](https://cursor.com)