### PR TITLE
fix(bitcoin-v2): Prevent setting 'max_amount_output' with existing outputs or change output

### DIFF
--- a/rust/chains/tw_bitcoin/src/modules/signing_request/standard_signing_request.rs
+++ b/rust/chains/tw_bitcoin/src/modules/signing_request/standard_signing_request.rs
@@ -12,6 +12,7 @@ use tw_coin_entry::coin_context::CoinContext;
 use tw_coin_entry::error::prelude::*;
 use tw_misc::traits::OptionalEmpty;
 use tw_proto::BitcoinV2::Proto;
+use tw_utxo::constants::check_max_input_output_count;
 use tw_utxo::context::UtxoContext;
 use tw_utxo::dust::DustPolicy;
 use tw_utxo::fee::fee_estimator::StandardFeeEstimator;
@@ -49,6 +50,13 @@ where
         builder
             .version(version)
             .lock_time(transaction_builder.lock_time);
+
+        check_max_input_output_count(
+            transaction_builder.inputs.len(),
+            transaction_builder.outputs.len(),
+            transaction_builder.change_output.is_some(),
+            transaction_builder.max_amount_output.is_some(),
+        )?;
 
         // Parse all UTXOs.
         for utxo_proto in transaction_builder.inputs.iter() {

--- a/rust/chains/tw_decred/src/modules/signing_request.rs
+++ b/rust/chains/tw_decred/src/modules/signing_request.rs
@@ -13,10 +13,23 @@ use tw_bitcoin::modules::tx_builder::output_protobuf::OutputProtobuf;
 use tw_bitcoin::modules::tx_builder::utxo_protobuf::UtxoProtobuf;
 use tw_coin_entry::coin_context::CoinContext;
 use tw_coin_entry::error::prelude::*;
+use tw_proto::BitcoinV2::Proto;
 use tw_proto::BitcoinV2::Proto::{SigningInput, TransactionBuilder};
 use tw_utxo::modules::tx_planner::{PlanRequest, RequestType};
 
 pub const DEFAULT_EXPIRY: u32 = 0;
+
+pub struct DecredExtraData {
+    pub expiry_height: u32,
+}
+
+impl Default for DecredExtraData {
+    fn default() -> Self {
+        Self {
+            expiry_height: DEFAULT_EXPIRY,
+        }
+    }
+}
 
 pub struct DecredSigningRequestBuilder;
 
@@ -26,6 +39,7 @@ impl SigningRequestBuilder<DecredContext> for DecredSigningRequestBuilder {
         input: &SigningInput,
         transaction_builder: &TransactionBuilder,
     ) -> SigningResult<PlanRequest<DecredContext>> {
+        let extra_data = Self::extra_data(transaction_builder)?;
         let chain_info = chain_info(coin, &input.chain_info)?;
         let dust_policy =
             StandardSigningRequestBuilder::dust_policy(&transaction_builder.dust_policy)?;
@@ -40,7 +54,7 @@ impl SigningRequestBuilder<DecredContext> for DecredSigningRequestBuilder {
         let mut builder = DecredTransactionBuilder::new();
         builder
             .lock_time(transaction_builder.lock_time)
-            .expiry(DEFAULT_EXPIRY);
+            .expiry(extra_data.expiry_height);
 
         // Parse all UTXOs.
         for utxo_proto in transaction_builder.inputs.iter() {
@@ -110,6 +124,25 @@ impl SigningRequestBuilder<DecredContext> for DecredSigningRequestBuilder {
             },
             dust_policy,
             fee_estimator,
+        })
+    }
+}
+
+impl DecredSigningRequestBuilder {
+    pub fn extra_data(proto: &TransactionBuilder) -> SigningResult<DecredExtraData> {
+        use Proto::mod_TransactionBuilder::OneOfchain_specific as ChainSpecific;
+
+        let extra_data = match proto.chain_specific {
+            ChainSpecific::decred_extra_data(ref decred) => decred,
+            ChainSpecific::zcash_extra_data(_) => {
+                return SigningError::err(SigningErrorType::Error_invalid_params)
+                    .context("Expected Decred extra data, but Zcash extra data was provided")
+            },
+            ChainSpecific::None => return Ok(DecredExtraData::default()),
+        };
+
+        Ok(DecredExtraData {
+            expiry_height: extra_data.expiry_height,
         })
     }
 }

--- a/rust/chains/tw_decred/src/modules/signing_request.rs
+++ b/rust/chains/tw_decred/src/modules/signing_request.rs
@@ -15,6 +15,7 @@ use tw_coin_entry::coin_context::CoinContext;
 use tw_coin_entry::error::prelude::*;
 use tw_proto::BitcoinV2::Proto;
 use tw_proto::BitcoinV2::Proto::{SigningInput, TransactionBuilder};
+use tw_utxo::constants::check_max_input_output_count;
 use tw_utxo::modules::tx_planner::{PlanRequest, RequestType};
 
 pub const DEFAULT_EXPIRY: u32 = 0;
@@ -55,6 +56,13 @@ impl SigningRequestBuilder<DecredContext> for DecredSigningRequestBuilder {
         builder
             .lock_time(transaction_builder.lock_time)
             .expiry(extra_data.expiry_height);
+
+        check_max_input_output_count(
+            transaction_builder.inputs.len(),
+            transaction_builder.outputs.len(),
+            transaction_builder.change_output.is_some(),
+            transaction_builder.max_amount_output.is_some(),
+        )?;
 
         // Parse all UTXOs.
         for utxo_proto in transaction_builder.inputs.iter() {

--- a/rust/chains/tw_decred/src/modules/signing_request.rs
+++ b/rust/chains/tw_decred/src/modules/signing_request.rs
@@ -54,6 +54,14 @@ impl SigningRequestBuilder<DecredContext> for DecredSigningRequestBuilder {
 
         // If `max_amount_output` is set, construct a transaction with only one output.
         if let Some(max_output_proto) = transaction_builder.max_amount_output.as_ref() {
+            if !transaction_builder.outputs.is_empty()
+                || transaction_builder.change_output.is_some()
+            {
+                return SigningError::err(SigningErrorType::Error_invalid_params).context(
+                    "'max_amount_output' cannot be set together with 'outputs' or 'change_output'",
+                );
+            }
+
             let output_builder =
                 OutputProtobuf::<DecredContext>::new(&chain_info, max_output_proto);
 

--- a/rust/chains/tw_decred/src/modules/transaction_builder/mod.rs
+++ b/rust/chains/tw_decred/src/modules/transaction_builder/mod.rs
@@ -60,6 +60,8 @@ impl DecredTransactionBuilder {
         self
     }
 
+    /// Pushes a standard transaction input to the builder, converting it to a DecredTransactionInput.
+    /// Since Decred does not support Segwit or Taproot, the input must use a legacy signing method, otherwise an error is returned.
     pub fn push_standard_input(
         &mut self,
         standard_input: TransactionInput,

--- a/rust/chains/tw_zcash/src/modules/signing_request.rs
+++ b/rust/chains/tw_zcash/src/modules/signing_request.rs
@@ -70,6 +70,14 @@ where
 
         // If `max_amount_output` is set, construct a transaction with only one output.
         if let Some(max_output_proto) = transaction_builder.max_amount_output.as_ref() {
+            if !transaction_builder.outputs.is_empty()
+                || transaction_builder.change_output.is_some()
+            {
+                return SigningError::err(SigningErrorType::Error_invalid_params).context(
+                    "'max_amount_output' cannot be set together with 'outputs' or 'change_output'",
+                );
+            }
+
             let output_builder = OutputProtobuf::<Context>::new(&chain_info, max_output_proto);
 
             let max_output = output_builder

--- a/rust/chains/tw_zcash/src/modules/signing_request.rs
+++ b/rust/chains/tw_zcash/src/modules/signing_request.rs
@@ -19,6 +19,7 @@ use tw_bitcoin::modules::signing_request::standard_signing_request::{
     chain_info, StandardSigningRequestBuilder,
 };
 use tw_hash::H32;
+use tw_utxo::constants::check_max_input_output_count;
 use tw_utxo::context::UtxoContext;
 
 pub struct ZcashExtraData {
@@ -57,6 +58,13 @@ where
             .lock_time(transaction_builder.lock_time)
             .expiry_height(extra_data.expiry_height)
             .branch_id(extra_data.branch_id);
+
+        check_max_input_output_count(
+            transaction_builder.inputs.len(),
+            transaction_builder.outputs.len(),
+            transaction_builder.change_output.is_some(),
+            transaction_builder.max_amount_output.is_some(),
+        )?;
 
         // Parse all UTXOs.
         for utxo_proto in transaction_builder.inputs.iter() {

--- a/rust/frameworks/tw_utxo/src/constants.rs
+++ b/rust/frameworks/tw_utxo/src/constants.rs
@@ -2,6 +2,35 @@
 //
 // Copyright © 2017 Trust Wallet.
 
+use tw_coin_entry::error::prelude::{ResultContext, SigningError, SigningErrorType, SigningResult};
+
 /// A standard transaction is limited to 400k weight units (WU).
 /// https://bitcoin.stackexchange.com/questions/35570/what-is-the-maximum-number-of-inputs-outputs-a-transaction-can-have
 pub const MAX_TRANSACTION_WEIGHT: usize = 400_000;
+/// We set a maximum of 10k inputs and outputs to avoid potential DoS attack leading to out of memory error.
+/// This is a very high number and should be enough for any real world use case.
+pub const MAX_INPUT_OUTPUT_COUNT: usize = 10_000;
+
+/// Check the input and output count of a transaction against the maximum allowed limit.
+pub fn check_max_input_output_count(
+    input_count: usize,
+    output_count: usize,
+    includes_change_output: bool,
+    includes_max_output: bool,
+) -> SigningResult<()> {
+    if input_count > MAX_INPUT_OUTPUT_COUNT {
+        return SigningError::err(SigningErrorType::Error_tx_too_big).context(format!(
+            "Too many inputs. Max allowed is {MAX_INPUT_OUTPUT_COUNT}"
+        ));
+    }
+
+    let total_output_count =
+        output_count + includes_change_output as usize + includes_max_output as usize;
+
+    if total_output_count > MAX_INPUT_OUTPUT_COUNT {
+        return SigningError::err(SigningErrorType::Error_tx_too_big).context(format!(
+            "Too many outputs. Max allowed is {MAX_INPUT_OUTPUT_COUNT}"
+        ));
+    }
+    Ok(())
+}

--- a/rust/tw_tests/tests/chains/decred/decred_sign.rs
+++ b/rust/tw_tests/tests/chains/decred/decred_sign.rs
@@ -6,7 +6,7 @@ use crate::chains::common::bitcoin::{
     dust_threshold, input, output, plan, sign, TransactionOneof, DUST, SIGHASH_ALL, SIGHASH_NONE,
     SIGHASH_SINGLE,
 };
-use crate::chains::decred::decred_info;
+use crate::chains::decred::{decred_extra_data, decred_info};
 use tw_coin_registry::coin_type::CoinType;
 use tw_encoding::hex::DecodeHex;
 use tw_keypair::ecdsa::secp256k1;
@@ -42,6 +42,7 @@ fn test_decred_sign_p2pkh_fake() {
         outputs: vec![out1],
         input_selector: Proto::InputSelector::UseAll,
         dust_policy: dust_threshold(0),
+        chain_specific: decred_extra_data(0),
         ..Default::default()
     };
 

--- a/rust/tw_tests/tests/chains/decred/decred_sign.rs
+++ b/rust/tw_tests/tests/chains/decred/decred_sign.rs
@@ -7,11 +7,13 @@ use crate::chains::common::bitcoin::{
     SIGHASH_SINGLE,
 };
 use crate::chains::decred::{decred_extra_data, decred_info};
+use tw_any_coin::test_utils::sign_utils::AnySignerHelper;
 use tw_coin_registry::coin_type::CoinType;
 use tw_encoding::hex::DecodeHex;
 use tw_keypair::ecdsa::secp256k1;
 use tw_misc::traits::ToBytesVec;
 use tw_proto::BitcoinV2::Proto;
+use tw_proto::Common;
 
 /// For this example, create a fake transaction that represents what would
 /// ordinarily be the real transaction that is being spent. It contains a
@@ -321,4 +323,112 @@ fn test_decred_sign_p2pkh_different_sighashes() {
             weight: 579 * 4,
             fee: 5850,
         });
+}
+
+#[test]
+fn test_decred_sign_both_outputs_and_max_amount_error() {
+    const PRIVATE_KEY: &str = "99ed469e6b7d9f188962940d9d0f9fd8582c6c37e52394348f177ff0526b8a03";
+    const MY_ADDRESS: &str = "DscNJ2Ki7HUPHrLGF2teBxSda3uxKSY7Fm6";
+    const TO_ADDRESS: &str = "Dsofok7qyhDLVRXcTqYdFgmGsUFSiHonbWH";
+
+    let private_key = secp256k1::PrivateKey::try_from(PRIVATE_KEY).unwrap();
+    let public_key = private_key.public();
+
+    let txid = "c5cc3b1fc20c9e43a7d1127ba7e4802d04c16515a7eaaad58a1bc388acacfeae";
+    let tx1 = Proto::Input {
+        out_point: input::out_point(txid, 0),
+        value: 100_000_000,
+        sighash_type: SIGHASH_ALL,
+        claiming_script: input::p2pkh(public_key.to_vec()),
+        ..Default::default()
+    };
+
+    let out = Proto::Output {
+        value: 10_000_000,
+        to_recipient: output::to_address(TO_ADDRESS),
+    };
+    let change_out = Proto::Output {
+        to_recipient: output::to_address(MY_ADDRESS),
+        ..Default::default()
+    };
+    let max_out = Proto::Output {
+        to_recipient: output::to_address(MY_ADDRESS),
+        ..Default::default()
+    };
+
+    // First, create transaction with both outputs and max amount set.
+    let builder = Proto::TransactionBuilder {
+        version: Proto::TransactionVersion::V1,
+        inputs: vec![tx1.clone()],
+        outputs: vec![out.clone()],
+        max_amount_output: Some(max_out.clone()),
+        input_selector: Proto::InputSelector::UseAll,
+        dust_policy: dust_threshold(DUST),
+        ..Default::default()
+    };
+
+    let signing = Proto::SigningInput {
+        private_keys: vec![PRIVATE_KEY.decode_hex().unwrap().into()],
+        chain_info: decred_info(),
+        transaction: TransactionOneof::builder(builder),
+        ..Default::default()
+    };
+
+    let mut signer = AnySignerHelper::<Proto::SigningOutput>::default();
+    let output = signer.sign(CoinType::Decred, signing);
+    assert_eq!(
+        output.error,
+        Common::Proto::SigningError::Error_invalid_params
+    );
+
+    // Secondly, create transaction with change output and max amount set.
+    let builder = Proto::TransactionBuilder {
+        version: Proto::TransactionVersion::V1,
+        inputs: vec![tx1.clone()],
+        change_output: Some(change_out.clone()),
+        max_amount_output: Some(max_out.clone()),
+        input_selector: Proto::InputSelector::UseAll,
+        dust_policy: dust_threshold(DUST),
+        ..Default::default()
+    };
+
+    let signing = Proto::SigningInput {
+        private_keys: vec![PRIVATE_KEY.decode_hex().unwrap().into()],
+        chain_info: decred_info(),
+        transaction: TransactionOneof::builder(builder),
+        ..Default::default()
+    };
+
+    let mut signer = AnySignerHelper::<Proto::SigningOutput>::default();
+    let output = signer.sign(CoinType::Decred, signing);
+    assert_eq!(
+        output.error,
+        Common::Proto::SigningError::Error_invalid_params
+    );
+
+    // Lastly, create transaction with all change output, outputs and max amount set.
+    let builder = Proto::TransactionBuilder {
+        version: Proto::TransactionVersion::V1,
+        inputs: vec![tx1],
+        outputs: vec![out],
+        change_output: Some(change_out),
+        max_amount_output: Some(max_out),
+        input_selector: Proto::InputSelector::UseAll,
+        dust_policy: dust_threshold(DUST),
+        ..Default::default()
+    };
+
+    let signing = Proto::SigningInput {
+        private_keys: vec![PRIVATE_KEY.decode_hex().unwrap().into()],
+        chain_info: decred_info(),
+        transaction: TransactionOneof::builder(builder),
+        ..Default::default()
+    };
+
+    let mut signer = AnySignerHelper::<Proto::SigningOutput>::default();
+    let output = signer.sign(CoinType::Decred, signing);
+    assert_eq!(
+        output.error,
+        Common::Proto::SigningError::Error_invalid_params
+    );
 }

--- a/rust/tw_tests/tests/chains/decred/mod.rs
+++ b/rust/tw_tests/tests/chains/decred/mod.rs
@@ -2,7 +2,9 @@
 //
 // Copyright © 2017 Trust Wallet.
 
+use crate::chains::common::bitcoin::ChainSpecific;
 use tw_proto::BitcoinV2::Proto;
+use tw_proto::DecredV2::Proto as DecredProto;
 
 mod decred_address;
 mod decred_compile;
@@ -17,4 +19,8 @@ pub fn decred_info() -> Option<Proto::ChainInfo<'static>> {
         p2sh_prefix: DECRED_P2PSH_PREFIX as u32,
         ..Proto::ChainInfo::default()
     })
+}
+
+pub fn decred_extra_data(expiry_height: u32) -> ChainSpecific<'static> {
+    ChainSpecific::decred_extra_data(DecredProto::TransactionBuilderExtraData { expiry_height })
 }

--- a/rust/tw_tests/tests/chains/zcash/zcash_sign.rs
+++ b/rust/tw_tests/tests/chains/zcash/zcash_sign.rs
@@ -194,6 +194,111 @@ fn test_zcash_sign_pczt() {
 }
 
 #[test]
+fn test_zcash_sign_both_outputs_and_max_amount_error() {
+    const PRIVATE_KEY: &str = "a9684f5bebd0e1208aae2e02bc9e9163bd1965ad23d8538644e1df8b99b99559";
+    const SENDER_ADDRESS: &str = "t1gWVE2uyrET2CxSmCaBiKzmWxQdHhnvMSz";
+    const TO_ADDRESS: &str = "t1QahNjDdibyE4EdYkawUSKBBcVTSqv64CS";
+
+    let txid = "3a19dd44032dfed61bfca5ba5751aab8a107b30609cbd5d70dc5ef09885b6853";
+    let tx1 = Proto::Input {
+        out_point: input::out_point(txid, 0),
+        value: 494_000,
+        sighash_type: SIGHASH_ALL,
+        claiming_script: input::receiver_address(SENDER_ADDRESS),
+        ..Default::default()
+    };
+
+    let out = Proto::Output {
+        value: 100_000,
+        to_recipient: output::to_address(TO_ADDRESS),
+    };
+    let change_out = Proto::Output {
+        to_recipient: output::to_address(SENDER_ADDRESS),
+        ..Default::default()
+    };
+    let max_out = Proto::Output {
+        to_recipient: output::to_address(SENDER_ADDRESS),
+        ..Default::default()
+    };
+
+    let extra_data = ZcashProto::TransactionBuilderExtraData {
+        branch_id: SAPLING_BRANCH_ID.into(),
+        zip_0317: false,
+        expiry_height: 0,
+    };
+
+    // First, create transaction with both outputs and max amount set.
+    let builder = Proto::TransactionBuilder {
+        version: Proto::TransactionVersion::UseDefault,
+        inputs: vec![tx1.clone()],
+        outputs: vec![out.clone()],
+        max_amount_output: Some(max_out.clone()),
+        input_selector: Proto::InputSelector::UseAll,
+        dust_policy: dust_threshold(DUST),
+        chain_specific: zcash_extra_data(extra_data.clone()),
+        ..Default::default()
+    };
+
+    let signing = Proto::SigningInput {
+        private_keys: vec![PRIVATE_KEY.decode_hex().unwrap().into()],
+        chain_info: zec_info(),
+        transaction: TransactionOneof::builder(builder),
+        ..Default::default()
+    };
+
+    let mut signer = AnySignerHelper::<Proto::SigningOutput>::default();
+    let output = signer.sign(CoinType::Zcash, signing);
+    assert_eq!(output.error, SigningError::Error_invalid_params);
+
+    // Secondly, create transaction with change output and max amount set.
+    let builder = Proto::TransactionBuilder {
+        version: Proto::TransactionVersion::UseDefault,
+        inputs: vec![tx1.clone()],
+        change_output: Some(change_out.clone()),
+        max_amount_output: Some(max_out.clone()),
+        input_selector: Proto::InputSelector::UseAll,
+        dust_policy: dust_threshold(DUST),
+        chain_specific: zcash_extra_data(extra_data.clone()),
+        ..Default::default()
+    };
+
+    let signing = Proto::SigningInput {
+        private_keys: vec![PRIVATE_KEY.decode_hex().unwrap().into()],
+        chain_info: zec_info(),
+        transaction: TransactionOneof::builder(builder),
+        ..Default::default()
+    };
+
+    let mut signer = AnySignerHelper::<Proto::SigningOutput>::default();
+    let output = signer.sign(CoinType::Zcash, signing);
+    assert_eq!(output.error, SigningError::Error_invalid_params);
+
+    // Lastly, create transaction with all change output, outputs and max amount set.
+    let builder = Proto::TransactionBuilder {
+        version: Proto::TransactionVersion::UseDefault,
+        inputs: vec![tx1],
+        outputs: vec![out],
+        change_output: Some(change_out),
+        max_amount_output: Some(max_out),
+        input_selector: Proto::InputSelector::UseAll,
+        dust_policy: dust_threshold(DUST),
+        chain_specific: zcash_extra_data(extra_data),
+        ..Default::default()
+    };
+
+    let signing = Proto::SigningInput {
+        private_keys: vec![PRIVATE_KEY.decode_hex().unwrap().into()],
+        chain_info: zec_info(),
+        transaction: TransactionOneof::builder(builder),
+        ..Default::default()
+    };
+
+    let mut signer = AnySignerHelper::<Proto::SigningOutput>::default();
+    let output = signer.sign(CoinType::Zcash, signing);
+    assert_eq!(output.error, SigningError::Error_invalid_params);
+}
+
+#[test]
 fn test_zcash_sign_pczt_unsupported_tx_version() {
     const PRIVATE_KEY: &str = "c9d84f11d992c1a527293b468ba67f739f8098c333748493da45b9cf53844ec4";
     const PSBT: &str = "UENaVAEAAAAFis6ctQLVoJzHDAEA4ua/AYUBgwABFRZQRxlNqLSGFmGot6F/FeWgAGC2IUW5epyMH5ttEEQAAf////8PAAAAoMuYARl2qRRVo2Xng7FIhowyPIZtZPlgrdDLaoisAAABAAAAAAAAAsPxfhl2qRQthdKs2GnpfCJRan162hFZgsQNXoisAAABI3QxTjJKajlkRG9ZUUVtRVdBQlZ4TmF6YndzR3VVcko0UDREALWWGBl2qRRVo2Xng7FIhowyPIZtZPlgrdDLaoisAAABI3QxUmdSQmpqbnhYU2cxcHRMRHJrYU1OaVY0dEpWWHU3ZFdWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";

--- a/src/proto/BitcoinV2.proto
+++ b/src/proto/BitcoinV2.proto
@@ -255,6 +255,8 @@ message TransactionBuilder {
     oneof chain_specific {
         // ZCash specific transaction data.
         Zcash.Proto.TransactionBuilderExtraData zcash_extra_data = 20;
+        // Decred specific transaction data.
+        DecredV2.Proto.TransactionBuilderExtraData decred_extra_data = 21;
     }
 }
 

--- a/src/proto/BitcoinV2.proto
+++ b/src/proto/BitcoinV2.proto
@@ -236,6 +236,8 @@ message TransactionBuilder {
     InputSelector input_selector = 5;
     // The amount of satoshis per vbyte ("satVb"), used for fee calculation.
     // Can be satoshis per byte ("satB") **ONLY** when transaction does not contain segwit UTXOs.
+    // In most cases, the fee rate is a positive integer, but it can be zero when fee validation is not necessary (`InputSelector.UseAll`),
+    // or the transaction is free or it contains a miner subsidy UTXO (eg. coinbase transaction).
     int64 fee_per_vb = 6;
     // (optional) The change output to be added (return to sender) at the end of the outputs list.
     // The `Output.value` will be overwritten, leave default.

--- a/src/proto/DecredV2.proto
+++ b/src/proto/DecredV2.proto
@@ -57,3 +57,9 @@ message TransactionOutput {
     // Usually contains the public key as a Decred script setting up conditions to claim this output.
     bytes script = 3;
 }
+
+// Extra data for transaction builder, such as expiry height.
+message TransactionBuilderExtraData {
+    // Zero in most cases.
+    uint32 expiry_height = 1;
+}


### PR DESCRIPTION
This pull request adds stricter validation to the transaction building logic for both Decred and Zcash chains. Specifically, it ensures that the `max_amount_output` parameter cannot be used together with regular outputs or a change output, preventing invalid transaction configurations.

Validation improvements for transaction building:

* Added a check in `DecredSigningRequestBuilder` to return an error if `max_amount_output` is set together with `outputs` or `change_output`, enforcing mutual exclusivity.
* Added the same validation logic to the Zcash signing request builder, ensuring consistent behavior across both chains.