### PR TITLE
fix(encoding): Add NULL character checks to prevent silent decoding failures

### DIFF
--- a/src/Base32.h
+++ b/src/Base32.h
@@ -18,6 +18,9 @@ inline bool decode(const std::string& encoded_in, Data& decoded_out, const char*
     if (encoded_in.empty()) {
         return true;
     }
+    if (encoded_in.find('\0') != std::string::npos) {
+        return false;
+    }
     Rust::CByteArrayResultWrapper res = Rust::decode_base32(encoded_in.c_str(), alphabet_in, false);
     if (res.isOk()) {
         decoded_out = res.unwrap().data;

--- a/src/Base64.cpp
+++ b/src/Base64.cpp
@@ -17,6 +17,9 @@ Data decode(const std::string& val, bool is_url) {
     if (val.empty()) {
         return {};
     }
+    if (val.find('\0') != std::string::npos) {
+        return {};
+    }
     Rust::CByteArrayResultWrapper res = Rust::decode_base64(val.c_str(), is_url);
     return res.unwrap_or_default().data;
 }

--- a/src/HexCoding.h
+++ b/src/HexCoding.h
@@ -25,7 +25,11 @@ inline Data parse_hex(const std::string& input) {
     if (input.empty()) {
         return {};
     }
-
+    // An embedded NUL is silently truncated by CStr::from_ptr in the Rust FFI,
+    // so "deadbeef\x00junk" would decode as just "deadbeef".
+    if (input.find('\0') != std::string::npos) {
+        return {};
+    }
     Rust::CByteArrayResultWrapper res = Rust::decode_hex(input.c_str());
     return res.unwrap_or_default().data;
 }
@@ -105,6 +109,9 @@ inline Data parse_hex(const std::string& string, bool padLeft = false) {
 /// \returns the array or parsed bytes, or an error if the string is not valid hexadecimal.
 inline Result<Data> parse_hex_checked(const std::string& string, bool padLeft = false) {
     const auto paddedString = internal::pad_left_hex(string, padLeft);
+    if (paddedString.find('\0') != std::string::npos) {
+        return Result<Data>::failure("Invalid hex string");
+    }
     Rust::CByteArrayResultWrapper res = Rust::decode_hex(paddedString.c_str());
     if (res.isErr()) {
         return Result<Data>::failure("Invalid hex string");

--- a/tests/common/Base64Tests.cpp
+++ b/tests/common/Base64Tests.cpp
@@ -79,4 +79,16 @@ TEST(Base64, isBase64) {
     EXPECT_FALSE(isBase64orBase64Url("MwCKhieGGl3ZbJ2zzggHsSLaXtRzk0znVopbSxw2HLsors=#"));
 }
 
+TEST(Base64, DecodeNullEmbedded) {
+    // "SGVsbG8=" decodes to "Hello"; appending a NUL must not let the pre-NUL
+    // portion decode silently.
+    auto with_nul = std::string("SGVsbG8=") + '\0' + "garbage";
+    auto decoded = decode(with_nul);
+    EXPECT_TRUE(decoded.empty());
+
+    auto trailing_nul = std::string("SGVsbG8=") + '\0';
+    decoded = decode(trailing_nul);
+    EXPECT_TRUE(decoded.empty());
+}
+
 } // namespace TW::Base64::tests

--- a/tests/common/BaseEncoding.cpp
+++ b/tests/common/BaseEncoding.cpp
@@ -66,4 +66,13 @@ TEST(Base32, DecodeInvalid) {
     ASSERT_FALSE(decode("ABC", decoded)); // invalid odd length
 }
 
+TEST(Base32, DecodeNullEmbedded) {
+    // "AE" is a valid 2-char base32 input; appending a NUL must not let the
+    // pre-NUL portion decode silently as "AE".
+    Data decoded;
+    auto with_nul = std::string("AE") + '\0' + "JUNK";
+    ASSERT_FALSE(decode(with_nul, decoded));
+    ASSERT_TRUE(decoded.empty());
+}
+
 } // namespace TW::Base32::tests

--- a/tests/common/HexCodingTests.cpp
+++ b/tests/common/HexCodingTests.cpp
@@ -88,6 +88,28 @@ TEST(HexCoding, ParseHexCheckedInvalidHex) {
     EXPECT_EQ(res.error(), "Invalid hex string");
 }
 
+TEST(HexCoding, ParseHexNullEmbedded) {
+    // "deadbeef" is valid hex; appending a NUL must not let the pre-NUL portion
+    // decode silently as {0xde, 0xad, 0xbe, 0xef}.
+    auto with_nul = std::string("deadbeef") + '\0' + "junk";
+    EXPECT_TRUE(parse_hex(with_nul).empty());
+
+    auto trailing_nul = std::string("deadbeef") + '\0';
+    EXPECT_TRUE(parse_hex(trailing_nul).empty());
+}
+
+TEST(HexCoding, ParseHexCheckedNullEmbedded) {
+    auto with_nul = std::string("deadbeef") + '\0' + "junk";
+    auto res = parse_hex_checked(with_nul);
+    ASSERT_FALSE(res.isSuccess());
+    EXPECT_EQ(res.error(), "Invalid hex string");
+
+    auto trailing_nul = std::string("deadbeef") + '\0';
+    res = parse_hex_checked(trailing_nul);
+    ASSERT_FALSE(res.isSuccess());
+    EXPECT_EQ(res.error(), "Invalid hex string");
+}
+
 TEST(HexCoding, PadLeftHex) {
     // Empty string
     EXPECT_EQ(internal::pad_left_hex(""), "");


### PR DESCRIPTION
This pull request improves the robustness of the Base32, Base64, and Hex decoding logic by ensuring that input strings containing embedded NUL characters are rejected, preventing silent truncation or partial decoding. It also adds comprehensive tests to verify this behavior across all affected decoders.

Input validation improvements:

* Added checks in `decode` for Base32 (`src/Base32.h`), Base64 (`src/Base64.cpp`), and `parse_hex`/`parse_hex_checked` for Hex (`src/HexCoding.h`) to return failure or empty results if the input contains embedded NUL characters, preventing partial or silent decoding of such strings.

Testing enhancements:

* Added new test cases in `Base64Tests.cpp`, `BaseEncoding.cpp`, and `HexCodingTests.cpp` to confirm that inputs with embedded NULs are rejected and do not decode partially or silently.