### PR TITLE
feat(skill): Add bc-check skill and bc-risk-router workflow for backward-compatibility audits

### DIFF
--- a/.claude/skills/bc-check/SKILL.md
+++ b/.claude/skills/bc-check/SKILL.md
@@ -102,22 +102,26 @@ Answer yes/no with file:line evidence:
 
 ### Token rules for "Suggested PR comment"
 
-| Verdict            | Valid token                          | Invalid tokens  |
-|--------------------|--------------------------------------|-----------------|
-| SAFE               | `[bc-check: Pass]`                   | —               |
-| RISK               | `[bc-check: Mitigated]` (after fix)  | `Pass`, `N/A`   |
-| BLOCKER            | `[bc-check: Mitigated]` (after fix)  | `Pass`, `N/A`   |
-| No persistence risk | `[bc-check: N/A]`                   | —               |
+| Verdict             | Valid token                                          | Invalid tokens  |
+|---------------------|------------------------------------------------------|-----------------|
+| SAFE                | `[bc-check: Pass]`                                   | —               |
+| RISK                | `[bc-check: Mitigated]` (after fix)                  | `Pass`, `N/A`   |
+| RISK                | `[bc-check: Risk-Accepted]` (investigated, no fix)   | `Pass`, `N/A`   |
+| BLOCKER             | `[bc-check: Mitigated]` (after fix)                  | `Pass`, `N/A`   |
+| BLOCKER             | `[bc-check: Risk-Accepted]` (investigated, no fix)   | `Pass`, `N/A`   |
+| No persistence risk | `[bc-check: N/A]`                                    | —               |
 
 **`N/A` means the scanner fired on a file that has zero BC relevance** (a renamed
 variable, a comment edit, a test fixture that happens to match the path filter). It
 does NOT mean "I found a real BC issue but accept the risk." Using `N/A` when the
 audit found a RISK or BLOCKER is incorrect and bypasses the gate dishonestly.
 
-**RISK / BLOCKER have one resolution: fix the problem, then post `Mitigated` with
-the post-fix audit output.** There is no "accept the risk" token. For wallet
-software where the blast radius is loss of user funds, shipping a known BC break is
-not a valid outcome.
+**`Risk-Accepted` is for cases where the finding is real but investigation confirms
+the blast radius is effectively zero** — e.g. telemetry or team confirmation that
+no user data in the wild can trigger the new restriction. It requires the same bar
+as `Mitigated`: full audit output pasted, plus explicit evidence for why the risk is
+acceptable (who confirmed it, what data or reasoning supports it). The audit trail
+must be visible to reviewers.
 
 ### Output format
 

--- a/.claude/skills/bc-check/SKILL.md
+++ b/.claude/skills/bc-check/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: bc-check
-description: Audit the current branch's diff for backward-compatibility risk against persisted user data and wire formats. Use when a PR tightens validation, changes deserialization of stored data, modifies a wire/backup format, or changes which exception a public API throws. Outputs a structured markdown report to paste into a `[bc-check: ...]` PR comment.
+description:
+  Audit the current branch's diff for backward-compatibility risk against persisted user data and wire formats. Use when a PR tightens validation, changes deserialization of stored data, modifies a wire/backup format, or changes which exception a public API throws. Outputs a structured markdown report to paste into a `[bc-check: ...]` PR comment.
 ---
 
 You are auditing the current branch's diff against the configured base branch
@@ -13,6 +14,7 @@ backups, or onto the network.
 validation" is precisely the framing that hides this class of bug.
 
 Before starting:
+
 1. Read `docs/bc-footguns.md` if it exists. Every entry is a known constraint.
 2. `git diff origin/master...HEAD` to get the full diff.
 3. Identify which files are on persistence paths (see WalletCore context below).
@@ -21,20 +23,20 @@ Before starting:
 
 ### WalletCore persistence context
 
-| Path | What lives there | Backup / off-device |
-|------|------------------|---------------------|
-| `src/Keystore/` | JSON keystore files — user's encrypted private keys and mnemonics | iCloud, Google Drive, manual export |
-| `src/proto/*.proto` | Protobuf `SigningInput` / `SigningOutput` wire formats | Potentially stored by app layer |
-| `include/TrustWalletCore/TW*.h` | Public C ABI — function signatures, enum values, exception types | SDK consumers, compiled language bindings |
-| `registry.json` | Coin metadata: SLIP44 ID, derivation paths, address encoding, curve | Drives every derived address for all wallets |
-| `src/Keystore/StoredKey.cpp` | Keystore load / save / migration logic | Same as Keystore above |
-| `src/PrivateKey*` | Private key encoding, validation, and signing entry points | Keys serialised into keystore files |
-| `src/PublicKey*` | Public key parsing and validation | Derived and stored in account records |
-| `src/HDWallet*` | HD wallet derivation — BIP32/39/44 logic | Drives all derived addresses; mnemonic import/export |
-| `swift/Sources/KeyStore*` | Swift-layer keystore read/write/migration | Same backup destinations as C++ keystore |
-| `swift/Sources/Wallet.swift` | Swift wallet account type | Serialised in Swift keystore JSON |
-| `swift/Sources/Watch.swift` | Swift watch-only account type | Serialised in Swift keystore JSON |
-| `wasm/src/keystore/` | WASM/TypeScript keystore bindings | Browser-side keystore files (localStorage, export) |
+| Path                            | What lives there                                                    | Backup / off-device                                  |
+|---------------------------------|---------------------------------------------------------------------|------------------------------------------------------|
+| `src/Keystore/`                 | JSON keystore files — user's encrypted private keys and mnemonics   | iCloud, Google Drive, manual export                  |
+| `src/proto/*.proto`             | Protobuf `SigningInput` / `SigningOutput` wire formats              | Potentially stored by app layer                      |
+| `include/TrustWalletCore/TW*.h` | Public C ABI — function signatures, enum values, exception types    | SDK consumers, compiled language bindings            |
+| `registry.json`                 | Coin metadata: SLIP44 ID, derivation paths, address encoding, curve | Drives every derived address for all wallets         |
+| `src/Keystore/StoredKey.cpp`    | Keystore load / save / migration logic                              | Same as Keystore above                               |
+| `src/PrivateKey*`               | Private key encoding, validation, and signing entry points          | Keys serialized into keystore files                  |
+| `src/PublicKey*`                | Public key parsing and validation                                   | Derived and stored in account records                |
+| `src/HDWallet*`                 | HD wallet derivation — BIP32/39/44 logic                            | Drives all derived addresses; mnemonic import/export |
+| `swift/Sources/KeyStore*`       | Swift-layer keystore read/write/migration                           | Same backup destinations as C++ keystore             |
+| `swift/Sources/Wallet.swift`    | Swift wallet account type                                           | Serialized in Swift keystore JSON                    |
+| `swift/Sources/Watch.swift`     | Swift watch-only account type                                       | Serialized in Swift keystore JSON                    |
+| `wasm/src/keystore/`            | WASM/TypeScript keystore bindings                                   | Browser-side keystore files (localStorage, export)   |
 
 **Blast-radius framing:** a bug in any of these paths means a user cannot decrypt their
 wallet or derives wrong addresses → cannot access funds. Even a 0.01 % blast radius is
@@ -45,12 +47,15 @@ unacceptable. Treat BLOCKER verdicts as such.
 Walk the 5 steps below. Cite file:line and commit SHAs everywhere.
 
 ### Step 1 — Classify
+
 (a) Tighten input validation, (b) change parsing of a persisted format, (c) change
 which exception type a public API throws, (d) remove an `if missing use default`
 fallback, or (e) move validation earlier? If none → "No persistence risk", stop.
 
 ### Step 2 — Historical baseline
+
 For each tightened rule:
+
 - Could a prior version have *produced* data that violates the new rule? `git log -p`
   / `git blame` going back ≥2 years. Cite SHAs.
 - Was there a partial migration ("regenerate on next user action")? Assume a
@@ -58,14 +63,17 @@ For each tightened rule:
 - Does the format ever leave the device? Backup / export / sync.
 
 ### Step 3 — Concrete failure scenarios
+
 For every "yes": old client version → action that produced the data → where it
 lives → exact upgrade code path (file:line) → user-visible symptom → blast radius.
 No hand-waving.
 
 ### Step 4 — Red-flag checklist
+
 Answer yes/no with file:line evidence:
 
 **Generic:**
+
 - New `throw` on read/load/decode/import path?
 - Removed `if (field missing) use default`?
 - New length/range/enum check on >1-year-old field?
@@ -75,6 +83,7 @@ Answer yes/no with file:line evidence:
 - Prior PR shipped "regenerate on next user action" partial migration? (cite SHA)
 
 **WalletCore-specific:**
+
 - Proto: field number reused or removed from an existing message?
 - Proto: field type changed (e.g. `bytes` → `string`) or `required` added to existing field?
 - Proto: enum value renumbered or removed?
@@ -85,12 +94,14 @@ Answer yes/no with file:line evidence:
 - C ABI: `TW*` function removed, renamed, or its return / exception behaviour changed?
 
 ### Step 5 — Required mitigations
+
 - Accept legacy at read time, normalize on write *(preferred)*.
 - Gate strict check behind "newly created" flag.
 - One-time migration with explicit failure UX.
 - Apply tightening to write paths only.
 
 ### Output format
+
 ```
 # BC-risk audit — <branch> @ <git SHA> — <ISO timestamp>
 

--- a/.claude/skills/bc-check/SKILL.md
+++ b/.claude/skills/bc-check/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: bc-check
+description: Audit the current branch's diff for backward-compatibility risk against persisted user data and wire formats. Use when a PR tightens validation, changes deserialization of stored data, modifies a wire/backup format, or changes which exception a public API throws. Outputs a structured markdown report to paste into a `[bc-check: ...]` PR comment.
+---
+
+You are auditing the current branch's diff against the configured base branch
+(`origin/master` by default) for **backward-compatibility risk against persisted user
+data and wire formats**. Find cases where this PR will reject, mis-parse, or
+mishandle inputs that older versions of our own software already wrote to disk, to
+backups, or onto the network.
+
+**Do not trust the PR description's framing.** "Just a security fix" / "stricter
+validation" is precisely the framing that hides this class of bug.
+
+Before starting:
+1. Read `docs/bc-footguns.md` if it exists. Every entry is a known constraint.
+2. `git diff origin/master...HEAD` to get the full diff.
+3. Identify which files are on persistence paths (see WalletCore context below).
+
+---
+
+### WalletCore persistence context
+
+| Path | What lives there | Backup / off-device |
+|------|------------------|---------------------|
+| `src/Keystore/` | JSON keystore files — user's encrypted private keys and mnemonics | iCloud, Google Drive, manual export |
+| `src/proto/*.proto` | Protobuf `SigningInput` / `SigningOutput` wire formats | Potentially stored by app layer |
+| `include/TrustWalletCore/TW*.h` | Public C ABI — function signatures, enum values, exception types | SDK consumers, compiled language bindings |
+| `registry.json` | Coin metadata: SLIP44 ID, derivation paths, address encoding, curve | Drives every derived address for all wallets |
+| `src/Keystore/StoredKey.cpp` | Keystore load / save / migration logic | Same as Keystore above |
+| `src/PrivateKey*` | Private key encoding, validation, and signing entry points | Keys serialised into keystore files |
+| `src/PublicKey*` | Public key parsing and validation | Derived and stored in account records |
+| `src/HDWallet*` | HD wallet derivation — BIP32/39/44 logic | Drives all derived addresses; mnemonic import/export |
+| `swift/Sources/KeyStore*` | Swift-layer keystore read/write/migration | Same backup destinations as C++ keystore |
+| `swift/Sources/Wallet.swift` | Swift wallet account type | Serialised in Swift keystore JSON |
+| `swift/Sources/Watch.swift` | Swift watch-only account type | Serialised in Swift keystore JSON |
+| `wasm/src/keystore/` | WASM/TypeScript keystore bindings | Browser-side keystore files (localStorage, export) |
+
+**Blast-radius framing:** a bug in any of these paths means a user cannot decrypt their
+wallet or derives wrong addresses → cannot access funds. Even a 0.01 % blast radius is
+unacceptable. Treat BLOCKER verdicts as such.
+
+---
+
+Walk the 5 steps below. Cite file:line and commit SHAs everywhere.
+
+### Step 1 — Classify
+(a) Tighten input validation, (b) change parsing of a persisted format, (c) change
+which exception type a public API throws, (d) remove an `if missing use default`
+fallback, or (e) move validation earlier? If none → "No persistence risk", stop.
+
+### Step 2 — Historical baseline
+For each tightened rule:
+- Could a prior version have *produced* data that violates the new rule? `git log -p`
+  / `git blame` going back ≥2 years. Cite SHAs.
+- Was there a partial migration ("regenerate on next user action")? Assume a
+  non-trivial fraction of users **never triggered it**.
+- Does the format ever leave the device? Backup / export / sync.
+
+### Step 3 — Concrete failure scenarios
+For every "yes": old client version → action that produced the data → where it
+lives → exact upgrade code path (file:line) → user-visible symptom → blast radius.
+No hand-waving.
+
+### Step 4 — Red-flag checklist
+Answer yes/no with file:line evidence:
+
+**Generic:**
+- New `throw` on read/load/decode/import path?
+- Removed `if (field missing) use default`?
+- New length/range/enum check on >1-year-old field?
+- Constructor: lenient parse → parse + validate?
+- Changed which exception type a public API throws?
+- Format ever in backup/export/sync?
+- Prior PR shipped "regenerate on next user action" partial migration? (cite SHA)
+
+**WalletCore-specific:**
+- Proto: field number reused or removed from an existing message?
+- Proto: field type changed (e.g. `bytes` → `string`) or `required` added to existing field?
+- Proto: enum value renumbered or removed?
+- Keystore: JSON key renamed, removed, or made required without a default fallback?
+- Keystore: `validate()` now called from the JSON-load constructor for the first time?
+- Registry: `slip44`, `curve`, or address-encoding field changed? (changes derived addresses)
+- Registry: `TWCoinType` enum value reordered or removed?
+- C ABI: `TW*` function removed, renamed, or its return / exception behaviour changed?
+
+### Step 5 — Required mitigations
+- Accept legacy at read time, normalize on write *(preferred)*.
+- Gate strict check behind "newly created" flag.
+- One-time migration with explicit failure UX.
+- Apply tightening to write paths only.
+
+### Output format
+```
+# BC-risk audit — <branch> @ <git SHA> — <ISO timestamp>
+
+## Verdict
+<SAFE / RISK / BLOCKER> — one sentence.
+
+## Step 1 — Classification
+...
+## Step 2 — Historical baseline
+...
+## Step 3 — Concrete failure scenarios
+...
+## Step 4 — Red-flag checklist
+...
+## Step 5 — Required mitigations
+...
+
+## Suggested PR comment
+[bc-check: <Pass|Mitigated|N/A>]
+<one-paragraph summary>
+
+## Suggested addition to docs/bc-footguns.md
+<draft entry, OR "none">
+```
+
+The skill never auto-posts to GitHub. Author copies the verdict + suggested comment
+into the PR; the human signs off.

--- a/.claude/skills/bc-check/SKILL.md
+++ b/.claude/skills/bc-check/SKILL.md
@@ -4,11 +4,10 @@ description:
   Audit the current branch's diff for backward-compatibility risk against persisted user data and wire formats. Use when a PR tightens validation, changes deserialization of stored data, modifies a wire/backup format, or changes which exception a public API throws. Outputs a structured markdown report to paste into a `[bc-check: ...]` PR comment.
 ---
 
-You are auditing the current branch's diff against the configured base branch
-(`origin/master` by default) for **backward-compatibility risk against persisted user
-data and wire formats**. Find cases where this PR will reject, mis-parse, or
-mishandle inputs that older versions of our own software already wrote to disk, to
-backups, or onto the network.
+You are auditing the current branch's diff against the PR's base branch for
+**backward-compatibility risk against persisted user data and wire formats**. Find
+cases where this PR will reject, mis-parse, or mishandle inputs that older versions of
+our own software already wrote to disk, to backups, or onto the network.
 
 **Do not trust the PR description's framing.** "Just a security fix" / "stricter
 validation" is precisely the framing that hides this class of bug.
@@ -16,7 +15,12 @@ validation" is precisely the framing that hides this class of bug.
 Before starting:
 
 1. Read `docs/bc-footguns.md` if it exists. Every entry is a known constraint.
-2. `git diff origin/master...HEAD` to get the full diff.
+2. Determine the base branch and get the full diff:
+   ```bash
+   BASE=$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null || echo "master")
+   git diff origin/$BASE...HEAD
+   ```
+   If `gh pr view` fails (e.g. no open PR yet), fall back to `origin/master`.
 3. Identify which files are on persistence paths (see WalletCore context below).
 
 ---
@@ -130,7 +134,7 @@ wrap the output in a code fence.
 
 ---
 
-# BC-risk audit — \<branch\> @ \<git SHA\> — \<ISO timestamp\>
+# BC-risk audit — \<branch\> → \<base-branch\> @ \<git SHA\> — \<ISO timestamp\>
 
 ## Verdict
 \<SAFE / RISK / BLOCKER\> — one sentence.
@@ -165,7 +169,7 @@ not the ` ```markdown ` / ` ``` ` lines themselves.
 ```markdown
 [bc-check: <token>]
 
-# BC-risk audit — <branch> @ <git SHA> — <ISO timestamp>
+# BC-risk audit — <branch> → <base-branch> @ <git SHA> — <ISO timestamp>
 
 Verdict: <SAFE (after fix) | SAFE | RISK | BLOCKER>
 

--- a/.claude/skills/bc-check/SKILL.md
+++ b/.claude/skills/bc-check/SKILL.md
@@ -125,35 +125,56 @@ must be visible to reviewers.
 
 ### Output format
 
-```
-# BC-risk audit — <branch> @ <git SHA> — <ISO timestamp>
+Emit all sections below as formatted markdown (bold, inline code, headers). Do not
+wrap the output in a code fence.
+
+---
+
+# BC-risk audit — \<branch\> @ \<git SHA\> — \<ISO timestamp\>
 
 ## Verdict
-<SAFE / RISK / BLOCKER> — one sentence.
+\<SAFE / RISK / BLOCKER\> — one sentence.
 
 ## Step 1 — Classification
 ...
+
 ## Step 2 — Historical baseline
 ...
+
 ## Step 3 — Concrete failure scenarios
 ...
+
 ## Step 4 — Red-flag checklist
 ...
+
 ## Step 5 — Required mitigations
 ...
 
 ## Suggested PR comment
-<choose the correct token per the table above>
+
+Emit this block as a GitHub-ready comment. Use markdown: **bold** for the verdict and
+key findings, `inline code` for file paths, function names, constants, commit SHAs,
+and token strings. Use a bullet list for multiple findings or mitigations if needed.
+
+The comment body must follow this structure exactly so the workflow gate accepts it.
+Wrap it in a fenced code block so the author can copy raw markdown:
+
+````
+```markdown
+[bc-check: <token>]
 
 # BC-risk audit — <branch> @ <git SHA> — <ISO timestamp>
 
 Verdict: <SAFE (after fix) | SAFE | RISK | BLOCKER>
 
-<one-paragraph summary>
+<one-paragraph summary using **bold** and `inline code`>
+```
+````
 
 ## Suggested addition to docs/bc-footguns.md
-<draft entry, OR "none">
-```
+\<draft entry, OR "none"\>
+
+---
 
 The skill never auto-posts to GitHub. Author copies the verdict + suggested comment
 into the PR; the human signs off.

--- a/.claude/skills/bc-check/SKILL.md
+++ b/.claude/skills/bc-check/SKILL.md
@@ -144,6 +144,11 @@ must be visible to reviewers.
 
 ## Suggested PR comment
 <choose the correct token per the table above>
+
+# BC-risk audit — <branch> @ <git SHA> — <ISO timestamp>
+
+Verdict: <SAFE (after fix) | SAFE | RISK | BLOCKER>
+
 <one-paragraph summary>
 
 ## Suggested addition to docs/bc-footguns.md

--- a/.claude/skills/bc-check/SKILL.md
+++ b/.claude/skills/bc-check/SKILL.md
@@ -100,6 +100,25 @@ Answer yes/no with file:line evidence:
 - One-time migration with explicit failure UX.
 - Apply tightening to write paths only.
 
+### Token rules for "Suggested PR comment"
+
+| Verdict            | Valid token                          | Invalid tokens  |
+|--------------------|--------------------------------------|-----------------|
+| SAFE               | `[bc-check: Pass]`                   | —               |
+| RISK               | `[bc-check: Mitigated]` (after fix)  | `Pass`, `N/A`   |
+| BLOCKER            | `[bc-check: Mitigated]` (after fix)  | `Pass`, `N/A`   |
+| No persistence risk | `[bc-check: N/A]`                   | —               |
+
+**`N/A` means the scanner fired on a file that has zero BC relevance** (a renamed
+variable, a comment edit, a test fixture that happens to match the path filter). It
+does NOT mean "I found a real BC issue but accept the risk." Using `N/A` when the
+audit found a RISK or BLOCKER is incorrect and bypasses the gate dishonestly.
+
+**RISK / BLOCKER have one resolution: fix the problem, then post `Mitigated` with
+the post-fix audit output.** There is no "accept the risk" token. For wallet
+software where the blast radius is loss of user funds, shipping a known BC break is
+not a valid outcome.
+
 ### Output format
 
 ```
@@ -120,7 +139,7 @@ Answer yes/no with file:line evidence:
 ...
 
 ## Suggested PR comment
-[bc-check: <Pass|Mitigated|N/A>]
+<choose the correct token per the table above>
 <one-paragraph summary>
 
 ## Suggested addition to docs/bc-footguns.md

--- a/.claude/skills/bc-check/SKILL.md
+++ b/.claude/skills/bc-check/SKILL.md
@@ -157,7 +157,9 @@ key findings, `inline code` for file paths, function names, constants, commit SH
 and token strings. Use a bullet list for multiple findings or mitigations if needed.
 
 The comment body must follow this structure exactly so the workflow gate accepts it.
-Wrap it in a fenced code block so the author can copy raw markdown:
+Wrap it in a fenced code block labelled `markdown` so the author can copy the raw
+text. The author must paste **only the content inside the fences** into GitHub —
+not the ` ```markdown ` / ` ``` ` lines themselves.
 
 ````
 ```markdown

--- a/.github/workflows/claude-bc-risk-router.yml
+++ b/.github/workflows/claude-bc-risk-router.yml
@@ -142,8 +142,9 @@ jobs:
               '',
               'Post a comment with one of:',
               '- `[bc-check: Pass]` — audit run, **Verdict: SAFE**. Must include audit output.',
-              '- `[bc-check: Mitigated]` — audit found RISK or BLOCKER; **you fixed it**. Must include the post-fix audit output.',
-              "- `[bc-check: N/A]` — scanner fired on a file with **zero BC relevance** (comment edit, test fixture, renamed variable). **Invalid if the audit found a real risk** — N/A does not mean 'I accept the risk'.",
+              '- `[bc-check: Mitigated]` — audit found RISK or BLOCKER; **you fixed it in code**. Must include the post-fix audit output.',
+              '- `[bc-check: Risk-Accepted]` — audit found RISK or BLOCKER; **investigation confirms blast radius is effectively zero** (no user data in the wild can trigger it). Must include audit output + explicit evidence (who confirmed it, what data or reasoning).',
+              "- `[bc-check: N/A]` — scanner fired on a file with **zero BC relevance** (comment edit, test fixture, renamed variable). **Invalid if the audit found a real risk.**",
               '',
               'Each token must be accompanied by >=${{ env.BC_SIGNOFF_MIN_CHARS }} chars of reasoning. The reasoning must be fresh — posted or edited at or after the HEAD commit.',
               '',
@@ -231,10 +232,9 @@ jobs:
             });
             const headCommitTime = new Date(headCommit.commit.committer.date);
 
-            const tokenRegex = /\[bc-check:\s*(Pass|Mitigated|N\/A)\]/i;
-            // Pass and Mitigated MUST include audit output.
-            // N/A does not require audit evidence, but is invalid when the audit
-            // found a real risk: reject N/A if the comment contains a RISK or BLOCKER verdict.
+            const tokenRegex = /\[bc-check:\s*(Pass|Mitigated|Risk-Accepted|N\/A)\]/i;
+            // Pass, Mitigated, and Risk-Accepted all require audit output.
+            // N/A does not, but is invalid when the audit contains a real risk verdict.
             const auditEvidenceRegex = /(^|\n)#\s*BC-risk audit\b|(^|\n)\s*Verdict\s*:/i;
             const riskVerdictRegex = /Verdict\s*[:\-]\s*(RISK|BLOCKER)\b/i;
 
@@ -244,6 +244,7 @@ jobs:
               const stripped = c.body.replace(tokenRegex, '').replace(/<!--[\s\S]*?-->/g, '').trim();
               if (stripped.length < ${{ env.BC_SIGNOFF_MIN_CHARS }}) return false;
               const verdict = tokenMatch[1].toLowerCase();
+              // All tokens except N/A require audit evidence.
               if (verdict !== 'n/a' && !auditEvidenceRegex.test(c.body)) return false;
               // N/A is invalid when the comment's own audit shows a real risk.
               if (verdict === 'n/a' && riskVerdictRegex.test(c.body)) return false;
@@ -255,11 +256,13 @@ jobs:
 
             if (!signoff) {
               core.setFailed(
-                'No fresh, evidence-backed `[bc-check: Pass|Mitigated|N/A]` sign-off found. Required:\n' +
+                'No fresh, evidence-backed sign-off found. Required:\n' +
+                '  * Token: `[bc-check: Pass|Mitigated|Risk-Accepted|N/A]`\n' +
                 '  * Token + reasoning >= ${{ env.BC_SIGNOFF_MIN_CHARS }} chars.\n' +
                 '  * Posted or edited at or after the HEAD commit.\n' +
-                '  * For Pass / Mitigated: must include audit output (a `# BC-risk audit ...` header or a `Verdict:` line). Run the embedded prompt or the `/bc-check` skill and paste the report.\n' +
-                "  * N/A is only valid when the change has zero BC relevance. It is rejected if the comment's audit shows a RISK or BLOCKER verdict.\n" +
+                '  * Pass / Mitigated / Risk-Accepted: must include audit output (a `# BC-risk audit ...` header or a `Verdict:` line).\n' +
+                '  * Risk-Accepted: must also include explicit evidence that blast radius is effectively zero.\n' +
+                "  * N/A is only valid when the change has zero BC relevance; rejected if the audit shows a RISK or BLOCKER verdict.\n" +
                 'If you pushed new commits after a previous sign-off, edit the existing comment (any edit counts as a refresh) so it reflects the current diff.'
               );
               return;

--- a/.github/workflows/claude-bc-risk-router.yml
+++ b/.github/workflows/claude-bc-risk-router.yml
@@ -56,7 +56,7 @@ jobs:
             2>/dev/null || true)
 
           if [ -n "$CHANGED" ]; then
-            echo "flags=$CHANGED" >> "$GITHUB_OUTPUT"
+            echo "flags=$(echo "$CHANGED" | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
           else
             echo "flags=" >> "$GITHUB_OUTPUT"
           fi
@@ -66,7 +66,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const changedFiles = `${{ steps.scan.outputs.flags }}`.trim().split('\n').filter(Boolean);
+            const changedFiles = `${{ steps.scan.outputs.flags }}`.trim().split(/\s+/).filter(Boolean);
             const marker = '<!-- bc-risk-router:reminder -->';
 
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/claude-bc-risk-router.yml
+++ b/.github/workflows/claude-bc-risk-router.yml
@@ -141,9 +141,9 @@ jobs:
               `This PR touches persistence-sensitive files: ${changedFiles.map(f => `\`${f}\``).join(', ')}.`,
               '',
               'Post a comment with one of:',
-              '- `[bc-check: Pass]` — audit run, no BC risk. **Must include audit output** (a `# BC-risk audit ...` header or `Verdict:` line).',
-              '- `[bc-check: Mitigated]` — audit found risk; you fixed it. **Must include the post-fix audit output.**',
-              "- `[bc-check: N/A]` — scanner flag is genuinely unrelated to BC (explain why). This is the only path that does not require audit evidence.",
+              '- `[bc-check: Pass]` — audit run, **Verdict: SAFE**. Must include audit output.',
+              '- `[bc-check: Mitigated]` — audit found RISK or BLOCKER; **you fixed it**. Must include the post-fix audit output.',
+              "- `[bc-check: N/A]` — scanner fired on a file with **zero BC relevance** (comment edit, test fixture, renamed variable). **Invalid if the audit found a real risk** — N/A does not mean 'I accept the risk'.",
               '',
               'Each token must be accompanied by >=${{ env.BC_SIGNOFF_MIN_CHARS }} chars of reasoning. The reasoning must be fresh — posted or edited at or after the HEAD commit.',
               '',
@@ -232,10 +232,11 @@ jobs:
             const headCommitTime = new Date(headCommit.commit.committer.date);
 
             const tokenRegex = /\[bc-check:\s*(Pass|Mitigated|N\/A)\]/i;
-            // Pass and Mitigated MUST include audit output — humans don't reliably ask
-            // the right BC question on every PR, so AI must be in the loop.
-            // N/A is the only path that does not require audit evidence.
+            // Pass and Mitigated MUST include audit output.
+            // N/A does not require audit evidence, but is invalid when the audit
+            // found a real risk: reject N/A if the comment contains a RISK or BLOCKER verdict.
             const auditEvidenceRegex = /(^|\n)#\s*BC-risk audit\b|(^|\n)\s*Verdict\s*:/i;
+            const riskVerdictRegex = /Verdict\s*[:\-]\s*(RISK|BLOCKER)\b/i;
 
             const signoff = comments.find(c => {
               const tokenMatch = c.body.match(tokenRegex);
@@ -244,6 +245,8 @@ jobs:
               if (stripped.length < ${{ env.BC_SIGNOFF_MIN_CHARS }}) return false;
               const verdict = tokenMatch[1].toLowerCase();
               if (verdict !== 'n/a' && !auditEvidenceRegex.test(c.body)) return false;
+              // N/A is invalid when the comment's own audit shows a real risk.
+              if (verdict === 'n/a' && riskVerdictRegex.test(c.body)) return false;
               // updated_at lets the author edit an existing comment after pushing
               // a fix instead of posting a brand-new one.
               const commentTime = new Date(c.updated_at);
@@ -256,7 +259,7 @@ jobs:
                 '  * Token + reasoning >= ${{ env.BC_SIGNOFF_MIN_CHARS }} chars.\n' +
                 '  * Posted or edited at or after the HEAD commit.\n' +
                 '  * For Pass / Mitigated: must include audit output (a `# BC-risk audit ...` header or a `Verdict:` line). Run the embedded prompt or the `/bc-check` skill and paste the report.\n' +
-                "  * N/A is the only path that does not require audit evidence — use it only if the scanner flag is genuinely unrelated to BC.\n" +
+                "  * N/A is only valid when the change has zero BC relevance. It is rejected if the comment's audit shows a RISK or BLOCKER verdict.\n" +
                 'If you pushed new commits after a previous sign-off, edit the existing comment (any edit counts as a refresh) so it reflects the current diff.'
               );
               return;

--- a/.github/workflows/claude-bc-risk-router.yml
+++ b/.github/workflows/claude-bc-risk-router.yml
@@ -172,7 +172,6 @@ jobs:
 
   verify-bc-check-comment:
     runs-on: ubuntu-latest
-    needs: scan-and-flag
     if: always()
     steps:
       - name: Verify sign-off token
@@ -210,15 +209,15 @@ jobs:
               repo: context.repo.repo,
             });
 
-            // On pull_request events the scan flags tell us if patterns were detected.
-            // On issue_comment events scan-and-flag is skipped so flags is always ''.
-            // Use the reminder comment's presence as the gate in that case.
-            // Without this check the job would fail on any comment posted to a clean PR.
-            const flags = '${{ needs.scan-and-flag.outputs.flags }}';
+            // Gate on the reminder comment's presence. This job runs independently of
+            // scan-and-flag (no `needs` dependency) so that it fires on every
+            // issue_comment event. The cascade that enforces the gate on PR open is:
+            // scan-and-flag posts the reminder → that triggers an issue_comment event
+            // → this job runs, finds the reminder, and fails until a sign-off exists.
             const reminderMarker = '<!-- bc-risk-router:reminder -->';
             const hasReminder = comments.some(c => c.body.includes(reminderMarker));
-            if (!flags && !hasReminder) {
-              core.info('No BC-risk patterns detected and no reminder posted; nothing to verify.');
+            if (!hasReminder) {
+              core.info('No BC-risk reminder posted; nothing to verify.');
               return;
             }
 

--- a/.github/workflows/claude-bc-risk-router.yml
+++ b/.github/workflows/claude-bc-risk-router.yml
@@ -5,19 +5,22 @@ name: bc-risk-router
 
 on:
   pull_request:
-    branches: [master, dev]
-    types: [opened, synchronize, reopened, edited]
+    branches: [ master, dev ]
+    types: [ opened, synchronize, reopened, edited, ready_for_review ]
   issue_comment:
-    types: [created, edited, deleted]
+    types: [ created, edited, deleted ]
 
 permissions:
   contents: read
   issues: write
   pull-requests: write
 
+env:
+  BC_SIGNOFF_MIN_CHARS: 60
+
 jobs:
   scan-and-flag:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       flags: ${{ steps.scan.outputs.flags }}
@@ -142,7 +145,7 @@ jobs:
               '- `[bc-check: Mitigated]` — audit found risk; you fixed it. **Must include the post-fix audit output.**',
               "- `[bc-check: N/A]` — scanner flag is genuinely unrelated to BC (explain why). This is the only path that does not require audit evidence.",
               '',
-              'Each token must be accompanied by ≥60 chars of reasoning. The reasoning must be fresh — posted or edited at or after the HEAD commit.',
+              'Each token must be accompanied by >=${{ env.BC_SIGNOFF_MIN_CHARS }} chars of reasoning. The reasoning must be fresh — posted or edited at or after the HEAD commit.',
               '',
               "**Why audit evidence is required for Pass / Mitigated:** humans don't reliably ask the right BC question on every PR. AI being in the loop is the whole point of this gate. The bot does not judge whether your reasoning is *correct* — reviewers do, like any other code review.",
               '',
@@ -190,6 +193,15 @@ jobs:
               return;
             }
 
+            if (pr.draft) {
+              core.info('PR is a draft; skipping.');
+              return;
+            }
+            if (!['master', 'dev'].includes(pr.base.ref)) {
+              core.info(`PR targets '${pr.base.ref}'; BC gate only applies to master and dev. Skipping.`);
+              return;
+            }
+
             // Fetch comments early — needed for both the reminder-gate check and sign-off search.
             const { data: comments } = await github.rest.issues.listComments({
               issue_number: prNumber,
@@ -229,7 +241,7 @@ jobs:
               const tokenMatch = c.body.match(tokenRegex);
               if (!tokenMatch) return false;
               const stripped = c.body.replace(tokenRegex, '').replace(/<!--[\s\S]*?-->/g, '').trim();
-              if (stripped.length < 60) return false;
+              if (stripped.length < ${{ env.BC_SIGNOFF_MIN_CHARS }}) return false;
               const verdict = tokenMatch[1].toLowerCase();
               if (verdict !== 'n/a' && !auditEvidenceRegex.test(c.body)) return false;
               // updated_at lets the author edit an existing comment after pushing
@@ -241,7 +253,7 @@ jobs:
             if (!signoff) {
               core.setFailed(
                 'No fresh, evidence-backed `[bc-check: Pass|Mitigated|N/A]` sign-off found. Required:\n' +
-                '  * Token + reasoning >= 60 chars.\n' +
+                '  * Token + reasoning >= ${{ env.BC_SIGNOFF_MIN_CHARS }} chars.\n' +
                 '  * Posted or edited at or after the HEAD commit.\n' +
                 '  * For Pass / Mitigated: must include audit output (a `# BC-risk audit ...` header or a `Verdict:` line). Run the embedded prompt or the `/bc-check` skill and paste the report.\n' +
                 "  * N/A is the only path that does not require audit evidence — use it only if the scanner flag is genuinely unrelated to BC.\n" +

--- a/.github/workflows/claude-bc-risk-router.yml
+++ b/.github/workflows/claude-bc-risk-router.yml
@@ -1,0 +1,252 @@
+name: bc-risk-router
+
+# To make verify-bc-check-comment actually BLOCK merging, add it as a required
+# status check in Settings -> Branches -> branch protection rules for master and dev.
+
+on:
+  pull_request:
+    branches: [master, dev]
+    types: [opened, synchronize, reopened, edited]
+  issue_comment:
+    types: [created, edited, deleted]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  scan-and-flag:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      flags: ${{ steps.scan.outputs.flags }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect hot-path changes
+        id: scan
+        run: |
+          set -e
+          BASE="origin/${{ github.base_ref }}"
+
+          # Any change to a persistence-sensitive path warrants a BC audit.
+          # The auditor decides what's risky — not grep patterns.
+          CHANGED=$(git diff --name-only "$BASE"...HEAD -- \
+            'src/Keystore/' \
+            'src/proto/' \
+            'include/TrustWalletCore/' \
+            'registry.json' \
+            'src/PrivateKey*' \
+            'src/PublicKey*' \
+            'src/HDWallet*' \
+            'swift/Sources/KeyStore*' \
+            'swift/Sources/Wallet.swift' \
+            'swift/Sources/Watch.swift' \
+            'wasm/src/keystore/' \
+            '**/Migration*' \
+            '**/StoredKey*' \
+            '**/backup/**' \
+            '**/schema*.sql' \
+            2>/dev/null || true)
+
+          if [ -n "$CHANGED" ]; then
+            echo "flags=$CHANGED" >> "$GITHUB_OUTPUT"
+          else
+            echo "flags=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post reminder comment (once per PR)
+        if: steps.scan.outputs.flags != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const changedFiles = `${{ steps.scan.outputs.flags }}`.trim().split('\n').filter(Boolean);
+            const marker = '<!-- bc-risk-router:reminder -->';
+
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            if (comments.some(c => c.body.includes(marker))) return;
+
+            const base = context.payload.pull_request.base.ref;
+
+            // Build the prompt as an array to avoid multi-line template literal
+            // indentation problems inside this YAML block scalar.
+            const promptLines = [
+              '```',
+              `You are auditing a Trust Wallet Core PR against origin/${base}`,
+              'for **backward-compatibility risk against persisted user data and wire formats**.',
+              'Find cases where this PR will reject, mis-parse, or mishandle inputs that older',
+              'versions of our software already wrote to disk, to backups, or onto the network.',
+              '',
+              '**Trust Wallet Core domain context:**',
+              '- src/Keystore/ — JSON keystore files (user encrypted keys/mnemonics).',
+              '  These live in iCloud, Google Drive, and manual exports.',
+              '  A parse failure = wallet inaccessible = user cannot access funds.',
+              '- src/proto/*.proto — Protobuf SigningInput/SigningOutput wire formats.',
+              '  Field numbers are permanent; reuse or removal silently corrupts binary data.',
+              '- include/TrustWalletCore/TW*.h — Public C ABI.',
+              '  Removing/renaming TW* functions or changing enum values breaks compiled bindings.',
+              '- registry.json — coin metadata (SLIP44, derivation path, curve, address encoding).',
+              '  Changing any of these re-derives different addresses for all existing wallets.',
+              '',
+              "Do NOT trust the PR description's framing.",
+              "'Just a security fix' / 'stricter validation' is exactly the framing that hides this class of bug.",
+              'Read docs/bc-footguns.md first.',
+              '',
+              'Walk these 5 steps. Cite file:line and commit SHA everywhere:',
+              '',
+              '1. Classify: tightening validation? Parsing change? Exception type change?',
+              "   Removing 'if missing use default'? Moving validation into a constructor?",
+              '2. Historical baseline. For each tightened rule:',
+              '   - Could a prior version have PRODUCED data that violates the new rule? (cite SHA)',
+              '   - Was there a partial migration that may not have completed for all users?',
+              '   - Does the format ever leave the device (backup, export, sync)?',
+              '3. Concrete failure scenarios: old version -> action -> where stored -> code path',
+              '   (file:line) -> user symptom -> blast radius. No hand-waving.',
+              '4. Red-flag checklist (yes/no + file:line evidence):',
+              '   - New throw on a read/load/decode/import path?',
+              "   - Removed an 'if missing use default' branch?",
+              '   - New length/range/enum check on a >1-year-old field?',
+              '   - Constructor changed from lenient parse to parse+validate?',
+              '   - Changed which exception type a public API throws?',
+              '   - Format ever in backup/export/sync?',
+              "   - Prior PR shipped a 'regenerate on next user action' partial migration? (cite SHA)",
+              '   - Proto: field number reused or removed? Enum value renumbered/removed?',
+              '   - Keystore: JSON key renamed/removed/made required without default fallback?',
+              '   - Registry: slip44, curve, or address-encoding field changed?',
+              '5. Mitigations: accept legacy at read + normalize on write (preferred);',
+              "   gate strict check behind 'newly created' flag; one-time migration with clear UX;",
+              '   or apply tightening to write paths only.',
+              '',
+              'Output a markdown report: Verdict (SAFE/RISK/BLOCKER) at top, then steps 1-5,',
+              "then a 'Suggested PR comment' block ([bc-check: Pass|Mitigated|N/A] + reasoning),",
+              "then a 'Suggested addition to docs/bc-footguns.md' block (or 'none').",
+              '```',
+            ];
+            const prompt = promptLines.join('\n');
+
+            const body = [
+              marker,
+              '⚠️ **Backward-compatibility check needed**',
+              '',
+              `This PR touches persistence-sensitive files: ${changedFiles.map(f => `\`${f}\``).join(', ')}.`,
+              '',
+              'Post a comment with one of:',
+              '- `[bc-check: Pass]` — audit run, no BC risk. **Must include audit output** (a `# BC-risk audit ...` header or `Verdict:` line).',
+              '- `[bc-check: Mitigated]` — audit found risk; you fixed it. **Must include the post-fix audit output.**',
+              "- `[bc-check: N/A]` — scanner flag is genuinely unrelated to BC (explain why). This is the only path that does not require audit evidence.",
+              '',
+              'Each token must be accompanied by ≥60 chars of reasoning. The reasoning must be fresh — posted or edited at or after the HEAD commit.',
+              '',
+              "**Why audit evidence is required for Pass / Mitigated:** humans don't reliably ask the right BC question on every PR. AI being in the loop is the whole point of this gate. The bot does not judge whether your reasoning is *correct* — reviewers do, like any other code review.",
+              '',
+              `Things worth thinking about: could a previous version have written data this PR's new check would now reject? Was there a partial migration ("regenerate on next user action") that may not have completed for all users? Does this format live in iCloud / Google Drive backup, exported files, or sync payloads? See \`docs/bc-footguns.md\` for known cases.`,
+              '',
+              `<details><summary>Changed files (${changedFiles.length})</summary>\n\n${changedFiles.map(f => `- \`${f}\``).join('\n')}\n\n</details>`,
+              '',
+              '<details><summary>Copy this audit prompt into Claude Code on this branch (or run the <code>/bc-check</code> skill) for a structured analysis you can paste into your sign-off</summary>',
+              '',
+              prompt,
+              '',
+              '</details>',
+              '',
+              'Merge is blocked by `verify-bc-check-comment` until a tagged comment is posted.',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });
+
+  verify-bc-check-comment:
+    runs-on: ubuntu-latest
+    needs: scan-and-flag
+    if: always()
+    steps:
+      - name: Verify sign-off token
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let prNumber, pr;
+            if (context.payload.pull_request) {
+              pr = context.payload.pull_request;
+              prNumber = pr.number;
+            } else if (context.payload.issue && context.payload.issue.pull_request) {
+              prNumber = context.payload.issue.number;
+              const { data } = await github.rest.pulls.get({
+                owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber
+              });
+              pr = data;
+            } else {
+              core.info('Not a PR-related event; skipping.');
+              return;
+            }
+
+            // Fetch comments early — needed for both the reminder-gate check and sign-off search.
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            // On pull_request events the scan flags tell us if patterns were detected.
+            // On issue_comment events scan-and-flag is skipped so flags is always ''.
+            // Use the reminder comment's presence as the gate in that case.
+            // Without this check the job would fail on any comment posted to a clean PR.
+            const flags = '${{ needs.scan-and-flag.outputs.flags }}';
+            const reminderMarker = '<!-- bc-risk-router:reminder -->';
+            const hasReminder = comments.some(c => c.body.includes(reminderMarker));
+            if (!flags && !hasReminder) {
+              core.info('No BC-risk patterns detected and no reminder posted; nothing to verify.');
+              return;
+            }
+
+            // Sign-off must be at least as recent as the HEAD commit, otherwise
+            // it was made against a stale diff (e.g. before a fix push or before
+            // additional changes requested by a reviewer).
+            const { data: headCommit } = await github.rest.repos.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: pr.head.sha,
+            });
+            const headCommitTime = new Date(headCommit.commit.committer.date);
+
+            const tokenRegex = /\[bc-check:\s*(Pass|Mitigated|N\/A)\]/i;
+            // Pass and Mitigated MUST include audit output — humans don't reliably ask
+            // the right BC question on every PR, so AI must be in the loop.
+            // N/A is the only path that does not require audit evidence.
+            const auditEvidenceRegex = /(^|\n)#\s*BC-risk audit\b|(^|\n)\s*Verdict\s*:/i;
+
+            const signoff = comments.find(c => {
+              const tokenMatch = c.body.match(tokenRegex);
+              if (!tokenMatch) return false;
+              const stripped = c.body.replace(tokenRegex, '').replace(/<!--[\s\S]*?-->/g, '').trim();
+              if (stripped.length < 60) return false;
+              const verdict = tokenMatch[1].toLowerCase();
+              if (verdict !== 'n/a' && !auditEvidenceRegex.test(c.body)) return false;
+              // updated_at lets the author edit an existing comment after pushing
+              // a fix instead of posting a brand-new one.
+              const commentTime = new Date(c.updated_at);
+              return commentTime >= headCommitTime;
+            });
+
+            if (!signoff) {
+              core.setFailed(
+                'No fresh, evidence-backed `[bc-check: Pass|Mitigated|N/A]` sign-off found. Required:\n' +
+                '  * Token + reasoning >= 60 chars.\n' +
+                '  * Posted or edited at or after the HEAD commit.\n' +
+                '  * For Pass / Mitigated: must include audit output (a `# BC-risk audit ...` header or a `Verdict:` line). Run the embedded prompt or the `/bc-check` skill and paste the report.\n' +
+                "  * N/A is the only path that does not require audit evidence — use it only if the scanner flag is genuinely unrelated to BC.\n" +
+                'If you pushed new commits after a previous sign-off, edit the existing comment (any edit counts as a refresh) so it reflects the current diff.'
+              );
+              return;
+            }
+            core.info(`Found fresh sign-off by @${signoff.user.login} at ${signoff.updated_at}.`);

--- a/.github/workflows/claude-bc-risk-router.yml
+++ b/.github/workflows/claude-bc-risk-router.yml
@@ -64,9 +64,11 @@ jobs:
       - name: Post reminder comment (once per PR)
         if: steps.scan.outputs.flags != ''
         uses: actions/github-script@v7
+        env:
+          FLAGS: ${{ steps.scan.outputs.flags }}
         with:
           script: |
-            const changedFiles = `${{ steps.scan.outputs.flags }}`.trim().split(/\s+/).filter(Boolean);
+            const changedFiles = (process.env.FLAGS || '').trim().split(/\s+/).filter(Boolean);
             const marker = '<!-- bc-risk-router:reminder -->';
 
             const { data: comments } = await github.rest.issues.listComments({
@@ -231,6 +233,7 @@ jobs:
             });
             const headCommitTime = new Date(headCommit.commit.committer.date);
 
+            const minChars = parseInt(process.env.BC_SIGNOFF_MIN_CHARS || '60', 10);
             const tokenRegex = /\[bc-check:\s*(Pass|Mitigated|Risk-Accepted|N\/A)\]/i;
             // Pass, Mitigated, and Risk-Accepted all require audit output.
             // N/A does not, but is invalid when the audit contains a real risk verdict.
@@ -241,7 +244,7 @@ jobs:
               const tokenMatch = c.body.match(tokenRegex);
               if (!tokenMatch) return false;
               const stripped = c.body.replace(tokenRegex, '').replace(/<!--[\s\S]*?-->/g, '').trim();
-              if (stripped.length < ${{ env.BC_SIGNOFF_MIN_CHARS }}) return false;
+              if (stripped.length < minChars) return false;
               const verdict = tokenMatch[1].toLowerCase();
               // All tokens except N/A require audit evidence.
               if (verdict !== 'n/a' && !auditEvidenceRegex.test(c.body)) return false;
@@ -257,7 +260,7 @@ jobs:
               core.setFailed(
                 'No fresh, evidence-backed sign-off found. Required:\n' +
                 '  * Token: `[bc-check: Pass|Mitigated|Risk-Accepted|N/A]`\n' +
-                '  * Token + reasoning >= ${{ env.BC_SIGNOFF_MIN_CHARS }} chars.\n' +
+                `  * Token + reasoning >= ${minChars} chars.\n` +
                 '  * Posted or edited at or after the HEAD commit.\n' +
                 '  * Pass / Mitigated / Risk-Accepted: must include audit output (a `# BC-risk audit ...` header or a `Verdict:` line).\n' +
                 '  * Risk-Accepted: must also include explicit evidence that blast radius is effectively zero.\n' +


### PR DESCRIPTION
This pull request introduces a robust backward-compatibility (BC) risk auditing workflow for persistence-sensitive changes. It adds a new GitHub Actions workflow to automatically detect PRs that touch files related to user data or wire formats, post a reminder comment requiring a BC-risk audit, and block merging until a structured, evidence-backed sign-off is provided. Additionally, it documents a standardized audit procedure as a Claude skill for consistent, thorough BC-risk analysis.

**Key changes:**

### Automated BC-risk detection and enforcement

* Added `.github/workflows/claude-bc-risk-router.yml` to scan PRs for changes to persistence-sensitive files (e.g., keystore, protobuf, public APIs, registry) and post a reminder comment if such changes are detected. The workflow blocks merging until a `[bc-check: Pass|Mitigated|N/A]` sign-off comment with sufficient reasoning and, for Pass/Mitigated, a structured audit is present and up-to-date with the latest commit.

### Standardized BC-risk audit skill

* Added `.claude/skills/bc-check/SKILL.md`, a detailed prompt and checklist for auditing backward-compatibility risk. It guides auditors through classifying the change, establishing historical context, enumerating concrete failure scenarios, running a red-flag checklist, and proposing mitigations, with output formats for PR comments and documentation.