### PR TITLE
fix(ton): Reject anycast addresses in TON address parsing

### DIFF
--- a/rust/frameworks/tw_ton_sdk/src/cell/cell_parser.rs
+++ b/rust/frameworks/tw_ton_sdk/src/cell/cell_parser.rs
@@ -130,6 +130,11 @@ impl<'a> CellParser<'a> {
         }
     }
 
+    /// Asserts that all bits in the cell have been consumed.
+    ///
+    /// Call this after finishing a fixed-structure parse to catch unexpected
+    /// trailing bits. [`Cell::parse_fully`] does this automatically; callers
+    /// using the raw [`Cell::parser`] API are responsible for calling it themselves.
     pub fn ensure_empty(&self) -> CellResult<()> {
         let remaining = self.remaining_bits();
         if remaining == 0 {

--- a/rust/frameworks/tw_ton_sdk/src/cell/cell_parser.rs
+++ b/rust/frameworks/tw_ton_sdk/src/cell/cell_parser.rs
@@ -104,7 +104,18 @@ impl<'a> CellParser<'a> {
         match tp {
             0 => Ok(AddressData::null()),
             2 => {
-                let _res1 = self.load_u8(1)?;
+                // Anycast is used for routing inside split-brain shards and is never set on
+                // normal wallet addresses. Accepting anycast=1 without consuming the Anycast
+                // payload (depth + rewrite_pfx) causes the subsequent workchain and hash reads
+                // to consume wrong bits, enabling recipient-address substitution attacks.
+                //
+                // Moreover, anycast addresses were deprecated in TVM 10.
+                // https://github.com/ton-blockchain/ton/blob/master/doc/GlobalVersions.md#version-10
+                let anycast = self.load_u8(1)?;
+                if anycast != 0 {
+                    return CellError::err(CellErrorType::CellParserError)
+                        .context("Anycast addresses are not supported");
+                }
                 let wc = self.load_u8(8)?;
                 let mut hash_part = H256::default();
                 self.load_slice(hash_part.as_mut_slice())?;

--- a/rust/frameworks/tw_ton_sdk/src/cell/cell_parser.rs
+++ b/rust/frameworks/tw_ton_sdk/src/cell/cell_parser.rs
@@ -40,6 +40,10 @@ impl<'a> CellParser<'a> {
             .tw_err(CellErrorType::CellParserError)
     }
 
+    pub fn load_i8(&mut self, bit_len: usize) -> CellResult<i8> {
+        Ok(self.load_u8(bit_len)? as i8)
+    }
+
     pub fn load_u32(&mut self, bit_len: usize) -> CellResult<u32> {
         self.bit_reader
             .read_u32(bit_len as u8)
@@ -116,7 +120,7 @@ impl<'a> CellParser<'a> {
                     return CellError::err(CellErrorType::CellParserError)
                         .context("Anycast addresses are not supported");
                 }
-                let wc = self.load_u8(8)?;
+                let wc = self.load_i8(8)?;
                 let mut hash_part = H256::default();
                 self.load_slice(hash_part.as_mut_slice())?;
                 Ok(AddressData::new(wc as i32, hash_part))

--- a/rust/frameworks/tw_ton_sdk/tests/cell_parser.rs
+++ b/rust/frameworks/tw_ton_sdk/tests/cell_parser.rs
@@ -2,11 +2,16 @@
 //
 // Copyright © 2017 Trust Wallet.
 
+use tw_hash::H256;
 use tw_number::U256;
 use tw_ton_sdk::address::address_data::AddressData;
+use tw_ton_sdk::address::raw_address::RawAddress;
 use tw_ton_sdk::address::user_friendly_address::UserFriendlyAddress;
 use tw_ton_sdk::boc::BagOfCells;
 use tw_ton_sdk::cell::cell_builder::CellBuilder;
+
+const MASTER_WORKCHAIN: i32 = -1;
+const BASE_WORKCHAIN: i32 = 0;
 
 /// In this test we parse a TON internal transfer message encoded as BoC.
 #[test]
@@ -54,6 +59,39 @@ fn test_cell_parse_internal_transfer_message() {
     assert_eq!(created_at, 0);
     assert_eq!(contains_state_init, false);
     assert_eq!(contains_data, false);
+}
+
+/// Verifies that load_address correctly sign-extends workchain byte 0xFF to -1
+/// (TON masterchain) rather than treating it as u8(255).
+#[test]
+fn test_load_address_masterchain_workchain() {
+    let hash = H256::from([0x33u8; 32]);
+    let expected = RawAddress::from(AddressData::new(MASTER_WORKCHAIN, hash));
+
+    let mut builder = CellBuilder::new();
+    builder.store_raw_address(&expected).unwrap();
+    let cell = builder.build().unwrap();
+
+    let parsed = cell.parse_fully(|p| p.load_address()).unwrap();
+
+    assert_eq!(parsed.workchain, MASTER_WORKCHAIN);
+    assert_eq!(parsed, expected.into_data());
+}
+
+/// Verifies that load_address correctly decodes workchain byte 0x00 as 0 (base workchain).
+#[test]
+fn test_load_address_base_workchain() {
+    let hash = H256::from([0x42u8; 32]);
+    let expected = RawAddress::from(AddressData::new(BASE_WORKCHAIN, hash));
+
+    let mut builder = CellBuilder::new();
+    builder.store_raw_address(&expected).unwrap();
+    let cell = builder.build().unwrap();
+
+    let parsed = cell.parse_fully(|p| p.load_address()).unwrap();
+
+    assert_eq!(parsed.workchain, BASE_WORKCHAIN);
+    assert_eq!(parsed, expected.into_data());
 }
 
 /// Anycast (Maybe Anycast = 1) in addr_std must be rejected.

--- a/rust/frameworks/tw_ton_sdk/tests/cell_parser.rs
+++ b/rust/frameworks/tw_ton_sdk/tests/cell_parser.rs
@@ -6,6 +6,7 @@ use tw_number::U256;
 use tw_ton_sdk::address::address_data::AddressData;
 use tw_ton_sdk::address::user_friendly_address::UserFriendlyAddress;
 use tw_ton_sdk::boc::BagOfCells;
+use tw_ton_sdk::cell::cell_builder::CellBuilder;
 
 /// In this test we parse a TON internal transfer message encoded as BoC.
 #[test]
@@ -53,4 +54,22 @@ fn test_cell_parse_internal_transfer_message() {
     assert_eq!(created_at, 0);
     assert_eq!(contains_state_init, false);
     assert_eq!(contains_data, false);
+}
+
+/// Anycast (Maybe Anycast = 1) in addr_std must be rejected.
+/// Before the fix, load_address() silently discarded the anycast bit and read the
+/// next 8 bits as the workchain, allowing a crafted BoC to substitute an attacker-chosen
+/// recipient address.
+#[test]
+fn test_load_address_rejects_anycast() {
+    // Build: addr_std$10 anycast=1 workchain=0 hash=zeros (267 bits total).
+    let mut builder = CellBuilder::new();
+    builder.store_u8(2, 0b10).unwrap(); // addr_std tag
+    builder.store_bit(true).unwrap(); // anycast = 1
+    builder.store_u8(8, 0).unwrap(); // workchain = 0
+    builder.store_slice(&[0u8; 32]).unwrap(); // hash
+    let cell = builder.build().unwrap();
+
+    // Must fail regardless of the specific error (anycast check or trailing-bits check).
+    assert!(cell.parse_fully(|p| p.load_address()).is_err());
 }

--- a/rust/tw_tests/tests/chains/ton/ton_address_converter.rs
+++ b/rust/tw_tests/tests/chains/ton/ton_address_converter.rs
@@ -3,6 +3,9 @@
 // Copyright © 2017 Trust Wallet.
 
 use tw_memory::test_utils::tw_string_helper::TWStringHelper;
+use tw_ton::modules::address_converter::AddressConverter;
+use tw_ton_sdk::boc::BagOfCells;
+use tw_ton_sdk::cell::cell_builder::CellBuilder;
 use wallet_core_rs::ffi::ton::address_converter::{
     tw_ton_address_converter_from_boc, tw_ton_address_converter_to_boc,
     tw_ton_address_converter_to_user_friendly,
@@ -178,5 +181,27 @@ fn test_address_converter_to_user_friendly_error() {
         "EQCKhieGGl3ZbJ2zzggHsSLaXtRzk0znVopbSxw2HLsor",
         false,
         false,
+    );
+}
+
+fn make_addr_cell(anycast: bool, workchain: u8, hash: &[u8; 32]) -> tw_ton_sdk::cell::Cell {
+    let mut builder = CellBuilder::new();
+    builder.store_u8(2, 0b10).unwrap(); // addr_std$10
+    builder.store_bit(anycast).unwrap();
+    builder.store_u8(8, workchain).unwrap();
+    builder.store_slice(hash).unwrap();
+    builder.build().unwrap()
+}
+
+/// A BoC with anycast=1 must be rejected by FromBoc.
+/// Previously load_address() discarded the anycast bit without consuming its payload,
+/// allowing a 267-bit cell to pass ensure_empty() and produce an attacker-chosen account.
+#[test]
+fn test_address_converter_from_boc_rejects_anycast() {
+    let cell = make_addr_cell(true, 0, &[0u8; 32]);
+    let boc = BagOfCells::from_root(cell);
+    assert!(
+        AddressConverter::parse_from_boc(&boc).is_err(),
+        "Anycast address must be rejected"
     );
 }


### PR DESCRIPTION
This pull request improves the security of address parsing in the TON SDK by strictly rejecting anycast addresses, which are deprecated and can be exploited for recipient-address substitution attacks. The changes ensure that any attempt to parse or convert addresses with the anycast bit set will result in an error. Comprehensive tests are added to verify the new behavior.

### Security and Address Parsing

* Updated `CellParser::load_address` to explicitly check for and reject anycast addresses by returning an error if the anycast bit is set, preventing potential substitution attacks and aligning with TVM 10 deprecation of anycast addresses (`cell/cell_parser.rs`).

### Testing and Validation

* Added a test (`test_load_address_rejects_anycast`) to confirm that parsing an address with anycast set fails, ensuring the fix is covered by unit tests (`tests/cell_parser.rs`).
* Added a helper function and a test (`test_address_converter_from_boc_rejects_anycast`) to verify that the `AddressConverter` also rejects anycast addresses when parsing from a BoC, protecting against crafted payloads (`tests/chains/ton/ton_address_converter.rs`).

### Test Infrastructure

* Imported `CellBuilder` in test modules to facilitate building custom address cells for testing purposes (`tests/cell_parser.rs`, `tests/chains/ton/ton_address_converter.rs`).