### PR TITLE
chore: Update CODEOWNERS to include @BSCSecChef

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @trustwallet/onchain-corex-enabling
+* @trustwallet/onchain-corex-enabling @BSCSecChef


### PR DESCRIPTION
This pull request makes a minor update to the `.github/CODEOWNERS` file by adding `@BSCSecChef` as a code owner alongside the existing owner.