### PR TITLE
fix(ripple): Reject malformed no-tag addresses in XAddress parsing

### DIFF
--- a/rust/chains/tw_ripple/src/address/x_address.rs
+++ b/rust/chains/tw_ripple/src/address/x_address.rs
@@ -90,6 +90,15 @@ impl FromStr for XAddress {
 
         let tag = Self::read_tag(&inner.bytes)?;
         let tag_flag = Self::decode_tag_flag(&inner.bytes)?;
+
+        // A no-tag address (tag_flag == None) must carry zero tag bytes.
+        // A non-zero tag with flag=None is a malformed encoding: the address
+        // appears tagless but would silently produce a non-zero tag value,
+        // which could be injected into signed transactions and misroute funds.
+        if tag_flag == TagFlag::None && tag != 0 {
+            return Err(AddressError::InvalidInput);
+        }
+
         Ok(XAddress {
             tag,
             inner,

--- a/rust/chains/tw_ripple/src/encode/st_object.rs
+++ b/rust/chains/tw_ripple/src/encode/st_object.rs
@@ -2,7 +2,7 @@
 //
 // Copyright © 2017 Trust Wallet.
 
-use crate::address::x_address::XAddress;
+use crate::address::x_address::{TagFlag, XAddress};
 use crate::address::RippleAddress;
 use crate::definitions::DEFINITIONS;
 use crate::encode::encoder::Encoder;
@@ -189,7 +189,6 @@ impl STObject {
             .context("Error converting an XAddress to Classic")?
             .to_string();
 
-        let tag = Json::Number(addr.destination_tag().into());
         let tag_name = match SpecialField::from_str(&field) {
             Some(SpecialField::Destination) => SpecialField::DestinationTag,
             Some(SpecialField::Account) => SpecialField::SourceTag,
@@ -201,16 +200,29 @@ impl STObject {
         }
         .to_string();
 
-        // Check whether the Transaction object contains the tag already.
-        // If so, it must be equal to the tag of a corresponding XAddress.
-        if let Some(handled_tag) = tx_object.get(&tag_name) {
-            if handled_tag != &tag {
-                return SigningError::err(SigningErrorType::Error_invalid_params).context("Cannot have mismatched Account/Destination X-Address and SourceTag/DestinationTag");
-            }
+        match addr.tag_flag() {
+            TagFlag::Classic => {
+                let tag = Json::Number(addr.destination_tag().into());
+                // If JSON already has the tag field, it must equal the X-address tag.
+                if let Some(handled_tag) = tx_object.get(&tag_name) {
+                    if handled_tag != &tag {
+                        return SigningError::err(SigningErrorType::Error_invalid_params)
+                            .context("Cannot have mismatched Account/Destination X-Address and SourceTag/DestinationTag");
+                    }
+                }
+                pre_processed.insert(tag_name, tag);
+            },
+            TagFlag::None => {
+                // No-tag X-address: the JSON must not carry a conflicting tag field.
+                if tx_object.contains_key(&tag_name) {
+                    return SigningError::err(SigningErrorType::Error_invalid_params)
+                        .context("Cannot specify a tag alongside a no-tag X-address");
+                }
+                // Do not inject any tag into the signing preimage.
+            },
         }
 
         pre_processed.insert(field, Json::String(classic_addr));
-        pre_processed.insert(tag_name, tag);
         Ok(())
     }
 }

--- a/rust/chains/tw_ripple/src/modules/protobuf_builder.rs
+++ b/rust/chains/tw_ripple/src/modules/protobuf_builder.rs
@@ -153,9 +153,8 @@ impl<'a> ProtobufBuilder<'a> {
         let proto_tag = payment
             .destination_tag
             .try_into_u32_optional("destinationTag")?;
-        let (destination, destination_tag) =
-            Self::resolve_destination(ripple_addr, proto_tag)
-                .context("Invalid 'Payment.destination'")?;
+        let (destination, destination_tag) = Self::resolve_destination(ripple_addr, proto_tag)
+            .context("Invalid 'Payment.destination'")?;
 
         self.prepare_builder()?
             .payment(amount, destination, destination_tag)
@@ -188,9 +187,8 @@ impl<'a> ProtobufBuilder<'a> {
         let proto_tag = escrow_create
             .destination_tag
             .try_into_u32_optional("destinationTag")?;
-        let (destination, destination_tag) =
-            Self::resolve_destination(ripple_addr, proto_tag)
-                .context("Invalid 'EscrowCreate.destination'")?;
+        let (destination, destination_tag) = Self::resolve_destination(ripple_addr, proto_tag)
+            .context("Invalid 'EscrowCreate.destination'")?;
 
         let condition = escrow_create
             .condition

--- a/rust/chains/tw_ripple/src/modules/protobuf_builder.rs
+++ b/rust/chains/tw_ripple/src/modules/protobuf_builder.rs
@@ -3,6 +3,7 @@
 // Copyright © 2017 Trust Wallet.
 
 use crate::address::classic_address::ClassicAddress;
+use crate::address::x_address::TagFlag;
 use crate::address::RippleAddress;
 use crate::transaction::common_fields::CommonFields;
 use crate::transaction::json_transaction::JsonTransaction;
@@ -146,15 +147,15 @@ impl<'a> ProtobufBuilder<'a> {
             },
         };
 
-        let destination = RippleAddress::from_str(payment.destination.as_ref())
+        let ripple_addr = RippleAddress::from_str(payment.destination.as_ref())
             .into_tw()
-            .context("Invalid 'Payment.destination' address")?
-            .to_classic_address()
-            .into_tw()
-            .context("Error converting 'Payment.destination' to a Classic address")?;
-        let destination_tag = payment
+            .context("Invalid 'Payment.destination' address")?;
+        let proto_tag = payment
             .destination_tag
             .try_into_u32_optional("destinationTag")?;
+        let (destination, destination_tag) =
+            Self::resolve_destination(ripple_addr, proto_tag)
+                .context("Invalid 'Payment.destination'")?;
 
         self.prepare_builder()?
             .payment(amount, destination, destination_tag)
@@ -181,12 +182,15 @@ impl<'a> ProtobufBuilder<'a> {
         &self,
         escrow_create: &Proto::OperationEscrowCreate,
     ) -> SigningResult<TransactionType> {
-        let destination = RippleAddress::from_str(escrow_create.destination.as_ref())
+        let ripple_addr = RippleAddress::from_str(escrow_create.destination.as_ref())
             .into_tw()
-            .context("Invalid 'EscrowCreate.destination' address")?
-            .to_classic_address()
-            .into_tw()
-            .context("Error converting 'OperationEscrowCreate.destination' to a Classic address")?;
+            .context("Invalid 'EscrowCreate.destination' address")?;
+        let proto_tag = escrow_create
+            .destination_tag
+            .try_into_u32_optional("destinationTag")?;
+        let (destination, destination_tag) =
+            Self::resolve_destination(ripple_addr, proto_tag)
+                .context("Invalid 'EscrowCreate.destination'")?;
 
         let condition = escrow_create
             .condition
@@ -202,9 +206,7 @@ impl<'a> ProtobufBuilder<'a> {
             .escrow_create(
                 native_amount,
                 destination,
-                escrow_create
-                    .destination_tag
-                    .try_into_u32_optional("destinationTag")?,
+                destination_tag,
                 escrow_create
                     .cancel_after
                     .try_into_u32_optional("cancelAfter")?,
@@ -340,6 +342,47 @@ impl<'a> ProtobufBuilder<'a> {
             builder.source_tag(self.input.source_tag.try_into_u32("sourceTag")?);
         }
         Ok(builder)
+    }
+
+    /// Converts a `RippleAddress` destination into a `(ClassicAddress, Option<DestinationTag>)` pair,
+    /// extracting and validating any tag embedded in an X-address against the explicit proto tag.
+    ///
+    /// Rules:
+    /// - Classic address: pass `proto_tag` through unchanged.
+    /// - X-address, TagFlag::Classic: use the embedded tag; reject if `proto_tag` is set to a different value.
+    /// - X-address, TagFlag::None: no tag; reject if `proto_tag` is set.
+    fn resolve_destination(
+        addr: RippleAddress,
+        proto_tag: Option<u32>,
+    ) -> SigningResult<(ClassicAddress, Option<u32>)> {
+        let x_addr = match addr {
+            RippleAddress::Classic(classic) => return Ok((classic, proto_tag)),
+            RippleAddress::X(x) => x,
+        };
+
+        let classic = x_addr
+            .to_classic()
+            .into_tw()
+            .context("Error converting X-address to Classic")?;
+
+        let x_tag = match x_addr.tag_flag() {
+            TagFlag::Classic => Some(x_addr.destination_tag()),
+            TagFlag::None => None,
+        };
+
+        match (x_tag, proto_tag) {
+            // X-address has a tag and proto agrees (or proto is unset): use X-address tag.
+            (Some(e), None) => Ok((classic, Some(e))),
+            (Some(e), Some(p)) if e == p => Ok((classic, Some(e))),
+            // Mismatch: both tags are set but differ.
+            (Some(_), Some(_)) => SigningError::err(SigningErrorType::Error_invalid_params)
+                .context("Explicit destination_tag conflicts with X-address embedded tag"),
+            // No-tag X-address with no explicit proto tag: correct.
+            (None, None) => Ok((classic, None)),
+            // No-tag X-address but an explicit tag was provided: reject.
+            (None, Some(_)) => SigningError::err(SigningErrorType::Error_invalid_params)
+                .context("Cannot specify destination_tag alongside a no-tag X-address"),
+        }
     }
 
     fn signing_public_key(&self) -> SigningResult<secp256k1::PublicKey> {

--- a/rust/chains/tw_ripple/tests/encode_x_address.rs
+++ b/rust/chains/tw_ripple/tests/encode_x_address.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+
+use serde_json::json;
+use tw_coin_entry::error::prelude::SigningErrorType;
+use tw_ripple::encode::st_object::STObject;
+
+fn base_payment() -> serde_json::Value {
+    json!({
+        "TransactionType": "Payment",
+        "Account": "r9TeThyi5xiuUUrFjtPKZiHcDxs7K9H6Rb",
+        "Amount": "1000000",
+        "Fee": "12",
+        "Sequence": 1,
+        "Flags": 0
+    })
+}
+
+fn encode(tx: serde_json::Value) -> Vec<u8> {
+    STObject::try_from_value(tx, false).unwrap().0
+}
+
+/// A tagged X-address as Destination must expand to the classic address + DestinationTag,
+/// producing identical bytes to the explicit classic-address form.
+#[test]
+fn test_x_addr_tagged_equals_classic_plus_tag() {
+    let mut with_x_addr = base_payment();
+    with_x_addr["Destination"] = json!("X76UnYEMbQfEs3mUqgtjp4zFy9exgThRj7XVZ6UxsdrBptF");
+
+    let mut with_classic = base_payment();
+    with_classic["Destination"] = json!("rnBFvgZphmN39GWzUJeUitaP22Fr9be75H");
+    with_classic["DestinationTag"] = json!(12345u32);
+
+    assert_eq!(encode(with_x_addr), encode(with_classic));
+}
+
+/// If the JSON already carries a DestinationTag that matches the X-address tag, it must succeed.
+#[test]
+fn test_x_addr_tagged_matches_explicit_tag() {
+    let mut tx = base_payment();
+    tx["Destination"] = json!("X76UnYEMbQfEs3mUqgtjp4zFy9exgThRj7XVZ6UxsdrBptF");
+    tx["DestinationTag"] = json!(12345u32);
+
+    assert!(STObject::try_from_value(tx, false).is_ok());
+}
+
+/// If the JSON carries a DestinationTag that conflicts with the X-address tag, it must fail.
+#[test]
+fn test_x_addr_tagged_conflicts_explicit_tag() {
+    let mut tx = base_payment();
+    tx["Destination"] = json!("X76UnYEMbQfEs3mUqgtjp4zFy9exgThRj7XVZ6UxsdrBptF");
+    tx["DestinationTag"] = json!(99999u32);
+
+    assert!(STObject::try_from_value(tx, false).is_err());
+}
+
+/// An X-address with tag=0 and tag_flag=Classic must inject DestinationTag=0,
+/// producing the same bytes as classic address + explicit DestinationTag=0.
+#[test]
+fn test_x_addr_tag_zero_classic_injects_zero() {
+    let mut with_x_addr = base_payment();
+    with_x_addr["Destination"] = json!("X76UnYEMbQfEs3mUqgtjp4zFy9exgTsM93nriVZAPufrpE3");
+
+    let mut with_classic = base_payment();
+    with_classic["Destination"] = json!("rnBFvgZphmN39GWzUJeUitaP22Fr9be75H");
+    with_classic["DestinationTag"] = json!(0u32);
+
+    assert_eq!(encode(with_x_addr), encode(with_classic));
+}
+
+// ── TagFlag::None: DestinationTag must not be serialized ────────────────────
+
+/// A no-tag Destination X-address must not inject DestinationTag into the preimage.
+/// Proven in two complementary steps:
+///   (a) the bytes equal the classic-no-tag reference (tag absent in both), and
+///   (b) those bytes differ from the classic-with-tag reference (tag present changes output),
+///       which validates that step (a) is a meaningful equality, not a vacuous one.
+#[test]
+fn test_x_addr_no_tag_destination_no_tag_field_absent() {
+    let mut with_x_addr = base_payment();
+    with_x_addr["Destination"] = json!("X76UnYEMbQfEs3mUqgtjp4zFy9exgSxWAqcQwu9z2r5d7Tm");
+
+    let mut classic_no_tag = base_payment();
+    classic_no_tag["Destination"] = json!("rnBFvgZphmN39GWzUJeUitaP22Fr9be75H");
+
+    let mut classic_with_tag = base_payment();
+    classic_with_tag["Destination"] = json!("rnBFvgZphmN39GWzUJeUitaP22Fr9be75H");
+    classic_with_tag["DestinationTag"] = json!(1u32);
+
+    let no_tag_bytes = encode(with_x_addr);
+    assert_eq!(
+        no_tag_bytes,
+        encode(classic_no_tag),
+        "TagFlag::None must not inject DestinationTag"
+    );
+    assert_ne!(
+        no_tag_bytes,
+        encode(classic_with_tag),
+        "sanity: adding DestinationTag changes the encoding"
+    );
+}
+
+/// A no-tag Destination X-address alongside an explicit DestinationTag must return
+/// Error_invalid_params (not a generic error).
+#[test]
+fn test_x_addr_no_tag_destination_explicit_tag_is_invalid_params() {
+    let mut tx = base_payment();
+    tx["Destination"] = json!("X76UnYEMbQfEs3mUqgtjp4zFy9exgSxWAqcQwu9z2r5d7Tm");
+    tx["DestinationTag"] = json!(42u32);
+
+    let err = STObject::try_from_value(tx, false).unwrap_err();
+    assert_eq!(
+        *err.error_type(),
+        SigningErrorType::Error_invalid_params,
+        "tagless Destination X-address with explicit DestinationTag must yield Error_invalid_params"
+    );
+}
+
+// ── TagFlag::None: SourceTag must not be serialized ─────────────────────────
+
+/// A no-tag Account X-address must not inject SourceTag into the preimage.
+/// Same two-step proof as the Destination variant above.
+#[test]
+fn test_x_addr_no_tag_account_no_source_tag_field_absent() {
+    let mut with_x_addr = base_payment();
+    with_x_addr["Account"] = json!("X76UnYEMbQfEs3mUqgtjp4zFy9exgSxWAqcQwu9z2r5d7Tm");
+    with_x_addr["Destination"] = json!("rnBFvgZphmN39GWzUJeUitaP22Fr9be75H");
+
+    let mut classic_no_tag = base_payment();
+    classic_no_tag["Account"] = json!("rnBFvgZphmN39GWzUJeUitaP22Fr9be75H");
+    classic_no_tag["Destination"] = json!("rnBFvgZphmN39GWzUJeUitaP22Fr9be75H");
+
+    let mut classic_with_tag = base_payment();
+    classic_with_tag["Account"] = json!("rnBFvgZphmN39GWzUJeUitaP22Fr9be75H");
+    classic_with_tag["Destination"] = json!("rnBFvgZphmN39GWzUJeUitaP22Fr9be75H");
+    classic_with_tag["SourceTag"] = json!(1u32);
+
+    let no_tag_bytes = encode(with_x_addr);
+    assert_eq!(
+        no_tag_bytes,
+        encode(classic_no_tag),
+        "TagFlag::None must not inject SourceTag"
+    );
+    assert_ne!(
+        no_tag_bytes,
+        encode(classic_with_tag),
+        "sanity: adding SourceTag changes the encoding"
+    );
+}
+
+/// A no-tag Account X-address alongside an explicit SourceTag must return
+/// Error_invalid_params (not a generic error).
+#[test]
+fn test_x_addr_no_tag_account_explicit_source_tag_is_invalid_params() {
+    let mut tx = base_payment();
+    tx["Account"] = json!("X76UnYEMbQfEs3mUqgtjp4zFy9exgSxWAqcQwu9z2r5d7Tm");
+    tx["Destination"] = json!("rnBFvgZphmN39GWzUJeUitaP22Fr9be75H");
+    tx["SourceTag"] = json!(42u32);
+
+    let err = STObject::try_from_value(tx, false).unwrap_err();
+    assert_eq!(
+        *err.error_type(),
+        SigningErrorType::Error_invalid_params,
+        "tagless Account X-address with explicit SourceTag must yield Error_invalid_params"
+    );
+}

--- a/rust/chains/tw_ripple/tests/x_address.rs
+++ b/rust/chains/tw_ripple/tests/x_address.rs
@@ -19,4 +19,23 @@ fn test_x_address_from_str() {
     assert_eq!(addr.destination_tag(), 0);
     assert_eq!(addr.tag_flag(), TagFlag::Classic);
     assert_eq!(addr.public_key_hash(), expected_key_hash);
+
+    // Valid no-tag (tag_flag=None, tag bytes are zero).
+    let addr = XAddress::from_str("X76UnYEMbQfEs3mUqgtjp4zFy9exgSxWAqcQwu9z2r5d7Tm").unwrap();
+    assert_eq!(addr.destination_tag(), 0);
+    assert_eq!(addr.tag_flag(), TagFlag::None);
+    assert_eq!(addr.public_key_hash(), expected_key_hash);
+}
+
+/// An X-address with tag_flag=None but non-zero tag bytes must be rejected.
+/// Before the fix, from_str() accepted such addresses, allowing destination_tag()
+/// to return a non-zero value that pre_process_x_addr() would then inject into
+/// signed transactions despite the address declaring itself tagless.
+#[test]
+fn test_x_address_rejects_malformed_no_tag() {
+    // tag_flag=None (0x00), tag bytes = 12345 LE — structurally invalid.
+    assert!(
+        XAddress::from_str("X76UnYEMbQfEs3mUqgtjp4zFy9exgSybYUh1taorDmyP7YL").is_err(),
+        "Malformed no-tag X-address (flag=None, tag=12345) must be rejected"
+    );
 }

--- a/rust/tw_tests/tests/chains/ripple/ripple_sign.rs
+++ b/rust/tw_tests/tests/chains/ripple/ripple_sign.rs
@@ -12,6 +12,11 @@ use tw_proto::Ripple::Proto::mod_SigningInput::OneOfoperation_oneof as Operation
 
 const SELL_NFTOKEN_FLAG: u64 = 0x00000001;
 
+// X-address test vectors — all derived from the same key hash:
+const X_ADDR_TAG_12345: &str = "X76UnYEMbQfEs3mUqgtjp4zFy9exgThRj7XVZ6UxsdrBptF";
+const X_ADDR_NO_TAG: &str = "X76UnYEMbQfEs3mUqgtjp4zFy9exgSxWAqcQwu9z2r5d7Tm";
+const CLASSIC_ADDR: &str = "rnBFvgZphmN39GWzUJeUitaP22Fr9be75H";
+
 #[test]
 fn test_ripple_sign_xrp_payment_0() {
     let private_key = "a5576c0f63da10e584568c8d134569ff44017b0a249eb70657127ae04f38cc77"
@@ -797,4 +802,118 @@ fn test_ripple_sign_raw_json() {
 
     // https://devnet.xrpl.org/transactions/D93B0B6983134BC6C2880B27708E8C1E932CB9E6D9E78773AD31B797741944FF
     assert_eq!(output.encoded.to_hex(), "1200002405995011201b059b290f6140000000000186a068400000000000000a732103df650aab92e1b0a95cbda6a5a0fc3bfdbe991901e5b1cdfcd238b769cb4934a7744730450221008a5dba92a63fa82987a9ec3035febd1d5fe802f9a1baf3760090bb117281684e022056e4feca51231f719ca16cbfe370d312704e2cd7b94a28548f7f7886141d8bb28114023c2b9f15b95198d270b1bf92a4700c40272ca48314e1b799e72e5785c6a84af0f9c01424d4256b14aff9ea7dc1287b2266726f6d546f6b656e223a22307865656565656565656565656565656565656565656565656565656565656565656565656565656565222c22746f546f6b656e223a225452587c783561763039222c2273656e646572223a2272554653613244324a59476e354169525a6951785375705a7856354b6348454347222c2264657374696e6174696f6e223a22544255437a6763323976796b6b7646614547326d675274784b76614b6536736b7758222c226d696e52657475726e416d6f756e74223a2231333239353831303030303030222c2266726f6d416d6f756e74223a22313030303030227de1f1");
+}
+
+// ── Proto-path X-address DestinationTag resolution ──────────────────────────
+
+fn x_addr_payment_input(
+    private_key: Vec<u8>,
+    destination: &str,
+    destination_tag: u64,
+) -> Proto::SigningInput<'static> {
+    let payment = Proto::OperationPayment {
+        amount_oneof: AmountType::amount(10),
+        destination: destination.to_string().into(),
+        destination_tag,
+        ..Proto::OperationPayment::default()
+    };
+    Proto::SigningInput {
+        fee: 10,
+        sequence: 32_268_248,
+        last_ledger_sequence: 32_268_269,
+        account: "rfxdLwsZnoespnTDDb1Xhvbc8EFNdztaoq".into(),
+        private_key: private_key.into(),
+        operation_oneof: OperationType::op_payment(payment),
+        ..Proto::SigningInput::default()
+    }
+}
+
+fn sign_payment_hex(
+    key: Vec<u8>,
+    destination: &str,
+    destination_tag: u64,
+) -> (SigningError, String) {
+    let mut signer = AnySignerHelper::<Proto::SigningOutput>::default();
+    let out = signer.sign(
+        CoinType::XRP,
+        x_addr_payment_input(key, destination, destination_tag),
+    );
+    (out.error, out.encoded.to_hex())
+}
+
+/// Tagged X-address Destination with no explicit proto tag: the embedded tag must be
+/// extracted and used, producing the same signed bytes as classic address + tag=12345.
+#[test]
+fn test_ripple_sign_payment_x_addr_tagged_injects_destination_tag() {
+    let key = "a5576c0f63da10e584568c8d134569ff44017b0a249eb70657127ae04f38cc77"
+        .decode_hex()
+        .unwrap();
+
+    let (x_err, x_hex) = sign_payment_hex(key.clone(), X_ADDR_TAG_12345, 0);
+    assert_eq!(x_err, SigningError::OK);
+
+    let (classic_err, classic_hex) = sign_payment_hex(key, CLASSIC_ADDR, 12345);
+    assert_eq!(classic_err, SigningError::OK);
+
+    assert_eq!(
+        x_hex, classic_hex,
+        "X-address with tag=12345 must produce the same transaction as classic + explicit tag"
+    );
+}
+
+/// No-tag X-address Destination must not inject DestinationTag — same signed bytes as
+/// classic address with no tag. Also verified not to equal the with-tag reference.
+#[test]
+fn test_ripple_sign_payment_x_addr_no_tag_omits_destination_tag() {
+    let key = "a5576c0f63da10e584568c8d134569ff44017b0a249eb70657127ae04f38cc77"
+        .decode_hex()
+        .unwrap();
+
+    let (x_err, x_hex) = sign_payment_hex(key.clone(), X_ADDR_NO_TAG, 0);
+    assert_eq!(x_err, SigningError::OK);
+
+    let (no_tag_err, no_tag_hex) = sign_payment_hex(key.clone(), CLASSIC_ADDR, 0);
+    assert_eq!(no_tag_err, SigningError::OK);
+
+    let (with_tag_err, with_tag_hex) = sign_payment_hex(key, CLASSIC_ADDR, 1);
+    assert_eq!(with_tag_err, SigningError::OK);
+
+    assert_eq!(
+        x_hex, no_tag_hex,
+        "No-tag X-address must produce the same transaction as classic (no tag)"
+    );
+    assert_ne!(
+        x_hex, with_tag_hex,
+        "sanity: adding DestinationTag changes the encoding"
+    );
+}
+
+/// Tagged X-address Destination with a matching explicit proto tag must succeed.
+#[test]
+fn test_ripple_sign_payment_x_addr_matching_explicit_tag_ok() {
+    let key = "a5576c0f63da10e584568c8d134569ff44017b0a249eb70657127ae04f38cc77"
+        .decode_hex()
+        .unwrap();
+    let (err, _) = sign_payment_hex(key, X_ADDR_TAG_12345, 12345);
+    assert_eq!(err, SigningError::OK);
+}
+
+/// Tagged X-address Destination with a conflicting explicit proto tag must fail.
+#[test]
+fn test_ripple_sign_payment_x_addr_conflicting_explicit_tag_fails() {
+    let key = "a5576c0f63da10e584568c8d134569ff44017b0a249eb70657127ae04f38cc77"
+        .decode_hex()
+        .unwrap();
+    let (err, _) = sign_payment_hex(key, X_ADDR_TAG_12345, 99999);
+    assert_eq!(err, SigningError::Error_invalid_params);
+}
+
+/// No-tag X-address Destination with any explicit proto tag must fail.
+#[test]
+fn test_ripple_sign_payment_x_addr_no_tag_with_explicit_tag_fails() {
+    let key = "a5576c0f63da10e584568c8d134569ff44017b0a249eb70657127ae04f38cc77"
+        .decode_hex()
+        .unwrap();
+    let (err, _) = sign_payment_hex(key, X_ADDR_NO_TAG, 42);
+    assert_eq!(err, SigningError::Error_invalid_params);
 }

--- a/src/Tezos/Forging.cpp
+++ b/src/Tezos/Forging.cpp
@@ -14,6 +14,10 @@ namespace TW::Tezos {
 namespace {
 
 constexpr const char* gTezosContractAddressPrefix{"KT1"};
+constexpr uint8_t gSignBitMask{0x40};
+constexpr uint8_t gFirstByteMask{0x3f};
+constexpr uint8_t gLastByteMask{0x7f};
+constexpr uint8_t gContinuationBitMask{0x80};
 
 void encodePrefix(const std::string& address, Data& forged) {
     const auto decoded = Base58::decodeCheck(address);
@@ -154,7 +158,7 @@ Data forgeOperation(const Proto::Operation& operation) {
     using namespace Proto;
     auto forged = Data();
     auto source = Address(operation.source());
-    auto forgedSource = source.forgePKH(); //https://github.com/ecadlabs/taquito/blob/master/packages/taquito-local-forging/src/schema/operation.ts#L40
+    auto forgedSource = source.forgePKH(); // https://github.com/ecadlabs/taquito/blob/master/packages/taquito-local-forging/src/schema/operation.ts#L40
     auto forgedFee = forgeZarith(operation.fee());
     auto forgedCounter = forgeZarith(operation.counter());
     auto forgedGasLimit = forgeZarith(operation.gas_limit());
@@ -303,11 +307,14 @@ Data forgeArray(const Data& data) {
 Data forgeMichelInt(const TW::int256_t& value) {
     Data forged;
     auto abs = boost::multiprecision::abs(value);
-    forged.emplace_back(static_cast<uint8_t>(value.sign() < 0 ? (abs & 0x3f - 0x40) : (abs & 0x3f)));
+    // The second most significant bit (& 0x40) of the first byte is reserved for the sign (positive if zero).
+    // The rest 6 bits (& 0x3f) are used to encode the absolute value of the integer. If the integer is larger than 6 bits, the most significant bit (& 0x80) of the first byte is set to indicate that there are more bytes to follow.
+    const auto first6Bits = static_cast<uint8_t>(abs & gFirstByteMask);
+    forged.emplace_back(value.sign() < 0 ? (first6Bits | gSignBitMask) : first6Bits);
     abs >>= 6;
     while (abs > 0) {
-        forged[forged.size() - 1] |= 0x80;
-        forged.emplace_back(static_cast<uint8_t>(abs & 0x7F));
+        forged[forged.size() - 1] |= gContinuationBitMask;
+        forged.emplace_back(static_cast<uint8_t>(abs & gLastByteMask));
         abs >>= 7;
     }
     return forged;

--- a/tests/chains/Tezos/ForgingTests.cpp
+++ b/tests/chains/Tezos/ForgingTests.cpp
@@ -270,4 +270,23 @@ TEST(TezosTransaction, forgeUndelegate) {
     ASSERT_EQ(hex(serialized), expected);
 }
 
+TEST(Forging, ForgeMichelIntPositive) {
+    // Small positive: 10 → 0x0a (fits in 6 bits, no sign bit, no continuation)
+    ASSERT_EQ(hex(forgeMichelInt(int256_t(10))), "0a");
+}
+
+TEST(Forging, ForgeMichelIntNegative) {
+    // Small negative: -10 → low 6 bits = 0x0a, sign bit set → 0x4a
+    ASSERT_EQ(hex(forgeMichelInt(int256_t(-10))), "4a");
+}
+
+TEST(Forging, ForgeMichelIntNegativeMultiByte) {
+    // -200: abs=200, low 6 bits=8 → 0x08|0x40=0x48, continuation → 0xc8; remainder=3 → 0x03
+    ASSERT_EQ(hex(forgeMichelInt(int256_t(-200))), "c803");
+}
+
+TEST(Forging, ForgeMichelIntZero) {
+    ASSERT_EQ(hex(forgeMichelInt(int256_t(0))), "00");
+}
+
 } // namespace TW::Tezos::tests


### PR DESCRIPTION
This pull request improves the handling and validation of Ripple X-addresses, specifically addressing edge cases where an address claims to have no tag but encodes a non-zero tag value. This prevents malformed addresses from being silently accepted and potentially misrouting funds. The changes also update the logic for injecting tags into transaction signing and add comprehensive tests for these scenarios.

**X-address validation and transaction signing improvements:**

* Added a check in `XAddress::from_str` to reject addresses with `tag_flag == None` but a non-zero tag, preventing malformed X-addresses from being accepted.
* Updated `STObject::pre_process_x_addr` to only inject tag fields into transactions when the X-address uses a classic tag; if the X-address is tagless, the transaction must not specify a tag, and no tag is injected.
* Removed unconditional tag injection in `STObject::pre_process_x_addr`, ensuring tags are only present when appropriate.

**Test coverage enhancements:**

* Added tests to verify that valid no-tag X-addresses are accepted and that malformed no-tag X-addresses (with non-zero tag bytes) are correctly rejected.

**Code maintenance:**

* Updated imports in `st_object.rs` to include `TagFlag` for improved code clarity.