### PR TITLE
Add signature size verification

### DIFF
--- a/src/PublicKey.cpp
+++ b/src/PublicKey.cpp
@@ -227,6 +227,9 @@ bool PublicKey::verify(const Data& signature, const Data& message) const {
 }
 
 bool PublicKey::verifyAsDER(const Data& signature, const Data& message) const {
+    if (signature.size() < derSignatureMinSize || signature.size() > derSignatureMaxSize) {
+        return false;
+    }
     if (message.size() != ecdsaMessageSize) {
         return false;
     }

--- a/src/PublicKey.h
+++ b/src/PublicKey.h
@@ -46,6 +46,11 @@ class PublicKey {
     /// Digest shorter than 32 bytes will be left-padded with zeros before verification.
     static const size_t starkexMessageMaxSize = 32;
 
+    /// The minimum number of bytes in a valid DER-encoded ECDSA signature.
+    static const size_t derSignatureMinSize = 2;
+    /// The maximum number of bytes in a valid DER-encoded ECDSA signature.
+    static const size_t derSignatureMaxSize = 72;
+
     /// The public key bytes.
     Data bytes;
 

--- a/tests/common/PublicKeyTests.cpp
+++ b/tests/common/PublicKeyTests.cpp
@@ -383,6 +383,15 @@ TEST(PublicKeyTests, VerifyAsDERRejectsShortDigest) {
     EXPECT_FALSE(publicKey.verifyAsDER(derSig, shortDigest));
 }
 
+TEST(PublicKeyTests, VerifyAsDERRejectsInvalidSignatureSize) {
+    const auto publicKey = PublicKey(parse_hex("0399c6f51ad6f98c9c583f8e92bb7758ab2ca9a04110c0a1126ec43e5453d196c1"), TWPublicKeyTypeSECP256k1);
+    const auto digest = parse_hex("afeefca74d9a325cf1d6b6911d61a65c32afa8e02bd5e78e2e4ac2910bab45f5");
+
+    EXPECT_FALSE(publicKey.verifyAsDER(Data(), digest));
+    EXPECT_FALSE(publicKey.verifyAsDER(parse_hex("30"), digest));
+    EXPECT_FALSE(publicKey.verifyAsDER(Data(73, 0x30), digest));
+}
+
 TEST(PublicKeyTests, VerifyNist256p1RejectsShortDigest) {
     const auto privateKey = PrivateKey(parse_hex("afeefca74d9a325cf1d6b6911d61a65c32afa8e02bd5e78e2e4ac2910bab45f5"), TWCurveNIST256p1);
     const auto publicKey = privateKey.getPublicKey(TWPublicKeyTypeNIST256p1);


### PR DESCRIPTION
This pull request adds stricter validation for DER-encoded ECDSA signature sizes in the `PublicKey::verifyAsDER` method, ensuring that only signatures within the valid size range are accepted. It also introduces corresponding constants and new unit tests to verify this behavior.

**Signature size validation improvements:**

* Added `derSignatureMinSize` and `derSignatureMaxSize` constants to `PublicKey` to define the valid size range for DER-encoded ECDSA signatures.
* Updated `PublicKey::verifyAsDER` to reject signatures whose sizes are outside the valid DER range by returning `false` early.

**Testing enhancements:**

* Added a new unit test `VerifyAsDERRejectsInvalidSignatureSize` to confirm that signatures with invalid sizes are correctly rejected by `verifyAsDER`.