### PR TITLE
fix(xrp): Don't set LastLedgerSequence when not provided in SigningInput

### DIFF
--- a/rust/chains/tw_ripple/src/modules/protobuf_builder.rs
+++ b/rust/chains/tw_ripple/src/modules/protobuf_builder.rs
@@ -103,9 +103,11 @@ impl<'a> ProtobufBuilder<'a> {
             tx.common_fields.sequence = Some(self.input.sequence);
         }
 
-        // Check whether `SigningInput.last_ledger_sequence` is specified, or JSON transaction doesn't contain that field,
-        // then override the field.
-        if self.input.last_ledger_sequence != 0 || tx.common_fields.last_ledger_sequence.is_none() {
+        // Check whether `SigningInput.last_ledger_sequence` is specified,
+        // then override the field. A value of 0 means "not provided" (proto default),
+        // so we must not set it — `LastLedgerSequence = 0` would cause
+        // immediate transaction expiry on the XRP Ledger.
+        if self.input.last_ledger_sequence != 0 {
             tx.common_fields.last_ledger_sequence = Some(self.input.last_ledger_sequence);
         }
 
@@ -332,8 +334,14 @@ impl<'a> ProtobufBuilder<'a> {
         builder
             .fee(fee)
             .flags(self.input.flags.try_into_u32("inputFlags")?)
-            .sequence(self.input.sequence)
-            .last_ledger_sequence(self.input.last_ledger_sequence)
+            .sequence(self.input.sequence);
+        // Only set `LastLedgerSequence` when explicitly provided (non-zero).
+        // Proto default 0 means "not provided" — setting it to 0 would cause
+        // immediate transaction expiry on the XRP Ledger.
+        if self.input.last_ledger_sequence != 0 {
+            builder.last_ledger_sequence(self.input.last_ledger_sequence);
+        }
+        builder
             .account_str(self.input.account.as_ref())?
             .signing_pub_key(&signing_public_key);
         if self.input.source_tag != 0 {


### PR DESCRIPTION
## Summary

- Guard `LastLedgerSequence` assignment in both `build_tx_json` and `prepare_builder` to only set the field when the proto input value is non-zero
- When not provided (proto default 0), the field stays `None` and is omitted from serialization, matching the old C++ behavior

## Problem

After the C++ → Rust migration in #4250, XRP transactions that don't explicitly set `lastLedgerSequence` in `SigningInput` get `LastLedgerSequence = 0` in the signed output. This means "expire at ledger 0", causing **immediate transaction expiry** on the XRP Ledger.

The root cause is in `protobuf_builder.rs`:

```rust
// build_tx_json path:
if self.input.last_ledger_sequence != 0 || tx.common_fields.last_ledger_sequence.is_none() {
    tx.common_fields.last_ledger_sequence = Some(self.input.last_ledger_sequence);
}

// prepare_builder path:
builder.last_ledger_sequence(self.input.last_ledger_sequence)
```

When `lastLedgerSequence` is not provided, the proto default is `0`. The condition `false || true = true` sets `Some(0)`, and `prepare_builder` unconditionally sets it. Since `CommonFields.last_ledger_sequence` is `Option<u32>` with `skip_serializing_if = "Option::is_none"`, `Some(0)` gets serialized into the transaction.

## Fix

Only set the field when the input value is non-zero:

```rust
// build_tx_json path:
if self.input.last_ledger_sequence != 0 {
    tx.common_fields.last_ledger_sequence = Some(self.input.last_ledger_sequence);
}

// prepare_builder path:
if self.input.last_ledger_sequence != 0 {
    builder.last_ledger_sequence(self.input.last_ledger_sequence);
}
```

Note: the same pattern (`!= 0` guard) is already correctly used for `source_tag` on line 339.

## Test plan

- All existing Ripple tests pass unchanged (they all use non-zero `last_ledger_sequence` values)
- Verified with real XRP mainnet transactions that the fix produces valid output

Fixes #4731