### PR TITLE
fix(scrypt): allow empty or missing salt for backward compatibility and improve hex parsing validation

### DIFF
--- a/src/HexCoding.h
+++ b/src/HexCoding.h
@@ -29,6 +29,21 @@ inline Data parse_hex(const std::string& input) {
     Rust::CByteArrayResultWrapper res = Rust::decode_hex(input.c_str());
     return res.unwrap_or_default().data;
 }
+
+/// Pads a hexadecimal string with a leading zero if it has an odd length and the `padLeft` flag is set.
+inline std::string pad_left_hex(const std::string& string, bool padLeft = false) {
+    if (string.size() % 2 != 0 && padLeft) {
+        std::string temp = string;
+        if (temp.compare(0, 2, "0x") == 0) {
+            temp.insert(2, 1, '0');
+        } else {
+            temp.insert(0, 1, '0');
+        }
+        return temp;
+    }
+    return string;
+}
+
 }
 
 namespace TW {
@@ -77,29 +92,19 @@ inline std::string hex(uint64_t value) {
     return hex(v);
 }
 
-/// Pads a hexadecimal string with a leading zero if it has an odd length and the `padLeft` flag is set.
-inline std::string pad_left_hex(const std::string& string, bool padLeft = false) {
-    if (string.size() % 2 != 0 && padLeft) {
-        std::string temp = string;
-        if (temp.compare(0, 2, "0x") == 0) {
-            temp.erase(0, 2);
-        }
-        temp.insert(0, 1, '0');
-        return temp;
-    }
-    return string;
-}
-
 /// Parses a string of hexadecimal values.
 ///
 /// \returns the array or parsed bytes or an empty array if the string is not
 /// valid hexadecimal.
 inline Data parse_hex(const std::string& string, bool padLeft = false) {
-    return internal::parse_hex(pad_left_hex(string, padLeft));
+    return internal::parse_hex(internal::pad_left_hex(string, padLeft));
 }
 
+/// Parses a string of hexadecimal values.
+///
+/// \returns the array or parsed bytes, or an error if the string is not valid hexadecimal.
 inline Result<Data> parse_hex_checked(const std::string& string, bool padLeft = false) {
-    const auto paddedString = pad_left_hex(string, padLeft);
+    const auto paddedString = internal::pad_left_hex(string, padLeft);
     Rust::CByteArrayResultWrapper res = Rust::decode_hex(paddedString.c_str());
     if (res.isErr()) {
         return Result<Data>::failure("Invalid hex string");

--- a/src/HexCoding.h
+++ b/src/HexCoding.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "Data.h"
+#include "Result.h"
 #include "rust/bindgen/WalletCoreRSBindgen.h"
 #include "rust/Wrapper.h"
 
@@ -76,20 +77,34 @@ inline std::string hex(uint64_t value) {
     return hex(v);
 }
 
-/// Parses a string of hexadecimal values.
-///
-/// \returns the array or parsed bytes or an empty array if the string is not
-/// valid hexadecimal.
-inline Data parse_hex(const std::string& string, bool padLeft = false) {
+/// Pads a hexadecimal string with a leading zero if it has an odd length and the `padLeft` flag is set.
+inline std::string pad_left_hex(const std::string& string, bool padLeft = false) {
     if (string.size() % 2 != 0 && padLeft) {
         std::string temp = string;
         if (temp.compare(0, 2, "0x") == 0) {
             temp.erase(0, 2);
         }
         temp.insert(0, 1, '0');
-        return internal::parse_hex(temp);
+        return temp;
     }
-    return internal::parse_hex(string);
+    return string;
+}
+
+/// Parses a string of hexadecimal values.
+///
+/// \returns the array or parsed bytes or an empty array if the string is not
+/// valid hexadecimal.
+inline Data parse_hex(const std::string& string, bool padLeft = false) {
+    return internal::parse_hex(pad_left_hex(string, padLeft));
+}
+
+inline Result<Data> parse_hex_checked(const std::string& string, bool padLeft = false) {
+    const auto paddedString = pad_left_hex(string, padLeft);
+    Rust::CByteArrayResultWrapper res = Rust::decode_hex(paddedString.c_str());
+    if (res.isErr()) {
+        return Result<Data>::failure("Invalid hex string");
+    }
+    return Result<Data>::success(std::move(res.unwrap_or_default().data));
 }
 
 inline const char* hex_char_to_bin(char c) {

--- a/src/Keystore/ScryptParameters.cpp
+++ b/src/Keystore/ScryptParameters.cpp
@@ -74,7 +74,8 @@ std::optional<ScryptValidationError> ScryptParameters::validate() const {
     if (desiredKeyLength > ((1ULL << 32) - 1) * 32) { // depending on size_t size on platform, may be always false
         return ScryptValidationError::desiredKeyLengthTooLarge;
     }
-    if (salt.size() < minSaltLength || salt.size() > maxSaltLength) {
+    // For backward compatibility with existing keys, we allow empty and less than 16 bytes salt.
+    if (salt.size() > maxSaltLength) {
         return ScryptValidationError::invalidSaltLength;
     }
     if (static_cast<uint64_t>(r) * static_cast<uint64_t>(p) >= (1 << 30)) {
@@ -108,12 +109,21 @@ ScryptParameters::ScryptParameters(const nlohmann::json& json) {
     if (json.count(CodingKeys::SP::n) == 0
         || json.count(CodingKeys::SP::p) == 0
         || json.count(CodingKeys::SP::r) == 0
-        || json.count(CodingKeys::SP::salt) == 0
         || json.count(CodingKeys::SP::desiredKeyLength) == 0) {
-        throw std::invalid_argument("Missing required scrypt parameters n, p, r, salt, or dklen");
+        throw std::invalid_argument("Missing required scrypt parameters n, p, r, or dklen");
     }
 
-    salt = parse_hex(json[CodingKeys::SP::salt].get<std::string>());
+    // For backward compatibility with existing keys, we allow missing salt, and fallback to empty salt in that case.
+    if (json.count(CodingKeys::SP::salt) == 0) {
+        salt = Data();
+    } else {
+        const auto res = parse_hex_checked(json[CodingKeys::SP::salt].get<std::string>());
+        if (res.isFailure()) {
+            throw std::invalid_argument("Invalid scrypt parameters: salt must be a valid hex");
+        }
+        salt = res.payload();
+    }
+
     desiredKeyLength = json[CodingKeys::SP::desiredKeyLength];
     n = json[CodingKeys::SP::n];
     p = json[CodingKeys::SP::p];

--- a/tests/common/HexCodingTests.cpp
+++ b/tests/common/HexCodingTests.cpp
@@ -33,4 +33,59 @@ TEST(HexCoding, isHexEncoded) {
     ASSERT_FALSE(is_hex_encoded("0xyahoo"));
 }
 
+TEST(HexCoding, ParseHexChecked) {
+    // Valid, well-padded
+    auto res = parse_hex_checked("0x7d8bf18c7ce84b3e175b339c4ca93aed1dd166f1");
+    ASSERT_TRUE(res.isSuccess());
+    EXPECT_EQ(hex(res.payload()), "7d8bf18c7ce84b3e175b339c4ca93aed1dd166f1");
+
+    // Valid, well-padded, no 0x
+    res = parse_hex_checked("7d8bf18c7ce84b3e175b339c4ca93aed1dd166f1");
+    ASSERT_TRUE(res.isSuccess());
+    EXPECT_EQ(hex(res.payload()), "7d8bf18c7ce84b3e175b339c4ca93aed1dd166f1");
+
+    // Empty string
+    res = parse_hex_checked("");
+    ASSERT_TRUE(res.isSuccess());
+    EXPECT_TRUE(res.payload().empty());
+
+    // 0x string
+    res = parse_hex_checked("0x");
+    ASSERT_TRUE(res.isSuccess());
+    EXPECT_TRUE(res.payload().empty());
+}
+
+TEST(HexCoding, ParseHexCheckedNotPaddedFailed) {
+    // Odd-length, not padded, padLeft = false
+    auto res = parse_hex_checked("0x123", false);
+    ASSERT_FALSE(res.isSuccess());
+    EXPECT_EQ(res.error(), "Invalid hex string");
+
+    res = parse_hex_checked("123", false);
+    ASSERT_FALSE(res.isSuccess());
+    EXPECT_EQ(res.error(), "Invalid hex string");
+}
+
+TEST(HexCoding, ParseHexCheckedNotPaddedSucceeds) {
+    // Odd-length, padLeft = true
+    auto res = parse_hex_checked("0x1", true);
+    ASSERT_TRUE(res.isSuccess());
+    EXPECT_EQ(hex(res.payload()), "01");
+
+    res = parse_hex_checked("abc", true);
+    ASSERT_TRUE(res.isSuccess());
+    EXPECT_EQ(hex(res.payload()), "0abc");
+}
+
+TEST(HexCoding, ParseHexCheckedInvalidHex) {
+    // Not valid hex
+    auto res = parse_hex_checked("0xMQqpqMQgCBuiPkoXfgZZsJvuzCeI1zc00z6vHJj4");
+    ASSERT_FALSE(res.isSuccess());
+    EXPECT_EQ(res.error(), "Invalid hex string");
+
+    res = parse_hex_checked("nothex");
+    ASSERT_FALSE(res.isSuccess());
+    EXPECT_EQ(res.error(), "Invalid hex string");
+}
+
 }

--- a/tests/common/HexCodingTests.cpp
+++ b/tests/common/HexCodingTests.cpp
@@ -88,4 +88,22 @@ TEST(HexCoding, ParseHexCheckedInvalidHex) {
     EXPECT_EQ(res.error(), "Invalid hex string");
 }
 
+TEST(HexCoding, PadLeftHex) {
+    // Empty string
+    EXPECT_EQ(internal::pad_left_hex(""), "");
+    // "0x" only
+    EXPECT_EQ(internal::pad_left_hex("0x"), "0x");
+    // Odd-length with 0x
+    EXPECT_EQ(internal::pad_left_hex("0x1", true), "0x01");
+    EXPECT_EQ(internal::pad_left_hex("0x12", true), "0x12");
+    EXPECT_EQ(internal::pad_left_hex("0x123", true), "0x0123");
+    // Odd-length without 0x
+    EXPECT_EQ(internal::pad_left_hex("1", true), "01");
+    EXPECT_EQ(internal::pad_left_hex("12", true), "12");
+    EXPECT_EQ(internal::pad_left_hex("123", true), "0123");
+    // padLeft = false (should not pad)
+    EXPECT_EQ(internal::pad_left_hex("0x1", false), "0x1");
+    EXPECT_EQ(internal::pad_left_hex("123", false), "123");
+}
+
 }

--- a/tests/common/Keystore/Data/scrypt-empty-salt.json
+++ b/tests/common/Keystore/Data/scrypt-empty-salt.json
@@ -1,0 +1,31 @@
+{
+  "activeAccounts": [
+    {
+      "address": "bc1qturc268v0f2srjh4r2zu4t6zk4gdutqd5a6zny",
+      "coin": 0,
+      "derivationPath": "m/84'/0'/0'/0/0",
+      "extendedPublicKey": "zpub6qbsWdbcKW9sC6shTKK4VEhfWvDCoWpfLnnVfYKHLHt31wKYUwH3aFDz4WLjZvjHZ5W4qVEyk37cRwzTbfrrT1Gnu8SgXawASnkdQ994atn",
+      "publicKey": "02df6fc590ab3101bbe0bb5765cbaeab9b5dcfe09ac9315d707047cbd13bc7e006"
+    }
+  ],
+  "crypto": {
+    "cipher": "aes-128-ctr",
+    "cipherparams": {
+      "iv": "f375d3903fa00839c43109b1d26436b7"
+    },
+    "ciphertext": "9768cdec22c3b0d5d7eced4e5387c138045367b9481d5cf017d262e645accd478f0f197f6dcb97e2ce9105fee0e7074d891a9826df3bc8f4dca17f5cdfb9992b86e40f26028c5a392cb2de17",
+    "kdf": "scrypt",
+    "kdfparams": {
+      "dklen": 32,
+      "n": 16384,
+      "p": 4,
+      "r": 8,
+      "salt": ""
+    },
+    "mac": "bbdba986c713d91828a7a2f031d3535414967fce81c6c826b50b0cfab8783dfc"
+  },
+  "id": "8e334366-020b-493f-81ab-a946432f536d",
+  "name": "name",
+  "type": "mnemonic",
+  "version": 3
+}

--- a/tests/common/Keystore/Data/scrypt-without-salt.json
+++ b/tests/common/Keystore/Data/scrypt-without-salt.json
@@ -1,0 +1,30 @@
+{
+  "activeAccounts": [
+    {
+      "address": "bc1qturc268v0f2srjh4r2zu4t6zk4gdutqd5a6zny",
+      "coin": 0,
+      "derivationPath": "m/84'/0'/0'/0/0",
+      "extendedPublicKey": "zpub6qbsWdbcKW9sC6shTKK4VEhfWvDCoWpfLnnVfYKHLHt31wKYUwH3aFDz4WLjZvjHZ5W4qVEyk37cRwzTbfrrT1Gnu8SgXawASnkdQ994atn",
+      "publicKey": "02df6fc590ab3101bbe0bb5765cbaeab9b5dcfe09ac9315d707047cbd13bc7e006"
+    }
+  ],
+  "crypto": {
+    "cipher": "aes-128-ctr",
+    "cipherparams": {
+      "iv": "f375d3903fa00839c43109b1d26436b7"
+    },
+    "ciphertext": "9768cdec22c3b0d5d7eced4e5387c138045367b9481d5cf017d262e645accd478f0f197f6dcb97e2ce9105fee0e7074d891a9826df3bc8f4dca17f5cdfb9992b86e40f26028c5a392cb2de17",
+    "kdf": "scrypt",
+    "kdfparams": {
+      "dklen": 32,
+      "n": 16384,
+      "p": 4,
+      "r": 8
+    },
+    "mac": "bbdba986c713d91828a7a2f031d3535414967fce81c6c826b50b0cfab8783dfc"
+  },
+  "id": "8e334366-020b-493f-81ab-a946432f536d",
+  "name": "name",
+  "type": "mnemonic",
+  "version": 3
+}

--- a/tests/common/Keystore/StoredKeyTests.cpp
+++ b/tests/common/Keystore/StoredKeyTests.cpp
@@ -831,4 +831,46 @@ TEST(StoredKey, CreateWithMnemonicAlternativeDerivation) {
     EXPECT_EQ(hex(key.privateKey(coin, TWDerivationSolanaSolana, gPassword).bytes), "d49a5fa7f77593534c7afd2ba8dc8e9d8b007bc6ec65fe8df25ffe6fafc57151");
 }
 
+TEST(StoredKey, LoadScryptWithEmptySalt) {
+    const auto path = testDataPath("scrypt-empty-salt.json");
+    auto key = StoredKey::load(path);
+    EXPECT_EQ(key.type, StoredKeyType::mnemonicPhrase);
+
+    // Decrypt mnemonic
+    const Data& mnemo2Data = key.payload.decrypt(gPassword);
+    EXPECT_EQ(string(mnemo2Data.begin(), mnemo2Data.end()), string(gMnemonic));
+
+    // JSON representation
+    const auto json = key.json();
+    ASSERT_TRUE(json["crypto"].is_object());
+    ASSERT_TRUE(json["crypto"].contains("kdfparams"));
+
+    const auto& kdfparams = json["crypto"]["kdfparams"];
+    ASSERT_TRUE(kdfparams.is_object());
+    // Salt must be present and empty
+    ASSERT_TRUE(kdfparams.contains("salt"));
+    EXPECT_EQ(kdfparams["salt"].get<std::string>(), "");
+}
+
+TEST(StoredKey, LoadScryptWithoutSalt) {
+    const auto path = testDataPath("scrypt-without-salt.json");
+    auto key = StoredKey::load(path);
+    EXPECT_EQ(key.type, StoredKeyType::mnemonicPhrase);
+
+    // Decrypt mnemonic
+    const Data& mnemo2Data = key.payload.decrypt(gPassword);
+    EXPECT_EQ(string(mnemo2Data.begin(), mnemo2Data.end()), string(gMnemonic));
+
+    // JSON representation
+    const auto json = key.json();
+    ASSERT_TRUE(json["crypto"].is_object());
+    ASSERT_TRUE(json["crypto"].contains("kdfparams"));
+
+    const auto& kdfparams = json["crypto"]["kdfparams"];
+    ASSERT_TRUE(kdfparams.is_object());
+    // Salt must be present and empty
+    ASSERT_TRUE(kdfparams.contains("salt"));
+    EXPECT_EQ(kdfparams["salt"].get<std::string>(), "");
+}
+
 } // namespace TW::Keystore


### PR DESCRIPTION
This pull request improves the handling and validation of hexadecimal and scrypt parameters, particularly for backward compatibility with keystore files that have empty or missing salts. It introduces a safer hex parsing function, updates scrypt parameter validation to allow for older key formats, and adds comprehensive tests to ensure correct behavior.

**Hexadecimal parsing improvements:**
- Added a new `parse_hex_checked` function in `HexCoding.h` that safely parses hex strings and returns a `Result<Data>` indicating success or failure, improving error handling and input validation.
- Refactored the hex string padding logic into a dedicated `pad_left_hex` function for clarity and reuse.
- Updated tests in `HexCodingTests.cpp` to cover new hex parsing logic, including edge cases for empty, odd-length, and invalid hex strings.

**Scrypt parameter compatibility and validation:**
- Modified `ScryptParameters` to allow empty or missing salt fields for backward compatibility with existing keystore files, defaulting to an empty salt if not present.
- Updated validation to only reject salts that exceed the maximum allowed length, not those that are empty or too short.

**Keystore loading and test coverage:**
- Added test vectors and tests to ensure keystore files with empty or missing salt fields are loaded and decrypted correctly, and that the JSON output always includes a (possibly empty) salt field.