### PR TITLE
fix(forging): Validate address length and reject embedded NULs in Base58 decoding

### DIFF
--- a/src/Base58.h
+++ b/src/Base58.h
@@ -17,6 +17,12 @@ namespace TW::Base58 {
         if (string.empty()) {
             return {};
         }
+        // An embedded NULL is silently truncated by CStr::from_ptr in the Rust FFI,
+        // so "valid\x00junk" would decode as just "valid" and pass later size/checksum
+        // checks on the shortened payload.
+        if (string.find('\0') != std::string::npos) {
+            return {};
+        }
         Rust::CByteArrayResultWrapper res = Rust::decode_base58(string.c_str(), alphabet);
         return res.unwrap_or_default().data;
     }

--- a/src/Tezos/Forging.cpp
+++ b/src/Tezos/Forging.cpp
@@ -17,9 +17,9 @@ constexpr const char* gTezosContractAddressPrefix{"KT1"};
 
 void encodePrefix(const std::string& address, Data& forged) {
     const auto decoded = Base58::decodeCheck(address);
-    constexpr auto prefixSize{3};
-    if (decoded.size() < prefixSize) {
-        throw std::invalid_argument("Invalid address: decoded payload too short");
+    constexpr size_t prefixSize{3};
+    if (decoded.size() != Address::size) {
+        throw std::invalid_argument("Invalid address: unexpected decoded payload size");
     }
     forged.insert(forged.end(), decoded.begin() + prefixSize, decoded.end());
 }
@@ -114,11 +114,11 @@ Data forgeAddress(const std::string& address) {
 // https://github.com/ecadlabs/taquito/blob/master/packages/taquito-local-forging/src/codec.ts#L19
 Data forgePrefix(std::array<TW::byte, 3> prefix, const std::string& val) {
     const auto decoded = Base58::decodeCheck(val);
-    if (decoded.size() < prefix.size() || !std::equal(prefix.begin(), prefix.end(), decoded.begin())) {
+    if (decoded.size() != Address::size || !std::equal(prefix.begin(), prefix.end(), decoded.begin())) {
         throw std::invalid_argument("prefix not match");
     }
 
-    const auto prefixSize = 3;
+    constexpr size_t prefixSize{3};
     Data forged = Data();
     forged.insert(forged.end(), decoded.begin() + prefixSize, decoded.end());
     return forged;

--- a/src/Tezos/Forging.cpp
+++ b/src/Tezos/Forging.cpp
@@ -114,8 +114,11 @@ Data forgeAddress(const std::string& address) {
 // https://github.com/ecadlabs/taquito/blob/master/packages/taquito-local-forging/src/codec.ts#L19
 Data forgePrefix(std::array<TW::byte, 3> prefix, const std::string& val) {
     const auto decoded = Base58::decodeCheck(val);
-    if (decoded.size() != Address::size || !std::equal(prefix.begin(), prefix.end(), decoded.begin())) {
-        throw std::invalid_argument("prefix not match");
+    if (decoded.size() != Address::size) {
+        throw std::invalid_argument("Invalid address: unexpected decoded payload size");
+    }
+    if (!std::equal(prefix.begin(), prefix.end(), decoded.begin())) {
+        throw std::invalid_argument("Prefix does not match");
     }
 
     constexpr size_t prefixSize{3};

--- a/src/Tezos/Forging.cpp
+++ b/src/Tezos/Forging.cpp
@@ -18,6 +18,9 @@ constexpr const char* gTezosContractAddressPrefix{"KT1"};
 void encodePrefix(const std::string& address, Data& forged) {
     const auto decoded = Base58::decodeCheck(address);
     constexpr auto prefixSize{3};
+    if (decoded.size() < prefixSize) {
+        throw std::invalid_argument("Invalid address: decoded payload too short");
+    }
     forged.insert(forged.end(), decoded.begin() + prefixSize, decoded.end());
 }
 
@@ -65,6 +68,9 @@ Data forgeEntrypoint(const std::string& value) {
 // Forge the given public key hash into a hex encoded string.
 // Note: This function supports tz1, tz2 and tz3 addresses.
 Data forgePublicKeyHash(const std::string& publicKeyHash) {
+    if (publicKeyHash.size() < 3) {
+        throw std::invalid_argument("Invalid address");
+    }
     Data forged = Data();
     // Adjust prefix based on tz1, tz2 or tz3.
     switch ((char)publicKeyHash[2]) {
@@ -108,7 +114,7 @@ Data forgeAddress(const std::string& address) {
 // https://github.com/ecadlabs/taquito/blob/master/packages/taquito-local-forging/src/codec.ts#L19
 Data forgePrefix(std::array<TW::byte, 3> prefix, const std::string& val) {
     const auto decoded = Base58::decodeCheck(val);
-    if (!std::equal(prefix.begin(), prefix.end(), decoded.begin())) {
+    if (decoded.size() < prefix.size() || !std::equal(prefix.begin(), prefix.end(), decoded.begin())) {
         throw std::invalid_argument("prefix not match");
     }
 

--- a/tests/chains/Tezos/AddressTests.cpp
+++ b/tests/chains/Tezos/AddressTests.cpp
@@ -94,4 +94,17 @@ TEST(TezosAddress, PublicKeyInit) {
     ASSERT_EQ(address.string(), expected);
 }
 
+TEST(TezosAddress, isInvalid_NullEmbedded) {
+    // A valid address followed by an embedded NULL must be rejected.
+    // Before the fix, Base58::decode passed string.c_str() to CStr::from_ptr which
+    // truncated at the NULL, letting the pre-NULL payload decode and pass size/checksum.
+    auto valid = std::string("tz1eZwq8b5cvE2bPKokatLkVMzkxz24z3Don");
+
+    auto with_junk = valid + '\0' + "garbage";
+    ASSERT_FALSE(Address::isValid(with_junk));
+
+    auto trailing_null = valid + '\0';
+    ASSERT_FALSE(Address::isValid(trailing_null));
+}
+
 } // namespace TW::Tezos::tests

--- a/tests/chains/Tezos/ForgingTests.cpp
+++ b/tests/chains/Tezos/ForgingTests.cpp
@@ -122,6 +122,19 @@ TEST(Forging, ForgeEntrypoint) {
     ASSERT_EQ(hex(forgeEntrypoint("transfer")), expected);
 }
 
+TEST(Forging, ForgePublicKeyHash_TooShort) {
+    ASSERT_THROW(forgePublicKeyHash(""), std::invalid_argument);
+    ASSERT_THROW(forgePublicKeyHash("ab"), std::invalid_argument);
+}
+
+TEST(Forging, ForgeAddress_NullEmbedded) {
+    // A valid address with an embedded NULL must throw rather than forge the
+    // pre-NULL payload.  Before the fix, CStr::from_ptr truncated the input and
+    // the shortened payload passed all prefix/checksum checks silently.
+    auto with_null = std::string("tz1eZwq8b5cvE2bPKokatLkVMzkxz24z3Don") + '\0' + "junk";
+    ASSERT_THROW(forgeAddress(with_null), std::invalid_argument);
+}
+
 TEST(Forging, ForgeMichelsonFA12) {
     Tezos::Proto::FA12Parameters data;
     data.set_entrypoint("transfer");


### PR DESCRIPTION
This pull request improves the robustness of Tezos address encoding and decoding by handling embedded NULL characters and adding stricter input validation. The changes prevent malformed or manipulated addresses from being incorrectly accepted or processed, and they introduce new test cases to verify these behaviors.

**Security and Validation Improvements:**

* Added a check in `Base58::decode` to reject strings containing embedded NULL characters, preventing truncation issues in the Rust FFI layer.
* Updated `forgePrefix` and `encodePrefix` in `Tezos/Forging.cpp` to validate that decoded addresses are of sufficient length before processing, throwing exceptions if not.
* Added input length validation to `forgePublicKeyHash` to throw an exception if the input is too short.

**Testing Enhancements:**

* Added tests to ensure that addresses with embedded NULLs are rejected and that too-short inputs throw exceptions in the relevant forging functions.