### PR TITLE
fix(crypto-box): Reject small-order public keys

### DIFF
--- a/rust/tw_keypair/src/nacl_crypto_box/public_key.rs
+++ b/rust/tw_keypair/src/nacl_crypto_box/public_key.rs
@@ -3,6 +3,13 @@
 // Copyright © 2017 Trust Wallet.
 
 use crate::KeyPairError;
+use curve25519_dalek::MontgomeryPoint;
+
+const PUBLIC_KEY_LEN: usize = 32;
+/// Use an arbitrary sign bit 0 – group order is unaffected by the sign.
+/// Please note it's only used to check if the public key is of small order,
+/// and not to determine the sign of the point.
+const EDWARDS_POINT_SIGN: u8 = 0;
 
 pub struct PublicKey {
     public: crypto_box::PublicKey,
@@ -26,8 +33,24 @@ impl<'a> TryFrom<&'a [u8]> for PublicKey {
     type Error = KeyPairError;
 
     fn try_from(value: &'a [u8]) -> Result<Self, Self::Error> {
-        let public =
-            crypto_box::PublicKey::from_slice(value).map_err(|_| KeyPairError::InvalidPublicKey)?;
+        // Reject low-order X25519 public keys to prevent small-subgroup attacks.
+        // Convert the Montgomery-encoded key to an EdwardsPoint and use
+        // curve25519_dalek's built-in is_small_order() check.
+        let arr: [u8; PUBLIC_KEY_LEN] = value
+            .try_into()
+            .map_err(|_| KeyPairError::InvalidPublicKey)?;
+        let mont = MontgomeryPoint(arr);
+
+        // to_edwards() returns None for the Montgomery point-at-infinity and
+        // for u-coordinates that have no Edwards image; both warrant rejection.
+        let edwards = mont
+            .to_edwards(EDWARDS_POINT_SIGN)
+            .ok_or(KeyPairError::InvalidPublicKey)?;
+        if edwards.is_small_order() {
+            return Err(KeyPairError::InvalidPublicKey);
+        }
+
+        let public = crypto_box::PublicKey::from(mont);
         Ok(PublicKey { public })
     }
 }

--- a/rust/tw_keypair/tests/x25519_small_order_points_tests.rs
+++ b/rust/tw_keypair/tests/x25519_small_order_points_tests.rs
@@ -5,6 +5,9 @@
 use tw_encoding::hex;
 use tw_keypair::nacl_crypto_box::public_key::PublicKey;
 
+// Some of these examples were taken from the libsodium blocklist:
+// https://github.com/jedisct1/libsodium/blob/master/src/libsodium/crypto_scalarmult/curve25519/ref10/x25519_ref10.c
+
 #[test]
 fn test_x25519_small_order_points() {
     let small_order_points = [

--- a/rust/tw_keypair/tests/x25519_small_order_points_tests.rs
+++ b/rust/tw_keypair/tests/x25519_small_order_points_tests.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+
+use tw_encoding::hex;
+use tw_keypair::nacl_crypto_box::public_key::PublicKey;
+
+#[test]
+fn test_x25519_small_order_points() {
+    let small_order_points = [
+        // The four canonical small-order Montgomery u-coordinates derived from
+        // the 8 Edwards torsion points (each ±Edwards pair shares one u-coordinate):
+        "0000000000000000000000000000000000000000000000000000000000000000", // order 1 – identity (u = 0)
+        "0100000000000000000000000000000000000000000000000000000000000000", // order 2
+        "5f9c95bca3508c24b1d0b1559c83ef5b04445cc4581c8e86d8224eddd09f1157", // order 4
+        "e0eb7a7c3b41b8ae1656e3faf19fc46ada098deb9c32b1fd866205165f49b800", // order 8
+        // Non-canonical encoding of the identity: u = p ≡ 0 (mod p).
+        // In little-endian, the field prime p = 2^255-19 is encoded as edfff...7f.
+        // curve25519_dalek correctly identifies this as small-order via is_small_order().
+        "edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f", // u = p ≡ 0 (mod p), non-canonical identity
+    ];
+
+    for point_hex in small_order_points {
+        let point = hex::decode(point_hex).expect("Invalid hex in test data");
+        let result = PublicKey::try_from(point.as_slice());
+        assert!(
+            result.is_err(),
+            "Expected error for small order point: {point_hex}"
+        );
+    }
+}
+
+#[test]
+fn test_x25519_invalid_encoded_points() {
+    // These u-coordinates have no valid Edwards birational image (to_edwards() returns None
+    // for both sign bits). They are NOT small-order points; they are simply invalid/
+    // non-canonical u-coordinates that do not correspond to any point on the Edwards curve.
+    let invalid_encoded_points = [
+        "0000000000000000000000000000000000000000000000000000000000000080", // high bit set (non-canonical)
+        "0100000000000000000000000000000000000000000000000000000000000080", // high bit set (non-canonical)
+        "edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", // high bit set (non-canonical)
+        // u = 2^255 - 64: not a quadratic residue mod p, so (u³+Au²+u) has no square root –
+        // this u-coordinate does not lie on the Montgomery curve and has no Edwards image.
+        "c0ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+    ];
+
+    for point_hex in invalid_encoded_points {
+        let point = hex::decode(point_hex).expect("Invalid hex in test data");
+        let result = PublicKey::try_from(point.as_slice());
+        assert!(
+            result.is_err(),
+            "Expected error for invalid encoded point: {point_hex}"
+        );
+    }
+}

--- a/rust/tw_keypair/tests/x25519_small_order_points_tests.rs
+++ b/rust/tw_keypair/tests/x25519_small_order_points_tests.rs
@@ -14,10 +14,11 @@ fn test_x25519_small_order_points() {
         "0100000000000000000000000000000000000000000000000000000000000000", // order 2
         "5f9c95bca3508c24b1d0b1559c83ef5b04445cc4581c8e86d8224eddd09f1157", // order 4
         "e0eb7a7c3b41b8ae1656e3faf19fc46ada098deb9c32b1fd866205165f49b800", // order 8
-        // Non-canonical encoding of the identity: u = p ≡ 0 (mod p).
-        // In little-endian, the field prime p = 2^255-19 is encoded as edfff...7f.
-        // curve25519_dalek correctly identifies this as small-order via is_small_order().
-        "edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f", // u = p ≡ 0 (mod p), non-canonical identity
+        // Non-canonical encodings: u-coordinates >= p are reduced mod p before use.
+        // u = p     ≡ 0 (mod p) — non-canonical identity, same group element as u=0.
+        "edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+        // u = p+1   ≡ 1 (mod p) — non-canonical encoding of u=1 (order 2).
+        "eeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
     ];
 
     for point_hex in small_order_points {
@@ -39,6 +40,10 @@ fn test_x25519_invalid_encoded_points() {
         "0000000000000000000000000000000000000000000000000000000000000080", // high bit set (non-canonical)
         "0100000000000000000000000000000000000000000000000000000000000080", // high bit set (non-canonical)
         "edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", // high bit set (non-canonical)
+        // u = p-1 ≡ -1 (mod p): the denominator of the Montgomery→Edwards map is (u+1) = 0,
+        // making the map undefined. to_edwards() returns None for both sign bits.
+        // libsodium also blocks this point (listed as "p-1, order 2" in their blocklist).
+        "ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
         // u = 2^255 - 64: not a quadratic residue mod p, so (u³+Au²+u) has no square root –
         // this u-coordinate does not lie on the Montgomery curve and has no Edwards image.
         "c0ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",


### PR DESCRIPTION
This pull request strengthens the validation of X25519 public keys in the `PublicKey` implementation to prevent small-subgroup attacks and adds comprehensive tests for small-order and invalid points. The main changes include rejecting low-order and invalid public keys during deserialization and introducing a new test suite to ensure these cases are properly handled.

**Security improvements:**

* Updated the `TryFrom<&[u8]> for PublicKey` implementation in `public_key.rs` to reject low-order X25519 public keys by converting the Montgomery point to an Edwards point and checking for small order or invalid mapping. This prevents small-subgroup attacks by ensuring only valid, non-small-order keys are accepted.
* Added constants and imports in `public_key.rs` to support the new validation logic, including `PUBLIC_KEY_LEN` and `EDWARDS_POINT_SIGN`.

**Testing:**

* Added a new test module `x25519_small_order_points_tests.rs` that verifies the rejection of small-order and invalid X25519 public keys, using test vectors from the libsodium blocklist and other non-canonical encodings.