### PR TITLE
fix(bitcoin): Ensure non-negative amounts in transaction processing

### DIFF
--- a/rust/chains/tw_bitcoin/src/modules/compiler.rs
+++ b/rust/chains/tw_bitcoin/src/modules/compiler.rs
@@ -119,14 +119,17 @@ impl<Context: BitcoinSigningContext> BitcoinCompiler<Context> {
         let signed_tx = TxCompiler::compile(unsigned_tx, &signatures)?;
 
         Ok(Proto::SigningOutput {
-            transaction: Context::ProtobufBuilder::tx_to_proto(&signed_tx),
+            transaction: Context::ProtobufBuilder::tx_to_proto(&signed_tx)?,
             encoded: Cow::from(signed_tx.encode_out()),
             txid: Cow::from(signed_tx.txid(Context::TX_HASHER)),
             // `vsize` could have been changed after the transaction being signed.
             vsize: signed_tx.vsize() as u64,
             weight: signed_tx.weight() as u64,
             // `fee` should haven't been changed since it's a difference between `sum(inputs)` and `sum(outputs)`.
-            fee: plan.fee_estimate,
+            fee: plan
+                .fee_estimate
+                .try_into()
+                .tw_err(SigningErrorType::Error_wrong_fee)?,
             ..Proto::SigningOutput::default()
         })
     }
@@ -145,13 +148,13 @@ impl<Context: BitcoinSigningContext> BitcoinCompiler<Context> {
         let signed_tx = TxCompiler::compile(unsigned_tx, &signatures)?;
 
         Ok(Proto::SigningOutput {
-            transaction: Context::ProtobufBuilder::tx_to_proto(&signed_tx),
+            transaction: Context::ProtobufBuilder::tx_to_proto(&signed_tx)?,
             encoded: Cow::from(signed_tx.encode_out()),
             txid: Cow::from(signed_tx.txid(Context::TX_HASHER)),
             // `vsize` could have been changed after the transaction being signed.
             vsize: signed_tx.vsize() as u64,
             weight: signed_tx.weight() as u64,
-            fee,
+            fee: fee.try_into().tw_err(SigningErrorType::Error_wrong_fee)?,
             ..Proto::SigningOutput::default()
         })
     }

--- a/rust/chains/tw_bitcoin/src/modules/planner/mod.rs
+++ b/rust/chains/tw_bitcoin/src/modules/planner/mod.rs
@@ -84,7 +84,10 @@ impl<Context: BitcoinSigningContext> BitcoinPlanner<Context> {
             );
 
             outputs_proto.push(Proto::Output {
-                value: selected_output.value(),
+                value: selected_output
+                    .value()
+                    .try_into()
+                    .tw_err(SigningErrorType::Error_invalid_requested_token_amount)?,
                 to_recipient,
             })
         }
@@ -92,11 +95,23 @@ impl<Context: BitcoinSigningContext> BitcoinPlanner<Context> {
         Ok(Proto::TransactionPlan {
             inputs: selected_inputs_proto,
             outputs: outputs_proto,
-            available_amount: plan.total_spend,
-            send_amount: plan.total_send,
+            available_amount: plan
+                .total_spend
+                .try_into()
+                .tw_err(SigningErrorType::Error_tx_too_big)?,
+            send_amount: plan
+                .total_send
+                .try_into()
+                .tw_err(SigningErrorType::Error_tx_too_big)?,
             vsize_estimate: plan.vsize_estimate as u64,
-            fee_estimate: plan.fee_estimate,
-            change: plan.change,
+            fee_estimate: plan
+                .fee_estimate
+                .try_into()
+                .tw_err(SigningErrorType::Error_wrong_fee)?,
+            change: plan
+                .change
+                .try_into()
+                .tw_err(SigningErrorType::Error_tx_too_big)?,
             ..Proto::TransactionPlan::default()
         })
     }

--- a/rust/chains/tw_bitcoin/src/modules/planner/psbt_planner.rs
+++ b/rust/chains/tw_bitcoin/src/modules/planner/psbt_planner.rs
@@ -55,10 +55,16 @@ impl<Context: BitcoinSigningContext> PsbtPlanner<Context> {
         Ok(Proto::TransactionPlan {
             inputs,
             outputs,
-            available_amount: total_input,
-            send_amount: total_input,
+            available_amount: total_input
+                .try_into()
+                .tw_err(SigningErrorType::Error_tx_too_big)?,
+            send_amount: total_input
+                .try_into()
+                .tw_err(SigningErrorType::Error_tx_too_big)?,
             vsize_estimate,
-            fee_estimate,
+            fee_estimate: fee_estimate
+                .try_into()
+                .tw_err(SigningErrorType::Error_wrong_fee)?,
             change: 0,
             ..Proto::TransactionPlan::default()
         })
@@ -87,7 +93,10 @@ impl<Context: BitcoinSigningContext> PsbtPlanner<Context> {
 
         Ok(Proto::Input {
             out_point: Some(out_point),
-            value: unsigned_txin.amount,
+            value: unsigned_txin
+                .amount
+                .try_into()
+                .tw_err(SigningErrorType::Error_invalid_utxo_amount)?,
             sighash_type: unsigned_txin.sighash_ty.raw_sighash(),
             sequence: Some(sequence),
             claiming_script: ClaimingScriptProto::receiver_address(from_address.into()),
@@ -109,7 +118,10 @@ impl<Context: BitcoinSigningContext> PsbtPlanner<Context> {
         };
 
         Ok(Proto::Output {
-            value: output.value(),
+            value: output
+                .value()
+                .try_into()
+                .tw_err(SigningErrorType::Error_invalid_requested_token_amount)?,
             to_recipient,
         })
     }

--- a/rust/chains/tw_bitcoin/src/modules/protobuf_builder/mod.rs
+++ b/rust/chains/tw_bitcoin/src/modules/protobuf_builder/mod.rs
@@ -2,6 +2,7 @@
 //
 // Copyright © 2017 Trust Wallet.
 
+use tw_coin_entry::error::prelude::*;
 use tw_utxo::context::UtxoContext;
 
 pub use tw_proto::BitcoinV2::Proto::mod_SigningOutput::OneOftransaction as ProtobufTransaction;
@@ -9,5 +10,5 @@ pub use tw_proto::BitcoinV2::Proto::mod_SigningOutput::OneOftransaction as Proto
 pub mod standard_protobuf_builder;
 
 pub trait ProtobufBuilder<Context: UtxoContext> {
-    fn tx_to_proto(tx: &Context::Transaction) -> ProtobufTransaction<'static>;
+    fn tx_to_proto(tx: &Context::Transaction) -> SigningResult<ProtobufTransaction<'static>>;
 }

--- a/rust/chains/tw_bitcoin/src/modules/protobuf_builder/standard_protobuf_builder.rs
+++ b/rust/chains/tw_bitcoin/src/modules/protobuf_builder/standard_protobuf_builder.rs
@@ -55,8 +55,8 @@ impl StandardProtobufBuilder {
             value: output
                 .value
                 .try_into()
-                .tw_err(SigningErrorType::Error_invalid_requested_token_amount)
-                .context("Output amount cannot be negative")?,
+                .tw_err(SigningErrorType::Error_invalid_utxo_amount)
+                .context("Transaction Input amount is too large")?,
         })
     }
 

--- a/rust/chains/tw_bitcoin/src/modules/protobuf_builder/standard_protobuf_builder.rs
+++ b/rust/chains/tw_bitcoin/src/modules/protobuf_builder/standard_protobuf_builder.rs
@@ -4,6 +4,7 @@
 
 use crate::modules::protobuf_builder::{ProtobufBuilder, ProtobufTransaction};
 use std::borrow::Cow;
+use tw_coin_entry::error::prelude::*;
 use tw_proto::Utxo::Proto as UtxoProto;
 use tw_utxo::context::UtxoContext;
 use tw_utxo::script::{Script, Witness};
@@ -19,16 +20,20 @@ impl<Context> ProtobufBuilder<Context> for StandardProtobufBuilder
 where
     Context: UtxoContext<Transaction = Transaction>,
 {
-    fn tx_to_proto(tx: &Context::Transaction) -> ProtobufTransaction<'static> {
+    fn tx_to_proto(tx: &Context::Transaction) -> SigningResult<ProtobufTransaction<'static>> {
         let inputs = tx.inputs().iter().map(Self::tx_input_to_proto).collect();
-        let outputs = tx.outputs().iter().map(Self::tx_output_to_proto).collect();
+        let outputs = tx
+            .outputs()
+            .iter()
+            .map(Self::tx_output_to_proto)
+            .collect::<SigningResult<Vec<_>>>()?;
 
-        ProtobufTransaction::bitcoin(UtxoProto::Transaction {
+        Ok(ProtobufTransaction::bitcoin(UtxoProto::Transaction {
             version: tx.version(),
             lock_time: tx.locktime,
             inputs,
             outputs,
-        })
+        }))
     }
 }
 
@@ -42,11 +47,17 @@ impl StandardProtobufBuilder {
         }
     }
 
-    pub fn tx_output_to_proto(output: &TransactionOutput) -> UtxoProto::TransactionOutput<'static> {
-        UtxoProto::TransactionOutput {
+    pub fn tx_output_to_proto(
+        output: &TransactionOutput,
+    ) -> SigningResult<UtxoProto::TransactionOutput<'static>> {
+        Ok(UtxoProto::TransactionOutput {
             script_pubkey: Self::script_data(&output.script_pubkey),
-            value: output.value,
-        }
+            value: output
+                .value
+                .try_into()
+                .tw_err(SigningErrorType::Error_invalid_requested_token_amount)
+                .context("Output amount cannot be negative")?,
+        })
     }
 
     pub fn out_point_to_proto(previous_output: &OutPoint) -> UtxoProto::OutPoint<'static> {

--- a/rust/chains/tw_bitcoin/src/modules/psbt_request/output_psbt.rs
+++ b/rust/chains/tw_bitcoin/src/modules/psbt_request/output_psbt.rs
@@ -17,12 +17,7 @@ impl<'a> OutputPsbt<'a> {
     }
 
     pub fn build(self) -> SigningResult<TransactionOutput> {
-        let value = self
-            .output
-            .value
-            .try_into()
-            .tw_err(SigningErrorType::Error_invalid_utxo_amount)
-            .context("PSBT Output amount is too large")?;
+        let value = self.output.value;
         let script_pubkey = Script::from(self.output.script_pubkey.to_bytes());
         Ok(TransactionOutput {
             value,

--- a/rust/chains/tw_bitcoin/src/modules/psbt_request/utxo_psbt.rs
+++ b/rust/chains/tw_bitcoin/src/modules/psbt_request/utxo_psbt.rs
@@ -126,11 +126,6 @@ impl<'a> UtxoPsbt<'a> {
                 .context("Only SIGHASH_ALL is supported for PSBT inputs");
         }
 
-        let amount = amount
-            .try_into()
-            .tw_err(SigningErrorType::Error_invalid_utxo_amount)
-            .context("PSBT UTXO amount is too large")?;
-
         Ok(UtxoBuilder::default()
             .prev_txid(prevout_hash)
             .prev_index(prevout_index)

--- a/rust/chains/tw_bitcoin/src/modules/signer.rs
+++ b/rust/chains/tw_bitcoin/src/modules/signer.rs
@@ -67,13 +67,16 @@ impl<Context: BitcoinSigningContext> BitcoinSigner<Context> {
             TxSigner::sign_tx(unsigned_tx, &keys_manager).context("Error signing transaction")?;
 
         Ok(Proto::SigningOutput {
-            transaction: Context::ProtobufBuilder::tx_to_proto(&signed_tx),
+            transaction: Context::ProtobufBuilder::tx_to_proto(&signed_tx)?,
             encoded: Cow::from(signed_tx.encode_out()),
             txid: Cow::from(signed_tx.txid(Context::TX_HASHER)),
             // `vsize` could have been changed after the transaction being signed.
             vsize: signed_tx.vsize() as u64,
             // `fee` should haven't been changed since it's a difference between `sum(inputs)` and `sum(outputs)`.
-            fee: plan.fee_estimate,
+            fee: plan
+                .fee_estimate
+                .try_into()
+                .tw_err(SigningErrorType::Error_wrong_fee)?,
             weight: signed_tx.weight() as u64,
             ..Proto::SigningOutput::default()
         })
@@ -104,12 +107,12 @@ impl<Context: BitcoinSigningContext> BitcoinSigner<Context> {
         Context::PsbtRequestHandler::update_signed(&mut psbt, &signed_tx)?;
 
         Ok(Proto::SigningOutput {
-            transaction: Context::ProtobufBuilder::tx_to_proto(&signed_tx),
+            transaction: Context::ProtobufBuilder::tx_to_proto(&signed_tx)?,
             encoded: Cow::from(signed_tx.encode_out()),
             txid: Cow::from(signed_tx.txid(Context::TX_HASHER)),
             // `vsize` could have been changed after the transaction being signed.
             vsize: signed_tx.vsize() as u64,
-            fee,
+            fee: fee.try_into().tw_err(SigningErrorType::Error_wrong_fee)?,
             weight: signed_tx.weight() as u64,
             psbt: Some(Proto::Psbt {
                 psbt: Cow::from(Context::PsbtRequestHandler::serialize_psbt(&psbt)?),

--- a/rust/chains/tw_bitcoin/src/modules/signing_request/standard_signing_request.rs
+++ b/rust/chains/tw_bitcoin/src/modules/signing_request/standard_signing_request.rs
@@ -149,7 +149,11 @@ impl StandardSigningRequestBuilder {
 
     pub fn dust_policy(proto: &ProtoDustPolicy) -> SigningResult<DustPolicy> {
         match proto {
-            ProtoDustPolicy::fixed_dust_threshold(fixed) => Ok(DustPolicy::FixedAmount(*fixed)),
+            ProtoDustPolicy::fixed_dust_threshold(fixed) => (*fixed)
+                .try_into()
+                .map(DustPolicy::FixedAmount)
+                .tw_err(SigningErrorType::Error_wrong_fee)
+                .context("Dust threshold cannot be negative"),
             ProtoDustPolicy::None => SigningError::err(SigningErrorType::Error_invalid_params)
                 .context("No dust policy provided"),
         }
@@ -158,7 +162,12 @@ impl StandardSigningRequestBuilder {
     pub fn fee_estimator<Transaction>(
         proto: &Proto::TransactionBuilder,
     ) -> SigningResult<StandardFeeEstimator<Transaction>> {
-        let fee_policy = FeePolicy::FeePerVb(proto.fee_per_vb);
+        let fee_per_vb = proto
+            .fee_per_vb
+            .try_into()
+            .tw_err(SigningErrorType::Error_wrong_fee)
+            .context("'fee_per_vb' cannot be negative")?;
+        let fee_policy = FeePolicy::FeePerVb(fee_per_vb);
         Ok(StandardFeeEstimator::new(fee_policy))
     }
 

--- a/rust/chains/tw_bitcoin/src/modules/tx_builder/output_protobuf.rs
+++ b/rust/chains/tw_bitcoin/src/modules/tx_builder/output_protobuf.rs
@@ -201,12 +201,14 @@ impl<'a, Context: UtxoContext> OutputProtobuf<'a, Context> {
     }
 
     pub fn prepare_builder(&self) -> SigningResult<OutputBuilder> {
-        if self.output.value < 0 {
-            return SigningError::err(SigningErrorType::Error_invalid_params)
-                .context("Transaction Output amount cannot be negative");
-        }
+        let value = self
+            .output
+            .value
+            .try_into()
+            .tw_err(SigningErrorType::Error_invalid_requested_token_amount)
+            .context("Transaction Output amount cannot be negative")?;
         Ok(OutputBuilder::with_public_key_hasher(
-            self.output.value,
+            value,
             Context::PUBLIC_KEY_HASHER,
         ))
     }

--- a/rust/chains/tw_bitcoin/src/modules/tx_builder/utxo_protobuf.rs
+++ b/rust/chains/tw_bitcoin/src/modules/tx_builder/utxo_protobuf.rs
@@ -193,11 +193,6 @@ impl<'a, Context: UtxoContext> UtxoProtobuf<'a, Context> {
         let OutPoint { hash, index } = parse_out_point(&self.input.out_point)?;
         let sighash_ty = self.sighash_ty()?;
 
-        if self.input.value < 0 {
-            return SigningError::err(SigningErrorType::Error_invalid_utxo_amount)
-                .context("UTXO amount cannot be negative");
-        }
-
         let sequence = self
             .input
             .sequence
@@ -206,11 +201,18 @@ impl<'a, Context: UtxoContext> UtxoProtobuf<'a, Context> {
             // Use the default 0xFFFFFFFF sequence value if not specified.
             .unwrap_or(u32::MAX);
 
+        let value = self
+            .input
+            .value
+            .try_into()
+            .tw_err(SigningErrorType::Error_invalid_utxo_amount)
+            .context("Transaction Input amount cannot be negative")?;
+
         Ok(UtxoBuilder::default()
             .prev_txid(hash)
             .prev_index(index)
             .sequence(sequence)
-            .amount(self.input.value)
+            .amount(value)
             .sighash_type(sighash_ty)
             .tx_hasher(Context::TX_HASHER)
             .public_key_hasher(Context::PUBLIC_KEY_HASHER))

--- a/rust/chains/tw_decred/src/modules/protobuf_builder.rs
+++ b/rust/chains/tw_decred/src/modules/protobuf_builder.rs
@@ -9,6 +9,7 @@ use crate::transaction::{
 use std::borrow::Cow;
 use tw_bitcoin::modules::protobuf_builder::standard_protobuf_builder::StandardProtobufBuilder;
 use tw_bitcoin::modules::protobuf_builder::{ProtobufBuilder, ProtobufTransaction};
+use tw_coin_entry::error::prelude::*;
 use tw_proto::DecredV2::Proto as DecredProto;
 use tw_utxo::transaction::transaction_interface::TransactionInterface;
 
@@ -17,38 +18,54 @@ pub struct DecredProtobufBuilder;
 impl DecredProtobufBuilder {
     pub fn tx_input_to_proto(
         input: &DecredTransactionInput,
-    ) -> DecredProto::TransactionInput<'static> {
-        DecredProto::TransactionInput {
+    ) -> SigningResult<DecredProto::TransactionInput<'static>> {
+        Ok(DecredProto::TransactionInput {
             out_point: Some(DecredProto::OutPoint {
                 hash: Cow::from(input.previous_output.out_point.hash.to_vec()),
                 vout: input.previous_output.out_point.index,
                 tree: input.previous_output.tree as u32,
             }),
             sequence: input.sequence,
-            value: input.value_in,
+            value: input
+                .value_in
+                .try_into()
+                .tw_err(SigningErrorType::Error_invalid_utxo_amount)
+                .context("Transaction Input amount cannot be negative")?,
             block_height: input.block_height,
             block_index: input.block_index,
             script_sig: StandardProtobufBuilder::script_data(&input.script_sig),
-        }
+        })
     }
 
     pub fn tx_output_to_proto(
         output: &DecredTransactionOutput,
-    ) -> DecredProto::TransactionOutput<'static> {
-        DecredProto::TransactionOutput {
-            value: output.value,
+    ) -> SigningResult<DecredProto::TransactionOutput<'static>> {
+        Ok(DecredProto::TransactionOutput {
+            value: output
+                .value
+                .try_into()
+                .tw_err(SigningErrorType::Error_invalid_requested_token_amount)
+                .context("Transaction Output amount cannot be negative")?,
             version: output.version as u32,
             script: StandardProtobufBuilder::script_data(&output.script_pubkey),
-        }
+        })
     }
 }
 
 impl ProtobufBuilder<DecredContext> for DecredProtobufBuilder {
-    fn tx_to_proto(tx: &DecredTransaction) -> ProtobufTransaction<'static> {
-        let inputs = tx.inputs().iter().map(Self::tx_input_to_proto).collect();
-        let outputs = tx.outputs().iter().map(Self::tx_output_to_proto).collect();
+    fn tx_to_proto(tx: &DecredTransaction) -> SigningResult<ProtobufTransaction<'static>> {
+        let inputs = tx
+            .inputs()
+            .iter()
+            .map(Self::tx_input_to_proto)
+            .collect::<SigningResult<Vec<_>>>()?;
+        let outputs = tx
+            .outputs()
+            .iter()
+            .map(Self::tx_output_to_proto)
+            .collect::<SigningResult<Vec<_>>>()?;
 
-        ProtobufTransaction::decred(DecredProto::Transaction {
+        Ok(ProtobufTransaction::decred(DecredProto::Transaction {
             // All serialized transactions include both prefix and witness.
             serialize_type: SerializeType::Full as u32,
             version: tx.version(),
@@ -56,6 +73,6 @@ impl ProtobufBuilder<DecredContext> for DecredProtobufBuilder {
             outputs,
             lock_time: tx.locktime,
             expiry: tx.expiry,
-        })
+        }))
     }
 }

--- a/rust/chains/tw_decred/src/modules/protobuf_builder.rs
+++ b/rust/chains/tw_decred/src/modules/protobuf_builder.rs
@@ -30,7 +30,7 @@ impl DecredProtobufBuilder {
                 .value_in
                 .try_into()
                 .tw_err(SigningErrorType::Error_invalid_utxo_amount)
-                .context("Transaction Input amount cannot be negative")?,
+                .context("Transaction Input amount is too large")?,
             block_height: input.block_height,
             block_index: input.block_index,
             script_sig: StandardProtobufBuilder::script_data(&input.script_sig),
@@ -45,7 +45,7 @@ impl DecredProtobufBuilder {
                 .value
                 .try_into()
                 .tw_err(SigningErrorType::Error_invalid_requested_token_amount)
-                .context("Transaction Output amount cannot be negative")?,
+                .context("Transaction Output amount is too large")?,
             version: output.version as u32,
             script: StandardProtobufBuilder::script_data(&output.script_pubkey),
         })

--- a/rust/chains/tw_zcash/src/modules/pczt_request/output_pczt.rs
+++ b/rust/chains/tw_zcash/src/modules/pczt_request/output_pczt.rs
@@ -3,7 +3,7 @@
 // Copyright © 2017 Trust Wallet.
 
 use crate::modules::pczt;
-use tw_coin_entry::error::prelude::{MapTWError, ResultContext, SigningErrorType, SigningResult};
+use tw_coin_entry::error::prelude::*;
 use tw_utxo::script::Script;
 use tw_utxo::transaction::standard_transaction::TransactionOutput;
 
@@ -18,12 +18,7 @@ impl<'a> OutputPczt<'a> {
     }
 
     pub fn build(self) -> SigningResult<TransactionOutput> {
-        let value = self
-            .output
-            .value
-            .try_into()
-            .tw_err(SigningErrorType::Error_invalid_requested_token_amount)
-            .context("PCZT Output amount is too large")?;
+        let value = self.output.value;
         let script_pubkey = Script::from(self.output.script_pubkey.clone());
         Ok(TransactionOutput {
             value,

--- a/rust/chains/tw_zcash/src/modules/pczt_request/utxo_pczt.rs
+++ b/rust/chains/tw_zcash/src/modules/pczt_request/utxo_pczt.rs
@@ -5,15 +5,12 @@
 use crate::modules::pczt;
 use tw_bitcoin::modules::tx_builder::public_keys::PublicKeys;
 use tw_bitcoin::modules::tx_builder::script_parser::{StandardScript, StandardScriptParser};
-use tw_coin_entry::error::prelude::{
-    MapTWError, ResultContext, SigningError, SigningErrorType, SigningResult,
-};
+use tw_coin_entry::error::prelude::*;
 use tw_hash::H256;
 use tw_utxo::script::Script;
 use tw_utxo::sighash::{SighashBase, SighashType};
 use tw_utxo::transaction::standard_transaction::builder::UtxoBuilder;
 use tw_utxo::transaction::standard_transaction::TransactionInput;
-use tw_utxo::transaction::transaction_parts::Amount;
 use tw_utxo::transaction::UtxoToSign;
 
 /// Currently, we rely on `pczt` crate to build our own [`UtxoToSign`].
@@ -37,12 +34,7 @@ impl<'a> UtxoPczt<'a> {
         let prevout_hash = H256::from(self.utxo.prevout_txid);
         let prevout_index = self.utxo.prevout_index;
         let sequence = self.utxo.sequence;
-        let amount: Amount = self
-            .utxo
-            .value
-            .try_into()
-            .tw_err(SigningErrorType::Error_invalid_utxo_amount)
-            .context("PCZT UTXO amount is too large")?;
+        let amount = self.utxo.value;
 
         // [`pczt::transparent::Input::sighash_type`] is a private field, assume it as default.
         let sighash_ty = SighashType::from_u32(self.utxo.sighash_type as u32)

--- a/rust/chains/tw_zcash/src/modules/protobuf_builder.rs
+++ b/rust/chains/tw_zcash/src/modules/protobuf_builder.rs
@@ -5,6 +5,7 @@
 use crate::transaction::ZcashTransaction;
 use tw_bitcoin::modules::protobuf_builder::standard_protobuf_builder::StandardProtobufBuilder;
 use tw_bitcoin::modules::protobuf_builder::{ProtobufBuilder, ProtobufTransaction};
+use tw_coin_entry::error::prelude::*;
 use tw_proto::Zcash::Proto as ZcashProto;
 use tw_utxo::context::UtxoContext;
 use tw_utxo::transaction::transaction_interface::TransactionInterface;
@@ -15,7 +16,7 @@ impl<Context> ProtobufBuilder<Context> for ZcashProtobufBuilder
 where
     Context: UtxoContext<Transaction = ZcashTransaction>,
 {
-    fn tx_to_proto(tx: &ZcashTransaction) -> ProtobufTransaction<'static> {
+    fn tx_to_proto(tx: &ZcashTransaction) -> SigningResult<ProtobufTransaction<'static>> {
         let inputs = tx
             .inputs()
             .iter()
@@ -25,17 +26,20 @@ where
             .outputs()
             .iter()
             .map(StandardProtobufBuilder::tx_output_to_proto)
-            .collect();
+            .collect::<SigningResult<Vec<_>>>()?;
 
-        ProtobufTransaction::zcash(ZcashProto::Transaction {
+        Ok(ProtobufTransaction::zcash(ZcashProto::Transaction {
             version: tx.version(),
             version_group_id: tx.version_group_id,
             inputs,
             outputs,
             lock_time: tx.locktime,
             expiry_height: tx.expiry_height,
-            sapling_value_balance: tx.sapling_value_balance,
+            sapling_value_balance: tx
+                .sapling_value_balance
+                .try_into()
+                .tw_err(SigningErrorType::Error_tx_too_big)?,
             branch_id: tx.branch_id.to_vec().into(),
-        })
+        }))
     }
 }

--- a/rust/chains/tw_zcash/src/modules/signing_request.rs
+++ b/rust/chains/tw_zcash/src/modules/signing_request.rs
@@ -129,7 +129,12 @@ impl ZcashSigningRequestBuilder {
             return Ok(ZcashFeeEstimator::Zip0317);
         }
 
-        let fee_per_vb = FeePolicy::FeePerVb(proto.fee_per_vb);
+        let fee_per_vb = proto
+            .fee_per_vb
+            .try_into()
+            .tw_err(SigningErrorType::Error_wrong_fee)
+            .context("'fee_per_vb' cannot be negative")?;
+        let fee_per_vb = FeePolicy::FeePerVb(fee_per_vb);
         let standard = StandardFeeEstimator::new(fee_per_vb);
         Ok(ZcashFeeEstimator::Standard(standard))
     }

--- a/rust/frameworks/tw_utxo/src/transaction/standard_transaction/mod.rs
+++ b/rust/frameworks/tw_utxo/src/transaction/standard_transaction/mod.rs
@@ -22,7 +22,8 @@ use tw_hash::H256;
 
 pub const DEFAULT_TX_HASHER: Hasher = Hasher::Sha256d;
 pub const DEFAULT_LOCKTIME: u32 = 0;
-pub const DEFAULT_OUTPUT_VALUE: Amount = -1;
+/// `u64::MAX` is equal to `-1`. Default value is used in particular in `SighashType::Single`.
+pub const DEFAULT_OUTPUT_VALUE: Amount = u64::MAX;
 
 pub mod builder;
 

--- a/rust/frameworks/tw_utxo/src/transaction/transaction_parts.rs
+++ b/rust/frameworks/tw_utxo/src/transaction/transaction_parts.rs
@@ -6,9 +6,9 @@ use crate::encode::stream::Stream;
 use crate::encode::Encodable;
 use tw_hash::H256;
 
-/// Amount in satoshis (Can be negative) in rare cases.
-/// https://github.com/bitcoin/bitcoin/blob/bd5d1688b4311e21c0e0ff89a3ae02ef7d0543b8/src/consensus/amount.h#L11-L12
-pub type Amount = i64;
+/// Amount in satoshis.
+/// In theory, can be negative in some cases, but we require it to be non-negative.
+pub type Amount = u64;
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct OutPoint {

--- a/rust/frameworks/tw_utxo/src/transaction/transaction_sighash/legacy_sighash.rs
+++ b/rust/frameworks/tw_utxo/src/transaction/transaction_sighash/legacy_sighash.rs
@@ -101,7 +101,7 @@ impl<Transaction: std::fmt::Debug + TransactionInterface> LegacySighash<Transact
                     if n == args.input_index {
                         out.clone()
                     } else {
-                        // `standard_transaction::TransactionOutput` defaults to `-1`.
+                        // `standard_transaction::TransactionOutput` defaults to `-1` (the same as 'u64::MAX').
                         Transaction::Output::default()
                     }
                 })

--- a/rust/frameworks/tw_utxo/src/transaction/unsigned_transaction.rs
+++ b/rust/frameworks/tw_utxo/src/transaction/unsigned_transaction.rs
@@ -123,7 +123,7 @@ where
     pub fn total_input(&self) -> SigningResult<Amount> {
         self.utxo_args
             .iter()
-            .try_fold(0i64, |total_in, utxo_args| {
+            .try_fold(0_u64, |total_in, utxo_args| {
                 total_in.checked_add(utxo_args.amount)
             })
             .or_tw_err(SigningErrorType::Error_tx_too_big)
@@ -134,7 +134,7 @@ where
         self.transaction
             .outputs()
             .iter()
-            .try_fold(0i64, |total_out, output| {
+            .try_fold(0_u64, |total_out, output| {
                 total_out.checked_add(output.value())
             })
             .or_tw_err(SigningErrorType::Error_tx_too_big)

--- a/rust/frameworks/tw_utxo/tests/build_tx.rs
+++ b/rust/frameworks/tw_utxo/tests/build_tx.rs
@@ -17,13 +17,13 @@ use tw_utxo::transaction::standard_transaction::builder::TransactionBuilder;
 use tw_utxo::transaction::standard_transaction::builder::UtxoBuilder;
 use tw_utxo::transaction::transaction_interface::TransactionInterface;
 
-const SATS_PER_VBYTE: i64 = 20;
+const SATS_PER_VBYTE: u64 = 20;
 
 #[track_caller]
 fn verify_fee<Transaction: TransactionInterface>(
     tx: &Transaction,
-    fee_per_vbyte: i64,
-    expected: i64,
+    fee_per_vbyte: u64,
+    expected: u64,
 ) {
     let actual = StandardFeeEstimator::new(FeePolicy::FeePerVb(fee_per_vbyte))
         .estimate_fee(tx)

--- a/rust/tw_tests/tests/chains/bitcoin/bitcoin_plan/plan_exact_error.rs
+++ b/rust/tw_tests/tests/chains/bitcoin/bitcoin_plan/plan_exact_error.rs
@@ -101,7 +101,10 @@ fn test_exact_selector_negative_output_error() {
 
     let mut planner = AnyPlannerHelper::<Proto::TransactionPlan>::default();
     let plan = planner.plan(CoinType::Bitcoin, input);
-    assert_eq!(plan.error, CommonProto::SigningError::Error_invalid_requested_token_amount);
+    assert_eq!(
+        plan.error,
+        CommonProto::SigningError::Error_invalid_requested_token_amount
+    );
 }
 
 #[test]

--- a/rust/tw_tests/tests/chains/bitcoin/bitcoin_plan/plan_exact_error.rs
+++ b/rust/tw_tests/tests/chains/bitcoin/bitcoin_plan/plan_exact_error.rs
@@ -101,7 +101,7 @@ fn test_exact_selector_negative_output_error() {
 
     let mut planner = AnyPlannerHelper::<Proto::TransactionPlan>::default();
     let plan = planner.plan(CoinType::Bitcoin, input);
-    assert_eq!(plan.error, CommonProto::SigningError::Error_invalid_params);
+    assert_eq!(plan.error, CommonProto::SigningError::Error_invalid_requested_token_amount);
 }
 
 #[test]

--- a/src/Bitcoin/Amount.h
+++ b/src/Bitcoin/Amount.h
@@ -32,7 +32,7 @@ inline int64_t tryToSigned(const Amount amount) {
     return static_cast<int64_t>(amount);
 }
 
-/// -1 (or uint64_t::MAX) is used when signing a transaction with SIGHASH_SINGLE and the output index is out of bounds.
+/// uint64_t::MAX (equivalent to -1) is used when signing a transaction with SIGHASH_SINGLE and the output index is out of bounds.
 inline Amount sighashSingleAmount() {
     return std::numeric_limits<Amount>::max();
 }

--- a/src/Bitcoin/Amount.h
+++ b/src/Bitcoin/Amount.h
@@ -7,20 +7,34 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 #include <stdexcept>
 #include <string>
 
 namespace TW::Bitcoin {
 
 /// Amount in satoshis (can be negative)
-using Amount = int64_t;
+using Amount = uint64_t;
 
 /// Throws std::invalid_argument if the amount is negative.
 /// Use this to validate amounts parsed from Proto::SigningInput.
-inline void assertValidAmount(const Amount amount) {
+inline Amount tryToUnsigned(const int64_t amount) {
     if (amount < 0) {
         throw std::invalid_argument("amount cannot be negative: " + std::to_string(amount));
     }
+    return static_cast<uint64_t>(amount);
+}
+
+inline int64_t tryToSigned(const Amount amount) {
+    if (amount > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+        throw std::invalid_argument("amount is too large to fit in int64: " + std::to_string(amount));
+    }
+    return static_cast<int64_t>(amount);
+}
+
+/// -1 (or uint64_t::MAX) is used when signing a transaction with SIGHASH_SINGLE and the output index is out of bounds.
+inline Amount sighashSingleAmount() {
+    return std::numeric_limits<Amount>::max();
 }
 
 } // namespace TW::Bitcoin

--- a/src/Bitcoin/Amount.h
+++ b/src/Bitcoin/Amount.h
@@ -7,10 +7,20 @@
 #pragma once
 
 #include <cstdint>
+#include <stdexcept>
+#include <string>
 
 namespace TW::Bitcoin {
 
 /// Amount in satoshis (can be negative)
 using Amount = int64_t;
+
+/// Throws std::invalid_argument if the amount is negative.
+/// Use this to validate amounts parsed from Proto::SigningInput.
+inline void assertValidAmount(const Amount amount) {
+    if (amount < 0) {
+        throw std::invalid_argument("amount cannot be negative: " + std::to_string(amount));
+    }
+}
 
 } // namespace TW::Bitcoin

--- a/src/Bitcoin/Amount.h
+++ b/src/Bitcoin/Amount.h
@@ -13,21 +13,21 @@
 
 namespace TW::Bitcoin {
 
-/// Amount in satoshis (can be negative)
+/// Non-negative amount in satoshis.
 using Amount = uint64_t;
 
 /// Throws std::invalid_argument if the amount is negative.
 /// Use this to validate amounts parsed from Proto::SigningInput.
-inline Amount tryToUnsigned(const int64_t amount) {
+inline Amount tryToUnsigned(const int64_t amount, const std::string& fieldName) {
     if (amount < 0) {
-        throw std::invalid_argument("amount cannot be negative: " + std::to_string(amount));
+        throw std::invalid_argument( fieldName + " cannot be negative: " + std::to_string(amount));
     }
     return static_cast<uint64_t>(amount);
 }
 
-inline int64_t tryToSigned(const Amount amount) {
+inline int64_t tryToSigned(const Amount amount, const std::string& fieldName) {
     if (amount > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
-        throw std::invalid_argument("amount is too large to fit in int64: " + std::to_string(amount));
+        throw std::invalid_argument(fieldName + " is too large to fit in int64: " + std::to_string(amount));
     }
     return static_cast<int64_t>(amount);
 }

--- a/src/Bitcoin/DustCalculator.cpp
+++ b/src/Bitcoin/DustCalculator.cpp
@@ -28,7 +28,8 @@ DustCalculatorShared getDustCalculator(const Proto::SigningInput& input) {
     }
 
     if (input.has_fixed_dust_threshold()) {
-        return std::make_shared<FixedDustCalculator>(input.fixed_dust_threshold());
+        const auto fixed_dust_threshold = tryToUnsigned(input.fixed_dust_threshold(), "fixed_dust_threshold");
+        return std::make_shared<FixedDustCalculator>(fixed_dust_threshold);
     }
 
     const auto coinType = static_cast<TWCoinType>(input.coin_type());

--- a/src/Bitcoin/Entry.cpp
+++ b/src/Bitcoin/Entry.cpp
@@ -175,7 +175,7 @@ Data Entry::preImageHashes([[maybe_unused]] TWCoinType coin, const Data& txInput
 
 void Entry::compile([[maybe_unused]] TWCoinType coin, const Data& txInputData, const std::vector<Data>& signatures,
                     const std::vector<PublicKey>& publicKeys, Data& dataOut) const {
-    auto txCompilerFunctor = [&signatures, &publicKeys](auto&& input, auto&& output) noexcept {
+    auto txCompilerFunctor = [&signatures, &publicKeys](auto&& input, auto&& output) {
         output = Signer::compile(input, signatures, publicKeys);
     };
     dataOut = txCompilerTemplate<Proto::SigningInput, Proto::SigningOutput>(txInputData,

--- a/src/Bitcoin/FeeCalculator.cpp
+++ b/src/Bitcoin/FeeCalculator.cpp
@@ -15,16 +15,16 @@ constexpr double gDecredBytesPerInput{166};
 constexpr double gDecredBytesPerOutput{38};
 constexpr double gDecredBytesBase{12};
 
-int64_t LinearFeeCalculator::calculate(int64_t inputs, int64_t outputs,
-                                       int64_t byteFee) const noexcept {
+Amount LinearFeeCalculator::calculate(size_t inputs, size_t outputs,
+                                       Amount byteFee) const noexcept {
     const auto txsize =
-        static_cast<int64_t>(std::ceil(bytesPerInput * static_cast<double>(inputs) +
+        static_cast<Amount>(std::ceil(bytesPerInput * static_cast<double>(inputs) +
                                        bytesPerOutput * static_cast<double>(outputs) + bytesBase));
     return txsize * byteFee;
 }
 
-int64_t LinearFeeCalculator::calculateSingleInput(int64_t byteFee) const noexcept {
-    return static_cast<int64_t>(std::ceil(bytesPerInput)) * byteFee; // std::ceil(101.25) = 102
+Amount LinearFeeCalculator::calculateSingleInput(Amount byteFee) const noexcept {
+    return static_cast<Amount>(std::ceil(bytesPerInput)) * byteFee; // std::ceil(101.25) = 102
 }
 
 class DecredFeeCalculator : public LinearFeeCalculator {
@@ -36,7 +36,7 @@ public:
         : LinearFeeCalculator(gDecredBytesPerInput, gDecredBytesPerOutput, gDecredBytesBase)
         , disableDustFilter(disableFilter) {}
 
-    int64_t calculateSingleInput(int64_t byteFee) const noexcept override {
+    Amount calculateSingleInput(Amount byteFee) const noexcept override {
         if (disableDustFilter) { 
             return 0; 
         }
@@ -90,10 +90,10 @@ const FeeCalculator& getFeeCalculator(TWCoinType coinType, bool disableFilter, b
 }
 
 // https://github.com/Zondax/ledger-zcash-tools/blob/5ecf1c04c69d2454b73aa7acea4eadda563dfeff/ledger-zcash-app-builder/src/txbuilder.rs#L342-L363
-int64_t Zip0317FeeCalculator::calculate(int64_t inputs, int64_t outputs, [[maybe_unused]] int64_t byteFee) const noexcept {
+Amount Zip0317FeeCalculator::calculate(size_t inputs, size_t outputs, [[maybe_unused]] Amount byteFee) const noexcept {
     const auto logicalActions = std::max(inputs, outputs);
     const auto actions = std::max(gGraceActions, logicalActions);
-    return gMarginalFee * actions;
+    return gMarginalFee * static_cast<Amount>(actions);
 }
 
 } // namespace TW::Bitcoin

--- a/src/Bitcoin/FeeCalculator.h
+++ b/src/Bitcoin/FeeCalculator.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <TrustWalletCore/TWCoinType.h>
+#include "Amount.h"
 
 namespace TW::Bitcoin {
 
@@ -19,9 +20,9 @@ inline constexpr double gSegwitBytesBase{gDefaultBytesBase};
 class FeeCalculator {
 public:
     virtual ~FeeCalculator() noexcept = default;
-    [[nodiscard]] virtual int64_t calculate(int64_t inputs, int64_t outputs,
-                                            int64_t byteFee) const noexcept = 0;
-    [[nodiscard]] virtual int64_t calculateSingleInput(int64_t byteFee) const noexcept = 0;
+    [[nodiscard]] virtual Amount calculate(size_t inputs, size_t outputs,
+                                            Amount byteFee) const noexcept = 0;
+    [[nodiscard]] virtual Amount calculateSingleInput(Amount byteFee) const noexcept = 0;
 };
 
 /// Generic fee calculator with linear input and output size, and a fix size
@@ -34,22 +35,22 @@ public:
                                            double bytesBase) noexcept
         : bytesPerInput(bytesPerInput), bytesPerOutput(bytesPerOutput), bytesBase(bytesBase) {}
 
-    [[nodiscard]] int64_t calculate(int64_t inputs, int64_t outputs,
-                                    int64_t byteFee) const noexcept override;
-    [[nodiscard]] int64_t calculateSingleInput(int64_t byteFee) const noexcept override;
+    [[nodiscard]] Amount calculate(size_t inputs, size_t outputs,
+                                    Amount byteFee) const noexcept override;
+    [[nodiscard]] Amount calculateSingleInput(Amount byteFee) const noexcept override;
 };
 
 /// Constant fee calculator
 class ConstantFeeCalculator : public FeeCalculator {
 public:
-    const int64_t fee;
-    explicit constexpr ConstantFeeCalculator(int64_t fee) noexcept : fee(fee) {}
+    const Amount fee;
+    explicit constexpr ConstantFeeCalculator(Amount fee) noexcept : fee(fee) {}
 
-    [[nodiscard]] int64_t calculate([[maybe_unused]] int64_t inputs, [[maybe_unused]] int64_t outputs,
-                                    [[maybe_unused]] int64_t byteFee) const noexcept final {
+    [[nodiscard]] Amount calculate([[maybe_unused]] size_t inputs, [[maybe_unused]] size_t outputs,
+                                    [[maybe_unused]] Amount byteFee) const noexcept final {
         return fee;
     }
-    [[nodiscard]] int64_t calculateSingleInput([[maybe_unused]] int64_t byteFee) const noexcept final { return 0; }
+    [[nodiscard]] Amount calculateSingleInput([[maybe_unused]] Amount byteFee) const noexcept final { return 0; }
 };
 
 /// Default Bitcoin transaction fee calculator, non-segwit.
@@ -62,7 +63,7 @@ public:
         : LinearFeeCalculator(gDefaultBytesPerInput, gDefaultBytesPerOutput, gDefaultBytesBase)
         , disableDustFilter(disableFilter) {}
     
-    [[nodiscard]] int64_t calculateSingleInput(int64_t byteFee) const noexcept override {
+    [[nodiscard]] Amount calculateSingleInput(Amount byteFee) const noexcept override {
         if (disableDustFilter) { 
             return 0; 
         }
@@ -80,7 +81,7 @@ public:
         : LinearFeeCalculator(gSegwitBytesPerInput, gSegwitBytesPerOutput, gSegwitBytesBase)
         , disableDustFilter(disableFilter) {}
 
-    [[nodiscard]] int64_t calculateSingleInput(int64_t byteFee) const noexcept override {
+    [[nodiscard]] Amount calculateSingleInput(Amount byteFee) const noexcept override {
         if (disableDustFilter) {
             return 0;
         }
@@ -90,13 +91,13 @@ public:
 
 class Zip0317FeeCalculator: public FeeCalculator {
 public:
-    static constexpr int64_t gMarginalFee = 5000ul;
-    static constexpr int64_t gGraceActions = 2ul;
+    static constexpr Amount gMarginalFee = 5000ul;
+    static constexpr size_t gGraceActions = 2ul;
 
     Zip0317FeeCalculator() noexcept = default;
 
-    [[nodiscard]] int64_t calculate(int64_t inputs, int64_t outputs, int64_t byteFee) const noexcept final;
-    [[nodiscard]] int64_t calculateSingleInput([[maybe_unused]] int64_t byteFee) const noexcept final {
+    [[nodiscard]] Amount calculate(size_t inputs, size_t outputs, Amount byteFee) const noexcept final;
+    [[nodiscard]] Amount calculateSingleInput([[maybe_unused]] Amount byteFee) const noexcept final {
         return gMarginalFee;
     }
 };

--- a/src/Bitcoin/InputSelector.cpp
+++ b/src/Bitcoin/InputSelector.cpp
@@ -116,7 +116,7 @@ InputSelector<TypeWithAmount>::select(Amount targetValue, Amount byteFee, size_t
     //    (3) and does not produce dust change.
     for (size_t numInputs = 1; numInputs <= n; ++numInputs) {
         const auto fee = feeCalculator.calculate(numInputs, numOutputs, byteFee);
-        const auto targetWithFeeAndDust = targetValue + fee + dustThreshold;
+        const auto targetWithFeeAndDust = addUnsignedChecked(addUnsignedChecked(targetValue, fee), dustThreshold);
         if (maxWithXInputs[numInputs] < targetWithFeeAndDust) {
             // no way to satisfy with only numInputs inputs, skip
             continue;
@@ -193,7 +193,7 @@ std::vector<TypeWithAmount> InputSelector<TypeWithAmount>::selectSimple(Amount t
             continue; // skip dust
         }
         selected.push_back(input);
-        sum += input.amount;
+        sum = addUnsignedChecked(sum, input.amount);
         if (sum >= increasedTargetValue) {
             // we have enough
             return selected;

--- a/src/Bitcoin/InputSelector.cpp
+++ b/src/Bitcoin/InputSelector.cpp
@@ -5,6 +5,7 @@
 #include "InputSelector.h"
 
 #include "UTXO.h"
+#include "Numeric.h"
 
 #include <algorithm>
 #include <optional>
@@ -13,10 +14,10 @@
 namespace TW::Bitcoin {
 
 template <typename TypeWithAmount>
-Amount InputSelector<TypeWithAmount>::sum(const std::vector<TypeWithAmount>& amounts) noexcept {
+Amount InputSelector<TypeWithAmount>::sum(const std::vector<TypeWithAmount>& amounts) {
     Amount sum = 0;
     for (auto& i : amounts) {
-        sum += i.amount;
+        sum = addUnsignedChecked(sum, i.amount);
     }
     return sum;
 }
@@ -24,7 +25,7 @@ Amount InputSelector<TypeWithAmount>::sum(const std::vector<TypeWithAmount>& amo
 template <typename TypeWithAmount>
 std::vector<TypeWithAmount>
 InputSelector<TypeWithAmount>::filterOutDust(const std::vector<TypeWithAmount>& inputs,
-                                             Amount byteFee) noexcept {
+                                             Amount byteFee) {
     auto dustThreshold = dustCalculator->dustAmount(byteFee);
     return filterThreshold(inputs, dustThreshold);
 }
@@ -33,7 +34,7 @@ InputSelector<TypeWithAmount>::filterOutDust(const std::vector<TypeWithAmount>& 
 template <typename TypeWithAmount>
 std::vector<TypeWithAmount>
 InputSelector<TypeWithAmount>::filterThreshold(const std::vector<TypeWithAmount>& inputs,
-                                               Amount minimumAmount) noexcept {
+                                               Amount minimumAmount) {
     std::vector<TypeWithAmount> filtered;
     for (auto& i : inputs) {
         if (static_cast<Amount>(i.amount) >= minimumAmount) {
@@ -86,7 +87,7 @@ InputSelector<TypeWithAmount>::select(Amount targetValue, Amount byteFee, size_t
     assert(sorted.size() >= 1);
 
     // definitions for the following calculation
-    const auto doubleTargetValue = targetValue * 2;
+    const auto doubleTargetValue = mulUnsignedChecked(targetValue, 2ull);
 
     // Precompute maximum amount possible to obtain with given number of inputs
     const auto n = sorted.size();
@@ -94,7 +95,7 @@ InputSelector<TypeWithAmount>::select(Amount targetValue, Amount byteFee, size_t
     maxWithXInputs.push_back(0);
     Amount maxSum = 0;
     for (auto i = 0ul; i < n; ++i) {
-        maxSum += sorted[n - 1 - i].amount;
+        maxSum = addUnsignedChecked(maxSum, sorted[n - 1 - i].amount);
         maxWithXInputs.push_back(maxSum);
     }
 
@@ -206,7 +207,7 @@ std::vector<TypeWithAmount> InputSelector<TypeWithAmount>::selectSimple(Amount t
 
 template <typename TypeWithAmount>
 std::vector<TypeWithAmount>
-InputSelector<TypeWithAmount>::selectMaxAmount(Amount byteFee) noexcept {
+InputSelector<TypeWithAmount>::selectMaxAmount(Amount byteFee) {
     return filterOutDust(_inputs, byteFee);
 }
 

--- a/src/Bitcoin/InputSelector.cpp
+++ b/src/Bitcoin/InputSelector.cpp
@@ -13,8 +13,8 @@
 namespace TW::Bitcoin {
 
 template <typename TypeWithAmount>
-uint64_t InputSelector<TypeWithAmount>::sum(const std::vector<TypeWithAmount>& amounts) noexcept {
-    uint64_t sum = 0;
+Amount InputSelector<TypeWithAmount>::sum(const std::vector<TypeWithAmount>& amounts) noexcept {
+    Amount sum = 0;
     for (auto& i : amounts) {
         sum += i.amount;
     }
@@ -24,8 +24,8 @@ uint64_t InputSelector<TypeWithAmount>::sum(const std::vector<TypeWithAmount>& a
 template <typename TypeWithAmount>
 std::vector<TypeWithAmount>
 InputSelector<TypeWithAmount>::filterOutDust(const std::vector<TypeWithAmount>& inputs,
-                                             int64_t byteFee) noexcept {
-    auto dustThreshold = static_cast<uint64_t>(dustCalculator->dustAmount(byteFee));
+                                             Amount byteFee) noexcept {
+    auto dustThreshold = dustCalculator->dustAmount(byteFee);
     return filterThreshold(inputs, dustThreshold);
 }
 
@@ -33,10 +33,10 @@ InputSelector<TypeWithAmount>::filterOutDust(const std::vector<TypeWithAmount>& 
 template <typename TypeWithAmount>
 std::vector<TypeWithAmount>
 InputSelector<TypeWithAmount>::filterThreshold(const std::vector<TypeWithAmount>& inputs,
-                                               uint64_t minimumAmount) noexcept {
+                                               Amount minimumAmount) noexcept {
     std::vector<TypeWithAmount> filtered;
     for (auto& i : inputs) {
-        if (static_cast<uint64_t>(i.amount) >= minimumAmount) {
+        if (static_cast<Amount>(i.amount) >= minimumAmount) {
             filtered.push_back(i);
         }
     }
@@ -64,7 +64,7 @@ slice(const std::vector<TypeWithAmount>& inputs, size_t sliceSize) {
 
 template <typename TypeWithAmount>
 std::vector<TypeWithAmount>
-InputSelector<TypeWithAmount>::select(uint64_t targetValue, uint64_t byteFee, uint64_t numOutputs) {
+InputSelector<TypeWithAmount>::select(Amount targetValue, Amount byteFee, size_t numOutputs) {
     // if target value is zero, no UTXOs are needed
     if (targetValue == 0) {
         return {};
@@ -90,23 +90,23 @@ InputSelector<TypeWithAmount>::select(uint64_t targetValue, uint64_t byteFee, ui
 
     // Precompute maximum amount possible to obtain with given number of inputs
     const auto n = sorted.size();
-    std::vector<uint64_t> maxWithXInputs = std::vector<uint64_t>();
+    std::vector<Amount> maxWithXInputs = std::vector<Amount>();
     maxWithXInputs.push_back(0);
-    int64_t maxSum = 0;
+    Amount maxSum = 0;
     for (auto i = 0ul; i < n; ++i) {
         maxSum += sorted[n - 1 - i].amount;
         maxWithXInputs.push_back(maxSum);
     }
 
     // difference from 2x targetValue
-    auto distFrom2x = [doubleTargetValue](uint64_t val) -> uint64_t {
+    auto distFrom2x = [doubleTargetValue](Amount val) -> Amount {
         if (val > doubleTargetValue) {
             return val - doubleTargetValue;
         }
         return doubleTargetValue - val;
     };
 
-    const int64_t dustThreshold = dustCalculator->dustAmount(byteFee);
+    const Amount dustThreshold = dustCalculator->dustAmount(byteFee);
 
     // 1. Find a combination of the fewest inputs that is
     //    (1) bigger than what we need
@@ -119,7 +119,7 @@ InputSelector<TypeWithAmount>::select(uint64_t targetValue, uint64_t byteFee, ui
             // no way to satisfy with only numInputs inputs, skip
             continue;
         }
-        auto slices = slice(sorted, static_cast<size_t>(numInputs));
+        auto slices = slice(sorted, numInputs);
 
         slices.erase(
             std::remove_if(slices.begin(), slices.end(),
@@ -163,9 +163,9 @@ InputSelector<TypeWithAmount>::select(uint64_t targetValue, uint64_t byteFee, ui
 }
 
 template <typename TypeWithAmount>
-std::vector<TypeWithAmount> InputSelector<TypeWithAmount>::selectSimple(int64_t targetValue,
-                                                                        int64_t byteFee,
-                                                                        int64_t numOutputs) {
+std::vector<TypeWithAmount> InputSelector<TypeWithAmount>::selectSimple(Amount targetValue,
+                                                                        Amount byteFee,
+                                                                        size_t numOutputs) {
     // if target value is zero, no UTXOs are needed
     if (targetValue == 0) {
         return {};
@@ -178,13 +178,13 @@ std::vector<TypeWithAmount> InputSelector<TypeWithAmount>::selectSimple(int64_t 
     // target value is larger than original, but not by a factor of 2 (optimized for large UTXO
     // cases)
     const auto increasedTargetValue =
-        (uint64_t)((double)targetValue * 1.1 +
+        (Amount)((double)targetValue * 1.1 +
                    feeCalculator.calculate(_inputs.size(), numOutputs, byteFee) + 1000);
 
-    const int64_t dustThreshold = dustCalculator->dustAmount(byteFee);
+    const Amount dustThreshold = dustCalculator->dustAmount(byteFee);
 
     // Go through inputs in a single pass, in the order they appear, no optimization
-    uint64_t sum = 0;
+    Amount sum = 0;
     std::vector<TypeWithAmount> selected;
     for (auto& input : _inputs) {
         if (input.amount <= dustThreshold) {
@@ -206,7 +206,7 @@ std::vector<TypeWithAmount> InputSelector<TypeWithAmount>::selectSimple(int64_t 
 
 template <typename TypeWithAmount>
 std::vector<TypeWithAmount>
-InputSelector<TypeWithAmount>::selectMaxAmount(int64_t byteFee) noexcept {
+InputSelector<TypeWithAmount>::selectMaxAmount(Amount byteFee) noexcept {
     return filterOutDust(_inputs, byteFee);
 }
 

--- a/src/Bitcoin/InputSelector.cpp
+++ b/src/Bitcoin/InputSelector.cpp
@@ -6,6 +6,7 @@
 
 #include "UTXO.h"
 #include "Numeric.h"
+#include "NumericLiteral.h"
 
 #include <algorithm>
 #include <optional>
@@ -87,7 +88,7 @@ InputSelector<TypeWithAmount>::select(Amount targetValue, Amount byteFee, size_t
     assert(sorted.size() >= 1);
 
     // definitions for the following calculation
-    const auto doubleTargetValue = mulUnsignedChecked(targetValue, 2ull);
+    const auto doubleTargetValue = mulUnsignedChecked(targetValue, 2_u64);
 
     // Precompute maximum amount possible to obtain with given number of inputs
     const auto n = sorted.size();

--- a/src/Bitcoin/InputSelector.h
+++ b/src/Bitcoin/InputSelector.h
@@ -21,8 +21,8 @@ public:
     /// \returns the list of indices of selected inputs. May return the entire list of UTXOs
     ///          even if they aren't enough to cover `targetValue + fee`.
     ///          That's because `InputSelector` has a rough segwit fee estimation algorithm, and the UTXOs can actually be enough.
-    std::vector<TypeWithAmount> select(uint64_t targetValue, uint64_t byteFee,
-                                       uint64_t numOutputs = 2);
+    std::vector<TypeWithAmount> select(Amount targetValue, Amount byteFee,
+                                       size_t numOutputs = 2);
 
     /// Selects unspent transactions to use given a target transaction value;
     /// Simplified version suitable for large number of inputs
@@ -30,12 +30,12 @@ public:
     /// \returns the list of indices of selected inputs. May return the entire list of UTXOs
     ///          even if they aren't enough to cover `targetValue + fee`.
     ///          That's because `InputSelector` has a rough segwit fee estimation algorithm, and the UTXOs can actually be enough.
-    std::vector<TypeWithAmount> selectSimple(int64_t targetValue, int64_t byteFee,
-                                             int64_t numOutputs = 2);
+    std::vector<TypeWithAmount> selectSimple(Amount targetValue, Amount byteFee,
+                                             size_t numOutputs = 2);
 
     /// Selects UTXOs for max amount; select all except those which would reduce output (dust).
     /// Return indices. One output and no change is assumed.
-    std::vector<TypeWithAmount> selectMaxAmount(int64_t byteFee) noexcept;
+    std::vector<TypeWithAmount> selectMaxAmount(Amount byteFee) noexcept;
 
     /// Construct, using provided feeCalculator (see getFeeCalculator()) and dustCalculator (see getDustCalculator()).
     explicit InputSelector(const std::vector<TypeWithAmount>& inputs,
@@ -53,13 +53,13 @@ public:
     }
 
     /// Sum of input amounts
-    static uint64_t sum(const std::vector<TypeWithAmount>& amounts) noexcept;
+    static Amount sum(const std::vector<TypeWithAmount>& amounts) noexcept;
     /// Filters out utxos that are dust
     inline std::vector<TypeWithAmount> filterOutDust(const std::vector<TypeWithAmount>& inputsIn,
-                                                     int64_t byteFee) noexcept;
+                                                     Amount byteFee) noexcept;
     /// Filters out inputsIn below (or equal) a certain threshold limit
     inline std::vector<TypeWithAmount> filterThreshold(const std::vector<TypeWithAmount>& inputsIn,
-                                                       uint64_t minimumAmount) noexcept;
+                                                       Amount minimumAmount) noexcept;
 
 private:
     const std::vector<TypeWithAmount> _inputs;

--- a/src/Bitcoin/InputSelector.h
+++ b/src/Bitcoin/InputSelector.h
@@ -35,31 +35,31 @@ public:
 
     /// Selects UTXOs for max amount; select all except those which would reduce output (dust).
     /// Return indices. One output and no change is assumed.
-    std::vector<TypeWithAmount> selectMaxAmount(Amount byteFee) noexcept;
+    std::vector<TypeWithAmount> selectMaxAmount(Amount byteFee);
 
     /// Construct, using provided feeCalculator (see getFeeCalculator()) and dustCalculator (see getDustCalculator()).
     explicit InputSelector(const std::vector<TypeWithAmount>& inputs,
                            const FeeCalculator& feeCalculator,
-                           DustCalculatorShared dustCalculator) noexcept
+                           DustCalculatorShared dustCalculator)
         : _inputs(inputs),
           feeCalculator(feeCalculator),
           dustCalculator(std::move(dustCalculator)) {
     }
 
-    explicit InputSelector(const std::vector<TypeWithAmount>& inputs) noexcept
+    explicit InputSelector(const std::vector<TypeWithAmount>& inputs)
         : _inputs(inputs),
           feeCalculator(getFeeCalculator(TWCoinTypeBitcoin)),
           dustCalculator(std::make_shared<LegacyDustCalculator>(TWCoinTypeBitcoin)) {
     }
 
     /// Sum of input amounts
-    static Amount sum(const std::vector<TypeWithAmount>& amounts) noexcept;
+    static Amount sum(const std::vector<TypeWithAmount>& amounts);
     /// Filters out utxos that are dust
-    inline std::vector<TypeWithAmount> filterOutDust(const std::vector<TypeWithAmount>& inputsIn,
-                                                     Amount byteFee) noexcept;
+    std::vector<TypeWithAmount> filterOutDust(const std::vector<TypeWithAmount>& inputsIn,
+                                                     Amount byteFee);
     /// Filters out inputsIn below (or equal) a certain threshold limit
-    inline std::vector<TypeWithAmount> filterThreshold(const std::vector<TypeWithAmount>& inputsIn,
-                                                       Amount minimumAmount) noexcept;
+    std::vector<TypeWithAmount> filterThreshold(const std::vector<TypeWithAmount>& inputsIn,
+                                                       Amount minimumAmount);
 
 private:
     const std::vector<TypeWithAmount> _inputs;

--- a/src/Bitcoin/Script.cpp
+++ b/src/Bitcoin/Script.cpp
@@ -148,7 +148,7 @@ bool Script::matchPayToWitnessScriptHash(Data& result) const {
     return true;
 }
 
-bool Script::matchMultisig(std::vector<Data>& keys, int& required) const {
+bool Script::matchMultisig(std::vector<Data>& keys, size_t& required) const {
     keys.clear();
     required = 0;
 
@@ -164,7 +164,14 @@ bool Script::matchMultisig(std::vector<Data>& keys, int& required) const {
     if (!op || !TWOpCodeIsSmallInteger(opcode)) {
         return false;
     }
-    required = decodeNumber(opcode);
+
+    int signedRequired = decodeNumber(opcode);
+    if (signedRequired < 0) {
+        return false;
+    }
+
+    required = static_cast<size_t>(signedRequired);
+
     while (true) {
         auto res = getScriptOp(it, opcode, operand);
         if (!res) {
@@ -181,7 +188,7 @@ bool Script::matchMultisig(std::vector<Data>& keys, int& required) const {
     }
 
     std::size_t expectedCount = decodeNumber(opcode);
-    if (keys.size() != expectedCount || expectedCount < static_cast<std::size_t>(required)) {
+    if (keys.size() != expectedCount || expectedCount < required) {
         return false;
     }
     if (it + 1 != bytes.size()) {

--- a/src/Bitcoin/Script.h
+++ b/src/Bitcoin/Script.h
@@ -86,7 +86,7 @@ class Script {
     bool matchPayToWitnessScriptHash(Data& scriptHash) const;
 
     /// Matches the script to a multisig script.
-    bool matchMultisig(std::vector<Data>& publicKeys, int& required) const;
+    bool matchMultisig(std::vector<Data>& publicKeys, size_t& required) const;
 
     /// Builds a pay-to-public-key (P2PK) script from a public key.
     static Script buildPayToPublicKey(const Data& publicKey);

--- a/src/Bitcoin/SignatureBuilder.cpp
+++ b/src/Bitcoin/SignatureBuilder.cpp
@@ -158,7 +158,7 @@ Result<std::vector<Data>, Common::Proto::SigningError> SignatureBuilder<Transact
     if (script.matchMultisig(keys, required)) {
         auto results = std::vector<Data>{{}}; // workaround CHECKMULTISIG bug
         for (auto& pubKey : keys) {
-            if (results.size() >= required + 1ul) {
+            if (results.size() >= static_cast<size_t>(required) + 1ul) {
                 break;
             }
             auto keyHash = Hash::ripemd(Hash::sha256(pubKey));
@@ -174,7 +174,7 @@ Result<std::vector<Data>, Common::Proto::SigningError> SignatureBuilder<Transact
             }
             results.push_back(signature);
         }
-        results.resize(required + 1);
+        results.resize(static_cast<size_t>(required) + 1ul);
         return Result<std::vector<Data>, Common::Proto::SigningError>::success(std::move(results));
     }
     if (script.matchPayToPublicKey(data)) {

--- a/src/Bitcoin/SignatureBuilder.cpp
+++ b/src/Bitcoin/SignatureBuilder.cpp
@@ -129,7 +129,7 @@ Result<std::vector<Data>, Common::Proto::SigningError> SignatureBuilder<Transact
 
     Data data;
     std::vector<Data> keys;
-    int required;
+    size_t required;
 
     if (script.matchPayToScriptHash(data) || script.matchPayToScriptHashReplay(data)) {
         auto redeemScript = scriptForScriptHash(data);
@@ -158,7 +158,7 @@ Result<std::vector<Data>, Common::Proto::SigningError> SignatureBuilder<Transact
     if (script.matchMultisig(keys, required)) {
         auto results = std::vector<Data>{{}}; // workaround CHECKMULTISIG bug
         for (auto& pubKey : keys) {
-            if (results.size() >= static_cast<size_t>(required) + 1ul) {
+            if (results.size() >= required + 1ul) {
                 break;
             }
             auto keyHash = Hash::ripemd(Hash::sha256(pubKey));
@@ -174,7 +174,7 @@ Result<std::vector<Data>, Common::Proto::SigningError> SignatureBuilder<Transact
             }
             results.push_back(signature);
         }
-        results.resize(static_cast<size_t>(required) + 1ul);
+        results.resize(required + 1ul);
         return Result<std::vector<Data>, Common::Proto::SigningError>::success(std::move(results));
     }
     if (script.matchPayToPublicKey(data)) {

--- a/src/Bitcoin/SigningInput.cpp
+++ b/src/Bitcoin/SigningInput.cpp
@@ -12,12 +12,8 @@ SigningInput::SigningInput()
 
 SigningInput::SigningInput(const Proto::SigningInput& input) {
     hashType = static_cast<TWBitcoinSigHashType>(input.hash_type());
-
-    assertValidAmount(input.amount());
-    amount = input.amount();
-
-    assertValidAmount(input.byte_fee());
-    byteFee = input.byte_fee();
+    amount = tryToUnsigned(input.amount());
+    byteFee = tryToUnsigned(input.byte_fee());
 
     toAddress = input.to_address();
     changeAddress = input.change_address();
@@ -47,9 +43,9 @@ SigningInput::SigningInput(const Proto::SigningInput& input) {
 
     extraOutputsAmount = 0;
     for (auto& output: input.extra_outputs()) {
-        assertValidAmount(output.amount());
-        extraOutputsAmount += output.amount();
-        extraOutputs.emplace_back(output.to_address(), output.amount());
+        const auto extraAmount = tryToUnsigned(output.amount());
+        extraOutputsAmount += extraAmount;
+        extraOutputs.emplace_back(output.to_address(), extraAmount);
     }
 
     dustCalculator = getDustCalculator(input);

--- a/src/Bitcoin/SigningInput.cpp
+++ b/src/Bitcoin/SigningInput.cpp
@@ -3,6 +3,7 @@
 // Copyright © 2017 Trust Wallet.
 
 #include "SigningInput.h"
+#include "Numeric.h"
 
 namespace TW::Bitcoin {
 
@@ -12,8 +13,8 @@ SigningInput::SigningInput()
 
 SigningInput::SigningInput(const Proto::SigningInput& input) {
     hashType = static_cast<TWBitcoinSigHashType>(input.hash_type());
-    amount = tryToUnsigned(input.amount());
-    byteFee = tryToUnsigned(input.byte_fee());
+    amount = tryToUnsigned(input.amount(), "amount");
+    byteFee = tryToUnsigned(input.byte_fee(), "byte_fee");
 
     toAddress = input.to_address();
     changeAddress = input.change_address();
@@ -43,8 +44,8 @@ SigningInput::SigningInput(const Proto::SigningInput& input) {
 
     extraOutputsAmount = 0;
     for (auto& output: input.extra_outputs()) {
-        const auto extraAmount = tryToUnsigned(output.amount());
-        extraOutputsAmount += extraAmount;
+        const auto extraAmount = tryToUnsigned(output.amount(), "output.amount");
+        extraOutputsAmount = addUnsignedChecked(extraOutputsAmount, extraAmount);
         extraOutputs.emplace_back(output.to_address(), extraAmount);
     }
 

--- a/src/Bitcoin/SigningInput.cpp
+++ b/src/Bitcoin/SigningInput.cpp
@@ -12,8 +12,13 @@ SigningInput::SigningInput()
 
 SigningInput::SigningInput(const Proto::SigningInput& input) {
     hashType = static_cast<TWBitcoinSigHashType>(input.hash_type());
+
+    assertValidAmount(input.amount());
     amount = input.amount();
+
+    assertValidAmount(input.byte_fee());
     byteFee = input.byte_fee();
+
     toAddress = input.to_address();
     changeAddress = input.change_address();
     for (auto&& key : input.private_key()) {
@@ -42,8 +47,9 @@ SigningInput::SigningInput(const Proto::SigningInput& input) {
 
     extraOutputsAmount = 0;
     for (auto& output: input.extra_outputs()) {
+        assertValidAmount(output.amount());
         extraOutputsAmount += output.amount();
-        extraOutputs.push_back(std::make_pair(output.to_address(), output.amount()));
+        extraOutputs.emplace_back(output.to_address(), output.amount());
     }
 
     dustCalculator = getDustCalculator(input);

--- a/src/Bitcoin/SigningInput.h
+++ b/src/Bitcoin/SigningInput.h
@@ -76,7 +76,7 @@ public:
 
     // Besides to_address and change_address,
     // we have other outputs that include address and value
-    std::vector<std::pair<std::string, int64_t>> extraOutputs;
+    std::vector<std::pair<std::string, Amount>> extraOutputs;
 
     // Total amount of the `extraOutputs`.
     Amount extraOutputsAmount = 0;

--- a/src/Bitcoin/Transaction.cpp
+++ b/src/Bitcoin/Transaction.cpp
@@ -252,7 +252,7 @@ Proto::Transaction Transaction::proto() const {
 
     for (const auto& output : outputs) {
         auto* protoOutput = protoTx.add_outputs();
-        protoOutput->set_value(tryToSigned(output.value));
+        protoOutput->set_value(tryToSigned(output.value, "output.value"));
         protoOutput->set_script(output.script.bytes.data(), output.script.bytes.size());
     }
 

--- a/src/Bitcoin/Transaction.cpp
+++ b/src/Bitcoin/Transaction.cpp
@@ -16,7 +16,7 @@
 namespace TW::Bitcoin {
 
 Data Transaction::getPreImage(const Script& scriptCode, size_t index,
-                              enum TWBitcoinSigHashType hashType, uint64_t amount) const {
+                              enum TWBitcoinSigHashType hashType, Amount amount) const {
     assert(index < inputs.size());
 
     Data data;
@@ -152,7 +152,7 @@ bool Transaction::hasWitness() const {
 }
 
 Data Transaction::getSignatureHash(const Script& scriptCode, size_t index,
-                                   enum TWBitcoinSigHashType hashType, uint64_t amount,
+                                   enum TWBitcoinSigHashType hashType, Amount amount,
                                    enum SignatureVersion version) const {
     if (version == BASE) {
         return getSignatureHashBase(scriptCode, index, hashType);
@@ -164,7 +164,7 @@ Data Transaction::getSignatureHash(const Script& scriptCode, size_t index,
 /// Generates the signature hash for Witness version 0 scripts.
 Data Transaction::getSignatureHashWitnessV0(const Script& scriptCode, size_t index,
                                             enum TWBitcoinSigHashType hashType,
-                                            uint64_t amount) const {
+                                            Amount amount) const {
     auto preimage = getPreImage(scriptCode, index, hashType, amount);
     auto hash = Hash::hash(hasher, preimage);
     return hash;
@@ -192,7 +192,7 @@ Data Transaction::getSignatureHashBase(const Script& scriptCode, size_t index,
     encodeVarInt(serializedOutputCount, data);
     for (auto subindex = 0ul; subindex < serializedOutputCount; subindex += 1) {
         if (hashSingle && subindex != index) {
-            auto output = TransactionOutput(-1, {});
+            auto output = TransactionOutput(sighashSingleAmount(), {});
             output.encode(data);
         } else {
             outputs[subindex].encode(data);
@@ -252,7 +252,7 @@ Proto::Transaction Transaction::proto() const {
 
     for (const auto& output : outputs) {
         auto* protoOutput = protoTx.add_outputs();
-        protoOutput->set_value(output.value);
+        protoOutput->set_value(tryToSigned(output.value));
         protoOutput->set_script(output.script.bytes.data(), output.script.bytes.size());
     }
 

--- a/src/Bitcoin/Transaction.h
+++ b/src/Bitcoin/Transaction.h
@@ -67,7 +67,7 @@ public:
     bool empty() const { return inputs.empty() && outputs.empty(); }
 
     /// Generates the signature pre-image.
-    Data getPreImage(const Script& scriptCode, size_t index, enum TWBitcoinSigHashType hashType, uint64_t amount) const;
+    Data getPreImage(const Script& scriptCode, size_t index, enum TWBitcoinSigHashType hashType, Amount amount) const;
     Data getPrevoutHash() const;
     Data getSequenceHash() const;
     Data getOutputsHash() const;
@@ -91,7 +91,7 @@ public:
 
     /// Generates the signature hash for this transaction.
     Data getSignatureHash(const Script& scriptCode, size_t index, enum TWBitcoinSigHashType hashType,
-                          uint64_t amount, enum SignatureVersion version) const;
+                          Amount amount, enum SignatureVersion version) const;
 
     void serializeInput(size_t subindex, const Script&, size_t index, enum TWBitcoinSigHashType hashType, Data& data) const;
 
@@ -101,7 +101,7 @@ public:
 private:
     /// Generates the signature hash for Witness version 0 scripts.
     Data getSignatureHashWitnessV0(const Script& scriptCode, size_t index,
-                                   enum TWBitcoinSigHashType hashType, uint64_t amount) const;
+                                   enum TWBitcoinSigHashType hashType, Amount amount) const;
 
     /// Generates the signature hash for for scripts other than witness scripts.
     Data getSignatureHashBase(const Script& scriptCode, size_t index,

--- a/src/Bitcoin/TransactionBuilder.cpp
+++ b/src/Bitcoin/TransactionBuilder.cpp
@@ -72,7 +72,7 @@ Amount estimateSegwitFee(const FeeCalculator& feeCalculator, const TransactionPl
         // (in other way: 3/4 of (smaller) non-segwit + 1/4 of segwit size)
         vSize = sizeNonSegwit + witnessSize/4_u64 + (witnessSize % 4 != 0_u64);
     }
-    const Amount fee = input.byteFee * vSize;
+    const Amount fee = mulUnsignedChecked(input.byteFee, vSize);
 
     return fee;
 }

--- a/src/Bitcoin/TransactionBuilder.cpp
+++ b/src/Bitcoin/TransactionBuilder.cpp
@@ -7,6 +7,7 @@
 #include "TransactionSigner.h"
 #include "SignatureBuilder.h"
 #include "Numeric.h"
+#include "NumericLiteral.h"
 
 #include "../Coin.h"
 
@@ -66,10 +67,10 @@ Amount estimateSegwitFee(const FeeCalculator& feeCalculator, const TransactionPl
     } else {
         Data dataWitness;
         transaction.encodeWitness(dataWitness);
-        Amount witnessSize = 2ull + dataWitness.size();
+        Amount witnessSize = 2_u64 + dataWitness.size();
         // compute virtual size:  (smaller) non-segwit + 1/4 of the diff (witness-only)
         // (in other way: 3/4 of (smaller) non-segwit + 1/4 of segwit size)
-        vSize = sizeNonSegwit + witnessSize/4ull + (witnessSize % 4 != 0ull);
+        vSize = sizeNonSegwit + witnessSize/4_u64 + (witnessSize % 4 != 0_u64);
     }
     const Amount fee = input.byteFee * vSize;
 
@@ -111,12 +112,12 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
         }
 
         auto extraOutputs = extraOutputCount(input);
-        size_t output_size = 2ull;
+        size_t output_size = 2_u64;
         UTXOs selectedInputs;
         if (!maxAmount) {
             // Please note that there may not be a "change" output if the "change.amount" is less than "dust",
             // but we use a max amount of transaction outputs to simplify the algorithm, so the fee can be slightly bigger in rare cases.
-            output_size = 2ull + extraOutputs; // output + change
+            output_size = 2_u64 + extraOutputs; // output + change
             if (input.useMaxUtxo) {
                 selectedInputs = inputSelector.selectMaxAmount(input.byteFee);
             } else if (input.utxos.size() <= SimpleModeLimit &&
@@ -127,7 +128,7 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
                     inputSelector.selectSimple(totalAmount, input.byteFee, output_size);
             }
         } else {
-            output_size = 1ull + extraOutputs; // output, no change
+            output_size = 1_u64 + extraOutputs; // output, no change
             selectedInputs = inputSelector.selectMaxAmount(input.byteFee);
         }
         if (selectedInputs.size() <= MaxUtxosHardLimit) {
@@ -141,11 +142,11 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
         }
 
         if (plan.utxos.empty()) {
-            plan.amount = 0ull;
+            plan.amount = 0_u64;
             plan.error = Common::Proto::Error_not_enough_utxos;
         } else if (maxAmount && !input.extraOutputs.empty()) {
             // As of now, we don't support `max` amount **and** extra outputs.
-            plan.amount = 0ull;
+            plan.amount = 0_u64;
             plan.error = Common::Proto::Error_invalid_params;
         } else {
             plan.availableAmount = InputSelector<UTXO>::sum(plan.utxos);
@@ -161,12 +162,12 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
             // must preliminary set change so that there is a second output
             if (!maxAmount) {
                 plan.amount = input.amount;
-                plan.fee = 0ull;
+                plan.fee = 0_u64;
                 plan.change = plan.availableAmount - totalAmount;
             } else {
                 plan.amount = plan.availableAmount;
-                plan.fee = 0ull;
-                plan.change = 0ull;
+                plan.fee = 0_u64;
+                plan.change = 0_u64;
             }
             plan.fee = estimateSegwitFee(feeCalculator, plan, output_size, input);
 
@@ -219,13 +220,13 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
                 plan.change = changeAmount;
             } else {
                 // Spend the change as tx fee if it's dust, otherwise the transaction won't be mined.
-                plan.change = 0ull;
+                plan.change = 0_u64;
                 plan.fee = addUnsignedChecked(plan.fee, changeAmount);
             }
         }
     }
     assert(plan.change <= plan.availableAmount);
-    assert(!maxAmount || plan.change == 0ull); // change is 0 in max amount case
+    assert(!maxAmount || plan.change == 0_u64); // change is 0 in max amount case
 
     assert(plan.error != Common::Proto::OK
            // `plan.error` is OK, check if the values are expected.

--- a/src/Bitcoin/TransactionBuilder.cpp
+++ b/src/Bitcoin/TransactionBuilder.cpp
@@ -184,7 +184,7 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
 
             // adjust/compute amount
             if (!maxAmount) {
-                // reduce amount if needed
+                // reduce amount if needed, plan.fee <= plan.availableAmount so subtraction is safe
                 plan.amount = std::min(plan.amount, plan.availableAmount - plan.fee);
             } else {
                 // max available amount; plan.fee <= plan.availableAmount so subtraction is safe

--- a/src/Bitcoin/TransactionBuilder.cpp
+++ b/src/Bitcoin/TransactionBuilder.cpp
@@ -30,12 +30,12 @@ std::optional<TransactionOutput> TransactionBuilder::prepareOutputWithScript(std
 
 
 /// Estimate encoded size by simple formula
-int64_t estimateSimpleFee(const FeeCalculator& feeCalculator, const TransactionPlan& plan, int outputSize, int64_t byteFee) {
+Amount estimateSimpleFee(const FeeCalculator& feeCalculator, const TransactionPlan& plan, size_t outputSize, Amount byteFee) {
     return feeCalculator.calculate(plan.utxos.size(), outputSize, byteFee);
 }
 
 /// Estimate encoded size by invoking sign(sizeOnly), get actual size
-int64_t estimateSegwitFee(const FeeCalculator& feeCalculator, const TransactionPlan& plan, int outputSize, const SigningInput& input) {
+Amount estimateSegwitFee(const FeeCalculator& feeCalculator, const TransactionPlan& plan, size_t outputSize, const SigningInput& input) {
     TWPurpose coinPurpose = TW::purpose(static_cast<TWCoinType>(input.coinType));
     if (coinPurpose != TWPurposeBIP84) {
         // not segwit, return default simple estimate
@@ -56,8 +56,8 @@ int64_t estimateSegwitFee(const FeeCalculator& feeCalculator, const TransactionP
     auto transaction = result.payload();
     Data dataNonSegwit;
     transaction.encode(dataNonSegwit, Transaction::SegwitFormatMode::NonSegwit);
-    int64_t sizeNonSegwit = dataNonSegwit.size();
-    uint64_t vSize = 0;
+    const auto sizeNonSegwit = static_cast<Amount>(dataNonSegwit.size());
+    Amount vSize = 0;
     // Check if there is segwit
     if (!transaction.hasWitness()) {
         // no segwit, virtual size is defined as non-segwit size
@@ -65,19 +65,19 @@ int64_t estimateSegwitFee(const FeeCalculator& feeCalculator, const TransactionP
     } else {
         Data dataWitness;
         transaction.encodeWitness(dataWitness);
-        int64_t witnessSize = 2 + dataWitness.size();
+        Amount witnessSize = 2ull + dataWitness.size();
         // compute virtual size:  (smaller) non-segwit + 1/4 of the diff (witness-only)
         // (in other way: 3/4 of (smaller) non-segwit + 1/4 of segwit size)
-        vSize = sizeNonSegwit + witnessSize/4 + (witnessSize % 4 != 0);
+        vSize = sizeNonSegwit + witnessSize/4ull + (witnessSize % 4 != 0ull);
     }
-    uint64_t fee = input.byteFee * vSize;
+    const Amount fee = input.byteFee * vSize;
 
     return fee;
 }
 
-int extraOutputCount(const SigningInput& input) {
-    int count = int(input.outputOpReturn.size() > 0);
-    return count + int(input.extraOutputs.size());
+size_t extraOutputCount(const SigningInput& input) {
+    const auto count = static_cast<size_t>(!input.outputOpReturn.empty());
+    return count + input.extraOutputs.size();
 }
 
 TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
@@ -105,17 +105,17 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
 
         // if amount requested is the same or more than available amount, it cannot be satisfied, but
         // treat this case as MaxAmount, and send maximum available (which will be less)
-        if (!maxAmount && static_cast<uint64_t>(totalAmount) >= inputSum) {
+        if (!maxAmount && totalAmount >= inputSum) {
             maxAmount = true;
         }
 
         auto extraOutputs = extraOutputCount(input);
-        auto output_size = 2;
+        size_t output_size = 2ull;
         UTXOs selectedInputs;
         if (!maxAmount) {
             // Please note that there may not be a "change" output if the "change.amount" is less than "dust",
             // but we use a max amount of transaction outputs to simplify the algorithm, so the fee can be slightly bigger in rare cases.
-            output_size = 2 + extraOutputs; // output + change
+            output_size = 2ull + extraOutputs; // output + change
             if (input.useMaxUtxo) {
                 selectedInputs = inputSelector.selectMaxAmount(input.byteFee);
             } else if (input.utxos.size() <= SimpleModeLimit &&
@@ -126,7 +126,7 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
                     inputSelector.selectSimple(totalAmount, input.byteFee, output_size);
             }
         } else {
-            output_size = 1 + extraOutputs; // output, no change
+            output_size = 1ull + extraOutputs; // output, no change
             selectedInputs = inputSelector.selectMaxAmount(input.byteFee);
         }
         if (selectedInputs.size() <= MaxUtxosHardLimit) {
@@ -140,11 +140,11 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
         }
 
         if (plan.utxos.empty()) {
-            plan.amount = 0;
+            plan.amount = 0ull;
             plan.error = Common::Proto::Error_not_enough_utxos;
         } else if (maxAmount && !input.extraOutputs.empty()) {
             // As of now, we don't support `max` amount **and** extra outputs.
-            plan.amount = 0;
+            plan.amount = 0ull;
             plan.error = Common::Proto::Error_invalid_params;
         } else {
             plan.availableAmount = InputSelector<UTXO>::sum(plan.utxos);
@@ -160,12 +160,12 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
             // must preliminary set change so that there is a second output
             if (!maxAmount) {
                 plan.amount = input.amount;
-                plan.fee = 0;
+                plan.fee = 0ull;
                 plan.change = plan.availableAmount - totalAmount;
             } else {
                 plan.amount = plan.availableAmount;
-                plan.fee = 0;
-                plan.change = 0;
+                plan.fee = 0ull;
+                plan.change = 0ull;
             }
             plan.fee = estimateSegwitFee(feeCalculator, plan, output_size, input);
 
@@ -180,17 +180,17 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
 
             // If fee is larger than availableAmount (can happen in special maxAmount case), we reduce it (and hope it will go through)
             plan.fee = std::min(plan.availableAmount, plan.fee);
-            assert(plan.fee >= 0 && plan.fee <= plan.availableAmount);
+            assert(plan.fee <= plan.availableAmount);
 
             // adjust/compute amount
             if (!maxAmount) {
                 // reduce amount if needed
-                plan.amount = std::max(Amount(0), std::min(plan.amount, plan.availableAmount - plan.fee));
+                plan.amount = std::min(plan.amount, plan.availableAmount - plan.fee);
             } else {
-                // max available amount
-                plan.amount = std::max(Amount(0), plan.availableAmount - plan.fee);
+                // max available amount; plan.fee <= plan.availableAmount so subtraction is safe
+                plan.amount = plan.availableAmount - plan.fee;
             }
-            assert(plan.amount >= 0 && plan.amount <= plan.availableAmount);
+            assert(plan.amount <= plan.availableAmount);
 
             // The total amount that will be spent.
             Amount totalSpendAmount = plan.amount + input.extraOutputsAmount + plan.fee;
@@ -215,13 +215,13 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
                 plan.change = changeAmount;
             } else {
                 // Spend the change as tx fee if it's dust, otherwise the transaction won't be mined.
-                plan.change = 0;
+                plan.change = 0ull;
                 plan.fee += changeAmount;
             }
         }
     }
-    assert(plan.change >= 0 && plan.change <= plan.availableAmount);
-    assert(!maxAmount || plan.change == 0); // change is 0 in max amount case
+    assert(plan.change <= plan.availableAmount);
+    assert(!maxAmount || plan.change == 0ull); // change is 0 in max amount case
 
     assert(plan.error != Common::Proto::OK
            // `plan.error` is OK, check if the values are expected.

--- a/src/Bitcoin/TransactionBuilder.cpp
+++ b/src/Bitcoin/TransactionBuilder.cpp
@@ -6,6 +6,7 @@
 #include "Script.h"
 #include "TransactionSigner.h"
 #include "SignatureBuilder.h"
+#include "Numeric.h"
 
 #include "../Coin.h"
 
@@ -88,7 +89,7 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
     plan.outputOpReturnIndex = input.outputOpReturnIndex;
 
     bool maxAmount = input.useMaxAmount;
-    Amount totalAmount = input.amount + input.extraOutputsAmount;
+    Amount totalAmount = addUnsignedChecked(input.amount, input.extraOutputsAmount);
     Amount dustThreshold = input.dustCalculator->dustAmount(input.byteFee);
 
     if (totalAmount == 0 && !maxAmount) {
@@ -172,7 +173,7 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
             // `InputSelector` has a rough segwit fee estimation algorithm,
             // so the fee could be increased or decreased (see `InputSelector::select`).
             // We need to make sure if we have enough UTXOs to cover "requested amount + final fee".
-            if (!maxAmount && plan.availableAmount < plan.fee + plan.amount) {
+            if (!maxAmount && plan.availableAmount < addUnsignedChecked(plan.fee, plan.amount)) {
                 TransactionPlan errorPlan;
                 errorPlan.error = Common::Proto::Error_not_enough_utxos;
                 return errorPlan;
@@ -193,7 +194,10 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
             assert(plan.amount <= plan.availableAmount);
 
             // The total amount that will be spent.
-            Amount totalSpendAmount = plan.amount + input.extraOutputsAmount + plan.fee;
+            Amount totalSpendAmount = addUnsignedChecked(
+                addUnsignedChecked(plan.amount, input.extraOutputsAmount),
+                plan.fee
+            );
 
             // Make sure that the output amount is greater or at least equal to the dust threshold.
             if (plan.amount < dustThreshold) {
@@ -216,7 +220,7 @@ TransactionPlan TransactionBuilder::plan(const SigningInput& input) {
             } else {
                 // Spend the change as tx fee if it's dust, otherwise the transaction won't be mined.
                 plan.change = 0ull;
-                plan.fee += changeAmount;
+                plan.fee = addUnsignedChecked(plan.fee, changeAmount);
             }
         }
     }

--- a/src/Bitcoin/TransactionBuilder.h
+++ b/src/Bitcoin/TransactionBuilder.h
@@ -59,7 +59,7 @@ public:
                 emplace_at = tx.outputs.begin();
                 std::advance(emplace_at, plan.outputOpReturnIndex.value());
             }
-            int64_t amount = 0;
+            Amount amount = 0;
             tx.outputs.emplace(emplace_at, amount, lockingScriptOpReturn);
         }
 

--- a/src/Bitcoin/TransactionPlan.h
+++ b/src/Bitcoin/TransactionPlan.h
@@ -52,21 +52,17 @@ struct TransactionPlan {
     TransactionPlan() = default;
 
     TransactionPlan(const Proto::TransactionPlan& plan)
-        : amount(plan.amount())
-        , availableAmount(plan.available_amount())
-        , fee(plan.fee())
-        , change(plan.change())
-        , utxos(std::vector<UTXO>(plan.utxos().begin(), plan.utxos().end()))
+        : utxos(std::vector<UTXO>(plan.utxos().begin(), plan.utxos().end()))
         , branchId(plan.branch_id().begin(), plan.branch_id().end())
         , preBlockHash(plan.preblockhash().begin(), plan.preblockhash().end())
         , preBlockHeight(plan.preblockheight())
         , outputOpReturn(plan.output_op_return().begin(), plan.output_op_return().end())
         , error(plan.error())
     {
-        assertValidAmount(amount);
-        assertValidAmount(availableAmount);
-        assertValidAmount(fee);
-        assertValidAmount(change);
+        amount = tryToUnsigned(plan.amount());
+        availableAmount = tryToUnsigned(plan.available_amount());
+        fee = tryToUnsigned(plan.fee());
+        change = tryToUnsigned(plan.change());
         if (plan.has_output_op_return_index()) {
             outputOpReturnIndex = plan.output_op_return_index().index();
         }
@@ -74,10 +70,10 @@ struct TransactionPlan {
 
     Proto::TransactionPlan proto() const {
         auto plan = Proto::TransactionPlan();
-        plan.set_amount(amount);
-        plan.set_available_amount(availableAmount);
-        plan.set_fee(fee);
-        plan.set_change(change);
+        plan.set_amount(tryToSigned(amount));
+        plan.set_available_amount(tryToSigned(availableAmount));
+        plan.set_fee(tryToSigned(fee));
+        plan.set_change(tryToSigned(change));
         for (auto& utxo: utxos) {
             *plan.add_utxos() = utxo.proto();
         }

--- a/src/Bitcoin/TransactionPlan.h
+++ b/src/Bitcoin/TransactionPlan.h
@@ -63,6 +63,10 @@ struct TransactionPlan {
         , outputOpReturn(plan.output_op_return().begin(), plan.output_op_return().end())
         , error(plan.error())
     {
+        assertValidAmount(amount);
+        assertValidAmount(availableAmount);
+        assertValidAmount(fee);
+        assertValidAmount(change);
         if (plan.has_output_op_return_index()) {
             outputOpReturnIndex = plan.output_op_return_index().index();
         }

--- a/src/Bitcoin/TransactionPlan.h
+++ b/src/Bitcoin/TransactionPlan.h
@@ -59,10 +59,10 @@ struct TransactionPlan {
         , outputOpReturn(plan.output_op_return().begin(), plan.output_op_return().end())
         , error(plan.error())
     {
-        amount = tryToUnsigned(plan.amount());
-        availableAmount = tryToUnsigned(plan.available_amount());
-        fee = tryToUnsigned(plan.fee());
-        change = tryToUnsigned(plan.change());
+        amount = tryToUnsigned(plan.amount(), "plan.amount");
+        availableAmount = tryToUnsigned(plan.available_amount(), "plan.available_amount");
+        fee = tryToUnsigned(plan.fee(), "plan.fee");
+        change = tryToUnsigned(plan.change(), "plan.change");
         if (plan.has_output_op_return_index()) {
             outputOpReturnIndex = plan.output_op_return_index().index();
         }
@@ -70,10 +70,10 @@ struct TransactionPlan {
 
     Proto::TransactionPlan proto() const {
         auto plan = Proto::TransactionPlan();
-        plan.set_amount(tryToSigned(amount));
-        plan.set_available_amount(tryToSigned(availableAmount));
-        plan.set_fee(tryToSigned(fee));
-        plan.set_change(tryToSigned(change));
+        plan.set_amount(tryToSigned(amount, "plan.amount"));
+        plan.set_available_amount(tryToSigned(availableAmount, "plan.available_amount"));
+        plan.set_fee(tryToSigned(fee, "plan.fee"));
+        plan.set_change(tryToSigned(change, "plan.change"));
         for (auto& utxo: utxos) {
             *plan.add_utxos() = utxo.proto();
         }

--- a/src/Bitcoin/UTXO.h
+++ b/src/Bitcoin/UTXO.h
@@ -31,14 +31,14 @@ public:
         : outPoint(utxo.out_point())
         , script(utxo.script().begin(), utxo.script().end())
     {
-        amount = tryToUnsigned(utxo.amount());
+        amount = tryToUnsigned(utxo.amount(), "utxo.amount");
     }
 
     Proto::UnspentTransaction proto() const {
         auto utxo = Proto::UnspentTransaction();
         *utxo.mutable_out_point() = outPoint.proto();
         utxo.set_script(std::string(script.bytes.begin(), script.bytes.end()));
-        utxo.set_amount(tryToSigned(amount));
+        utxo.set_amount(tryToSigned(amount, "utxo.amount"));
         return utxo;
     }
 };

--- a/src/Bitcoin/UTXO.h
+++ b/src/Bitcoin/UTXO.h
@@ -30,16 +30,15 @@ public:
     UTXO(const Proto::UnspentTransaction& utxo)
         : outPoint(utxo.out_point())
         , script(utxo.script().begin(), utxo.script().end())
-        , amount(utxo.amount())
     {
-        assertValidAmount(utxo.amount());
+        amount = tryToUnsigned(utxo.amount());
     }
 
     Proto::UnspentTransaction proto() const {
         auto utxo = Proto::UnspentTransaction();
         *utxo.mutable_out_point() = outPoint.proto();
         utxo.set_script(std::string(script.bytes.begin(), script.bytes.end()));
-        utxo.set_amount(amount);
+        utxo.set_amount(tryToSigned(amount));
         return utxo;
     }
 };

--- a/src/Bitcoin/UTXO.h
+++ b/src/Bitcoin/UTXO.h
@@ -31,7 +31,9 @@ public:
         : outPoint(utxo.out_point())
         , script(utxo.script().begin(), utxo.script().end())
         , amount(utxo.amount())
-        {}
+    {
+        assertValidAmount(utxo.amount());
+    }
 
     Proto::UnspentTransaction proto() const {
         auto utxo = Proto::UnspentTransaction();

--- a/src/BitcoinDiamond/Transaction.cpp
+++ b/src/BitcoinDiamond/Transaction.cpp
@@ -197,7 +197,7 @@ Bitcoin::Proto::Transaction Transaction::proto() const {
 
     for (const auto& output : outputs) {
         auto* protoOutput = protoTx.add_outputs();
-        protoOutput->set_value(Bitcoin::tryToSigned(output.value));
+        protoOutput->set_value(Bitcoin::tryToSigned(output.value, "output.value"));
         protoOutput->set_script(output.script.bytes.data(), output.script.bytes.size());
     }
 

--- a/src/BitcoinDiamond/Transaction.cpp
+++ b/src/BitcoinDiamond/Transaction.cpp
@@ -14,7 +14,7 @@ using namespace TW;
 namespace TW::BitcoinDiamond {
 
 Data Transaction::getPreImage(const Bitcoin::Script& scriptCode, size_t index,
-                              enum TWBitcoinSigHashType hashType, uint64_t amount) const {
+                              enum TWBitcoinSigHashType hashType, Bitcoin::Amount amount) const {
     assert(index < inputs.size());
 
     Data data;
@@ -118,7 +118,7 @@ void Transaction::encode(Data& data, enum SegwitFormatMode segwitFormat) const {
 
 
 Data Transaction::getSignatureHash(const Bitcoin::Script& scriptCode, size_t index,
-                                   enum TWBitcoinSigHashType hashType, uint64_t amount,
+                                   enum TWBitcoinSigHashType hashType, Bitcoin::Amount amount,
                                    enum Bitcoin::SignatureVersion version) const {
     switch (version) {
     case Bitcoin::BASE:
@@ -131,7 +131,7 @@ Data Transaction::getSignatureHash(const Bitcoin::Script& scriptCode, size_t ind
 /// Generates the signature hash for Witness version 0 scripts.
 Data Transaction::getSignatureHashWitnessV0(const Bitcoin::Script& scriptCode, size_t index,
                                             enum TWBitcoinSigHashType hashType,
-                                            uint64_t amount) const {
+                                            Bitcoin::Amount amount) const {
     auto preimage = getPreImage(scriptCode, index, hashType, amount);
     auto hash = Hash::hash(hasher, preimage);
     return hash;
@@ -164,7 +164,7 @@ Data Transaction::getSignatureHashBase(const Bitcoin::Script& scriptCode, size_t
     encodeVarInt(serializedOutputCount, data);
     for (auto subindex = 0ul; subindex < serializedOutputCount; subindex += 1) {
         if (hashSingle && subindex != index) {
-            auto output = Bitcoin::TransactionOutput(-1, {});
+            auto output = Bitcoin::TransactionOutput(Bitcoin::sighashSingleAmount(), {});
             output.encode(data);
         } else {
             outputs[subindex].encode(data);
@@ -197,7 +197,7 @@ Bitcoin::Proto::Transaction Transaction::proto() const {
 
     for (const auto& output : outputs) {
         auto* protoOutput = protoTx.add_outputs();
-        protoOutput->set_value(output.value);
+        protoOutput->set_value(Bitcoin::tryToSigned(output.value));
         protoOutput->set_script(output.script.bytes.data(), output.script.bytes.size());
     }
 

--- a/src/BitcoinDiamond/Transaction.h
+++ b/src/BitcoinDiamond/Transaction.h
@@ -6,6 +6,7 @@
 
 #include <TrustWalletCore/TWBitcoinSigHashType.h>
 
+#include "../Bitcoin/Amount.h"
 #include "../Bitcoin/Script.h"
 #include "../Bitcoin/Transaction.h"
 #include "../Bitcoin/TransactionInput.h"
@@ -29,21 +30,21 @@ public:
         : Bitcoin::Transaction(version, lockTime, TW::Hash::HasherSha256d)
         , preBlockHash(blockHash) {}
 
-    Data getPreImage(const Bitcoin::Script& scriptCode, size_t index, enum TWBitcoinSigHashType hashType, uint64_t amount) const;
+    Data getPreImage(const Bitcoin::Script& scriptCode, size_t index, enum TWBitcoinSigHashType hashType, Bitcoin::Amount amount) const;
     
     /// Encodes the transaction into the provided buffer.
     void encode(Data& data, enum SegwitFormatMode segwitFormat) const;
     void encode(Data& data) const { encode(data, SegwitFormatMode::IfHasWitness); }
 
     Data getSignatureHash(const Bitcoin::Script& scriptCode, size_t index, enum TWBitcoinSigHashType hashType,
-                          uint64_t amount, enum Bitcoin::SignatureVersion version) const;
+                          Bitcoin::Amount amount, enum Bitcoin::SignatureVersion version) const;
     /// Converts to Protobuf model
     Bitcoin::Proto::Transaction proto() const;
 
 private:
     /// Generates the signature hash for Witness version 0 scripts.
     Data getSignatureHashWitnessV0(const Bitcoin::Script& scriptCode, size_t index,
-                                   enum TWBitcoinSigHashType hashType, uint64_t amount) const;
+                                   enum TWBitcoinSigHashType hashType, Bitcoin::Amount amount) const;
 
     /// Generates the signature hash for for scripts other than witness scripts.
     Data getSignatureHashBase(const Bitcoin::Script& scriptCode, size_t index,

--- a/src/Decred/Signer.cpp
+++ b/src/Decred/Signer.cpp
@@ -147,7 +147,7 @@ Result<std::vector<Data>, Common::Proto::SigningError> Signer::signStep(Bitcoin:
 
     Data data;
     std::vector<Data> keys;
-    int required;
+    size_t required;
 
     if (script.matchPayToPublicKey(data)) {
         auto keyHash = TW::Hash::ripemd(TW::Hash::blake256(data));
@@ -216,7 +216,7 @@ Result<std::vector<Data>, Common::Proto::SigningError> Signer::signStep(Bitcoin:
             }
             results.push_back(signature);
         }
-        results.resize(required + 1);
+        results.resize(required + 1ul);
         return Result<std::vector<Data>, Common::Proto::SigningError>::success(std::move(results));
     } else {
         // Error: Invalid output script

--- a/src/Decred/Transaction.cpp
+++ b/src/Decred/Transaction.cpp
@@ -202,7 +202,7 @@ Proto::Transaction Transaction::proto() const {
 
     for (const auto& output : outputs) {
         auto* protoOutput = protoTx.add_outputs();
-        protoOutput->set_value(Bitcoin::tryToSigned(output.value));
+        protoOutput->set_value(Bitcoin::tryToSigned(output.value, "output.value"));
         protoOutput->set_script(output.script.bytes.data(), output.script.bytes.size());
     }
 

--- a/src/Decred/Transaction.cpp
+++ b/src/Decred/Transaction.cpp
@@ -99,7 +99,7 @@ Data Transaction::computePrefixHash(const std::vector<TransactionInput>& inputsT
         auto value = output.value;
         auto pkScript = output.script;
         if (Bitcoin::hashTypeIsSingle(hashType) && i != index) {
-            value = -1;
+            value = Bitcoin::sighashSingleAmount();
             pkScript = {};
         }
         encode64LE(value, preimage);
@@ -202,7 +202,7 @@ Proto::Transaction Transaction::proto() const {
 
     for (const auto& output : outputs) {
         auto* protoOutput = protoTx.add_outputs();
-        protoOutput->set_value(output.value);
+        protoOutput->set_value(Bitcoin::tryToSigned(output.value));
         protoOutput->set_script(output.script.bytes.data(), output.script.bytes.size());
     }
 

--- a/src/Decred/TransactionInput.h
+++ b/src/Decred/TransactionInput.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "OutPoint.h"
+#include "../Bitcoin/Amount.h"
 #include "../Bitcoin/Script.h"
 #include "Data.h"
 
@@ -25,7 +26,7 @@ class TransactionInput {
     /// before inclusion into a block.
     uint32_t sequence = std::numeric_limits<uint32_t>::max();
 
-    int64_t valueIn = 0;
+    Bitcoin::Amount valueIn = 0;
     uint32_t blockHeight = 0;
     uint32_t blockIndex = std::numeric_limits<uint32_t>::max();
 

--- a/src/Decred/TransactionOutput.h
+++ b/src/Decred/TransactionOutput.h
@@ -27,7 +27,6 @@ struct TransactionOutput {
     /// Initializes a transaction output with a value and a script.
     TransactionOutput(Bitcoin::Amount value, uint16_t version, Bitcoin::Script script)
         : value(value), version(version), script(std::move(script)) {
-        Bitcoin::assertValidAmount(value);
     }
 
     /// Encodes the output into the provided buffer.

--- a/src/Decred/TransactionOutput.h
+++ b/src/Decred/TransactionOutput.h
@@ -26,7 +26,9 @@ struct TransactionOutput {
 
     /// Initializes a transaction output with a value and a script.
     TransactionOutput(Bitcoin::Amount value, uint16_t version, Bitcoin::Script script)
-        : value(value), version(version), script(std::move(script)) {}
+        : value(value), version(version), script(std::move(script)) {
+        Bitcoin::assertValidAmount(value);
+    }
 
     /// Encodes the output into the provided buffer.
     void encode(Data& data) const;

--- a/src/Numeric.h
+++ b/src/Numeric.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <numeric>
+#include <stdexcept>
 
 namespace TW {
 
@@ -25,6 +26,28 @@ bool checkMulUnsignedOverflow(T x, T y) {
         return false;
     }
     return x > std::numeric_limits<T>::max() / y;
+}
+
+template <
+    typename T,
+    typename = std::enable_if_t<std::is_unsigned_v<T>>
+>
+T addUnsignedChecked(T x, T y) {
+    if (checkAddUnsignedOverflow(x, y)) {
+        throw std::overflow_error("Unsigned integer addition overflow");
+    }
+    return x + y;
+}
+
+template <
+    typename T,
+    typename = std::enable_if_t<std::is_unsigned_v<T>>
+>
+T mulUnsignedChecked(T x, T y) {
+    if (checkMulUnsignedOverflow(x, y)) {
+        throw std::overflow_error("Unsigned integer multiplication overflow");
+    }
+    return x * y;
 }
 
 } // namespace TW

--- a/src/NumericLiteral.h
+++ b/src/NumericLiteral.h
@@ -12,6 +12,6 @@ inline constexpr std::size_t operator"" _uz(unsigned long long int n) {
     return n;
 }
 
-inline constexpr std::uint64_t operator"" _u64(std::uint64_t n) {
+inline constexpr std::uint64_t operator"" _u64(unsigned long long int n) {
     return n;
 }

--- a/src/NumericLiteral.h
+++ b/src/NumericLiteral.h
@@ -5,8 +5,13 @@
 #pragma once
 
 #include <cstddef> // std::size_t
+#include <cstdint>
 
 // https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p0330r8.html
 inline constexpr std::size_t operator"" _uz(unsigned long long int n) {
+    return n;
+}
+
+inline constexpr std::uint64_t operator"" _u64(std::uint64_t n) {
     return n;
 }

--- a/src/Verge/Transaction.cpp
+++ b/src/Verge/Transaction.cpp
@@ -18,7 +18,7 @@ using namespace TW;
 namespace TW::Verge {
 
 Data Transaction::getPreImage(const Bitcoin::Script& scriptCode, size_t index,
-                              enum TWBitcoinSigHashType hashType, uint64_t amount) const {
+                              enum TWBitcoinSigHashType hashType, Bitcoin::Amount amount) const {
     assert(index < inputs.size());
 
     Data data;
@@ -115,7 +115,7 @@ void Transaction::encode(Data& data, enum SegwitFormatMode segwitFormat) const {
 }
 
 Data Transaction::getSignatureHash(const Bitcoin::Script& scriptCode, size_t index,
-                                   enum TWBitcoinSigHashType hashType, uint64_t amount,
+                                   enum TWBitcoinSigHashType hashType, Bitcoin::Amount amount,
                                    enum Bitcoin::SignatureVersion version) const {
     switch (version) {
     case Bitcoin::BASE:
@@ -128,7 +128,7 @@ Data Transaction::getSignatureHash(const Bitcoin::Script& scriptCode, size_t ind
 /// Generates the signature hash for Witness version 0 scripts.
 Data Transaction::getSignatureHashWitnessV0(const Bitcoin::Script& scriptCode, size_t index,
                                             enum TWBitcoinSigHashType hashType,
-                                            uint64_t amount) const {
+                                            Bitcoin::Amount amount) const {
     auto preimage = getPreImage(scriptCode, index, hashType, amount);
     auto hash = Hash::hash(hasher, preimage);
     return hash;

--- a/src/Verge/Transaction.h
+++ b/src/Verge/Transaction.h
@@ -31,7 +31,7 @@ public:
         , time(time) {}
 
     /// Generates the signature pre-image.
-    Data getPreImage(const Bitcoin::Script& scriptCode, size_t index, enum TWBitcoinSigHashType hashType, uint64_t amount) const;
+    Data getPreImage(const Bitcoin::Script& scriptCode, size_t index, enum TWBitcoinSigHashType hashType, Bitcoin::Amount amount) const;
 
     /// Encodes the transaction into the provided buffer.
     void encode(Data& data, enum SegwitFormatMode segwitFormat) const;
@@ -41,12 +41,12 @@ public:
 
     /// Generates the signature hash for this transaction.
     Data getSignatureHash(const Bitcoin::Script& scriptCode, size_t index, enum TWBitcoinSigHashType hashType,
-                          uint64_t amount, enum Bitcoin::SignatureVersion version) const;
+                          Bitcoin::Amount amount, enum Bitcoin::SignatureVersion version) const;
 
 private:
     /// Generates the signature hash for Witness version 0 scripts.
     Data getSignatureHashWitnessV0(const Bitcoin::Script& scriptCode, size_t index,
-                                   enum TWBitcoinSigHashType hashType, uint64_t amount) const;
+                                   enum TWBitcoinSigHashType hashType, Bitcoin::Amount amount) const;
 
     /// Generates the signature hash for for scripts other than witness scripts.
     Data getSignatureHashBase(const Bitcoin::Script& scriptCode, size_t index,

--- a/src/Zcash/Transaction.cpp
+++ b/src/Zcash/Transaction.cpp
@@ -205,7 +205,7 @@ Bitcoin::Proto::Transaction Transaction::proto() const {
 
     for (const auto& output : outputs) {
         auto* protoOutput = protoTx.add_outputs();
-        protoOutput->set_value(Bitcoin::tryToSigned(output.value));
+        protoOutput->set_value(Bitcoin::tryToSigned(output.value, "output.value"));
         protoOutput->set_script(output.script.bytes.data(), output.script.bytes.size());
     }
 

--- a/src/Zcash/Transaction.cpp
+++ b/src/Zcash/Transaction.cpp
@@ -27,7 +27,7 @@ const std::array<TW::byte, 4> BlossomBranchID = {0x60, 0x0e, 0xb4, 0x2b};
 const std::array<byte, 4> Nu6BranchID = {0x55, 0x10, 0xe7, 0xc8};
 
 Data Transaction::getPreImage(const Bitcoin::Script& scriptCode, size_t index, enum TWBitcoinSigHashType hashType,
-                              uint64_t amount) const {
+                              Bitcoin::Amount amount) const {
     assert(index < inputs.size());
 
     auto data = Data{};
@@ -177,7 +177,7 @@ void Transaction::encode(Data& data) const {
 }
 
 Data Transaction::getSignatureHash(const Bitcoin::Script& scriptCode, size_t index,
-                                   enum TWBitcoinSigHashType hashType, uint64_t amount,
+                                   enum TWBitcoinSigHashType hashType, Bitcoin::Amount amount,
                                    [[maybe_unused]] Bitcoin::SignatureVersion version) const {
     Data personalization;
     personalization.reserve(16);
@@ -205,7 +205,7 @@ Bitcoin::Proto::Transaction Transaction::proto() const {
 
     for (const auto& output : outputs) {
         auto* protoOutput = protoTx.add_outputs();
-        protoOutput->set_value(output.value);
+        protoOutput->set_value(Bitcoin::tryToSigned(output.value));
         protoOutput->set_script(output.script.bytes.data(), output.script.bytes.size());
     }
 

--- a/src/Zcash/Transaction.h
+++ b/src/Zcash/Transaction.h
@@ -26,7 +26,7 @@ struct Transaction {
     uint32_t versionGroupId = 0x892F2085;
     uint32_t lockTime = 0;
     uint32_t expiryHeight = 0;
-    uint64_t valueBalance = 0;
+    Bitcoin::Amount valueBalance = 0;
 
     Bitcoin::TransactionInputs<Bitcoin::TransactionInput> inputs;
     Bitcoin::TransactionOutputs<Bitcoin::TransactionOutput> outputs;
@@ -38,7 +38,7 @@ struct Transaction {
     Transaction() = default;
 
     Transaction(uint32_t version, uint32_t versionGroupId, uint32_t lockTime, uint32_t expiryHeight,
-                uint64_t valueBalance, std::array<byte, 4> branchId)
+                Bitcoin::Amount valueBalance, std::array<byte, 4> branchId)
         : _version(version)
         , versionGroupId(versionGroupId)
         , lockTime(lockTime)
@@ -51,7 +51,7 @@ struct Transaction {
 
     /// Generates the signature pre-image.
     Data getPreImage(const Bitcoin::Script& scriptCode, size_t index,
-                     enum TWBitcoinSigHashType hashType, uint64_t amount) const;
+                     enum TWBitcoinSigHashType hashType, Bitcoin::Amount amount) const;
     Data getPrevoutHash() const;
     Data getSequenceHash() const;
     Data getOutputsHash() const;
@@ -64,7 +64,7 @@ struct Transaction {
     void encode(Data& data) const;
 
     Data getSignatureHash(const Bitcoin::Script& scriptCode, size_t index,
-                          enum TWBitcoinSigHashType hashType, uint64_t amount,
+                          enum TWBitcoinSigHashType hashType, Bitcoin::Amount amount,
                           enum Bitcoin::SignatureVersion version) const;
 
     /// Converts to Protobuf model

--- a/src/Zen/TransactionBuilder.h
+++ b/src/Zen/TransactionBuilder.h
@@ -67,7 +67,7 @@ struct TransactionBuilder {
                 emplace_at = tx.outputs.begin();
                 std::advance(emplace_at, plan.outputOpReturnIndex.value());
             }
-            const int64_t amount = 0;
+            const Bitcoin::Amount amount = 0;
             tx.outputs.emplace(emplace_at, amount, lockingScriptOpReturn);
         }
 
@@ -85,7 +85,6 @@ struct TransactionBuilder {
 
     /// Prepares a TransactionOutput with given address and amount, prepares script for it
     static std::optional<Bitcoin::TransactionOutput> prepareOutputWithScript(const std::string& addr, Bitcoin::Amount amount, enum TWCoinType coin, const Data& blockHash, int64_t blockHeight) {
-        Bitcoin::assertValidAmount(amount);
         auto lockingScript = Bitcoin::Script::lockScriptForAddress(addr, coin, blockHash, blockHeight);
         if (lockingScript.empty()) {
             return {};

--- a/src/Zen/TransactionBuilder.h
+++ b/src/Zen/TransactionBuilder.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "Address.h"
+#include "../Bitcoin/Amount.h"
 #include "../Bitcoin/Transaction.h"
 #include "../Bitcoin/TransactionBuilder.h"
 #include "../Bitcoin/TransactionPlan.h"
@@ -84,6 +85,7 @@ struct TransactionBuilder {
 
     /// Prepares a TransactionOutput with given address and amount, prepares script for it
     static std::optional<Bitcoin::TransactionOutput> prepareOutputWithScript(const std::string& addr, Bitcoin::Amount amount, enum TWCoinType coin, const Data& blockHash, int64_t blockHeight) {
+        Bitcoin::assertValidAmount(amount);
         auto lockingScript = Bitcoin::Script::lockScriptForAddress(addr, coin, blockHash, blockHeight);
         if (lockingScript.empty()) {
             return {};

--- a/tests/chains/Bitcoin/BitcoinScriptTests.cpp
+++ b/tests/chains/Bitcoin/BitcoinScriptTests.cpp
@@ -239,7 +239,7 @@ TEST(BitcoinScript, GetScriptOp) {
 
 TEST(BitcoinScript, MatchMultiSig) {
     std::vector<Data> keys;
-    int required;
+    size_t required;
     EXPECT_EQ(Script(parse_hex("")).matchMultisig(keys, required), false);
     EXPECT_EQ(Script(parse_hex("20")).matchMultisig(keys, required), false);
     EXPECT_EQ(Script(parse_hex("ae")).matchMultisig(keys, required), false);

--- a/tests/chains/Bitcoin/FeeCalculatorTests.cpp
+++ b/tests/chains/Bitcoin/FeeCalculatorTests.cpp
@@ -10,92 +10,92 @@ namespace TW::Bitcoin {
 
 TEST(BitcoinFeeCalculator, ConstantFeeCalculator) {
     const auto feeCalculator = ConstantFeeCalculator(33);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 1), 33);
-    EXPECT_EQ(feeCalculator.calculate(0, 2, 1), 33);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 10), 33);
-    EXPECT_EQ(feeCalculator.calculateSingleInput(10), 0);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, 1ull), 33ull);
+    EXPECT_EQ(feeCalculator.calculate(0ull, 2ull, 1ull), 33ull);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, 10ull), 33ull);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(10ull), 0ull);
 }
 
 TEST(BitcoinFeeCalculator, LinearFeeCalculator) {
     const auto feeCalculator = LinearFeeCalculator(10, 20, 50);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 1), 100);
-    EXPECT_EQ(feeCalculator.calculate(1, 1, 1), 80);
-    EXPECT_EQ(feeCalculator.calculate(0, 2, 1), 90);
-    EXPECT_EQ(feeCalculator.calculate(1, 0, 1), 60);
-    EXPECT_EQ(feeCalculator.calculate(0, 0, 1), 50);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 10), 1000);
-    EXPECT_EQ(feeCalculator.calculateSingleInput(10), 100);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, 1ull), 100ull);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 1ull, 1ull), 80ull);
+    EXPECT_EQ(feeCalculator.calculate(0ull, 2ull, 1ull), 90ull);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 0ull, 1ull), 60ull);
+    EXPECT_EQ(feeCalculator.calculate(0ull, 0ull, 1ull), 50ull);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, 10ull), 1000ull);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(10ull), 100ull);
 }
 
 TEST(BitcoinFeeCalculator, BitcoinCalculate) {
     const FeeCalculator& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 1), 174);
-    EXPECT_EQ(feeCalculator.calculate(1, 1, 1), 143);
-    EXPECT_EQ(feeCalculator.calculate(0, 2, 1), 72);
-    EXPECT_EQ(feeCalculator.calculate(1, 0, 1), 112);
-    EXPECT_EQ(feeCalculator.calculate(0, 0, 1), 10);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 10), 1740);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, 1ull), 174ull);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 1ull, 1ull), 143ull);
+    EXPECT_EQ(feeCalculator.calculate(0ull, 2ull, 1ull), 72ull);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 0ull, 1ull), 112ull);
+    EXPECT_EQ(feeCalculator.calculate(0ull, 0ull, 1ull), 10ull);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, 10ull), 1740ull);
 }
 
 TEST(BitcoinFeeCalculator, SegwitCalculate) {
     const FeeCalculator& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 1), 174);
-    EXPECT_EQ(feeCalculator.calculate(1, 1, 1), 143);
-    EXPECT_EQ(feeCalculator.calculate(0, 2, 1), 72);
-    EXPECT_EQ(feeCalculator.calculate(1, 0, 1), 112);
-    EXPECT_EQ(feeCalculator.calculate(0, 0, 1), 10);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 10), 1740);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, 1ull), 174ull);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 1ull, 1ull), 143ull);
+    EXPECT_EQ(feeCalculator.calculate(0ull, 2ull, 1ull), 72ull);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 0ull, 1ull), 112ull);
+    EXPECT_EQ(feeCalculator.calculate(0ull, 0ull, 1ull), 10ull);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, 10ull), 1740ull);
 }
 
 TEST(BitcoinFeeCalculator, BitcoinCalculateNoDustFilter) {
     const FeeCalculator& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin, true);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 1), 174);
-    EXPECT_EQ(feeCalculator.calculate(1, 1, 1), 143);
-    EXPECT_EQ(feeCalculator.calculate(0, 2, 1), 72);
-    EXPECT_EQ(feeCalculator.calculate(1, 0, 1), 112);
-    EXPECT_EQ(feeCalculator.calculate(0, 0, 1), 10);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 10), 1740);
-    EXPECT_EQ(feeCalculator.calculateSingleInput(1), 0);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, 1ull), 174ull);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 1ull, 1ull), 143ull);
+    EXPECT_EQ(feeCalculator.calculate(0ull, 2ull, 1ull), 72ull);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 0ull, 1ull), 112ull);
+    EXPECT_EQ(feeCalculator.calculate(0ull, 0ull, 1ull), 10ull);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, 10ull), 1740ull);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(1ull), 0ull);
 }
 
 TEST(BitcoinFeeCalculator, DefaultCalculate) {
     DefaultFeeCalculator defaultFeeCalculator;
-    EXPECT_EQ(defaultFeeCalculator.calculate(1, 2, 1), 226);
-    EXPECT_EQ(defaultFeeCalculator.calculate(1, 1, 1), 192);
-    EXPECT_EQ(defaultFeeCalculator.calculate(0, 2, 1), 78);
-    EXPECT_EQ(defaultFeeCalculator.calculate(1, 0, 1), 158);
-    EXPECT_EQ(defaultFeeCalculator.calculate(0, 0, 1), 10);
-    EXPECT_EQ(defaultFeeCalculator.calculate(1, 2, 10), 2260);
-    EXPECT_EQ(defaultFeeCalculator.calculateSingleInput(1), 148);
-    EXPECT_EQ(defaultFeeCalculator.calculateSingleInput(2), 296);
-    EXPECT_EQ(defaultFeeCalculator.calculateSingleInput(10), 1480);
+    EXPECT_EQ(defaultFeeCalculator.calculate(1ull, 2ull, 1ull), 226ull);
+    EXPECT_EQ(defaultFeeCalculator.calculate(1ull, 1ull, 1ull), 192ull);
+    EXPECT_EQ(defaultFeeCalculator.calculate(0ull, 2ull, 1ull), 78ull);
+    EXPECT_EQ(defaultFeeCalculator.calculate(1ull, 0ull, 1ull), 158ull);
+    EXPECT_EQ(defaultFeeCalculator.calculate(0ull, 0ull, 1ull), 10ull);
+    EXPECT_EQ(defaultFeeCalculator.calculate(1ull, 2ull, 10ull), 2260ull);
+    EXPECT_EQ(defaultFeeCalculator.calculateSingleInput(1ull), 148ull);
+    EXPECT_EQ(defaultFeeCalculator.calculateSingleInput(2ull), 296ull);
+    EXPECT_EQ(defaultFeeCalculator.calculateSingleInput(10ull), 1480ull);
 }
 
 TEST(BitcoinFeeCalculator, DefaultCalculateNoDustFilter) {
     DefaultFeeCalculator defaultFeeCalculator(true);
-    EXPECT_EQ(defaultFeeCalculator.calculate(1, 2, 1), 226);
-    EXPECT_EQ(defaultFeeCalculator.calculate(1, 1, 1), 192);
-    EXPECT_EQ(defaultFeeCalculator.calculate(0, 2, 1), 78);
-    EXPECT_EQ(defaultFeeCalculator.calculate(1, 0, 1), 158);
-    EXPECT_EQ(defaultFeeCalculator.calculate(0, 0, 1), 10);
-    EXPECT_EQ(defaultFeeCalculator.calculate(1, 2, 10), 2260);
-    EXPECT_EQ(defaultFeeCalculator.calculateSingleInput(1), 0);
+    EXPECT_EQ(defaultFeeCalculator.calculate(1ull, 2ull, 1ull), 226ull);
+    EXPECT_EQ(defaultFeeCalculator.calculate(1ull, 1ull, 1ull), 192ull);
+    EXPECT_EQ(defaultFeeCalculator.calculate(0ull, 2ull, 1ull), 78ull);
+    EXPECT_EQ(defaultFeeCalculator.calculate(1ull, 0ull, 1ull), 158ull);
+    EXPECT_EQ(defaultFeeCalculator.calculate(0ull, 0ull, 1ull), 10ull);
+    EXPECT_EQ(defaultFeeCalculator.calculate(1ull, 2ull, 10ull), 2260ull);
+    EXPECT_EQ(defaultFeeCalculator.calculateSingleInput(1ull), 0ull);
 }
 
 TEST(BitcoinFeeCalculator, DecredCalculate) {
     const FeeCalculator& feeCalculator = getFeeCalculator(TWCoinTypeDecred);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 1), 254);
-    EXPECT_EQ(feeCalculator.calculate(0, 0, 1), 12);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 10), 2540);
-    EXPECT_EQ(feeCalculator.calculateSingleInput(1), 166);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, 1ull), 254ull);
+    EXPECT_EQ(feeCalculator.calculate(0ull, 0ull, 1ull), 12ull);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, 10ull), 2540ull);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(1ull), 166ull);
 }
 
 TEST(BitcoinFeeCalculator, DecredCalculateNoDustFilter) {
     const FeeCalculator& feeCalculator = getFeeCalculator(TWCoinTypeDecred, true);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 1), 254);
-    EXPECT_EQ(feeCalculator.calculate(0, 0, 1), 12);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 10), 2540);
-    EXPECT_EQ(feeCalculator.calculateSingleInput(1), 0);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, 1ull), 254ull);
+    EXPECT_EQ(feeCalculator.calculate(0ull, 0ull, 1ull), 12ull);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, 10ull), 2540ull);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(1ull), 0ull);
 }
 
 } // namespace TW::Bitcoin

--- a/tests/chains/Bitcoin/InputSelectorTests.cpp
+++ b/tests/chains/Bitcoin/InputSelectorTests.cpp
@@ -12,492 +12,492 @@
 namespace TW::Bitcoin {
 
 TEST(BitcoinInputSelector, SelectUnspents1) {
-    auto utxos = buildTestUTXOs({4000, 2000, 6000, 1000, 11000, 12000});
+    auto utxos = buildTestUTXOs({4000ull, 2000ull, 6000ull, 1000ull, 11000ull, 12000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(5000, 1);
+    auto selected = selector.select(5000ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {11000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {11000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectUnspents2) {
-    auto utxos = buildTestUTXOs({4000, 2000, 6000, 1000, 50000, 120000});
+    auto utxos = buildTestUTXOs({4000ull, 2000ull, 6000ull, 1000ull, 50000ull, 120000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(10000, 1);
+    auto selected = selector.select(10000ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {50000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {50000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectUnspents3) {
-    auto utxos = buildTestUTXOs({4000, 2000, 5000});
+    auto utxos = buildTestUTXOs({4000ull, 2000ull, 5000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(6000, 1);
+    auto selected = selector.select(6000ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {4000, 5000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {4000ull, 5000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectUnspents4) {
-    auto utxos = buildTestUTXOs({40000, 30000, 30000});
+    auto utxos = buildTestUTXOs({40000ull, 30000ull, 30000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(50000, 1);
+    auto selected = selector.select(50000ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {30000, 40000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {30000ull, 40000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectUnspents5) {
-    auto utxos = buildTestUTXOs({1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000});
+    auto utxos = buildTestUTXOs({1000ull, 2000ull, 3000ull, 4000ull, 5000ull, 6000ull, 7000ull, 8000ull, 9000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(28000, 1);
+    auto selected = selector.select(28000ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {6000, 7000, 8000, 9000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {6000ull, 7000ull, 8000ull, 9000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectUnspents5_simple) {
-    auto utxos = buildTestUTXOs({1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000});
+    auto utxos = buildTestUTXOs({1000ull, 2000ull, 3000ull, 4000ull, 5000ull, 6000ull, 7000ull, 8000ull, 9000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.selectSimple(28000, 1);
+    auto selected = selector.selectSimple(28000ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {1000ull, 2000ull, 3000ull, 4000ull, 5000ull, 6000ull, 7000ull, 8000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectUnspentsInsufficient) {
-    auto utxos = buildTestUTXOs({4000, 4000, 4000});
+    auto utxos = buildTestUTXOs({4000ull, 4000ull, 4000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(15000, 1);
+    auto selected = selector.select(15000ull, 1ull);
 
     EXPECT_TRUE(verifySelectedUTXOs(selected, {}));
 }
 
 TEST(BitcoinInputSelector, SelectCustomCase) {
-    auto utxos = buildTestUTXOs({794121, 2289357});
+    auto utxos = buildTestUTXOs({794121ull, 2289357ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(2287189, 61);
+    auto selected = selector.select(2287189ull, 61ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {794121, 2289357}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {794121ull, 2289357ull}));
 }
 
 TEST(BitcoinInputSelector, SelectNegativeNoUTXOs) {
     auto utxos = buildTestUTXOs({});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(100000, 1);
+    auto selected = selector.select(100000ull, 1ull);
 
     EXPECT_TRUE(verifySelectedUTXOs(selected, {}));
 }
 
 TEST(BitcoinInputSelector, SelectNegativeTarget0) {
-    auto utxos = buildTestUTXOs({100'000});
+    auto utxos = buildTestUTXOs({100'000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(0, 1);
+    auto selected = selector.select(0ull, 1ull);
 
     EXPECT_TRUE(verifySelectedUTXOs(selected, {}));
 }
 
 TEST(BitcoinInputSelector, SelectOneTypical) {
-    auto utxos = buildTestUTXOs({100'000});
+    auto utxos = buildTestUTXOs({100'000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(50'000, 1);
+    auto selected = selector.select(50'000ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectOneInsufficient) {
-    auto utxos = buildTestUTXOs({100'000});
+    auto utxos = buildTestUTXOs({100'000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(200'000, 1);
+    auto selected = selector.select(200'000ull, 1ull);
 
     EXPECT_TRUE(verifySelectedUTXOs(selected, {}));
 }
 
 TEST(BitcoinInputSelector, SelectOneInsufficientEqual) {
-    auto utxos = buildTestUTXOs({100'000});
+    auto utxos = buildTestUTXOs({100'000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(100'000, 1);
+    auto selected = selector.select(100'000ull, 1ull);
 
     // `InputSelector` returns the entire list of UTXOs even if they are not enough.
     // That's because `InputSelector` has a rough segwit fee estimation algorithm, and the UTXOs can actually be enough.
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectOneInsufficientHigher) {
-    auto utxos = buildTestUTXOs({100'000});
+    auto utxos = buildTestUTXOs({100'000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(99'900, 1);
+    auto selected = selector.select(99'900ull, 1ull);
 
     // `InputSelector` returns the entire list of UTXOs even if they are not enough.
     // That's because `InputSelector` has a rough segwit fee estimation algorithm, and the UTXOs can actually be enough.
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectOneInsufficientHigherFilterDust) {
-    auto utxos = buildTestUTXOs({22, 100'000, 40});
+    auto utxos = buildTestUTXOs({22ull, 100'000ull, 40ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(99'900, 1);
+    auto selected = selector.select(99'900ull, 1ull);
 
     // `InputSelector` returns the entire list of UTXOs even if they are not enough.
     // That's because `InputSelector` has a rough segwit fee estimation algorithm, and the UTXOs can actually be enough.
     // However, the list of result UTXOs does not include dust inputs.
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectOneFitsExactly) {
-    auto utxos = buildTestUTXOs({100'000});
+    auto utxos = buildTestUTXOs({100'000ull});
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
     auto selector = InputSelector<UTXO>(utxos);
-    auto expectedFee = 174;
-    auto selected = selector.select(100'000 - expectedFee, 1);
+    const Amount expectedFee = 174ull;
+    auto selected = selector.select(100'000ull - expectedFee, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000ull}));
 
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 1), expectedFee);
-    EXPECT_EQ(feeCalculator.calculate(1, 1, 1), 143);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, 1ull), expectedFee);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 1ull, 1ull), 143ull);
 
     // 1 sat more and does not fit any more.
     // However, `InputSelector` returns the entire list of UTXOs even if they are not enough.
     // That's because `InputSelector` has a rough segwit fee estimation algorithm, and the UTXOs can actually be enough.
-    selected = selector.select(100'000 - expectedFee + 1, 1);
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000}));
+    selected = selector.select(100'000ull - expectedFee + 1ull, 1ull);
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectOneFitsExactlyHighfee) {
-    auto utxos = buildTestUTXOs({100'000});
+    auto utxos = buildTestUTXOs({100'000ull});
 
-    const auto byteFee = 10;
+    const Amount byteFee = 10ull;
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
     auto selector = InputSelector<UTXO>(utxos);
-    auto expectedFee = 1740;
-    auto selected = selector.select(100'000 - expectedFee, byteFee);
+    const Amount expectedFee = 1740ull;
+    auto selected = selector.select(100'000ull - expectedFee, byteFee);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000ull}));
 
-    EXPECT_EQ(feeCalculator.calculate(1, 2, byteFee), expectedFee);
-    EXPECT_EQ(feeCalculator.calculate(1, 1, byteFee), 1430);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, byteFee), expectedFee);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 1ull, byteFee), 1430ull);
 
     // 1 sat more and does not fit any more.
     // However, `InputSelector` returns the entire list of UTXOs even if they are not enough.
     // That's because `InputSelector` has a rough segwit fee estimation algorithm, and the UTXOs can actually be enough.
-    selected = selector.select(100'000 - expectedFee + 1, byteFee);
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000}));
+    selected = selector.select(100'000ull - expectedFee + 1ull, byteFee);
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectThreeNoDust) {
-    auto utxos = buildTestUTXOs({100'000, 70'000, 75'000});
+    auto utxos = buildTestUTXOs({100'000ull, 70'000ull, 75'000ull});
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(100'000 - 174 - 10, 1);
+    auto selected = selector.select(100'000ull - 174ull - 10ull, 1ull);
 
     // 100'000 would fit with dust; instead two UTXOs are selected not to leave dust
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {75'000, 100'000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {75'000ull, 100'000ull}));
 
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 1), 174);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, 1ull), 174ull);
 
-    const auto dustLimit = 102;
+    const Amount dustLimit = 102ull;
     // Now 100'000 fits with no dust
-    selected = selector.select(100'000 - 174 - dustLimit, 1);
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000}));
+    selected = selector.select(100'000ull - 174ull - dustLimit, 1ull);
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000ull}));
 
     // One more and we are over dust limit
-    selected = selector.select(100'000 - 174 - dustLimit + 1, 1);
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {75'000, 100'000}));
+    selected = selector.select(100'000ull - 174ull - dustLimit + 1ull, 1ull);
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {75'000ull, 100'000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectTwoFirstEnough) {
-    auto utxos = buildTestUTXOs({20'000, 80'000});
+    auto utxos = buildTestUTXOs({20'000ull, 80'000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(15'000, 1);
+    auto selected = selector.select(15'000ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {20'000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {20'000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectTwoSecondEnough) {
-    auto utxos = buildTestUTXOs({20'000, 80'000});
+    auto utxos = buildTestUTXOs({20'000ull, 80'000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(70'000, 1);
+    auto selected = selector.select(70'000ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {80'000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {80'000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectTwoBoth) {
-    auto utxos = buildTestUTXOs({20'000, 80'000});
+    auto utxos = buildTestUTXOs({20'000ull, 80'000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(90'000, 1);
+    auto selected = selector.select(90'000ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {20'000, 80'000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {20'000ull, 80'000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectTwoFirstEnoughButSecond) {
-    auto utxos = buildTestUTXOs({20'000, 22'000});
+    auto utxos = buildTestUTXOs({20'000ull, 22'000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(18'000, 1);
+    auto selected = selector.select(18'000ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {22'000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {22'000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectTenThree) {
-    auto utxos = buildTestUTXOs({1'000, 2'000, 100'000, 3'000, 4'000, 5'000, 125'000, 6'000, 150'000, 7'000});
+    auto utxos = buildTestUTXOs({1'000ull, 2'000ull, 100'000ull, 3'000ull, 4'000ull, 5'000ull, 125'000ull, 6'000ull, 150'000ull, 7'000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(300'000, 1);
+    auto selected = selector.select(300'000ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000, 125'000, 150'000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000ull, 125'000ull, 150'000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectTenThree_simple1) {
-    auto utxos = buildTestUTXOs({1'000, 2'000, 100'000, 3'000, 4'000, 5'000, 125'000, 6'000, 150'000, 7'000});
+    auto utxos = buildTestUTXOs({1'000ull, 2'000ull, 100'000ull, 3'000ull, 4'000ull, 5'000ull, 125'000ull, 6'000ull, 150'000ull, 7'000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.selectSimple(300'000, 1);
+    auto selected = selector.selectSimple(300'000ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {1'000, 2'000, 100'000, 3'000, 4'000, 5'000, 125'000, 6'000, 150'000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {1'000ull, 2'000ull, 100'000ull, 3'000ull, 4'000ull, 5'000ull, 125'000ull, 6'000ull, 150'000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectTenThree_simple2) {
-    auto utxos = buildTestUTXOs({150'000, 125'000, 100'000, 7'000, 6'000, 5'000, 4'000, 3'000, 2'000, 1'000});
+    auto utxos = buildTestUTXOs({150'000ull, 125'000ull, 100'000ull, 7'000ull, 6'000ull, 5'000ull, 4'000ull, 3'000ull, 2'000ull, 1'000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.selectSimple(300'000, 1);
+    auto selected = selector.selectSimple(300'000ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {150'000, 125'000, 100'000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {150'000ull, 125'000ull, 100'000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectTenThree_simple3) {
-    auto utxos = buildTestUTXOs({1'000, 2'000, 3'000, 4'000, 5'000, 6'000, 7'000, 100'000, 125'000, 150'000});
+    auto utxos = buildTestUTXOs({1'000ull, 2'000ull, 3'000ull, 4'000ull, 5'000ull, 6'000ull, 7'000ull, 100'000ull, 125'000ull, 150'000ull});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.selectSimple(300'000, 1);
+    auto selected = selector.selectSimple(300'000ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {1'000, 2'000, 3'000, 4'000, 5'000, 6'000, 7'000, 100'000, 125'000, 150'000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {1'000ull, 2'000ull, 3'000ull, 4'000ull, 5'000ull, 6'000ull, 7'000ull, 100'000ull, 125'000ull, 150'000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectTenThreeExact) {
-    auto utxos = buildTestUTXOs({1'000, 2'000, 100'000, 3'000, 4'000, 5'000, 125'000, 6'000, 150'000, 7'000});
+    auto utxos = buildTestUTXOs({1'000ull, 2'000ull, 100'000ull, 3'000ull, 4'000ull, 5'000ull, 125'000ull, 6'000ull, 150'000ull, 7'000ull});
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
     auto selector = InputSelector<UTXO>(utxos);
-    const auto dustLimit = 102;
-    auto selected = selector.select(375'000 - 376 - dustLimit, 1);
+    const Amount dustLimit = 102ull;
+    auto selected = selector.select(375'000ull - 376ull - dustLimit, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000, 125'000, 150'000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {100'000ull, 125'000ull, 150'000ull}));
 
-    ASSERT_EQ(feeCalculator.calculate(3, 2, 1), 376);
+    ASSERT_EQ(feeCalculator.calculate(3ull, 2ull, 1ull), 376ull);
 
     // one more, and it's too much
-    selected = selector.select(375'000 - 376 - dustLimit + 1, 1);
+    selected = selector.select(375'000ull - 376ull - dustLimit + 1ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {7'000, 100'000, 125'000, 150'000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {7'000ull, 100'000ull, 125'000ull, 150'000ull}));
 }
 
 TEST(BitcoinInputSelector, SelectMaxAmountOne) {
-    auto utxos = buildTestUTXOs({10189534});
+    auto utxos = buildTestUTXOs({10189534ull});
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.selectMaxAmount(1);
+    auto selected = selector.selectMaxAmount(1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {10189534}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {10189534ull}));
 
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 1), 174);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, 1ull), 174ull);
 }
 
 TEST(BitcoinInputSelector, SelectAllAvail) {
-    auto utxos = buildTestUTXOs({10189534});
+    auto utxos = buildTestUTXOs({10189534ull});
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.select(10189534 - 226, 1);
+    auto selected = selector.select(10189534ull - 226ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {10189534}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {10189534ull}));
 
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 1), 174);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 2ull, 1ull), 174ull);
 }
 
 TEST(BitcoinInputSelector, SelectMaxAmount5of5) {
-    auto utxos = buildTestUTXOs({400, 500, 600, 800, 1000});
+    auto utxos = buildTestUTXOs({400ull, 500ull, 600ull, 800ull, 1000ull});
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
     auto selector = InputSelector<UTXO>(utxos);
-    auto byteFee = 1;
+    const Amount byteFee = 1ull;
     auto selected = selector.selectMaxAmount(byteFee);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {400, 500, 600, 800, 1000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {400ull, 500ull, 600ull, 800ull, 1000ull}));
 
-    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 102);
-    EXPECT_EQ(feeCalculator.calculate(5, 1, byteFee), 548);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 102ull);
+    EXPECT_EQ(feeCalculator.calculate(5ull, 1ull, byteFee), 548ull);
 }
 
 TEST(BitcoinInputSelector, SelectMaxAmount4of5) {
-    auto utxos = buildTestUTXOs({400, 500, 600, 800, 1000});
+    auto utxos = buildTestUTXOs({400ull, 500ull, 600ull, 800ull, 1000ull});
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
     auto selector = InputSelector<UTXO>(utxos);
-    auto byteFee = 4;
+    const Amount byteFee = 4ull;
     auto selected = selector.selectMaxAmount(byteFee);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {500, 600, 800, 1000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {500ull, 600ull, 800ull, 1000ull}));
 
-    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 408);
-    EXPECT_EQ(feeCalculator.calculate(4, 1, byteFee), 1784);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 408ull);
+    EXPECT_EQ(feeCalculator.calculate(4ull, 1ull, byteFee), 1784ull);
 }
 
 TEST(BitcoinInputSelector, SelectMaxAmount1of5) {
-    auto utxos = buildTestUTXOs({400, 500, 600, 800, 1000});
+    auto utxos = buildTestUTXOs({400ull, 500ull, 600ull, 800ull, 1000ull});
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
     auto selector = InputSelector<UTXO>(utxos);
-    auto byteFee = 8;
+    const Amount byteFee = 8ull;
     auto selected = selector.selectMaxAmount(byteFee);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {1000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {1000ull}));
 
-    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 816);
-    EXPECT_EQ(feeCalculator.calculate(1, 1, byteFee), 1144);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 816ull);
+    EXPECT_EQ(feeCalculator.calculate(1ull, 1ull, byteFee), 1144ull);
 }
 
 TEST(BitcoinInputSelector, SelectMaxAmountNone) {
-    auto utxos = buildTestUTXOs({400, 500, 600, 800, 1000});
+    auto utxos = buildTestUTXOs({400ull, 500ull, 600ull, 800ull, 1000ull});
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
     auto selector = InputSelector<UTXO>(utxos);
-    auto byteFee = 10;
+    const Amount byteFee = 10ull;
     auto selected = selector.selectMaxAmount(byteFee);
 
     EXPECT_TRUE(verifySelectedUTXOs(selected, {}));
 
-    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 1020);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 1020ull);
 }
 
 TEST(BitcoinInputSelector, SelectMaxAmountNoUTXOs) {
     auto utxos = buildTestUTXOs({});
 
     auto selector = InputSelector<UTXO>(utxos);
-    auto selected = selector.selectMaxAmount(1);
+    auto selected = selector.selectMaxAmount(1ull);
 
     EXPECT_TRUE(verifySelectedUTXOs(selected, {}));
 }
 
 TEST(BitcoinInputSelector, SelectZcashUnspents) {
-    auto utxos = buildTestUTXOs({100000, 2592, 73774});
+    auto utxos = buildTestUTXOs({100000ull, 2592ull, 73774ull});
 
     auto selector = InputSelector<UTXO>(utxos, getFeeCalculator(TWCoinTypeZcash), std::make_shared<LegacyDustCalculator>(TWCoinTypeZcash));
-    auto selected = selector.select(10000, 1);
+    auto selected = selector.select(10000ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {73774}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {73774ull}));
 }
 
 TEST(BitcoinInputSelector, SelectGroestlUnspents) {
-    auto utxos = buildTestUTXOs({499971976});
+    auto utxos = buildTestUTXOs({499971976ull});
 
     auto selector = InputSelector<UTXO>(utxos, getFeeCalculator(TWCoinTypeZcash), std::make_shared<LegacyDustCalculator>(TWCoinTypeZcash));
-    auto selected = selector.select(499951976, 1, 1);
+    auto selected = selector.select(499951976ull, 1ull, 1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {499971976}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {499971976ull}));
 }
 
 TEST(BitcoinInputSelector, SelectZcashMaxAmount) {
-    auto utxos = buildTestUTXOs({100000, 2592, 73774});
+    auto utxos = buildTestUTXOs({100000ull, 2592ull, 73774ull});
 
     auto selector = InputSelector<UTXO>(utxos, getFeeCalculator(TWCoinTypeZcash), std::make_shared<LegacyDustCalculator>(TWCoinTypeZcash));
-    auto selected = selector.selectMaxAmount(1);
+    auto selected = selector.selectMaxAmount(1ull);
 
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {100000, 2592, 73774}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {100000ull, 2592ull, 73774ull}));
 }
 
 TEST(BitcoinInputSelector, SelectZcashMaxUnspents2) {
-    auto utxos = buildTestUTXOs({100000, 2592, 73774});
+    auto utxos = buildTestUTXOs({100000ull, 2592ull, 73774ull});
 
     auto selector = InputSelector<UTXO>(utxos, getFeeCalculator(TWCoinTypeZcash), std::make_shared<LegacyDustCalculator>(TWCoinTypeZcash));
-    auto selected = selector.select(176366 - 6, 1);
+    auto selected = selector.select(176366ull - 6ull, 1ull);
 
     // `InputSelector` returns the entire list of UTXOs even if they are not enough.
     // That's because `InputSelector` has a rough segwit fee estimation algorithm, and the UTXOs can actually be enough.
-    EXPECT_TRUE(verifySelectedUTXOs(selected, {2592, 73774, 100000}));
+    EXPECT_TRUE(verifySelectedUTXOs(selected, {2592ull, 73774ull, 100000ull}));
 }
 
 TEST(BitcoinInputSelector, ManyUtxos_900) {
     const auto n = 900;
-    const auto byteFee = 10;
-    std::vector<int64_t> values;
-    uint64_t valueSum = 0;
+    const Amount byteFee = 10ull;
+    std::vector<Amount> values;
+    Amount valueSum = 0ull;
     for (int i = 0; i < n; ++i) {
-        const uint64_t val = (i + 1) * 100;
+        const Amount val = static_cast<Amount>(i + 1) * 100ull;
         values.push_back(val);
         valueSum += val;
     }
-    const uint64_t requestedAmount = valueSum / 8;
-    EXPECT_EQ(requestedAmount, 5'068'125ul);
+    const Amount requestedAmount = valueSum / 8ull;
+    EXPECT_EQ(requestedAmount, 5'068'125ull);
     auto utxos = buildTestUTXOs(values);
 
     auto selector = InputSelector<UTXO>(utxos);
     auto selected = selector.select(requestedAmount, byteFee);
 
     // expected result: 59 utxos, with the largest amounts
-    std::vector<int64_t> subset;
-    uint64_t subsetSum = 0;
+    std::vector<Amount> subset;
+    Amount subsetSum = 0ull;
     for (int i = n - 59; i < n; ++i) {
-        const uint64_t val = (i + 1) * 100;
+        const Amount val = static_cast<Amount>(i + 1) * 100ull;
         subset.push_back(val);
         subsetSum += val;
     }
-    EXPECT_EQ(subset.size(), 59ul);
-    EXPECT_EQ(subsetSum, 5'138'900ul);
+    EXPECT_EQ(subset.size(), 59ull);
+    EXPECT_EQ(subsetSum, 5'138'900ull);
     EXPECT_TRUE(verifySelectedUTXOs(selected, subset));
 }
 
 TEST(BitcoinInputSelector, ManyUtxos_5000_simple) {
     const auto n = 5000;
-    const auto byteFee = 10;
-    std::vector<int64_t> values;
-    uint64_t valueSum = 0;
+    const Amount byteFee = 10ull;
+    std::vector<Amount> values;
+    Amount valueSum = 0ull;
     for (int i = 0; i < n; ++i) {
-        const uint64_t val = (i + 1) * 100;
+        const Amount val = static_cast<Amount>(i + 1) * 100ull;
         values.push_back(val);
         valueSum += val;
     }
-    const uint64_t requestedAmount = valueSum / 20;
-    EXPECT_EQ(requestedAmount, 62'512'500ul);
+    const Amount requestedAmount = valueSum / 20ull;
+    EXPECT_EQ(requestedAmount, 62'512'500ull);
     auto utxos = buildTestUTXOs(values);
 
     auto selector = InputSelector<UTXO>(utxos);
     auto selected = selector.selectSimple(requestedAmount, byteFee);
 
     // expected result: 1205 utxos, with the smaller amounts (except the very small dust ones)
-    std::vector<int64_t> subset;
-    uint64_t subsetSum = 0;
+    std::vector<Amount> subset;
+    Amount subsetSum = 0ull;
     for (int i = 10; i < 1205 + 10; ++i) {
-        const uint64_t val = (i + 1) * 100;
+        const Amount val = static_cast<Amount>(i + 1) * 100ull;
         subset.push_back(val);
         subsetSum += val;
     }
-    EXPECT_EQ(subset.size(), 1205ul);
-    EXPECT_EQ(subsetSum, 73'866'500ul);
+    EXPECT_EQ(subset.size(), 1205ull);
+    EXPECT_EQ(subsetSum, 73'866'500ull);
     EXPECT_TRUE(verifySelectedUTXOs(selected, subset));
 }
 
 TEST(BitcoinInputSelector, ManyUtxos_MaxAmount_5000) {
     const auto n = 5000;
-    const auto byteFee = 10;
-    std::vector<int64_t> values;
+    const Amount byteFee = 10ull;
+    std::vector<Amount> values;
     for (int i = 0; i < n; ++i) {
-        const uint64_t val = (i + 1) * 100;
+        const Amount val = static_cast<Amount>(i + 1) * 100ull;
         values.push_back(val);
     }
     auto utxos = buildTestUTXOs(values);
@@ -506,15 +506,15 @@ TEST(BitcoinInputSelector, ManyUtxos_MaxAmount_5000) {
     auto selected = selector.selectMaxAmount(byteFee);
 
     // expected result: 4990 utxos (none of which is dust)
-    std::vector<int64_t> subset;
-    uint64_t subsetSum = 0;
+    std::vector<Amount> subset;
+    Amount subsetSum = 0ull;
     for (int i = 10; i < 4990 + 10; ++i) {
-        const uint64_t val = (i + 1) * 100;
+        const Amount val = static_cast<Amount>(i + 1) * 100ull;
         subset.push_back(val);
         subsetSum += val;
     }
-    EXPECT_EQ(subset.size(), 4990ul);
-    EXPECT_EQ(subsetSum, 1'250'244'500ul);
+    EXPECT_EQ(subset.size(), 4990ull);
+    EXPECT_EQ(subsetSum, 1'250'244'500ull);
     EXPECT_TRUE(verifySelectedUTXOs(selected, subset));
 }
 

--- a/tests/chains/Bitcoin/TWBitcoinSigningTests.cpp
+++ b/tests/chains/Bitcoin/TWBitcoinSigningTests.cpp
@@ -369,6 +369,212 @@ TEST(BitcoinSigning, SignMaxAmount) {
     EXPECT_EQ(output0.value(), amountWithoutFee);
 }
 
+TEST(BitcoinSigning, SignNegativeUtxoAmount) {
+    const auto privateKey = parse_hex("4646464646464646464646464646464646464646464646464646464646464646");
+    const auto ownAddress = "bc1qhkfq3zahaqkkzx5mjnamwjsfpq2jk7z00ppggv";
+
+    const auto revUtxoHash0 =
+        parse_hex("07c42b969286be06fae38528c85f0a1ce508d4df837eb5ac4cf5f2a7a9d65fa8");
+    const auto inPubKey0 =
+        parse_hex("024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382");
+    const auto inPubKeyHash0 = parse_hex("bd92088bb7e82d611a9b94fbb74a0908152b784f");
+    const auto utxoScript0 = parse_hex("0014bd92088bb7e82d611a9b94fbb74a0908152b784f");
+
+    const auto initialAmount = 10'189'533;
+
+    Proto::SigningInput signingInput;
+    signingInput.set_coin_type(TWCoinTypeBitcoin);
+    signingInput.set_hash_type(TWBitcoinSigHashTypeAll);
+    signingInput.set_amount(initialAmount);
+    signingInput.set_byte_fee(1);
+    signingInput.set_to_address("bc1q2dsdlq3343vk29runkgv4yc292hmq53jedfjmp");
+    signingInput.set_change_address(ownAddress);
+    signingInput.set_use_max_amount(true);
+
+    *signingInput.add_private_key() = std::string(privateKey.begin(), privateKey.end());
+
+    // Add UTXO
+    auto utxo = signingInput.add_utxo();
+    utxo->set_script(utxoScript0.data(), utxoScript0.size());
+    utxo->set_amount(-10'000ll);
+    utxo->mutable_out_point()->set_hash(
+        std::string(revUtxoHash0.begin(), revUtxoHash0.end()));
+    utxo->mutable_out_point()->set_index(0);
+    utxo->mutable_out_point()->set_sequence(UINT32_MAX);
+
+    // Plan
+    Proto::TransactionPlan plan;
+    ANY_PLAN(signingInput, plan, TWCoinTypeBitcoin);
+    // An exception must be caught gracefully.
+    EXPECT_EQ(plan.error(), Common::Proto::Error_invalid_params);
+
+    // Sign
+    Proto::SigningOutput output;
+    ANY_SIGN(signingInput, TWCoinTypeBitcoin);
+    // An exception must be caught gracefully.
+    EXPECT_EQ(output.error(), Common::Proto::Error_invalid_params);
+}
+
+TEST(BitcoinSigning, SignUtxoAmountSumExceedsInt64) {
+    const auto privateKey = parse_hex("4646464646464646464646464646464646464646464646464646464646464646");
+    const auto ownAddress = "bc1qhkfq3zahaqkkzx5mjnamwjsfpq2jk7z00ppggv";
+
+    const auto revUtxoHash0 =
+        parse_hex("07c42b969286be06fae38528c85f0a1ce508d4df837eb5ac4cf5f2a7a9d65fa8");
+    const auto inPubKey0 =
+        parse_hex("024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382");
+    const auto inPubKeyHash0 = parse_hex("bd92088bb7e82d611a9b94fbb74a0908152b784f");
+    const auto utxoScript0 = parse_hex("0014bd92088bb7e82d611a9b94fbb74a0908152b784f");
+
+    const auto initialAmount = 10'189'533;
+
+    Proto::SigningInput signingInput;
+    signingInput.set_coin_type(TWCoinTypeBitcoin);
+    signingInput.set_hash_type(TWBitcoinSigHashTypeAll);
+    signingInput.set_amount(initialAmount);
+    signingInput.set_byte_fee(1);
+    signingInput.set_to_address("bc1q2dsdlq3343vk29runkgv4yc292hmq53jedfjmp");
+    signingInput.set_change_address(ownAddress);
+    signingInput.set_use_max_amount(true);
+
+    *signingInput.add_private_key() = std::string(privateKey.begin(), privateKey.end());
+
+    // Add UTXO
+    auto utxo1 = signingInput.add_utxo();
+    utxo1->set_script(utxoScript0.data(), utxoScript0.size());
+    utxo1->set_amount(std::numeric_limits<int64_t>::max());
+    utxo1->mutable_out_point()->set_hash(
+        std::string(revUtxoHash0.begin(), revUtxoHash0.end()));
+    utxo1->mutable_out_point()->set_index(0);
+    utxo1->mutable_out_point()->set_sequence(UINT32_MAX);
+
+    auto utxo2 = signingInput.add_utxo();
+    utxo2->set_script(utxoScript0.data(), utxoScript0.size());
+    utxo2->set_amount(std::numeric_limits<int64_t>::max());
+    utxo2->mutable_out_point()->set_hash(
+        std::string(revUtxoHash0.begin(), revUtxoHash0.end()));
+    utxo2->mutable_out_point()->set_index(1);
+    utxo2->mutable_out_point()->set_sequence(UINT32_MAX);
+
+    // Plan
+    Proto::TransactionPlan plan;
+    ANY_PLAN(signingInput, plan, TWCoinTypeBitcoin);
+    // An exception must be caught gracefully.
+    EXPECT_EQ(plan.error(), Common::Proto::Error_invalid_params);
+
+    // Sign
+    Proto::SigningOutput output;
+    ANY_SIGN(signingInput, TWCoinTypeBitcoin);
+    // An exception must be caught gracefully.
+    EXPECT_EQ(output.error(), Common::Proto::Error_invalid_params);
+}
+
+TEST(BitcoinSigning, SignUtxoAmountOverflow) {
+    const auto privateKey = parse_hex("4646464646464646464646464646464646464646464646464646464646464646");
+    const auto ownAddress = "bc1qhkfq3zahaqkkzx5mjnamwjsfpq2jk7z00ppggv";
+
+    const auto revUtxoHash0 =
+        parse_hex("07c42b969286be06fae38528c85f0a1ce508d4df837eb5ac4cf5f2a7a9d65fa8");
+    const auto inPubKey0 =
+        parse_hex("024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382");
+    const auto inPubKeyHash0 = parse_hex("bd92088bb7e82d611a9b94fbb74a0908152b784f");
+    const auto utxoScript0 = parse_hex("0014bd92088bb7e82d611a9b94fbb74a0908152b784f");
+
+    const auto initialAmount = 10'189'533;
+
+    Proto::SigningInput signingInput;
+    signingInput.set_coin_type(TWCoinTypeBitcoin);
+    signingInput.set_hash_type(TWBitcoinSigHashTypeAll);
+    signingInput.set_amount(initialAmount);
+    signingInput.set_byte_fee(1);
+    signingInput.set_to_address("bc1q2dsdlq3343vk29runkgv4yc292hmq53jedfjmp");
+    signingInput.set_change_address(ownAddress);
+    signingInput.set_use_max_amount(true);
+
+    *signingInput.add_private_key() = std::string(privateKey.begin(), privateKey.end());
+
+    // Add UTXO
+    auto utxo1 = signingInput.add_utxo();
+    utxo1->set_script(utxoScript0.data(), utxoScript0.size());
+    utxo1->set_amount(std::numeric_limits<int64_t>::max());
+    utxo1->mutable_out_point()->set_hash(
+        std::string(revUtxoHash0.begin(), revUtxoHash0.end()));
+    utxo1->mutable_out_point()->set_index(0);
+    utxo1->mutable_out_point()->set_sequence(UINT32_MAX);
+
+    auto utxo2 = signingInput.add_utxo();
+    utxo2->set_script(utxoScript0.data(), utxoScript0.size());
+    utxo2->set_amount(std::numeric_limits<int64_t>::max());
+    utxo2->mutable_out_point()->set_hash(
+        std::string(revUtxoHash0.begin(), revUtxoHash0.end()));
+    utxo2->mutable_out_point()->set_index(1);
+    utxo2->mutable_out_point()->set_sequence(UINT32_MAX);
+
+    auto utxo3 = signingInput.add_utxo();
+    utxo3->set_script(utxoScript0.data(), utxoScript0.size());
+    utxo3->set_amount(10'000ll);
+    utxo3->mutable_out_point()->set_hash(
+        std::string(revUtxoHash0.begin(), revUtxoHash0.end()));
+    utxo3->mutable_out_point()->set_index(2);
+    utxo3->mutable_out_point()->set_sequence(UINT32_MAX);
+
+    // Plan
+    Proto::TransactionPlan plan;
+    ANY_PLAN(signingInput, plan, TWCoinTypeBitcoin);
+    // An exception must be caught gracefully.
+    EXPECT_EQ(plan.error(), Common::Proto::Error_invalid_params);
+
+    // Sign
+    Proto::SigningOutput output;
+    ANY_SIGN(signingInput, TWCoinTypeBitcoin);
+    // An exception must be caught gracefully.
+    EXPECT_EQ(output.error(), Common::Proto::Error_invalid_params);
+}
+
+TEST(BitcoinSigning, SignNegativeOutputAmount) {
+    const auto privateKey = parse_hex("4646464646464646464646464646464646464646464646464646464646464646");
+    const auto ownAddress = "bc1qhkfq3zahaqkkzx5mjnamwjsfpq2jk7z00ppggv";
+
+    const auto revUtxoHash0 =
+        parse_hex("07c42b969286be06fae38528c85f0a1ce508d4df837eb5ac4cf5f2a7a9d65fa8");
+    const auto inPubKey0 =
+        parse_hex("024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382");
+    const auto inPubKeyHash0 = parse_hex("bd92088bb7e82d611a9b94fbb74a0908152b784f");
+    const auto utxoScript0 = parse_hex("0014bd92088bb7e82d611a9b94fbb74a0908152b784f");
+
+    Proto::SigningInput signingInput;
+    signingInput.set_coin_type(TWCoinTypeBitcoin);
+    signingInput.set_hash_type(TWBitcoinSigHashTypeAll);
+    signingInput.set_amount(-10'000);
+    signingInput.set_byte_fee(1);
+    signingInput.set_to_address("bc1q2dsdlq3343vk29runkgv4yc292hmq53jedfjmp");
+    signingInput.set_change_address(ownAddress);
+    signingInput.set_use_max_amount(true);
+
+    *signingInput.add_private_key() = std::string(privateKey.begin(), privateKey.end());
+
+    // Add UTXO
+    auto utxo1 = signingInput.add_utxo();
+    utxo1->set_script(utxoScript0.data(), utxoScript0.size());
+    utxo1->set_amount(4863);
+    utxo1->mutable_out_point()->set_hash(
+        std::string(revUtxoHash0.begin(), revUtxoHash0.end()));
+    utxo1->mutable_out_point()->set_index(0);
+    utxo1->mutable_out_point()->set_sequence(UINT32_MAX);
+
+    // Plan
+    Proto::TransactionPlan plan;
+    ANY_PLAN(signingInput, plan, TWCoinTypeBitcoin);
+    // An exception must be caught gracefully.
+    EXPECT_EQ(plan.error(), Common::Proto::Error_invalid_params);
+
+    // Sign
+    Proto::SigningOutput output;
+    ANY_SIGN(signingInput, TWCoinTypeBitcoin);
+    // An exception must be caught gracefully.
+    EXPECT_EQ(output.error(), Common::Proto::Error_invalid_params);
+}
+
 // Tests the BitcoinV2 API through the legacy `SigningInput`.
 TEST(BitcoinSigning, SignBRC20TransferCommitV2) {
     auto privateKey = parse_hex("e253373989199da27c48680e3a3fc0f648d50f9a727ef17a7fe6a4dc3b159129");

--- a/tests/chains/Bitcoin/TWBitcoinSigningTests.cpp
+++ b/tests/chains/Bitcoin/TWBitcoinSigningTests.cpp
@@ -40,8 +40,8 @@ SigningInput buildInputP2PKH(bool omitKey = false) {
     // Setup input
     SigningInput input;
     input.hashType = hashTypeForCoin(TWCoinTypeBitcoin);
-    input.amount = 335'790'000;
-    input.byteFee = 1;
+    input.amount = 335'790'000ull;
+    input.byteFee = 1ull;
     input.toAddress = "1Bp9U1ogV3A14FMvKbRJms7ctyso4Z4Tcx";
     input.changeAddress = "1FQc5LdgGHMHEN9nwkjmz6tWkxhPpxBvBU";
     input.coinType = TWCoinTypeBitcoin;
@@ -69,14 +69,14 @@ SigningInput buildInputP2PKH(bool omitKey = false) {
 
     UTXO utxo0;
     utxo0.script = utxo0Script;
-    utxo0.amount = 625'000'000;
+    utxo0.amount = 625'000'000ull;
     utxo0.outPoint = OutPoint(hash0, 0, UINT32_MAX);
     input.utxos.push_back(utxo0);
 
     UTXO utxo1;
     utxo1.script = Script(parse_hex("0014"
                                     "1d0f172a0ecb48aee1be1f2687d2963ae33f71a1"));
-    utxo1.amount = 600'000'000;
+    utxo1.amount = 600'000'000ull;
     utxo1.outPoint = OutPoint(hash1, 1, UINT32_MAX);
     input.utxos.push_back(utxo1);
 
@@ -94,15 +94,15 @@ TEST(BitcoinSigning, SpendMinimumAmountP2WPKH) {
     auto utxoHash = parse_hex("e8b3c2d0d5851cef139d87dfb5794db8897ce90ce1b6961526f61923baf5b5a3");
     std::reverse(utxoHash.begin(), utxoHash.end());
 
-    auto segwitDustAmount = 294;
+    auto segwitDustAmount = 294ull;
 
     // Setup input
     SigningInput input;
     input.hashType = hashTypeForCoin(TWCoinTypeBitcoin);
-    input.amount = 546;
+    input.amount = 546ull;
     input.useMaxAmount = false;
     input.useMaxUtxo = true;
-    input.byteFee = 27;
+    input.byteFee = 27ull;
     input.toAddress = "bc1qvrt7ukvhvmdny0a3j9k8l8jasx92lrqm30t2u2";
     input.changeAddress = "bc1qvrt7ukvhvmdny0a3j9k8l8jasx92lrqm30t2u2";
     input.coinType = TWCoinTypeBitcoin;
@@ -119,15 +119,15 @@ TEST(BitcoinSigning, SpendMinimumAmountP2WPKH) {
 
     UTXO utxo1;
     utxo1.script = redeemScript;
-    utxo1.amount = 16776;
+    utxo1.amount = 16776ull;
     utxo1.outPoint = OutPoint(utxoHash, 1, UINT32_MAX);
     input.utxos.push_back(utxo1);
 
     {
         // test plan (but do not reuse plan result)
         auto plan = TransactionBuilder::plan(input);
-        EXPECT_TRUE(verifyPlan(plan, {294, 16776}, 546, 5643));
-        EXPECT_EQ(plan.change, 10881);
+        EXPECT_TRUE(verifyPlan(plan, {294, 16776}, 546ull, 5643ull));
+        EXPECT_EQ(plan.change, 10881ull);
     }
 
     // Signs
@@ -149,9 +149,9 @@ TEST(BitcoinSigning, ExtraOutputs) {
     auto privateKey = parse_hex("e253373989199da27c48680e3a3fc0f648d50f9a727ef17a7fe6a4dc3b159129");
     auto ownAddress = "1MhdctqCwYMn2DT4mshpwvYtfF98wBojXS";
     auto toAddress = "1PRuxNSZwUXym6A31kmrArdT2BGJiTna19";
-    auto utxoAmount = 10000;
-    auto toAmount = 2000;
-    int byteFee = 6;
+    const Amount utxoAmount = 10000ull;
+    const Amount toAmount = 2000ull;
+    const Amount byteFee = 6ull;
 
     auto signingInput = Proto::SigningInput();
     signingInput.set_hash_type(TWBitcoinSigHashTypeAll);
@@ -174,11 +174,11 @@ TEST(BitcoinSigning, ExtraOutputs) {
 
     auto& output1 = *signingInput.add_extra_outputs();
     output1.set_to_address("bc1qkm0awulcn94gmtjwzwkvnpflc3ytt7a6cjentn");
-    output1.set_amount(2000UL);
+    output1.set_amount(2000ull);
 
     auto& output2 = *signingInput.add_extra_outputs();
     output2.set_to_address("bc1pqa49cxxdqyr49nwe2379tq4xsc4e8qe8mdxyjx3mprnftcde0v4s3lnhzq");
-    output2.set_amount(2000UL);
+    output2.set_amount(2000ull);
 
     Proto::TransactionPlan plan;
     ANY_PLAN(signingInput, plan, TWCoinTypeBitcoin);
@@ -207,9 +207,9 @@ TEST(BitcoinSigning, ExtraOutputsExceedAvailableAmount) {
     auto privateKey = parse_hex("e253373989199da27c48680e3a3fc0f648d50f9a727ef17a7fe6a4dc3b159129");
     auto ownAddress = "1MhdctqCwYMn2DT4mshpwvYtfF98wBojXS";
     auto toAddress = "1PRuxNSZwUXym6A31kmrArdT2BGJiTna19";
-    auto utxoAmount = 10000;
-    auto toAmount = 5999;
-    int byteFee = 6;
+    const Amount utxoAmount = 10000ull;
+    const Amount toAmount = 5999ull;
+    const Amount byteFee = 6ull;
 
     auto signingInput = Proto::SigningInput();
     signingInput.set_hash_type(TWBitcoinSigHashTypeAll);
@@ -232,11 +232,11 @@ TEST(BitcoinSigning, ExtraOutputsExceedAvailableAmount) {
 
     auto& output1 = *signingInput.add_extra_outputs();
     output1.set_to_address("bc1qkm0awulcn94gmtjwzwkvnpflc3ytt7a6cjentn");
-    output1.set_amount(2000UL);
+    output1.set_amount(2000ull);
 
     auto& output2 = *signingInput.add_extra_outputs();
     output2.set_to_address("bc1pqa49cxxdqyr49nwe2379tq4xsc4e8qe8mdxyjx3mprnftcde0v4s3lnhzq");
-    output2.set_amount(2000UL);
+    output2.set_amount(2000ull);
 
     Proto::TransactionPlan plan;
     ANY_PLAN(signingInput, plan, TWCoinTypeBitcoin);
@@ -1138,13 +1138,13 @@ TEST(BitcoinSigning, EncodeP2WSH) {
 SigningInput buildInputP2WSH(enum TWBitcoinSigHashType hashType, bool omitScript = false, bool omitKeys = false) {
     SigningInput input;
     input.hashType = hashType;
-    input.amount = 1000;
-    input.byteFee = 1;
+    input.amount = 1000ull;
+    input.byteFee = 1ull;
     input.toAddress = "1Bp9U1ogV3A14FMvKbRJms7ctyso4Z4Tcx";
     input.changeAddress = "1FQc5LdgGHMHEN9nwkjmz6tWkxhPpxBvBU";
     // Set the very low fixed Dust threshold just to fix the tests.
     // Actually, transactions in these tests have change=79 and change=52 that will lead to Dust error when broadcasting it.
-    input.dustCalculator = std::make_shared<FixedDustCalculator>(50);
+    input.dustCalculator = std::make_shared<FixedDustCalculator>(50ull);
 
     if (!omitKeys) {
         auto utxoKey0 = PrivateKey(parse_hex("ed00a0841cd53aedf89b0c616742d1d2a930f8ae2b0fb514765a17bb62c7521a"), TWCurveSECP256k1);
@@ -1163,7 +1163,7 @@ SigningInput buildInputP2WSH(enum TWBitcoinSigHashType hashType, bool omitScript
     UTXO utxo0;
     auto p2wsh = Script::buildPayToWitnessScriptHash(parse_hex("ff25429251b5a84f452230a3c75fd886b7fc5a7865ce4a7bb7a9d7c5be6da3db"));
     utxo0.script = p2wsh;
-    utxo0.amount = 1226;
+    utxo0.amount = 1226ull;
     auto hash0 = parse_hex("0001000000000000000000000000000000000000000000000000000000000000");
     utxo0.outPoint = OutPoint(hash0, 0, UINT32_MAX);
     input.utxos.push_back(utxo0);
@@ -1178,7 +1178,7 @@ TEST(BitcoinSigning, SignP2WSH) {
     {
         // test plan (but do not reuse plan result)
         auto plan = TransactionBuilder::plan(input);
-        EXPECT_TRUE(verifyPlan(plan, {1'226}, 1'000, 147));
+        EXPECT_TRUE(verifyPlan(plan, {1'226ull}, 1'000ull, 147ull));
     }
 
     // Sign
@@ -1189,7 +1189,7 @@ TEST(BitcoinSigning, SignP2WSH) {
 
     Data serialized;
     signedTx.encode(serialized);
-    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{231, 119, 147}));
+    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{231ull, 119ull, 147ull}));
     EXPECT_TRUE(validateEstimatedSize(signedTx, -1, 1));
     ASSERT_EQ(hex(serialized), // printed using prettyPrintTransaction
         "01000000" // version
@@ -1212,7 +1212,7 @@ TEST(BitcoinSigning, SignP2WSH_HashNone) {
     {
         // test plan (but do not reuse plan result)
         auto plan = TransactionBuilder::plan(input);
-        EXPECT_TRUE(verifyPlan(plan, {1'226}, 1'000, 147));
+        EXPECT_TRUE(verifyPlan(plan, {1'226ull}, 1'000ull, 147ull));
     }
 
     // Sign
@@ -1223,7 +1223,7 @@ TEST(BitcoinSigning, SignP2WSH_HashNone) {
 
     Data serialized;
     signedTx.encode(serialized);
-    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{231, 119, 147}));
+    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{231ull, 119ull, 147ull}));
     EXPECT_TRUE(validateEstimatedSize(signedTx, -1, 1));
     ASSERT_EQ(hex(serialized), // printed using prettyPrintTransaction
         "01000000" // version
@@ -1246,7 +1246,7 @@ TEST(BitcoinSigning, SignP2WSH_HashSingle) {
     {
         // test plan (but do not reuse plan result)
         auto plan = TransactionBuilder::plan(input);
-        EXPECT_TRUE(verifyPlan(plan, {1'226}, 1'000, 147));
+        EXPECT_TRUE(verifyPlan(plan, {1'226ull}, 1'000ull, 147ull));
     }
 
     // Sign
@@ -1257,7 +1257,7 @@ TEST(BitcoinSigning, SignP2WSH_HashSingle) {
 
     Data serialized;
     signedTx.encode(serialized);
-    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{230, 119, 147}));
+    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{230ull, 119ull, 147ull}));
     EXPECT_TRUE(validateEstimatedSize(signedTx, -1, 1));
     ASSERT_EQ(hex(serialized), // printed using prettyPrintTransaction
         "01000000" // version
@@ -1280,7 +1280,7 @@ TEST(BitcoinSigning, SignP2WSH_HashAnyoneCanPay) {
     {
         // test plan (but do not reuse plan result)
         auto plan = TransactionBuilder::plan(input);
-        EXPECT_TRUE(verifyPlan(plan, {1'226}, 1'000, 147));
+        EXPECT_TRUE(verifyPlan(plan, {1'226ull}, 1'000ull, 147ull));
     }
 
     // Sign
@@ -1292,7 +1292,7 @@ TEST(BitcoinSigning, SignP2WSH_HashAnyoneCanPay) {
     Data serialized;
     signedTx.encode(serialized);
     EXPECT_EQ(serialized.size(), 231ul);
-    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{231, 119, 147}));
+    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{231ull, 119ull, 147ull}));
     EXPECT_TRUE(validateEstimatedSize(signedTx, -1, 1));
     ASSERT_EQ(hex(serialized), // printed using prettyPrintTransaction
         "01000000" // version
@@ -1314,7 +1314,7 @@ TEST(BitcoinSigning, SignP2WSH_NegativeMissingScript) {
     {
         // test plan (but do not reuse plan result)
         auto plan = TransactionBuilder::plan(input);
-        EXPECT_TRUE(verifyPlan(plan, {1'226}, 1'000, 174));
+        EXPECT_TRUE(verifyPlan(plan, {1'226ull}, 1'000ull, 174ull));
     }
 
     // Sign
@@ -1330,7 +1330,7 @@ TEST(BitcoinSigning, SignP2WSH_NegativeMissingKeys) {
     {
         // test plan (but do not reuse plan result). Plan works even with missing keys.
         auto plan = TransactionBuilder::plan(input);
-        EXPECT_TRUE(verifyPlan(plan, {1'226}, 1'000, 147));
+        EXPECT_TRUE(verifyPlan(plan, {1'226ull}, 1'000ull, 147ull));
     }
 
     // Sign
@@ -1386,10 +1386,10 @@ TEST(BitcoinSigning, EncodeP2SH_P2WPKH) {
     unsignedTx.inputs.emplace_back(outpoint0, Script(), 0xfffffffe);
 
     auto outScript0 = Script(parse_hex("76a914a457b684d7f0d539a46a45bbc043f35b59d0d96388ac"));
-    unsignedTx.outputs.emplace_back(199'996'600, outScript0);
+    unsignedTx.outputs.emplace_back(199'996'600ull, outScript0);
 
     auto outScript1 = Script(parse_hex("76a914fd270b1ee6abcaea97fea7ad0402e8bd8ad6d77c88ac"));
-    unsignedTx.outputs.emplace_back(800'000'000, outScript1);
+    unsignedTx.outputs.emplace_back(800'000'000ull, outScript1);
 
     Data unsignedData;
     unsignedTx.encode(unsignedData, Transaction::SegwitFormatMode::NonSegwit);
@@ -1408,8 +1408,8 @@ SigningInput buildInputP2SH_P2WPKH(bool omitScript = false, bool omitKeys = fals
     // Setup input
     SigningInput input;
     input.hashType = hashTypeForCoin(TWCoinTypeBitcoin);
-    input.amount = 200'000'000;
-    input.byteFee = 1;
+    input.amount = 200'000'000ull;
+    input.byteFee = 1ull;
     input.toAddress = "1Bp9U1ogV3A14FMvKbRJms7ctyso4Z4Tcx";
     input.changeAddress = "1FQc5LdgGHMHEN9nwkjmz6tWkxhPpxBvBU";
     input.coinType = TWCoinTypeBitcoin;
@@ -1439,7 +1439,7 @@ SigningInput buildInputP2SH_P2WPKH(bool omitScript = false, bool omitKeys = fals
         utxo0Script = Script(parse_hex("FFFEFDFCFB"));
     }
     utxo0.script = utxo0Script;
-    utxo0.amount = 1'000'000'000;
+    utxo0.amount = 1'000'000'000ull;
     auto hash0 = parse_hex("db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a5477");
     utxo0.outPoint = OutPoint(hash0, 1, UINT32_MAX);
     input.utxos.push_back(utxo0);
@@ -1452,7 +1452,7 @@ TEST(BitcoinSigning, SignP2SH_P2WPKH) {
     {
         // test plan (but do not reuse plan result)
         auto plan = TransactionBuilder::plan(input);
-        EXPECT_TRUE(verifyPlan(plan, {1'000'000'000}, 200'000'000, 170));
+        EXPECT_TRUE(verifyPlan(plan, {1'000'000'000ull}, 200'000'000ull, 170ull));
     }
 
     // Sign
@@ -1463,7 +1463,7 @@ TEST(BitcoinSigning, SignP2SH_P2WPKH) {
 
     Data serialized;
     signedTx.encode(serialized);
-    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{251, 142, 170}));
+    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{251ull, 142ull, 170ull}));
     EXPECT_TRUE(validateEstimatedSize(signedTx, -1, 1));
     ASSERT_EQ(hex(serialized), // printed using prettyPrintTransaction
         "01000000" // version
@@ -1484,7 +1484,7 @@ TEST(BitcoinSigning, SignP2SH_P2WPKH_NegativeOmitScript) {
     {
         // test plan (but do not reuse plan result)
         auto plan = TransactionBuilder::plan(input);
-        EXPECT_TRUE(verifyPlan(plan, {1'000'000'000}, 200'000'000, 174));
+        EXPECT_TRUE(verifyPlan(plan, {1'000'000'000ull}, 200'000'000ull, 174ull));
     }
 
     // Sign
@@ -1499,7 +1499,7 @@ TEST(BitcoinSigning, SignP2SH_P2WPKH_NegativeInvalidOutputScript) {
     {
         // test plan (but do not reuse plan result)
         auto plan = TransactionBuilder::plan(input);
-        EXPECT_TRUE(verifyPlan(plan, {1'000'000'000}, 200'000'000, 174));
+        EXPECT_TRUE(verifyPlan(plan, {1'000'000'000ull}, 200'000'000ull, 174ull));
     }
 
     // Sign
@@ -1514,7 +1514,7 @@ TEST(BitcoinSigning, SignP2SH_P2WPKH_NegativeInvalidRedeemScript) {
     {
         // test plan (but do not reuse plan result)
         auto plan = TransactionBuilder::plan(input);
-        EXPECT_TRUE(verifyPlan(plan, {1'000'000'000}, 200'000'000, 174));
+        EXPECT_TRUE(verifyPlan(plan, {1'000'000'000ull}, 200'000'000ull, 174ull));
     }
 
     // Sign
@@ -1529,7 +1529,7 @@ TEST(BitcoinSigning, SignP2SH_P2WPKH_NegativeOmitKeys) {
     {
         // test plan (but do not reuse plan result). Plan works even with missing keys.
         auto plan = TransactionBuilder::plan(input);
-        EXPECT_TRUE(verifyPlan(plan, {1'000'000'000}, 200'000'000, 170));
+        EXPECT_TRUE(verifyPlan(plan, {1'000'000'000ull}, 200'000'000ull, 170ull));
     }
 
     // Sign
@@ -1547,10 +1547,10 @@ TEST(BitcoinSigning, EncodeP2SH_P2WSH) {
     unsignedTx.inputs.emplace_back(outpoint0, Script(), 0xffffffff);
 
     auto outScript0 = Script(parse_hex("76a914389ffce9cd9ae88dcc0631e88a821ffdbe9bfe2688ac"));
-    unsignedTx.outputs.emplace_back(0x0000000035a4e900, outScript0);
+    unsignedTx.outputs.emplace_back(0x0000000035a4e900ull, outScript0);
 
     auto outScript1 = Script(parse_hex("76a9147480a33f950689af511e6e84c138dbbd3c3ee41588ac"));
-    unsignedTx.outputs.emplace_back(0x00000000052f83c0, outScript1);
+    unsignedTx.outputs.emplace_back(0x00000000052f83c0ull, outScript1);
 
     Data unsignedData;
     unsignedTx.encode(unsignedData, Transaction::SegwitFormatMode::NonSegwit);
@@ -1568,7 +1568,7 @@ TEST(BitcoinSigning, EncodeP2SH_P2WSH) {
 TEST(BitcoinSigning, SignP2SH_P2WSH) {
     // Setup signing input
     SigningInput input;
-    input.amount = 900000000;
+    input.amount = 900000000ull;
     input.hashType = (TWBitcoinSigHashType)0;
     input.toAddress = "16AQVuBMt818u2HBcbxztAZTT2VTDKupPS";
     input.changeAddress = "1Bd1VA2bnLjoBk4ook3H19tZWETk8s6Ym5";
@@ -1607,13 +1607,13 @@ TEST(BitcoinSigning, SignP2SH_P2WSH) {
     UTXO utxo;
     utxo.outPoint = OutPoint(parse_hex("36641869ca081e70f394c6948e8af409e18b619df2ed74aa106c1ca29787b96e"), 1, UINT32_MAX);
     utxo.script = utxo0Script;
-    utxo.amount = 987654321;
+    utxo.amount = 987654321ull;
     input.utxos.push_back(utxo);
 
     TransactionPlan plan;
     plan.amount = input.amount;
     plan.availableAmount = input.utxos[0].amount;
-    plan.change = 87000000;
+    plan.change = 87000000ull;
     plan.fee = plan.availableAmount - plan.amount - plan.change;
     plan.utxos = input.utxos;
     input.plan = plan;
@@ -1647,7 +1647,7 @@ TEST(BitcoinSigning, SignP2SH_P2WSH) {
 
     Data serialized;
     signedTx.encode(serialized);
-    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{800, 154, 316}));
+    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{800ull, 154ull, 316ull}));
     EXPECT_TRUE(validateEstimatedSize(signedTx, -1, 1));
     ASSERT_EQ(hex(serialized), expected);
 }
@@ -1659,8 +1659,8 @@ TEST(BitcoinSigning, Sign_NegativeNoUtxos) {
     // Setup input
     SigningInput input;
     input.hashType = TWBitcoinSigHashTypeAll;
-    input.amount = 335'790'000;
-    input.byteFee = 1;
+    input.amount = 335'790'000ull;
+    input.byteFee = 1ull;
     input.toAddress = "1Bp9U1ogV3A14FMvKbRJms7ctyso4Z4Tcx";
     input.changeAddress = "1FQc5LdgGHMHEN9nwkjmz6tWkxhPpxBvBU";
 
@@ -1676,7 +1676,7 @@ TEST(BitcoinSigning, Sign_NegativeNoUtxos) {
     {
         // plan returns empty, as there are 0 utxos
         auto plan = TransactionBuilder::plan(input);
-        EXPECT_TRUE(verifyPlan(plan, {}, 0, 0, Common::Proto::Error_missing_input_utxos));
+        EXPECT_TRUE(verifyPlan(plan, {}, 0ull, 0ull, Common::Proto::Error_missing_input_utxos));
     }
 
     // Invoke Sign nonetheless
@@ -1694,8 +1694,8 @@ TEST(BitcoinSigning, Sign_NegativeInvalidAddress) {
     // Setup input
     SigningInput input;
     input.hashType = TWBitcoinSigHashTypeAll;
-    input.amount = 335'790'000;
-    input.byteFee = 1;
+    input.amount = 335'790'000ull;
+    input.byteFee = 1ull;
     input.toAddress = "THIS-IS-NOT-A-BITCOIN-ADDRESS";
     input.changeAddress = "THIS-IS-NOT-A-BITCOIN-ADDRESS-EITHER";
 
@@ -1717,21 +1717,21 @@ TEST(BitcoinSigning, Sign_NegativeInvalidAddress) {
     UTXO utxo0;
     auto utxo0Script = Script(parse_hex("2103c9f4836b9a4f77fc0d81f7bcb01b7f1b35916864b9476c241ce9fc198bd25432ac"));
     utxo0.script = utxo0Script;
-    utxo0.amount = 625'000'000;
+    utxo0.amount = 625'000'000ull;
     utxo0.outPoint = OutPoint(hash0, 0, UINT32_MAX);
     input.utxos.push_back(utxo0);
 
     UTXO utxo1;
     auto utxo1Script = Script(parse_hex("00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1"));
     utxo1.script = utxo1Script;
-    utxo1.amount = 600'000'000;
+    utxo1.amount = 600'000'000ull;
     utxo1.outPoint = OutPoint(hash1, 1, UINT32_MAX);
     input.utxos.push_back(utxo1);
 
     {
         // test plan (but do not reuse plan result)
         auto plan = TransactionBuilder::plan(std::move(input));
-        EXPECT_TRUE(verifyPlan(plan, {625'000'000}, 335'790'000, 174));
+        EXPECT_TRUE(verifyPlan(plan, {625'000'000ull}, 335'790'000ull, 174ull));
     }
 
     // Sign
@@ -1758,7 +1758,7 @@ TEST(BitcoinSigning, Plan_10input_MaxAmount) {
 
         UTXO utxo;
         utxo.script = utxoScript;
-        utxo.amount = 1'000'000 + i * 10'000;
+        utxo.amount = 1'000'000ull + i * 10'000ull;
         auto hash = parse_hex("a85fd6a9a7f2f54cacb57e83dfd408e51c0a5fc82885e3fa06be8692962bc407");
         std::reverse(hash.begin(), hash.end());
         utxo.outPoint = OutPoint(hash, 0, UINT32_MAX);
@@ -1768,8 +1768,8 @@ TEST(BitcoinSigning, Plan_10input_MaxAmount) {
     input.coinType = TWCoinTypeBitcoin;
     input.hashType = hashTypeForCoin(TWCoinTypeBitcoin);
     input.useMaxAmount = true;
-    input.amount = 2'000'000;
-    input.byteFee = 1;
+    input.amount = 2'000'000ull;
+    input.byteFee = 1ull;
     input.toAddress = "bc1qauwlpmzamwlf9tah6z4w0t8sunh6pnyyjgk0ne";
     input.changeAddress = ownAddress;
 
@@ -1777,7 +1777,7 @@ TEST(BitcoinSigning, Plan_10input_MaxAmount) {
     // Estimated size: witness size: 10 * (1 + 1 + 72 + 1 + 33) + 2 = 1082; base 451; raw 451 + 1082 = 1533; vsize 451 + 1082/4 --> 722
     // Actual size:    witness size:                                  1078; base 451; raw 451 + 1078 = 1529; vsize 451 + 1078/4 --> 721
     auto plan = TransactionBuilder::plan(input);
-    EXPECT_TRUE(verifyPlan(plan, {1'000'000, 1'010'000, 1'020'000, 1'030'000, 1'040'000, 1'050'000, 1'060'000, 1'070'000, 1'080'000, 1'090'000}, 10'449'278, 722));
+    EXPECT_TRUE(verifyPlan(plan, {1'000'000ull, 1'010'000ull, 1'020'000ull, 1'030'000ull, 1'040'000ull, 1'050'000ull, 1'060'000ull, 1'070'000ull, 1'080'000ull, 1'090'000ull}, 10'449'278ull, 722ull));
 
     // Extend input with keys, reuse plan, Sign
     auto privKey = PrivateKey(parse_hex(ownPrivateKey), TWCurveSECP256k1);
@@ -1792,7 +1792,7 @@ TEST(BitcoinSigning, Plan_10input_MaxAmount) {
 
     Data serialized;
     signedTx.encode(serialized);
-    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{1529, 451, 721}));
+    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{1529ull, 451ull, 721ull}));
     EXPECT_TRUE(validateEstimatedSize(signedTx, -1, 1));
 
     ASSERT_EQ(serialized.size(), 1529ul);
@@ -1807,9 +1807,9 @@ TEST(BitcoinSigning, Sign_LitecoinReal_a85f) {
     SigningInput input;
     input.coinType = coin;
     input.hashType = hashTypeForCoin(coin);
-    input.amount = 3'899'774;
+    input.amount = 3'899'774ull;
     input.useMaxAmount = true;
-    input.byteFee = 1;
+    input.byteFee = 1ull;
     input.toAddress = "ltc1q0dvup9kzplv6yulzgzzxkge8d35axkq4n45hum";
     input.changeAddress = ownAddress;
 
@@ -1826,7 +1826,7 @@ TEST(BitcoinSigning, Sign_LitecoinReal_a85f) {
 
     UTXO utxo0;
     utxo0.script = utxo0Script;
-    utxo0.amount = 3'900'000;
+    utxo0.amount = 3'900'000ull;
     auto hash0 = parse_hex("7051cd18189401a844abf0f9c67e791315c4c154393870453f8ad98a818efdb5");
     std::reverse(hash0.begin(), hash0.end());
     utxo0.outPoint = OutPoint(hash0, 9, UINT32_MAX - 1);
@@ -1834,13 +1834,13 @@ TEST(BitcoinSigning, Sign_LitecoinReal_a85f) {
 
     // set plan, to match real tx
     TransactionPlan plan;
-    plan.availableAmount = 3'900'000;
-    plan.amount = 3'899'774;
-    plan.fee = 226;
-    plan.change = 0;
+    plan.availableAmount = 3'900'000ull;
+    plan.amount = 3'899'774ull;
+    plan.fee = 226ull;
+    plan.change = 0ull;
     plan.utxos.push_back(input.utxos[0]);
     input.plan = plan;
-    EXPECT_TRUE(verifyPlan(input.plan.value(), {3'900'000}, 3'899'774, 226));
+    EXPECT_TRUE(verifyPlan(input.plan.value(), {3'900'000ull}, 3'899'774ull, 226ull));
 
     // Sign
     auto result = TransactionSigner<Transaction, TransactionBuilder>::sign(input);
@@ -1876,9 +1876,9 @@ TEST(BitcoinSigning, PlanAndSign_LitecoinReal_8435) {
     SigningInput input;
     input.coinType = coin;
     input.hashType = hashTypeForCoin(coin);
-    input.amount = 1'200'000;
+    input.amount = 1'200'000ull;
     input.useMaxAmount = false;
-    input.byteFee = 1;
+    input.byteFee = 1ull;
     input.toAddress = "ltc1qt36tu30tgk35tyzsve6jjq3dnhu2rm8l8v5q00";
     input.changeAddress = ownAddress;
 
@@ -1892,7 +1892,7 @@ TEST(BitcoinSigning, PlanAndSign_LitecoinReal_8435) {
 
     UTXO utxo0;
     utxo0.script = utxo0Script;
-    utxo0.amount = 3'899'774;
+    utxo0.amount = 3'899'774ull;
     auto hash0 = parse_hex("a85fd6a9a7f2f54cacb57e83dfd408e51c0a5fc82885e3fa06be8692962bc407");
     std::reverse(hash0.begin(), hash0.end());
     utxo0.outPoint = OutPoint(hash0, 0, UINT32_MAX);
@@ -1900,7 +1900,7 @@ TEST(BitcoinSigning, PlanAndSign_LitecoinReal_8435) {
 
     // Plan
     auto plan = TransactionBuilder::plan(input);
-    EXPECT_TRUE(verifyPlan(plan, {3'899'774}, 1'200'000, 141));
+    EXPECT_TRUE(verifyPlan(plan, {3'899'774ull}, 1'200'000ull, 141ull));
 
     // Extend input with keys and plan, for Sign
     auto privKey = PrivateKey(parse_hex(ownPrivateKey), TWCurveSECP256k1);
@@ -1915,7 +1915,7 @@ TEST(BitcoinSigning, PlanAndSign_LitecoinReal_8435) {
 
     Data serialized;
     signedTx.encode(serialized);
-    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{222, 113, 141}));
+    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{222ull, 113ull, 141ull}));
     EXPECT_TRUE(validateEstimatedSize(signedTx, -1, 1));
 
     // https://blockchair.com/litecoin/transaction/8435d205614ee70066060734adf03af4194d0c3bc66dd01bb124ab7fd25e2ef8
@@ -1955,7 +1955,7 @@ TEST(BitcoinSigning, Sign_ManyUtxos_400) {
 
         UTXO utxo;
         utxo.script = utxoScript;
-        utxo.amount = 1000 + (i + 1) * 10;
+        utxo.amount = 1000ull + static_cast<Amount>(i + 1) * 10ull;
         auto hash = parse_hex("a85fd6a9a7f2f54cacb57e83dfd408e51c0a5fc82885e3fa06be8692962bc407");
         std::reverse(hash.begin(), hash.end());
         utxo.outPoint = OutPoint(hash, 0, UINT32_MAX);
@@ -1967,8 +1967,8 @@ TEST(BitcoinSigning, Sign_ManyUtxos_400) {
     input.coinType = TWCoinTypeBitcoin;
     input.hashType = hashTypeForCoin(TWCoinTypeBitcoin);
     input.useMaxAmount = false;
-    input.amount = 300'000;
-    input.byteFee = 1;
+    input.amount = 300'000ull;
+    input.byteFee = 1ull;
     input.toAddress = "bc1qauwlpmzamwlf9tah6z4w0t8sunh6pnyyjgk0ne";
     input.changeAddress = ownAddress;
 
@@ -1976,16 +1976,16 @@ TEST(BitcoinSigning, Sign_ManyUtxos_400) {
     auto plan = TransactionBuilder::plan(input);
 
     // expected result: 66 utxos, with the largest amounts
-    std::vector<int64_t> subset;
-    uint64_t subsetSum = 0;
-    for (int i = n - 66; i < n; ++i) {
-        const uint64_t val = 1000 + (i + 1) * 10;
+    std::vector<Amount> subset;
+    Amount subsetSum = 0;
+    for (Amount i = n - 66; i < n; ++i) {
+        const Amount val = 1000 + (i + 1) * 10;
         subset.push_back(val);
         subsetSum += val;
     }
     EXPECT_EQ(subset.size(), 66ul);
     EXPECT_EQ(subsetSum, 308'550ul);
-    EXPECT_TRUE(verifyPlan(plan, subset, 300'000, 4'561));
+    EXPECT_TRUE(verifyPlan(plan, subset, 300'000ull, 4'561ull));
 
     // Extend input with keys, reuse plan, Sign
     auto privKey = PrivateKey(parse_hex(ownPrivateKey), TWCurveSECP256k1);
@@ -2011,9 +2011,9 @@ TEST(BitcoinSigning, Sign_ManyUtxos_2000) {
     // Setup input
     SigningInput input;
 
-    const auto n = 2000;
-    uint64_t utxoSum = 0;
-    for (int i = 0; i < n; ++i) {
+    const auto n = 2000ull;
+    Amount utxoSum = 0;
+    for (Amount i = 0; i < n; ++i) {
         auto utxoScript = Script::lockScriptForAddress(ownAddress, TWCoinTypeBitcoin);
         Data keyHash;
         EXPECT_TRUE(utxoScript.matchPayToWitnessPublicKeyHash(keyHash));
@@ -2024,7 +2024,7 @@ TEST(BitcoinSigning, Sign_ManyUtxos_2000) {
 
         UTXO utxo;
         utxo.script = utxoScript;
-        utxo.amount = 1000 + (i + 1) * 10;
+        utxo.amount = 1000ull + (i + 1ull) * 10ull;
         auto hash = parse_hex("a85fd6a9a7f2f54cacb57e83dfd408e51c0a5fc82885e3fa06be8692962bc407");
         std::reverse(hash.begin(), hash.end());
         utxo.outPoint = OutPoint(hash, 0, UINT32_MAX);
@@ -2036,8 +2036,8 @@ TEST(BitcoinSigning, Sign_ManyUtxos_2000) {
     input.coinType = TWCoinTypeBitcoin;
     input.hashType = hashTypeForCoin(TWCoinTypeBitcoin);
     input.useMaxAmount = false;
-    input.amount = 2'000'000;
-    input.byteFee = 1;
+    input.amount = 2'000'000ull;
+    input.byteFee = 1ull;
     input.toAddress = "bc1qauwlpmzamwlf9tah6z4w0t8sunh6pnyyjgk0ne";
     input.changeAddress = ownAddress;
 
@@ -2045,16 +2045,16 @@ TEST(BitcoinSigning, Sign_ManyUtxos_2000) {
     auto plan = TransactionBuilder::plan(input);
 
     // expected result: 601 utxos (smaller ones)
-    std::vector<int64_t> subset;
-    uint64_t subsetSum = 0;
-    for (int i = 0; i < 601; ++i) {
-        const uint64_t val = 1000 + (i + 1) * 10;
+    std::vector<Amount> subset;
+    Amount subsetSum = 0;
+    for (Amount i = 0; i < 601; ++i) {
+        const Amount val = 1000ull + (i + 1ull) * 10ull;
         subset.push_back(val);
         subsetSum += val;
     }
     EXPECT_EQ(subset.size(), 601ul);
     EXPECT_EQ(subsetSum, 2'410'010ul);
-    EXPECT_TRUE(verifyPlan(plan, subset, 2'000'000, 40'943));
+    EXPECT_TRUE(verifyPlan(plan, subset, 2'000'000ull, 40'943ull));
 
     // Extend input with keys, reuse plan, Sign
     auto privKey = PrivateKey(parse_hex(ownPrivateKey), TWCurveSECP256k1);
@@ -2079,9 +2079,9 @@ TEST(BitcoinSigning, EncodeThreeOutput) {
     auto ownPrivateKey = "b820f41f96c8b7442f3260acd23b3897e1450b8c7c6580136a3c2d3a14e34674";
     auto toAddress0 = "ltc1qgknskahmm6svn42e33gum5wc4dz44wt9vc76q4";
     auto toAddress1 = "ltc1qulgtqdgxyd9nxnn5yxft6jykskz0ffl30nu32z";
-    auto utxo0Amount = 3'851'829;
-    auto toAmount0 = 1'000'000;
-    auto toAmount1 = 2'000'000;
+    auto utxo0Amount = 3'851'829ull;
+    auto toAmount0 = 1'000'000ull;
+    auto toAmount1 = 2'000'000ull;
 
     auto unsignedTx = Transaction(1);
 
@@ -2096,7 +2096,7 @@ TEST(BitcoinSigning, EncodeThreeOutput) {
     unsignedTx.outputs.emplace_back(toAmount1, lockingScript1);
     // change
     auto lockingScript2 = Script::lockScriptForAddress(ownAddress, coin);
-    unsignedTx.outputs.emplace_back(utxo0Amount - toAmount0 - toAmount1 - 172, lockingScript2);
+    unsignedTx.outputs.emplace_back(utxo0Amount - toAmount0 - toAmount1 - 172ull, lockingScript2);
 
     Data unsignedData;
     unsignedTx.encode(unsignedData, Transaction::SegwitFormatMode::Segwit);
@@ -2181,7 +2181,7 @@ TEST(BitcoinSigning, RedeemExtendedPubkeyUTXO) {
     SigningInput input;
     input.coinType = TWCoinTypeBitcoin;
     input.hashType = hashTypeForCoin(TWCoinTypeBitcoin);
-    input.amount = 26972;
+    input.amount = 26972ull;
     input.useMaxAmount = true;
     input.byteFee = 1;
     input.toAddress = addressString;
@@ -2190,7 +2190,7 @@ TEST(BitcoinSigning, RedeemExtendedPubkeyUTXO) {
 
     UTXO utxo0;
     utxo0.script = utxo0Script;
-    utxo0.amount = 16874;
+    utxo0.amount = 16874ull;
     auto hash0 = parse_hex("6ae3f1d245521b0ea7627231d27d613d58c237d6bf97a1471341a3532e31906c");
     std::reverse(hash0.begin(), hash0.end());
     utxo0.outPoint = OutPoint(hash0, 0, UINT32_MAX);
@@ -2198,7 +2198,7 @@ TEST(BitcoinSigning, RedeemExtendedPubkeyUTXO) {
 
     UTXO utxo1;
     utxo1.script = utxo0Script;
-    utxo1.amount = 10098;
+    utxo1.amount = 10098ull;
     auto hash1 = parse_hex("fd1ea8178228e825d4106df0acb61a4fb14a8f04f30cd7c1f39c665c9427bf13");
     std::reverse(hash1.begin(), hash1.end());
     utxo1.outPoint = OutPoint(hash1, 0, UINT32_MAX);
@@ -2226,9 +2226,9 @@ TEST(BitcoinSigning, SignP2TR_5df51e) {
     // Setup input
     SigningInput input;
     input.hashType = hashTypeForCoin(coin);
-    input.amount = 1100;
+    input.amount = 1100ull;
     input.useMaxAmount = false;
-    input.byteFee = 1;
+    input.byteFee = 1ull;
     input.toAddress = toAddress;
     input.changeAddress = ownAddress;
     input.coinType = coin;
@@ -2251,7 +2251,7 @@ TEST(BitcoinSigning, SignP2TR_5df51e) {
     auto utxo0Script = Script::lockScriptForAddress(ownAddress, coin);
     EXPECT_EQ(hex(utxo0Script.bytes), "00140cb9f5c6b62c03249367bc20a90dd2425e6926af");
     utxo0.script = utxo0Script;
-    utxo0.amount = 49429;
+    utxo0.amount = 49429ull;
     auto hash0 = parse_hex("c24bd72e3eaea797bd5c879480a0db90980297bc7085efda97df2bf7d31413fb");
     std::reverse(hash0.begin(), hash0.end());
     utxo0.outPoint = OutPoint(hash0, 1, UINT32_MAX);
@@ -2260,7 +2260,7 @@ TEST(BitcoinSigning, SignP2TR_5df51e) {
     {
         // test plan (but do not reuse plan result)
         auto plan = TransactionBuilder::plan(input);
-        EXPECT_TRUE(verifyPlan(plan, {49429}, 1100, 153));
+        EXPECT_TRUE(verifyPlan(plan, {49429ull}, 1100ull, 153ull));
     }
 
     // Sign
@@ -2271,7 +2271,7 @@ TEST(BitcoinSigning, SignP2TR_5df51e) {
 
     Data serialized;
     signedTx.encode(serialized);
-    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{234, 125, 153}));
+    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{234ull, 125ull, 153ull}));
     EXPECT_TRUE(validateEstimatedSize(signedTx, -1, 1));
     // https://mempool.space/tx/5df51e13bfeb79f386e1e17237f06d1b5c87c5bfcaa907c0c1cfe51cd7ca446d
     EXPECT_EQ(hex(serialized), // printed using prettyPrintTransaction
@@ -2294,9 +2294,9 @@ TEST(BitcoinSigning, Build_OpReturn_THORChainSwap_eb4c) {
     auto coin = TWCoinTypeBitcoin;
     auto ownAddress = "bc1q7s0a2l4aguksehx8hf93hs9yggl6njxds6m02g";
     auto toAddress = "bc1qxu5a8gtnjxw3xwdlmr2gl9d76h9fysu3zl656e";
-    auto utxoAmount = 342101;
-    auto toAmount = 300000;
-    int fee = 36888;
+    auto utxoAmount = 342101ull;
+    auto toAmount = 300000ull;
+    auto fee = 36888ull;
 
     auto unsignedTx = Transaction(2, 0);
 
@@ -2361,9 +2361,9 @@ TEST(BitcoinSigning, Sign_OpReturn_THORChainSwap) {
     auto ownAddressString = ownAddress.string();
     EXPECT_EQ(ownAddressString, "bc1q2gzg42w98ytatvmsgxfc8vrg6l24c25pydup9u");
     auto toAddress = "bc1qxu5a8gtnjxw3xwdlmr2gl9d76h9fysu3zl656e";
-    auto utxoAmount = 342101;
-    auto toAmount = 300000;
-    int byteFee = 126;
+    auto utxoAmount = 342101ull;
+    auto toAmount = 300000ull;
+    auto byteFee = 126ull;
     Data memo = data("SWAP:THOR.RUNE:thor1tpercamkkxec0q0jk6ltdnlqvsw29guap8wmcl:");
 
     SigningInput input;
@@ -2393,7 +2393,7 @@ TEST(BitcoinSigning, Sign_OpReturn_THORChainSwap) {
     {
         // test plan (but do not reuse plan result)
         auto plan = TransactionBuilder::plan(input);
-        EXPECT_TRUE(verifyPlan(plan, {342101}, 300000, 26586));
+        EXPECT_TRUE(verifyPlan(plan, {342101ull}, 300000ull, 26586ull));
         EXPECT_EQ(plan.outputOpReturn.size(), 59ul);
     }
 
@@ -2405,7 +2405,7 @@ TEST(BitcoinSigning, Sign_OpReturn_THORChainSwap) {
 
     Data serialized;
     signedTx.encode(serialized);
-    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{293, 183, 211}));
+    EXPECT_EQ(getEncodedTxSize(signedTx), (EncodedTxSize{293ull, 183ull, 211ull}));
     EXPECT_TRUE(validateEstimatedSize(signedTx, -1, 1));
     ASSERT_EQ(hex(serialized), // printed using prettyPrintTransaction
         "01000000" // version

--- a/tests/chains/Bitcoin/TransactionPlanTests.cpp
+++ b/tests/chains/Bitcoin/TransactionPlanTests.cpp
@@ -690,15 +690,15 @@ TEST(TransactionPlan, ManyUtxosMax_5000_simple) {
 TEST(TransactionPlan, OpReturn) {
     auto ownAddress = "bc1q7s0a2l4aguksehx8hf93hs9yggl6njxds6m02g";
     auto toAddress = "bc1qxu5a8gtnjxw3xwdlmr2gl9d76h9fysu3zl656e";
-    const Amount utxoAmount = 342101ull;
-    const Amount toAmount = 300000ull;
-    const Amount byteFee = 126ull;
+    const int64_t utxoAmount = 342101ll;
+    const int64_t toAmount = 300000ll;
+    const int64_t byteFee = 126ll;
     Data memo = data("SWAP:THOR.RUNE:thor1tpercamkkxec0q0jk6ltdnlqvsw29guap8wmcl:");
 
     auto signingInput = Proto::SigningInput();
     signingInput.set_hash_type(TWBitcoinSigHashTypeAll);
-    signingInput.set_amount(tryToSigned(toAmount));
-    signingInput.set_byte_fee(tryToSigned(byteFee));
+    signingInput.set_amount(toAmount);
+    signingInput.set_byte_fee(byteFee);
     signingInput.set_to_address(toAddress);
     signingInput.set_change_address(ownAddress);
     signingInput.set_output_op_return(memo.data(), memo.size());
@@ -709,18 +709,18 @@ TEST(TransactionPlan, OpReturn) {
     utxo.mutable_out_point()->set_hash(utxoHash.data(), utxoHash.size());
     utxo.mutable_out_point()->set_index(1);
     utxo.mutable_out_point()->set_sequence(UINT32_MAX);
-    utxo.set_amount(tryToSigned(utxoAmount));
+    utxo.set_amount(utxoAmount);
 
     auto txPlan = TransactionBuilder::plan(signingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {342101}, 300000ull, 205ull * byteFee));
+    EXPECT_TRUE(verifyPlan(txPlan, {342101}, 300000ull, 205ull * static_cast<Amount>(byteFee)));
     EXPECT_EQ(txPlan.outputOpReturn.size(), 59ull);
     EXPECT_EQ(hex(txPlan.outputOpReturn), "535741503a54484f522e52554e453a74686f72317470657263616d6b6b7865633071306a6b366c74646e6c7176737732396775617038776d636c3a");
     EXPECT_FALSE(txPlan.outputOpReturnIndex.has_value());
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, byteFee), 174ull * byteFee);
-    EXPECT_EQ(feeCalculator.calculate(1, 3, byteFee), 205ull * byteFee);
+    EXPECT_EQ(feeCalculator.calculate(1, 2, byteFee), 174ull * static_cast<Amount>(byteFee));
+    EXPECT_EQ(feeCalculator.calculate(1, 3, byteFee), 205ull * static_cast<Amount>(byteFee));
 }
 
 } // namespace TW::Bitcoin

--- a/tests/chains/Bitcoin/TransactionPlanTests.cpp
+++ b/tests/chains/Bitcoin/TransactionPlanTests.cpp
@@ -18,221 +18,222 @@ namespace TW::Bitcoin {
 
 TEST(TransactionPlan, OneTypical) {
     auto utxos = buildTestUTXOs({100'000});
-    auto byteFee = 1;
-    auto sigingInput = buildSigningInput(50'000, byteFee, utxos);
+    const Amount byteFee = 1ull;
+    auto sigingInput = buildSigningInput(50'000ull, byteFee, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 50'000, 147));
+    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 50'000ull, 147ull));
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, byteFee), 174);
+    EXPECT_EQ(feeCalculator.calculate(1, 2, byteFee), 174ull);
 }
 
 TEST(TransactionPlan, OneInsufficient) {
     auto utxos = buildTestUTXOs({100'000});
-    auto sigingInput = buildSigningInput(200'000, 1, utxos);
+    auto sigingInput = buildSigningInput(200'000ull, 1ull, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
     // Max is returned
-    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 99'887, 113));
+    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 99'887ull, 113ull));
 }
 
 TEST(TransactionPlan, OneInsufficientEqual) {
     auto utxos = buildTestUTXOs({100'000});
-    auto sigingInput = buildSigningInput(100'000, 1, utxos);
+    auto sigingInput = buildSigningInput(100'000ull, 1ull, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
     // Max is returned
-    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 99'887, 113));
+    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 99'887ull, 113ull));
 }
 
 TEST(TransactionPlan, OneInsufficientLower100) {
     // requested is only slightly lower than avail, not enough for fee, cannot be satisfied
     auto utxos = buildTestUTXOs({100'000});
-    auto sigingInput = buildSigningInput(100'000 - 100, 1, utxos);
+    auto sigingInput = buildSigningInput(100'000ull - 100ull, 1ull, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {}, 0, 0, Common::Proto::Error_not_enough_utxos));
+    EXPECT_TRUE(verifyPlan(txPlan, {}, 0ull, 0ull, Common::Proto::Error_not_enough_utxos));
 }
 
 TEST(TransactionPlan, OneInsufficient146) {
     // requested is only slightly lower than avail, not enough for fee, cannot be satisfied
     auto utxos = buildTestUTXOs({100'000});
-    auto sigingInput = buildSigningInput(100'000 - 146, 1, utxos);
+    auto sigingInput = buildSigningInput(100'000ull - 146ull, 1ull, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {}, 0, 0, Common::Proto::Error_not_enough_utxos));
+    EXPECT_TRUE(verifyPlan(txPlan, {}, 0ull, 0ull, Common::Proto::Error_not_enough_utxos));
 }
 
 TEST(TransactionPlan, OneSufficientLower170) {
     // requested is only slightly lower than avail, not enough for fee, cannot be satisfied
     auto utxos = buildTestUTXOs({100'000});
-    auto sigingInput = buildSigningInput(100'000 - 170, 1, utxos);
+    auto sigingInput = buildSigningInput(100'000ull - 170ull, 1ull, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    auto dustChange = 23;
-    auto actualFee = 147 + dustChange;
-    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 100'000 - 170, actualFee));
+    const Amount dustChange = 23ull;
+    const Amount actualFee = 147ull + dustChange;
+    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 100'000ull - 170ull, actualFee));
 }
 
 TEST(TransactionPlan, OneSufficientLower300) {
     auto utxos = buildTestUTXOs({100'000});
-    auto sigingInput = buildSigningInput(100'000 - 300, 1, utxos);
+    auto sigingInput = buildSigningInput(100'000ull - 300ull, 1ull, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 100'000 - 300, 147));
+    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 100'000ull - 300ull, 147ull));
 }
 
 TEST(TransactionPlan, OneMoreRequested) {
     auto utxos = buildTestUTXOs({100'000});
-    auto byteFee = 1;
-    auto sigingInput = buildSigningInput(150'000, byteFee, utxos);
+    const Amount byteFee = 1ull;
+    auto sigingInput = buildSigningInput(150'000ull, byteFee, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
     // Max is returned
-    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 99'887, 113));
+    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 99'887ull, 113ull));
 }
 
 TEST(TransactionPlan, OneFitsExactly) {
     auto utxos = buildTestUTXOs({100'000});
-    auto byteFee = 1;
-    auto dustChange = 27;
+    const Amount byteFee = 1ull;
+    const Amount dustChange = 27ull;
     // Change amount is too low (less than dust), so we just waste it as the transaction fee.
-    auto expectedFee = 147 + dustChange;
-    auto sigingInput = buildSigningInput(100'000 - 174, byteFee, utxos);
+    const Amount expectedFee = 147ull + dustChange;
+    auto sigingInput = buildSigningInput(100'000ull - 174ull, byteFee, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 100'000 - 174, expectedFee));
+    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 100'000ull - 174ull, expectedFee));
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, byteFee), 174);
+    EXPECT_EQ(feeCalculator.calculate(1, 2, byteFee), 174ull);
 }
 
 TEST(TransactionPlan, OneFitsExactlyHighFee) {
     auto utxos = buildTestUTXOs({100'000});
-    auto byteFee = 10;
-    auto dustChange = 270;
+    const Amount byteFee = 10ull;
+    const Amount dustChange = 270ull;
     // Change amount is too low (less than dust), so we just waste it as the transaction fee.
-    auto expectedFee = 1470 + dustChange;
-    auto sigingInput = buildSigningInput(100'000 - 1740, byteFee, utxos);
+    const Amount expectedFee = 1470ull + dustChange;
+    auto sigingInput = buildSigningInput(100'000ull - 1740ull, byteFee, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 100'000 - 1740, expectedFee));
+    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 100'000ull - 1740ull, expectedFee));
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, byteFee), 1740);
+    EXPECT_EQ(feeCalculator.calculate(1, 2, byteFee), 1740ull);
 }
 
 TEST(TransactionPlan, OneMissingPrivateKey) {
     auto utxos = buildTestUTXOs({100'000});
-    auto byteFee = 1;
-    auto sigingInput = buildSigningInput(50'000, byteFee, utxos, false, TWCoinTypeBitcoin, true);
+    const Amount byteFee = 1ull;
+    auto sigingInput = buildSigningInput(50'000ull, byteFee, utxos, false, TWCoinTypeBitcoin, true);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 50'000, 147));
+    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 50'000ull, 147ull));
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, byteFee), 174);
+    EXPECT_EQ(feeCalculator.calculate(1, 2, byteFee), 174ull);
 }
 
 TEST(TransactionPlan, TwoFirstEnough) {
     auto utxos = buildTestUTXOs({20'000, 80'000});
-    auto sigingInput = buildSigningInput(15'000, 1, utxos);
+    auto sigingInput = buildSigningInput(15'000ull, 1ull, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {20'000}, 15'000, 147));
+    EXPECT_TRUE(verifyPlan(txPlan, {20'000}, 15'000ull, 147ull));
 }
 
 TEST(TransactionPlan, TwoSecondEnough) {
     auto utxos = buildTestUTXOs({20'000, 80'000});
-    auto sigingInput = buildSigningInput(70'000, 1, utxos);
+    auto sigingInput = buildSigningInput(70'000ull, 1ull, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {80'000}, 70'000, 147));
+    EXPECT_TRUE(verifyPlan(txPlan, {80'000}, 70'000ull, 147ull));
 }
 
 TEST(TransactionPlan, TwoBoth) {
     auto utxos = buildTestUTXOs({20'000, 80'000});
-    auto sigingInput = buildSigningInput(90'000, 1, utxos);
+    auto sigingInput = buildSigningInput(90'000ull, 1ull, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {20'000, 80'000}, 90'000, 215));
+    EXPECT_TRUE(verifyPlan(txPlan, {20'000, 80'000}, 90'000ull, 215ull));
 }
 
 TEST(TransactionPlan, TwoFirstEnoughButSecond) {
     auto utxos = buildTestUTXOs({20'000, 22'000});
-    auto sigingInput = buildSigningInput(18'000, 1, utxos);
+    auto sigingInput = buildSigningInput(18'000ull, 1ull, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {22'000}, 18'000, 147));
+    EXPECT_TRUE(verifyPlan(txPlan, {22'000}, 18'000ull, 147ull));
 }
 
 TEST(TransactionPlan, ThreeNoDust) {
     auto utxos = buildTestUTXOs({100'000, 70'000, 75'000});
-    auto sigingInput = buildSigningInput(100'000 - 174 - 10, 1, utxos);
+    auto sigingInput = buildSigningInput(100'000ull - 174ull - 10ull, 1ull, utxos);
 
     // 100'000 would fit with dust; instead two UTXOs are selected not to leave dust
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {75'000, 100'000}, 100'000 - 174 - 10, 215));
+    EXPECT_TRUE(verifyPlan(txPlan, {75'000, 100'000}, 100'000ull - 174ull - 10ull, 215ull));
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, 1), 174);
-    EXPECT_EQ(feeCalculator.calculate(2, 2, 1), 275);
+    EXPECT_EQ(feeCalculator.calculate(1, 2, 1ull), 174ull);
+    EXPECT_EQ(feeCalculator.calculate(2, 2, 1ull), 275ull);
 
-    const auto dustLimit = 102;
+    const Amount dustLimit = 102ull;
     // Now 100'000 fits with no dust
-    sigingInput = buildSigningInput(100'000 - 174 - dustLimit, 1, utxos);
+    sigingInput = buildSigningInput(100'000ull - 174ull - dustLimit, 1ull, utxos);
     txPlan = TransactionBuilder::plan(sigingInput);
-    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 100'000 - 174 - dustLimit, 147));
+    EXPECT_TRUE(verifyPlan(txPlan, {100'000}, 100'000ull - 174ull - dustLimit, 147ull));
 
     // One more and we are over dust limit
-    sigingInput = buildSigningInput(100'000 - 174 - dustLimit + 1, 1, utxos);
+    sigingInput = buildSigningInput(100'000ull - 174ull - dustLimit + 1ull, 1ull, utxos);
     txPlan = TransactionBuilder::plan(sigingInput);
-    EXPECT_TRUE(verifyPlan(txPlan, {75'000, 100'000}, 100'000 - 174 - dustLimit + 1, 215));
+    EXPECT_TRUE(verifyPlan(txPlan, {75'000, 100'000}, 100'000ull - 174ull - dustLimit + 1ull, 215ull));
 }
 
 TEST(TransactionPlan, TenThree) {
-    auto utxos = buildTestUTXOs({1'000, 2'000, 100'000, 3'000, 4'000, 5, 000, 125'000, 6'000, 150'000, 7'000});
-    auto sigingInput = buildSigningInput(300'000, 1, utxos);
+    // Note: was `5, 000` (typo) — fixed to `5'000`
+    auto utxos = buildTestUTXOs({1'000, 2'000, 100'000, 3'000, 4'000, 5'000, 125'000, 6'000, 150'000, 7'000});
+    auto sigingInput = buildSigningInput(300'000ull, 1ull, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {100'000, 125'000, 150'000}, 300'000, 283));
+    EXPECT_TRUE(verifyPlan(txPlan, {100'000, 125'000, 150'000}, 300'000ull, 283ull));
 }
 
 TEST(TransactionPlan, NonMaxAmount) {
     auto utxos = buildTestUTXOs({4000, 2000, 6000, 1000, 50000, 120000});
-    auto sigingInput = buildSigningInput(10000, 1, utxos);
+    auto sigingInput = buildSigningInput(10000ull, 1ull, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {50000}, 10000, 147));
+    EXPECT_TRUE(verifyPlan(txPlan, {50000}, 10000ull, 147ull));
 }
 
 TEST(TransactionPlan, UnspentsInsufficient) {
     auto utxos = buildTestUTXOs({4000, 4000, 4000});
-    auto sigingInput = buildSigningInput(15000, 1, utxos);
+    auto sigingInput = buildSigningInput(15000ull, 1ull, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
     // Max is returned
-    EXPECT_TRUE(verifyPlan(txPlan, {4000, 4000, 4000}, 11751, 249));
+    EXPECT_TRUE(verifyPlan(txPlan, {4000, 4000, 4000}, 11751ull, 249ull));
 }
 
 TEST(TransactionPlan, SelectionSuboptimal_ExtraSmallUtxo) {
@@ -240,19 +241,19 @@ TEST(TransactionPlan, SelectionSuboptimal_ExtraSmallUtxo) {
     // Better solution: 3-in-2-out {600, 800, 1000} avail 2400 txamount 1570 fee 566 change 264
     // Previously, with with higher fee estimation used in UTXO selection, solution found was 5-in-2-out {400, 500, 600, 800, 1000} avail 3300 txamount 1570 fee 838 change 892
     auto utxos = buildTestUTXOs({400, 500, 600, 800, 1'000});
-    auto byteFee = 2;
-    auto sigingInput = buildSigningInput(1'570, byteFee, utxos);
+    const Amount byteFee = 2ull;
+    auto sigingInput = buildSigningInput(1'570ull, byteFee, utxos);
 
     // UTXOs smaller than singleInputFee are not included
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    auto expectedFee = 702;
-    EXPECT_TRUE(verifyPlan(txPlan, {500, 600, 800, 1'000}, 1'570, expectedFee));
-    auto change = 2'900 - 1'570 - expectedFee;
-    auto firstUtxo = txPlan.utxos[0].amount;
-    EXPECT_TRUE(change - 204 < txPlan.utxos[0].amount);
-    EXPECT_EQ(change, 628);
-    EXPECT_EQ(firstUtxo, 500);
+    const Amount expectedFee = 702ull;
+    EXPECT_TRUE(verifyPlan(txPlan, {500, 600, 800, 1'000}, 1'570ull, expectedFee));
+    const Amount change = 2'900ull - 1'570ull - expectedFee;
+    const Amount firstUtxo = txPlan.utxos[0].amount;
+    EXPECT_TRUE(change - 204ull < txPlan.utxos[0].amount);
+    EXPECT_EQ(change, 628ull);
+    EXPECT_EQ(firstUtxo, 500ull);
 }
 
 TEST(TransactionPlan, SelectionSuboptimal_ExtraSmallUtxoFixedDust) {
@@ -260,311 +261,311 @@ TEST(TransactionPlan, SelectionSuboptimal_ExtraSmallUtxoFixedDust) {
     // Better solution: 3-in-2-out {600, 800, 1000} avail 2400 txamount 1390 fee 566 change 444
     // Previously, with with higher fee estimation used in UTXO selection, solution found was 5-in-2-out {400, 500, 600, 800, 1000} avail 3300 txamount 1390 fee 838 change 1072
     auto utxos = buildTestUTXOs({400, 500, 600, 800, 1'000});
-    auto byteFee = 2;
-    auto signingInput = buildSigningInput(1'390, byteFee, utxos);
-    signingInput.dustCalculator = std::make_shared<FixedDustCalculator>(450);
+    const Amount byteFee = 2ull;
+    auto signingInput = buildSigningInput(1'390ull, byteFee, utxos);
+    signingInput.dustCalculator = std::make_shared<FixedDustCalculator>(450ull);
 
     // UTXOs smaller than singleInputFee are not included
     auto txPlan = TransactionBuilder::plan(signingInput);
 
-    auto expectedFee = 702;
-    EXPECT_TRUE(verifyPlan(txPlan, {500, 600, 800, 1'000}, 1'390, expectedFee));
-    auto change = 2'900 - 1'390 - expectedFee;
-    auto firstUtxo = txPlan.utxos[0].amount;
-    EXPECT_EQ(change, 808);
-    EXPECT_EQ(firstUtxo, 500);
+    const Amount expectedFee = 702ull;
+    EXPECT_TRUE(verifyPlan(txPlan, {500, 600, 800, 1'000}, 1'390ull, expectedFee));
+    const Amount change = 2'900ull - 1'390ull - expectedFee;
+    const Amount firstUtxo = txPlan.utxos[0].amount;
+    EXPECT_EQ(change, 808ull);
+    EXPECT_EQ(firstUtxo, 500ull);
 }
 
 TEST(TransactionPlan, Selection_Satisfied5) {
     // 5-input case, with a 5-input solution.
     // Previously, with with higher fee estimation used in UTXO selection, no solution would be found.
     auto utxos = buildTestUTXOs({400, 500, 600, 800, 1'000});
-    auto byteFee = 2;
-    auto sigingInput = buildSigningInput(1'775, byteFee, utxos);
+    const Amount byteFee = 2ull;
+    auto sigingInput = buildSigningInput(1'775ull, byteFee, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {400, 500, 600, 800, 1000}, 1775, 838));
+    EXPECT_TRUE(verifyPlan(txPlan, {400, 500, 600, 800, 1000}, 1775ull, 838ull));
 }
 
 TEST(TransactionPlan, Inputs5_33Req19NoDustFee2) {
     auto utxos = buildTestUTXOs({600, 1'200, 6'000, 8'000, 10'000});
-    auto byteFee = 2;
-    auto sigingInput = buildSigningInput(19'000, byteFee, utxos);
+    const Amount byteFee = 2ull;
+    auto sigingInput = buildSigningInput(19'000ull, byteFee, utxos);
 
     // UTXOs smaller than singleInputFee are not included
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    auto expectedFee = 283 * byteFee;
-    EXPECT_TRUE(verifyPlan(txPlan, {6'000, 8'000, 10'000}, 19'000, expectedFee));
+    const Amount expectedFee = 283ull * byteFee;
+    EXPECT_TRUE(verifyPlan(txPlan, {6'000, 8'000, 10'000}, 19'000ull, expectedFee));
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 204);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 204ull);
 }
 
 TEST(TransactionPlan, Inputs5_33Req19Dust1Fee5) {
     auto utxos = buildTestUTXOs({600, 1'200, 6'000, 8'000, 10'000});
-    auto byteFee = 5;
-    auto sigingInput = buildSigningInput(19'000, byteFee, utxos);
+    const Amount byteFee = 5ull;
+    auto sigingInput = buildSigningInput(19'000ull, byteFee, utxos);
 
     // UTXOs smaller than singleInputFee are not included
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    auto expectedFee = 283 * byteFee;
-    EXPECT_TRUE(verifyPlan(txPlan, {6'000, 8'000, 10'000}, 19'000, expectedFee));
+    const Amount expectedFee = 283ull * byteFee;
+    EXPECT_TRUE(verifyPlan(txPlan, {6'000, 8'000, 10'000}, 19'000ull, expectedFee));
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 510);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 510ull);
 }
 
 TEST(TransactionPlan, Inputs5_33Req19Dust1Fee9) {
     auto utxos = buildTestUTXOs({600, 1'200, 6'000, 8'000, 10'000});
-    auto byteFee = 9;
-    auto sigingInput = buildSigningInput(19'000, byteFee, utxos);
+    const Amount byteFee = 9ull;
+    auto sigingInput = buildSigningInput(19'000ull, byteFee, utxos);
 
     // UTXOs smaller than singleInputFee are not included
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    auto expectedFee = 283 * byteFee;
-    EXPECT_TRUE(verifyPlan(txPlan, {6'000, 8'000, 10'000}, 19'000, expectedFee));
+    const Amount expectedFee = 283ull * byteFee;
+    EXPECT_TRUE(verifyPlan(txPlan, {6'000, 8'000, 10'000}, 19'000ull, expectedFee));
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 918);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 918ull);
 }
 
 TEST(TransactionPlan, Inputs5_33Req19Fee20) {
     auto utxos = buildTestUTXOs({600, 1'200, 6'000, 8'000, 10'000});
-    auto byteFee = 20;
-    auto sigingInput = buildSigningInput(19'000, byteFee, utxos);
+    const Amount byteFee = 20ull;
+    auto sigingInput = buildSigningInput(19'000ull, byteFee, utxos);
 
     // UTXOs smaller than singleInputFee are not included
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {}, 0, 0, Common::Proto::Error_not_enough_utxos));
+    EXPECT_TRUE(verifyPlan(txPlan, {}, 0ull, 0ull, Common::Proto::Error_not_enough_utxos));
 }
 
 TEST(TransactionPlan, Inputs5_33Req13Fee20) {
     auto utxos = buildTestUTXOs({600, 1'200, 6'000, 8'000, 10'000});
-    auto byteFee = 20;
-    auto sigingInput = buildSigningInput(13'000, byteFee, utxos);
+    const Amount byteFee = 20ull;
+    auto sigingInput = buildSigningInput(13'000ull, byteFee, utxos);
 
     // UTXOs smaller than singleInputFee are not included
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    auto expectedFee = 283 * byteFee;
-    EXPECT_TRUE(verifyPlan(txPlan, {6'000, 8'000, 10'000}, 13'000, expectedFee));
+    const Amount expectedFee = 283ull * byteFee;
+    EXPECT_TRUE(verifyPlan(txPlan, {6'000, 8'000, 10'000}, 13'000ull, expectedFee));
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 2040);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 2040ull);
 }
 
 TEST(TransactionPlan, NoUTXOs) {
     auto utxos = buildTestUTXOs({});
-    auto sigingInput = buildSigningInput(15000, 1, utxos);
+    auto sigingInput = buildSigningInput(15000ull, 1ull, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {}, 0, 0, Common::Proto::Error_missing_input_utxos));
+    EXPECT_TRUE(verifyPlan(txPlan, {}, 0ull, 0ull, Common::Proto::Error_missing_input_utxos));
 }
 
 TEST(TransactionPlan, CustomCase) {
     auto utxos = buildTestUTXOs({794121, 2289357});
-    auto byteFee = 61;
-    auto sigingInput = buildSigningInput(2287189, byteFee, utxos);
+    const Amount byteFee = 61ull;
+    auto sigingInput = buildSigningInput(2287189ull, byteFee, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {794121, 2289357}, 2287189, 13115));
+    EXPECT_TRUE(verifyPlan(txPlan, {794121, 2289357}, 2287189ull, 13115ull));
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculate(2, 2, byteFee), 16775);
+    EXPECT_EQ(feeCalculator.calculate(2, 2, byteFee), 16775ull);
 }
 
 TEST(TransactionPlan, Target0) {
     auto utxos = buildTestUTXOs({2000, 3000});
-    auto sigingInput = buildSigningInput(0, 1, utxos);
+    auto sigingInput = buildSigningInput(0ull, 1ull, utxos);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {}, 0, 0, Common::Proto::Error_zero_amount_requested));
+    EXPECT_TRUE(verifyPlan(txPlan, {}, 0ull, 0ull, Common::Proto::Error_zero_amount_requested));
 }
 
 TEST(TransactionPlan, MaxAmount) {
     auto utxos = buildTestUTXOs({4000, 2000, 15000, 15000, 3000, 200});
-    ASSERT_EQ(sumUTXOs(utxos), 39200);
-    auto byteFee = 40;
-    auto sigingInput = buildSigningInput(39200, byteFee, utxos, true);
+    ASSERT_EQ(sumUTXOs(utxos), 39200ull);
+    const Amount byteFee = 40ull;
+    auto sigingInput = buildSigningInput(39200ull, byteFee, utxos, true);
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 4080);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 4080ull);
 
     // UTXOs smaller than singleInputFee are not included
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    auto expectedFee = 7240;
-    EXPECT_TRUE(verifyPlan(txPlan, {15000, 15000}, 30000 - expectedFee, expectedFee));
+    const Amount expectedFee = 7240ull;
+    EXPECT_TRUE(verifyPlan(txPlan, {15000, 15000}, 30000ull - expectedFee, expectedFee));
 }
 
 TEST(TransactionPlan, MaxAmountOne) {
     auto utxos = buildTestUTXOs({10189534});
-    auto sigingInput = buildSigningInput(100, 1, utxos, true);
+    auto sigingInput = buildSigningInput(100ull, 1ull, utxos, true);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    auto expectedFee = 113;
-    EXPECT_TRUE(verifyPlan(txPlan, {10189534}, 10189534 - expectedFee, expectedFee));
+    const Amount expectedFee = 113ull;
+    EXPECT_TRUE(verifyPlan(txPlan, {10189534}, 10189534ull - expectedFee, expectedFee));
 }
 
 TEST(TransactionPlan, AmountEqualsMaxButNotUseMax) {
     // amount is set to max, but UseMax is not set --> Max is returned
     auto utxos = buildTestUTXOs({10189534});
-    auto sigingInput = buildSigningInput(10189534, 1, utxos, false);
+    auto sigingInput = buildSigningInput(10189534ull, 1ull, utxos, false);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {10189534}, 10189421, 113));
+    EXPECT_TRUE(verifyPlan(txPlan, {10189534}, 10189421ull, 113ull));
 }
 
 TEST(TransactionPlan, MaxAmountRequestedIsLower) {
     auto utxos = buildTestUTXOs({4000, 2000, 15000, 15000, 3000, 200});
-    ASSERT_EQ(sumUTXOs(utxos), 39200);
-    auto byteFee = 40;
-    auto sigingInput = buildSigningInput(10, byteFee, utxos, true);
+    ASSERT_EQ(sumUTXOs(utxos), 39200ull);
+    const Amount byteFee = 40ull;
+    auto sigingInput = buildSigningInput(10ull, byteFee, utxos, true);
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 4080);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 4080ull);
 
     // UTXOs smaller than singleInputFee are not included
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    auto expectedFee = 7240;
-    EXPECT_TRUE(verifyPlan(txPlan, {15000, 15000}, 30000 - expectedFee, expectedFee));
+    const Amount expectedFee = 7240ull;
+    EXPECT_TRUE(verifyPlan(txPlan, {15000, 15000}, 30000ull - expectedFee, expectedFee));
 }
 
 TEST(TransactionPlan, MaxAmountRequestedZero) {
     auto utxos = buildTestUTXOs({4000, 2000, 15000, 15000, 3000, 200});
-    ASSERT_EQ(sumUTXOs(utxos), 39200);
-    auto byteFee = 40;
-    auto sigingInput = buildSigningInput(0, byteFee, utxos, true);
+    ASSERT_EQ(sumUTXOs(utxos), 39200ull);
+    const Amount byteFee = 40ull;
+    auto sigingInput = buildSigningInput(0ull, byteFee, utxos, true);
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 4080);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 4080ull);
 
     // UTXOs smaller than singleInputFee are not included
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    auto expectedFee = 7240;
-    EXPECT_TRUE(verifyPlan(txPlan, {15000, 15000}, 30000 - expectedFee, expectedFee));
+    const Amount expectedFee = 7240ull;
+    EXPECT_TRUE(verifyPlan(txPlan, {15000, 15000}, 30000ull - expectedFee, expectedFee));
 }
 
 TEST(TransactionPlan, MaxAmountNoDustFee2) {
     auto utxos = buildTestUTXOs({400, 500, 600, 800, 1000});
-    auto byteFee = 2;
-    auto sigingInput = buildSigningInput(100, byteFee, utxos, true);
+    const Amount byteFee = 2ull;
+    auto sigingInput = buildSigningInput(100ull, byteFee, utxos, true);
 
     // UTXOs smaller than singleInputFee are not included
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    auto expectedFee = 770;
-    EXPECT_TRUE(verifyPlan(txPlan, {400, 500, 600, 800, 1000}, 3'300 - expectedFee, expectedFee));
+    const Amount expectedFee = 770ull;
+    EXPECT_TRUE(verifyPlan(txPlan, {400, 500, 600, 800, 1000}, 3'300ull - expectedFee, expectedFee));
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 204);
-    EXPECT_EQ(feeCalculator.calculate(5, 1, byteFee), 1096);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 204ull);
+    EXPECT_EQ(feeCalculator.calculate(5, 1, byteFee), 1096ull);
 }
 
 TEST(TransactionPlan, MaxAmountDust1Fee4) {
     auto utxos = buildTestUTXOs({400, 500, 600, 800, 1000});
-    auto byteFee = 4;
-    auto sigingInput = buildSigningInput(100, byteFee, utxos, true);
+    const Amount byteFee = 4ull;
+    auto sigingInput = buildSigningInput(100ull, byteFee, utxos, true);
 
     // UTXOs smaller than singleInputFee are not included
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    auto expectedFee = 1268;
-    EXPECT_TRUE(verifyPlan(txPlan, {500, 600, 800, 1000}, 2'900 - expectedFee, expectedFee));
+    const Amount expectedFee = 1268ull;
+    EXPECT_TRUE(verifyPlan(txPlan, {500, 600, 800, 1000}, 2'900ull - expectedFee, expectedFee));
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 408);
-    EXPECT_EQ(feeCalculator.calculate(4, 1, byteFee), 1784);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 408ull);
+    EXPECT_EQ(feeCalculator.calculate(4, 1, byteFee), 1784ull);
 }
 
 TEST(TransactionPlan, MaxAmountDust2Fee5) {
     auto utxos = buildTestUTXOs({400, 500, 600, 800, 1000});
-    auto byteFee = 5;
-    auto sigingInput = buildSigningInput(100, byteFee, utxos, true);
+    const Amount byteFee = 5ull;
+    auto sigingInput = buildSigningInput(100ull, byteFee, utxos, true);
 
     // UTXOs smaller than singleInputFee are not included
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    auto expectedFee = 1245;
-    EXPECT_TRUE(verifyPlan(txPlan, {600, 800, 1000}, 2'400 - expectedFee, expectedFee));
+    const Amount expectedFee = 1245ull;
+    EXPECT_TRUE(verifyPlan(txPlan, {600, 800, 1000}, 2'400ull - expectedFee, expectedFee));
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 510);
-    EXPECT_EQ(feeCalculator.calculate(3, 1, byteFee), 1725);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 510ull);
+    EXPECT_EQ(feeCalculator.calculate(3, 1, byteFee), 1725ull);
 }
 
 TEST(TransactionPlan, MaxAmountDustAllFee10) {
     auto utxos = buildTestUTXOs({400, 500, 600, 800, 1000});
-    auto byteFee = 10;
-    auto sigingInput = buildSigningInput(100, byteFee, utxos, true);
+    const Amount byteFee = 10ull;
+    auto sigingInput = buildSigningInput(100ull, byteFee, utxos, true);
 
     // UTXOs smaller than singleInputFee are not included
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {}, 0, 0, Common::Proto::Error_not_enough_utxos));
+    EXPECT_TRUE(verifyPlan(txPlan, {}, 0ull, 0ull, Common::Proto::Error_not_enough_utxos));
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 1020);
+    EXPECT_EQ(feeCalculator.calculateSingleInput(byteFee), 1020ull);
 }
 
 TEST(TransactionPlan, One_MaxAmount_FeeMoreThanAvailable) {
     auto utxos = buildTestUTXOs({340});
-    auto byteFee = 1;
-    auto expectedFee = 113;
-    auto sigingInput = buildSigningInput(340, byteFee, utxos, true);
+    const Amount byteFee = 1ull;
+    const Amount expectedFee = 113ull;
+    auto sigingInput = buildSigningInput(340ull, byteFee, utxos, true);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
     // Fee is reduced to availableAmount
-    EXPECT_TRUE(verifyPlan(txPlan, {340}, 340 - expectedFee, expectedFee));
+    EXPECT_TRUE(verifyPlan(txPlan, {340}, 340ull - expectedFee, expectedFee));
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculate(1, 1, byteFee), 143);
+    EXPECT_EQ(feeCalculator.calculate(1, 1, byteFee), 143ull);
 }
 
 TEST(TransactionPlan, MaxAmountDoge) {
-    auto utxos = buildTestUTXOs({Amount(100000000), Amount(2000000000), Amount(200000000)});
-    ASSERT_EQ(sumUTXOs(utxos), Amount(2300000000));
-    auto sigingInput = buildSigningInput(Amount(2300000000), 100, utxos, true, TWCoinTypeDogecoin);
+    auto utxos = buildTestUTXOs({100000000, 2000000000, 200000000});
+    ASSERT_EQ(sumUTXOs(utxos), 2300000000ull);
+    auto sigingInput = buildSigningInput(2300000000ull, 100ull, utxos, true, TWCoinTypeDogecoin);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {100000000, 2000000000, 200000000}, 2299951200, 48800));
+    EXPECT_TRUE(verifyPlan(txPlan, {100000000, 2000000000, 200000000}, 2299951200ull, 48800ull));
 }
 
 TEST(TransactionPlan, AmountDecred) {
-    auto utxos = buildTestUTXOs({Amount(39900000)});
-    auto sigingInput = buildSigningInput(Amount(10000000), 10, utxos, false, TWCoinTypeDecred);
+    auto utxos = buildTestUTXOs({39900000});
+    auto sigingInput = buildSigningInput(10000000ull, 10ull, utxos, false, TWCoinTypeDecred);
 
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {39900000}, 10000000, 2540));
+    EXPECT_TRUE(verifyPlan(txPlan, {39900000}, 10000000ull, 2540ull));
 }
 
 TEST(TransactionPlan, ManyUtxosNonmax_400) {
     const auto n = 400;
-    const auto byteFee = 10;
-    std::vector<int64_t> values;
-    uint64_t valueSum = 0;
+    const Amount byteFee = 10ull;
+    std::vector<Amount> values;
+    Amount valueSum = 0ull;
     for (int i = 0; i < n; ++i) {
-        const uint64_t val = (i + 1) * 100;
+        const Amount val = static_cast<Amount>(i + 1) * 100ull;
         values.push_back(val);
         valueSum += val;
     }
-    const uint64_t requestedAmount = valueSum / 8;
-    EXPECT_EQ(requestedAmount, 1'002'500ul);
+    const Amount requestedAmount = valueSum / 8ull;
+    EXPECT_EQ(requestedAmount, 1'002'500ull);
 
     auto utxos = buildTestUTXOs(values);
     auto sigingInput = buildSigningInput(requestedAmount, byteFee, utxos, false, TWCoinTypeBitcoin);
@@ -572,30 +573,30 @@ TEST(TransactionPlan, ManyUtxosNonmax_400) {
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
     // expected result: 27 utxos, with the largest amounts
-    std::vector<int64_t> subset;
-    uint64_t subsetSum = 0;
+    std::vector<Amount> subset;
+    Amount subsetSum = 0ull;
     for (int i = n - 27; i < n; ++i) {
-        const uint64_t val = (i + 1) * 100;
+        const Amount val = static_cast<Amount>(i + 1) * 100ull;
         subset.push_back(val);
         subsetSum += val;
     }
-    EXPECT_EQ(subset.size(), 27ul);
-    EXPECT_EQ(subsetSum, 1'044'900ul);
-    EXPECT_TRUE(verifyPlan(txPlan, subset, requestedAmount, 19'150));
+    EXPECT_EQ(subset.size(), 27ull);
+    EXPECT_EQ(subsetSum, 1'044'900ull);
+    EXPECT_TRUE(verifyPlan(txPlan, subset, requestedAmount, 19'150ull));
 }
 
 TEST(TransactionPlan, ManyUtxosNonmax_5000_simple) {
     const auto n = 5000;
-    const auto byteFee = 10;
-    std::vector<int64_t> values;
-    uint64_t valueSum = 0;
+    const Amount byteFee = 10ull;
+    std::vector<Amount> values;
+    Amount valueSum = 0ull;
     for (int i = 0; i < n; ++i) {
-        const uint64_t val = (i + 1) * 100;
+        const Amount val = static_cast<Amount>(i + 1) * 100ull;
         values.push_back(val);
         valueSum += val;
     }
-    const uint64_t requestedAmount = valueSum / 20;
-    EXPECT_EQ(requestedAmount, 62'512'500ul);
+    const Amount requestedAmount = valueSum / 20ull;
+    EXPECT_EQ(requestedAmount, 62'512'500ull);
 
     // Use Ravencoin, because of faster non-segwit estimation, and one of the original issues was with this coin.
     auto utxos = buildTestUTXOs(values);
@@ -604,25 +605,25 @@ TEST(TransactionPlan, ManyUtxosNonmax_5000_simple) {
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
     // expected result: 1220 utxos, with the smaller amounts (except the very small dust ones)
-    std::vector<int64_t> subset;
-    uint64_t subsetSum = 0;
+    std::vector<Amount> subset;
+    Amount subsetSum = 0ull;
     for (int i = 14; i < 1220 + 14; ++i) {
-        const uint64_t val = (i + 1) * 100;
+        const Amount val = static_cast<Amount>(i + 1) * 100ull;
         subset.push_back(val);
         subsetSum += val;
     }
-    EXPECT_EQ(subset.size(), 1220ul);
-    EXPECT_EQ(subsetSum, 76'189'000ul);
-    EXPECT_TRUE(verifyPlan(txPlan, subset, requestedAmount, 1'806'380));
+    EXPECT_EQ(subset.size(), 1220ull);
+    EXPECT_EQ(subsetSum, 76'189'000ull);
+    EXPECT_TRUE(verifyPlan(txPlan, subset, requestedAmount, 1'806'380ull));
 }
 
 TEST(TransactionPlan, ManyUtxosMax_400) {
     const auto n = 400;
-    const auto byteFee = 10;
-    std::vector<int64_t> values;
-    uint64_t valueSum = 0;
+    const Amount byteFee = 10ull;
+    std::vector<Amount> values;
+    Amount valueSum = 0ull;
     for (int i = 0; i < n; ++i) {
-        const uint64_t val = (i + 1) * 100;
+        const Amount val = static_cast<Amount>(i + 1) * 100ull;
         values.push_back(val);
         valueSum += val;
     }
@@ -634,30 +635,30 @@ TEST(TransactionPlan, ManyUtxosMax_400) {
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
     // all are selected, except a few smallest UTXOs are filtered out
-    const uint64_t dustLimit = byteFee * 148;
-    std::vector<int64_t> filteredValues;
-    uint64_t filteredValueSum = 0;
+    const Amount dustLimit = byteFee * 148ull;
+    std::vector<Amount> filteredValues;
+    Amount filteredValueSum = 0ull;
     for (int i = 0; i < n; ++i) {
-        const uint64_t val = (i + 1) * 100;
+        const Amount val = static_cast<Amount>(i + 1) * 100ull;
         if (val > dustLimit) {
             filteredValues.push_back(val);
             filteredValueSum += val;
         }
     }
-    EXPECT_EQ(valueSum, 8'020'000ul);
-    EXPECT_EQ(dustLimit, 1480ul);
-    EXPECT_EQ(filteredValues.size(), 386ul);
-    EXPECT_EQ(filteredValueSum, 80'09'500ul);
-    EXPECT_TRUE(verifyPlan(txPlan, filteredValues, 7'437'780, 571'720));
+    EXPECT_EQ(valueSum, 8'020'000ull);
+    EXPECT_EQ(dustLimit, 1480ull);
+    EXPECT_EQ(filteredValues.size(), 386ull);
+    EXPECT_EQ(filteredValueSum, 8'009'500ull);
+    EXPECT_TRUE(verifyPlan(txPlan, filteredValues, 7'437'780ull, 571'720ull));
 }
 
 TEST(TransactionPlan, ManyUtxosMax_5000_simple) {
     const auto n = 5000;
-    const auto byteFee = 10;
-    std::vector<int64_t> values;
-    uint64_t valueSum = 0;
+    const Amount byteFee = 10ull;
+    std::vector<Amount> values;
+    Amount valueSum = 0ull;
     for (int i = 0; i < n; ++i) {
-        const uint64_t val = (i + 1) * 100;
+        const Amount val = static_cast<Amount>(i + 1) * 100ull;
         values.push_back(val);
         valueSum += val;
     }
@@ -669,35 +670,35 @@ TEST(TransactionPlan, ManyUtxosMax_5000_simple) {
     auto txPlan = TransactionBuilder::plan(sigingInput);
 
     // only 3000 are selected, the first ones minus a few small dust ones
-    const uint64_t dustLimit = byteFee * 150;
-    std::vector<int64_t> filteredValues;
-    uint64_t filteredValueSum = 0;
+    const Amount dustLimit = byteFee * 150ull;
+    std::vector<Amount> filteredValues;
+    Amount filteredValueSum = 0ull;
     for (int i = 0; i < 3000 + 14; ++i) {
-        const uint64_t val = (i + 1) * 100;
+        const Amount val = static_cast<Amount>(i + 1) * 100ull;
         if (val >= dustLimit) {
             filteredValues.push_back(val);
             filteredValueSum += val;
         }
     }
-    EXPECT_EQ(valueSum, 1'250'250'000ul);
-    EXPECT_EQ(dustLimit, 1500ul);
-    EXPECT_EQ(filteredValues.size(), 3000ul);
-    EXPECT_EQ(filteredValueSum, 454'350'000ul);
-    EXPECT_TRUE(verifyPlan(txPlan, filteredValues, 449'909'560, 4'440'440));
+    EXPECT_EQ(valueSum, 1'250'250'000ull);
+    EXPECT_EQ(dustLimit, 1500ull);
+    EXPECT_EQ(filteredValues.size(), 3000ull);
+    EXPECT_EQ(filteredValueSum, 454'350'000ull);
+    EXPECT_TRUE(verifyPlan(txPlan, filteredValues, 449'909'560ull, 4'440'440ull));
 }
 
 TEST(TransactionPlan, OpReturn) {
     auto ownAddress = "bc1q7s0a2l4aguksehx8hf93hs9yggl6njxds6m02g";
     auto toAddress = "bc1qxu5a8gtnjxw3xwdlmr2gl9d76h9fysu3zl656e";
-    auto utxoAmount = 342101;
-    auto toAmount = 300000;
-    int byteFee = 126;
+    const Amount utxoAmount = 342101ull;
+    const Amount toAmount = 300000ull;
+    const Amount byteFee = 126ull;
     Data memo = data("SWAP:THOR.RUNE:thor1tpercamkkxec0q0jk6ltdnlqvsw29guap8wmcl:");
 
     auto signingInput = Proto::SigningInput();
     signingInput.set_hash_type(TWBitcoinSigHashTypeAll);
-    signingInput.set_amount(toAmount);
-    signingInput.set_byte_fee(byteFee);
+    signingInput.set_amount(tryToSigned(toAmount));
+    signingInput.set_byte_fee(tryToSigned(byteFee));
     signingInput.set_to_address(toAddress);
     signingInput.set_change_address(ownAddress);
     signingInput.set_output_op_return(memo.data(), memo.size());
@@ -708,18 +709,18 @@ TEST(TransactionPlan, OpReturn) {
     utxo.mutable_out_point()->set_hash(utxoHash.data(), utxoHash.size());
     utxo.mutable_out_point()->set_index(1);
     utxo.mutable_out_point()->set_sequence(UINT32_MAX);
-    utxo.set_amount(utxoAmount);
+    utxo.set_amount(tryToSigned(utxoAmount));
 
     auto txPlan = TransactionBuilder::plan(signingInput);
 
-    EXPECT_TRUE(verifyPlan(txPlan, {342101}, 300000, 205 * byteFee));
-    EXPECT_EQ(txPlan.outputOpReturn.size(), 59ul);
+    EXPECT_TRUE(verifyPlan(txPlan, {342101}, 300000ull, 205ull * byteFee));
+    EXPECT_EQ(txPlan.outputOpReturn.size(), 59ull);
     EXPECT_EQ(hex(txPlan.outputOpReturn), "535741503a54484f522e52554e453a74686f72317470657263616d6b6b7865633071306a6b366c74646e6c7176737732396775617038776d636c3a");
     EXPECT_FALSE(txPlan.outputOpReturnIndex.has_value());
 
     auto& feeCalculator = getFeeCalculator(TWCoinTypeBitcoin);
-    EXPECT_EQ(feeCalculator.calculate(1, 2, byteFee), 174 * byteFee);
-    EXPECT_EQ(feeCalculator.calculate(1, 3, byteFee), 205 * byteFee);
+    EXPECT_EQ(feeCalculator.calculate(1, 2, byteFee), 174ull * byteFee);
+    EXPECT_EQ(feeCalculator.calculate(1, 3, byteFee), 205ull * byteFee);
 }
 
 } // namespace TW::Bitcoin

--- a/tests/chains/Bitcoin/TxComparisonHelper.cpp
+++ b/tests/chains/Bitcoin/TxComparisonHelper.cpp
@@ -21,7 +21,7 @@ namespace TW::Bitcoin {
 
 auto emptyTxOutPoint = OutPoint(parse_hex("b33082a5fad105c1d9712e8d503971fe4d84713065bd323fd1019636ed940e8d"), 0);
 
-UTXO buildTestUTXO(int64_t amount) {
+UTXO buildTestUTXO(Amount amount) {
     UTXO utxo;
     utxo.amount = amount;
     utxo.outPoint = emptyTxOutPoint;
@@ -31,15 +31,15 @@ UTXO buildTestUTXO(int64_t amount) {
     return utxo;
 }
 
-UTXOs buildTestUTXOs(const std::vector<int64_t>& amounts) {
+UTXOs buildTestUTXOs(const std::vector<Amount>& amounts) {
     UTXOs utxos;
-    for (long long amount : amounts) {
+    for (Amount amount : amounts) {
         utxos.push_back(buildTestUTXO(amount));
     }
     return utxos;
 }
 
-SigningInput buildSigningInput(Amount amount, int byteFee, const UTXOs& utxos, bool useMaxAmount, enum TWCoinType coin, bool omitPrivateKey) {
+SigningInput buildSigningInput(Amount amount, Amount byteFee, const UTXOs& utxos, bool useMaxAmount, enum TWCoinType coin, bool omitPrivateKey) {
     SigningInput input;
     input.amount = amount;
     input.byteFee = byteFee;
@@ -61,15 +61,15 @@ SigningInput buildSigningInput(Amount amount, int byteFee, const UTXOs& utxos, b
     return input;
 }
 
-int64_t sumUTXOs(const UTXOs& utxos) {
-    int64_t s = 0u;
+Amount sumUTXOs(const UTXOs& utxos) {
+    Amount s = 0u;
     for (auto& utxo : utxos) {
         s += utxo.amount;
     }
     return s;
 }
 
-bool verifySelectedUTXOs(const UTXOs& selected, const std::vector<int64_t>& expectedAmounts) {
+bool verifySelectedUTXOs(const UTXOs& selected, const std::vector<Amount>& expectedAmounts) {
     bool ret = true;
     if (selected.size() != expectedAmounts.size()) {
         ret = false;
@@ -88,7 +88,7 @@ bool verifySelectedUTXOs(const UTXOs& selected, const std::vector<int64_t>& expe
     return ret;
 }
 
-bool verifyPlan(const TransactionPlan& plan, const std::vector<int64_t>& utxoAmounts, int64_t outputAmount, int64_t fee, Common::Proto::SigningError error) {
+bool verifyPlan(const TransactionPlan& plan, const std::vector<Amount>& utxoAmounts, Amount outputAmount, Amount fee, Common::Proto::SigningError error) {
     bool ret = true;
     if (!verifySelectedUTXOs(plan.utxos, utxoAmounts)) {
         ret = false;
@@ -101,15 +101,15 @@ bool verifyPlan(const TransactionPlan& plan, const std::vector<int64_t>& utxoAmo
         ret = false;
         std::cerr << "Mismatch in fee, act " << plan.fee << ", exp " << fee << std::endl;
     }
-    int64_t sumExpectedUTXOs = 0;
-    for (long long utxoAmount : utxoAmounts) {
+    Amount sumExpectedUTXOs = 0;
+    for (Amount utxoAmount : utxoAmounts) {
         sumExpectedUTXOs += utxoAmount;
     }
     if (plan.availableAmount != sumExpectedUTXOs) {
         ret = false;
         std::cerr << "Mismatch in availableAmount, act " << plan.availableAmount << ", exp " << sumExpectedUTXOs << std::endl;
     }
-    int64_t expectedChange = sumExpectedUTXOs - outputAmount - fee;
+    Amount expectedChange = sumExpectedUTXOs - outputAmount - fee;
     if (plan.change != expectedChange) {
         ret = false;
         std::cerr << "Mismatch in change, act " << plan.change << ", exp " << expectedChange << std::endl;
@@ -149,7 +149,7 @@ EncodedTxSize getEncodedTxSize(const Transaction& tx) {
         tx.encode(data, Transaction::SegwitFormatMode::NonSegwit);
         size.nonSegwit = data.size();
     }
-    int64_t witnessSize = 0;
+    Amount witnessSize = 0;
     { // double check witness part: witness plus 2 bytes is the difference between segwit and non-segwit size
         Data data;
         tx.encodeWitness(data);
@@ -157,10 +157,10 @@ EncodedTxSize getEncodedTxSize(const Transaction& tx) {
         assert(size.segwit - size.nonSegwit == 2ul + witnessSize);
     }
     // compute virtual size: 3/4 of (smaller) non-segwit + 1/4 of segwit size
-    uint64_t sum = size.nonSegwit * 3 + size.segwit;
+    Amount sum = size.nonSegwit * 3 + size.segwit;
     size.virtualBytes = sum / 4 + (sum % 4 != 0);
     // alternative computation: (smaller) non-segwit + 1/4 of the diff (witness-only)
-    uint64_t vSize2 = size.nonSegwit + (witnessSize + 2) / 4 + ((witnessSize + 2) % 4 != 0);
+    Amount vSize2 = size.nonSegwit + (witnessSize + 2) / 4 + ((witnessSize + 2) % 4 != 0);
     assert(size.virtualBytes == vSize2);
     return size;
 }
@@ -172,7 +172,7 @@ bool validateEstimatedSize(const Transaction& tx, int smallerTolerance, int bigg
     }
     bool ret = true;
     auto estSize = tx.previousEstimatedVirtualSize;
-    uint64_t vsize = getEncodedTxSize(tx).virtualBytes;
+    int64_t vsize = static_cast<int64_t>(getEncodedTxSize(tx).virtualBytes);
     int64_t diff = estSize - vsize;
     if (diff < smallerTolerance) {
         ret = false;

--- a/tests/chains/Bitcoin/TxComparisonHelper.h
+++ b/tests/chains/Bitcoin/TxComparisonHelper.h
@@ -17,28 +17,28 @@
 namespace TW::Bitcoin {
 
 /// Build a dummy UTXO with the given amount
-UTXO buildTestUTXO(int64_t amount);
+UTXO buildTestUTXO(Amount amount);
 
 /// Build a set of dummy UTXO with the given amounts
-UTXOs buildTestUTXOs(const std::vector<int64_t>& amounts);
+UTXOs buildTestUTXOs(const std::vector<Amount>& amounts);
 
-SigningInput buildSigningInput(Amount amount, int byteFee, const UTXOs& utxos,
+SigningInput buildSigningInput(Amount amount, Amount byteFee, const UTXOs& utxos,
                                bool useMaxAmount = false, enum TWCoinType coin = TWCoinTypeBitcoin, bool omitPrivateKey = false);
 
 /// Compare a set of selected UTXOs to the expected set of amounts.
 /// Returns false on mismatch, and error is printed (stderr).
-bool verifySelectedUTXOs(const UTXOs& selected, const std::vector<int64_t>& expectedAmounts);
+bool verifySelectedUTXOs(const UTXOs& selected, const std::vector<Amount>& expectedAmounts);
 
 /// Compare a transaction plan against expected values (UTXO amounts, amount, fee, change is implicit).
 /// Returns false on mismatch, and error is printed (stderr).
-bool verifyPlan(const TransactionPlan& plan, const std::vector<int64_t>& utxoAmounts, int64_t outputAmount, int64_t fee, Common::Proto::SigningError error = Common::Proto::OK);
+bool verifyPlan(const TransactionPlan& plan, const std::vector<Amount>& utxoAmounts, Amount outputAmount, Amount fee, Common::Proto::SigningError error = Common::Proto::OK);
 
-int64_t sumUTXOs(const UTXOs& utxos);
+Amount sumUTXOs(const UTXOs& utxos);
 
 struct EncodedTxSize {
-    uint64_t segwit;
-    uint64_t nonSegwit;
-    uint64_t virtualBytes;
+    Amount segwit;
+    Amount nonSegwit;
+    Amount virtualBytes;
 };
 bool operator==(const EncodedTxSize& s1, const EncodedTxSize& s2);
 

--- a/tests/chains/Zen/TransactionBuilderTests.cpp
+++ b/tests/chains/Zen/TransactionBuilderTests.cpp
@@ -61,7 +61,7 @@ TEST(ZenTransactionBuilder, Build) {
     input.add_private_key(utxoKey0.bytes.data(), utxoKey0.bytes.size());
 
     auto plan = Bitcoin::TransactionSigner<Bitcoin::Transaction, Zen::TransactionBuilder>::plan(input);
-    ASSERT_EQ(plan.fee, 294);
+    ASSERT_EQ(plan.fee, 294ull);
     plan.preBlockHash = blockHash;
     plan.preBlockHeight = blockHeight;
 
@@ -75,7 +75,7 @@ TEST(ZenTransactionBuilder, Build) {
     result = Zen::TransactionBuilder::build<Bitcoin::Transaction>(plan, input).payload();
   
     ASSERT_EQ(result.outputs.size(), 4ul);
-    ASSERT_EQ(result.outputs[3].value, 7000);
+    ASSERT_EQ(result.outputs[3].value, 7000ull);
 }
 
 TEST(ZenTransactionBuilder, BuildScript) {
@@ -86,6 +86,6 @@ TEST(ZenTransactionBuilder, BuildScript) {
     // invalid address
     auto result = Zen::TransactionBuilder::prepareOutputWithScript(
         "DRyNFvJaybnF22UfMS6NR1Qav3mqxPj86E",
-        10000, TWCoinTypeZen, blockHash, blockHeight);
+        10000ull, TWCoinTypeZen, blockHash, blockHeight);
     ASSERT_FALSE(result.has_value());
 }

--- a/tests/chains/Zen/TransactionCompilerTests.cpp
+++ b/tests/chains/Zen/TransactionCompilerTests.cpp
@@ -60,11 +60,11 @@ TEST(ZenCompiler, CompileWithSignatures) {
     utxo0->set_script(script0.bytes.data(), script0.bytes.size());
 
     auto plan = Zen::TransactionBuilder::plan(input);
-    ASSERT_EQ(plan.fee, 226);
+    ASSERT_EQ(plan.fee, 226ull);
     plan.preBlockHash = blockHash;
     plan.preBlockHeight = blockHeight;
-    plan.fee = 302;
-    plan.change = 1249057 - plan.amount - plan.fee;
+    plan.fee = 302ull;
+    plan.change = 1249057ull - plan.amount - plan.fee;
 
     auto& protoPlan = *input.mutable_plan();
     protoPlan = plan.proto();


### PR DESCRIPTION
This pull request strengthens type safety and error handling for transaction value conversions across Bitcoin, Decred, and Zcash modules. The main goal is to ensure that all monetary values (inputs, outputs, fees, etc.) are properly checked and converted, preventing negative or out-of-range values from propagating through the codebase. This is achieved by consistently using `try_into()` with contextual error mapping and updating relevant method signatures to return `SigningResult` for better error propagation.

**Key changes by theme:**

#### Improved Type Safety and Error Handling for Value Conversions

* Replaced direct assignments of transaction amounts (inputs, outputs, fees, etc.) with `try_into()` conversions and mapped errors using `.tw_err(...)` and `.context(...)` for detailed error reporting in Bitcoin and Decred modules. This affects planners, signers, protobuf builders, and transaction builders.

* Updated method signatures in protobuf builders and related functions (e.g., `tx_to_proto`, `tx_input_to_proto`, `tx_output_to_proto`) to return `SigningResult<T>` instead of plain values, ensuring errors are properly propagated up the call stack.

#### Refactoring and Clean-up

* Removed redundant or now-unnecessary manual negative value checks in favor of the new conversion and error handling approach, simplifying logic in transaction and UTXO builders.

#### Consistency Across Chains

* Applied the same conversion and error handling logic to Decred and Zcash modules, ensuring uniformity and reducing the risk of inconsistencies or missed edge cases.

These changes make the codebase more robust, preventing invalid transaction values from causing subtle bugs or security issues, and provide clearer error messages for debugging and user feedback.