### PR TITLE
chore(polkadot): Update explorer URLs for Kusama and Polkadot

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1985,11 +1985,11 @@
     "addressHasher": "keccak256",
     "ss58Prefix": 0,
     "explorer": {
-      "url": "https://polkadot.subscan.io",
+      "url": "https://assethub-polkadot.subscan.io",
       "txPath": "/extrinsic/",
       "accountPath": "/account/",
-      "sampleTx": "0xb96f97d8ee508f420e606e1a6dcc74b88844713ddec2bd7cf4e3aa6b1d6beef4",
-      "sampleAccount": "13hJFqnkqQbmgnGQteGntjMjTdmTBRE8Z93JqxsrpgT7Yjd2"
+      "sampleTx": "0x5aaaeec678ab1bd5a19d2c9bfd596037a32e3d1e831383c62f315459e85fa85d",
+      "sampleAccount": "14QKFrBmnhP5xoH1t7nC2q7mssgj671AhzThsGewVj3Ea8Xt"
     },
     "info": {
       "url": "https://polkadot.network/",
@@ -2097,11 +2097,11 @@
     "addressHasher": "keccak256",
     "ss58Prefix": 2,
     "explorer": {
-      "url": "https://kusama.subscan.io",
+      "url": "https://assethub-kusama.subscan.io",
       "txPath": "/extrinsic/",
       "accountPath": "/account/",
-      "sampleTx": "0xcbe0c2e2851c1245bedaae4d52f06eaa6b4784b786bea2f0bff11af7715973dd",
-      "sampleAccount": "DbCNECPna3k6MXFWWNZa5jGsuWycqEE6zcUxZYkxhVofrFk"
+      "sampleTx": "0x834220074151531626b34acf4568cd5763a47b2eb2647bd0f0b7e46f980e0c50",
+      "sampleAccount": "FfnS7Vk2i19AdFMf6D8ZRVUhNsYWVtsLmqQEnAmTqQBqsSy"
     },
     "info": {
       "url": "https://kusama.network",

--- a/tests/chains/Kusama/TWCoinTypeTests.cpp
+++ b/tests/chains/Kusama/TWCoinTypeTests.cpp
@@ -13,9 +13,9 @@
 
 TEST(TWKusamaCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypeKusama));
-    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("0xcbe0c2e2851c1245bedaae4d52f06eaa6b4784b786bea2f0bff11af7715973dd"));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("0x834220074151531626b34acf4568cd5763a47b2eb2647bd0f0b7e46f980e0c50"));
     auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypeKusama, txId.get()));
-    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("DbCNECPna3k6MXFWWNZa5jGsuWycqEE6zcUxZYkxhVofrFk"));
+    auto accId = WRAPS(TWStringCreateWithUTF8Bytes("FfnS7Vk2i19AdFMf6D8ZRVUhNsYWVtsLmqQEnAmTqQBqsSy"));
     auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypeKusama, accId.get()));
     auto id = WRAPS(TWCoinTypeConfigurationGetID(TWCoinTypeKusama));
     auto name = WRAPS(TWCoinTypeConfigurationGetName(TWCoinTypeKusama));
@@ -25,8 +25,8 @@ TEST(TWKusamaCoinType, TWCoinType) {
     ASSERT_EQ(0x0, TWCoinTypeP2shPrefix(TWCoinTypeKusama));
     ASSERT_EQ(0x0, TWCoinTypeStaticPrefix(TWCoinTypeKusama));
     assertStringsEqual(symbol, "KSM");
-    assertStringsEqual(txUrl, "https://kusama.subscan.io/extrinsic/0xcbe0c2e2851c1245bedaae4d52f06eaa6b4784b786bea2f0bff11af7715973dd");
-    assertStringsEqual(accUrl, "https://kusama.subscan.io/account/DbCNECPna3k6MXFWWNZa5jGsuWycqEE6zcUxZYkxhVofrFk");
+    assertStringsEqual(txUrl, "https://assethub-kusama.subscan.io/extrinsic/0x834220074151531626b34acf4568cd5763a47b2eb2647bd0f0b7e46f980e0c50");
+    assertStringsEqual(accUrl, "https://assethub-kusama.subscan.io/account/FfnS7Vk2i19AdFMf6D8ZRVUhNsYWVtsLmqQEnAmTqQBqsSy");
     assertStringsEqual(id, "kusama");
     assertStringsEqual(name, "Kusama");
 }

--- a/tests/chains/Polkadot/TWCoinTypeTests.cpp
+++ b/tests/chains/Polkadot/TWCoinTypeTests.cpp
@@ -12,7 +12,7 @@
 
 TEST(TWPolkadotCoinType, TWCoinType) {
     auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(TWCoinTypePolkadot));
-    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("0xb96f97d8ee508f420e606e1a6dcc74b88844713ddec2bd7cf4e3aa6b1d6beef4"));
+    auto txId = WRAPS(TWStringCreateWithUTF8Bytes("0x5aaaeec678ab1bd5a19d2c9bfd596037a32e3d1e831383c62f315459e85fa85d"));
     auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(TWCoinTypePolkadot, txId.get()));
     auto accId = WRAPS(TWStringCreateWithUTF8Bytes("13hJFqnkqQbmgnGQteGntjMjTdmTBRE8Z93JqxsrpgT7Yjd2"));
     auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(TWCoinTypePolkadot, accId.get()));
@@ -24,8 +24,8 @@ TEST(TWPolkadotCoinType, TWCoinType) {
     ASSERT_EQ(0x0, TWCoinTypeP2shPrefix(TWCoinTypePolkadot));
     ASSERT_EQ(0x0, TWCoinTypeStaticPrefix(TWCoinTypePolkadot));
     assertStringsEqual(symbol, "DOT");
-    assertStringsEqual(txUrl, "https://polkadot.subscan.io/extrinsic/0xb96f97d8ee508f420e606e1a6dcc74b88844713ddec2bd7cf4e3aa6b1d6beef4");
-    assertStringsEqual(accUrl, "https://polkadot.subscan.io/account/13hJFqnkqQbmgnGQteGntjMjTdmTBRE8Z93JqxsrpgT7Yjd2");
+    assertStringsEqual(txUrl, "https://assethub-polkadot.subscan.io/extrinsic/0x5aaaeec678ab1bd5a19d2c9bfd596037a32e3d1e831383c62f315459e85fa85d");
+    assertStringsEqual(accUrl, "https://assethub-polkadot.subscan.io/account/13hJFqnkqQbmgnGQteGntjMjTdmTBRE8Z93JqxsrpgT7Yjd2");
     assertStringsEqual(id, "polkadot");
     assertStringsEqual(name, "Polkadot");
 }


### PR DESCRIPTION
This pull request updates the explorer URLs and sample data for Polkadot and Kusama networks to use the AssetHub explorers instead of the main Subscan explorers. It also updates the corresponding test cases to reflect these changes.

**Explorer configuration updates:**

* Changed the Polkadot explorer URL in `registry.json` to `https://assethub-polkadot.subscan.io`, and updated the sample transaction and account to match the AssetHub explorer.
* Changed the Kusama explorer URL in `registry.json` to `https://assethub-kusama.subscan.io`, and updated the sample transaction and account accordingly.

**Test updates:**

* Updated `tests/chains/Polkadot/TWCoinTypeTests.cpp` to use the new Polkadot AssetHub explorer URLs and sample transaction hash in its assertions.
* Updated `tests/chains/Kusama/TWCoinTypeTests.cpp` to use the new Kusama AssetHub explorer URLs and sample transaction hash in its assertions.