### PR TITLE
fix(solana): Prevent overflow by rejecting too many accounts in transaction

### DIFF
--- a/rust/chains/tw_solana/src/modules/insert_instruction.rs
+++ b/rust/chains/tw_solana/src/modules/insert_instruction.rs
@@ -18,20 +18,74 @@ fn increment_counter(counter: &mut u8) -> SigningResult<()> {
     Ok(())
 }
 
-pub trait InsertInstruction {
-    /// Pushes an instruction
-    fn push_instruction(
-        &mut self,
+pub trait InsertInstruction: Clone + Sized {
+    // =========================================================================
+    // Public API
+    // Each method clones `self`, runs all mutations on the clone, and returns
+    // the updated clone on success.  On error the clone is dropped and `self`
+    // is left completely untouched.
+    // =========================================================================
+
+    fn with_instruction(
+        &self,
         program_id: SolanaAddress,
         accounts: Vec<AccountMeta>,
         data: Data,
-    ) -> SigningResult<()> {
-        let insert_at = self.instructions_mut().len();
-        self.insert_instruction(insert_at, program_id, accounts, data)
+    ) -> SigningResult<Self> {
+        let mut draft = self.clone();
+        let insert_at = draft.instructions_mut().len();
+        draft.insert_instruction_mut(insert_at, program_id, accounts, data)?;
+        Ok(draft)
     }
 
-    /// Inserts an instruction at the given `insert_at` index.
-    fn insert_instruction(
+    fn with_instruction_at(
+        &self,
+        insert_at: usize,
+        program_id: SolanaAddress,
+        accounts: Vec<AccountMeta>,
+        data: Data,
+    ) -> SigningResult<Self> {
+        let mut draft = self.clone();
+        draft.insert_instruction_mut(insert_at, program_id, accounts, data)?;
+        Ok(draft)
+    }
+
+    fn with_simple_instruction(
+        &self,
+        program_id: SolanaAddress,
+        data: Data,
+    ) -> SigningResult<Self> {
+        let mut draft = self.clone();
+        let insert_at = draft.instructions_mut().len();
+        draft.insert_simple_instruction_mut(insert_at, program_id, data)?;
+        Ok(draft)
+    }
+
+    fn with_simple_instruction_at(
+        &self,
+        insert_at: usize,
+        program_id: SolanaAddress,
+        data: Data,
+    ) -> SigningResult<Self> {
+        let mut draft = self.clone();
+        draft.insert_simple_instruction_mut(insert_at, program_id, data)?;
+        Ok(draft)
+    }
+
+    fn with_fee_payer(&self, account: SolanaAddress) -> SigningResult<Self> {
+        let mut draft = self.clone();
+        draft.set_fee_payer_mut(account)?;
+        Ok(draft)
+    }
+
+    // =========================================================================
+    // Internal mutation helpers
+    // These operate on `&mut self` and may leave the message in a partially
+    // mutated state when they return `Err`.  They must only be called on a
+    // draft that will be discarded on error (see the public wrappers above).
+    // =========================================================================
+
+    fn insert_instruction_mut(
         &mut self,
         insert_at: usize,
         program_id: SolanaAddress,
@@ -46,7 +100,7 @@ pub trait InsertInstruction {
         // Step 1 - add the `account` in the accounts list.
         let accounts: Vec<u8> = accounts
             .iter()
-            .map(|account_meta| self.push_account(account_meta))
+            .map(|account_meta| self.push_account_mut(account_meta))
             .collect::<Result<Vec<u8>, _>>()?;
 
         // Step 2 - find or add the `program_id` in the accounts list.
@@ -56,7 +110,7 @@ pub trait InsertInstruction {
             .position(|acc| *acc == program_id)
         {
             Some(pos) => try_into_u8(pos)?,
-            None => self.push_readonly_unsigned_account(program_id)?,
+            None => self.push_readonly_unsigned_account_mut(program_id)?,
         };
 
         // Step 3 - Create a `CompiledInstruction` based on the `program_id` index and instruction `accounts` and `data`.
@@ -72,18 +126,7 @@ pub trait InsertInstruction {
         Ok(())
     }
 
-    /// Pushes a simple instruction that doesn't have accounts.
-    fn push_simple_instruction(
-        &mut self,
-        program_id: SolanaAddress,
-        data: Data,
-    ) -> SigningResult<()> {
-        let insert_at = self.instructions_mut().len();
-        self.insert_simple_instruction(insert_at, program_id, data)
-    }
-
-    /// Inserts a simple instruction that doesn't have accounts at the given `insert_at` index.
-    fn insert_simple_instruction(
+    fn insert_simple_instruction_mut(
         &mut self,
         insert_at: usize,
         program_id: SolanaAddress,
@@ -101,7 +144,7 @@ pub trait InsertInstruction {
             .position(|acc| *acc == program_id)
         {
             Some(pos) => try_into_u8(pos)?,
-            None => self.push_readonly_unsigned_account(program_id)?,
+            None => self.push_readonly_unsigned_account_mut(program_id)?,
         };
 
         // Step 2 - Create a `CompiledInstruction` based on the `program_id` index and instruction `data`.
@@ -118,9 +161,9 @@ pub trait InsertInstruction {
     }
 
     /// Pushes an account to the message.
-    /// If the account already exists, it must match the `is_signer` and `is_writable` attributes
+    /// If the account already exists, it must match the `is_signer` and `is_writable` attributes.
     /// Returns the index of the account in the account list.
-    fn push_account(&mut self, account: &AccountMeta) -> SigningResult<u8> {
+    fn push_account_mut(&mut self, account: &AccountMeta) -> SigningResult<u8> {
         // The layout of the account keys is as follows:
         // +-------------------------------------+
         // | Writable and required signature     |                                     \
@@ -251,7 +294,7 @@ pub trait InsertInstruction {
         Ok(account_added_at)
     }
 
-    fn push_readonly_unsigned_account(&mut self, account: SolanaAddress) -> SigningResult<u8> {
+    fn push_readonly_unsigned_account_mut(&mut self, account: SolanaAddress) -> SigningResult<u8> {
         debug_assert!(
             !self.account_keys_mut().contains(&account),
             "Account must not be in the account list yet"
@@ -293,7 +336,7 @@ pub trait InsertInstruction {
 
     /// Adds a fee payer account to the message.
     /// Note: The fee payer must NOT be in the account list yet.
-    fn set_fee_payer(&mut self, account: SolanaAddress) -> SigningResult<()> {
+    fn set_fee_payer_mut(&mut self, account: SolanaAddress) -> SigningResult<()> {
         if self.account_keys_mut().contains(&account) {
             // For security reasons, we don't allow adding a fee payer if it's already in the account list.
             //
@@ -336,6 +379,10 @@ pub trait InsertInstruction {
 
         Ok(())
     }
+
+    // =========================================================================
+    // Abstract methods — implementors must provide these.
+    // =========================================================================
 
     /// Returns ALT (Address Lookup Tables) if supported by the message version.
     fn address_table_lookups(&self) -> Option<&[MessageAddressTableLookup]>;

--- a/rust/chains/tw_solana/src/modules/insert_instruction.rs
+++ b/rust/chains/tw_solana/src/modules/insert_instruction.rs
@@ -235,7 +235,8 @@ pub trait InsertInstruction: Clone + Sized {
         // Determine the insertion position based on is_signer and is_writable
         let insert_at = match (account.is_signer, account.is_writable) {
             (true, true) => {
-                increment_counter(&mut self.message_header_mut().num_required_signatures)?;
+                increment_counter(&mut self.message_header_mut().num_required_signatures)
+                    .context("num_required_signatures overflow")?;
                 // The account is added at the end of the writable and signer accounts
                 (self.message_header_mut().num_required_signatures
                     - self.message_header_mut().num_readonly_signed_accounts)
@@ -243,8 +244,10 @@ pub trait InsertInstruction: Clone + Sized {
                     - 1
             },
             (true, false) => {
-                increment_counter(&mut self.message_header_mut().num_required_signatures)?;
-                increment_counter(&mut self.message_header_mut().num_readonly_signed_accounts)?;
+                increment_counter(&mut self.message_header_mut().num_required_signatures)
+                    .context("num_required_signatures overflow")?;
+                increment_counter(&mut self.message_header_mut().num_readonly_signed_accounts)
+                    .context("num_readonly_signed_accounts overflow")?;
                 // The account is added at the end of the read-only and signer accounts
                 self.message_header_mut().num_required_signatures as usize - 1
             },
@@ -255,7 +258,8 @@ pub trait InsertInstruction: Clone + Sized {
                     .ok_or(SigningErrorType::Error_internal)?
             },
             (false, false) => {
-                increment_counter(&mut self.message_header_mut().num_readonly_unsigned_accounts)?;
+                increment_counter(&mut self.message_header_mut().num_readonly_unsigned_accounts)
+                    .context("num_readonly_unsigned_accounts overflow")?;
                 // The account is added at the end of the list
                 accounts_number_before
             },
@@ -301,7 +305,8 @@ pub trait InsertInstruction: Clone + Sized {
         );
 
         self.account_keys_mut().push(account);
-        increment_counter(&mut self.message_header_mut().num_readonly_unsigned_accounts)?;
+        increment_counter(&mut self.message_header_mut().num_readonly_unsigned_accounts)
+            .context("num_readonly_unsigned_accounts overflow")?;
 
         let account_added_at = try_into_u8(self.account_keys_mut().len() - 1)?;
 
@@ -357,7 +362,8 @@ pub trait InsertInstruction: Clone + Sized {
 
         // Insert the fee payer account at the beginning of the account list.
         self.account_keys_mut().insert(0, account);
-        increment_counter(&mut self.message_header_mut().num_required_signatures)?;
+        increment_counter(&mut self.message_header_mut().num_required_signatures)
+            .context("num_required_signatures overflow")?;
 
         // Update `program id indexes` and `account id indexes` in every instruction as we inserted the account at the beginning of the list.
         self.instructions_mut()

--- a/rust/chains/tw_solana/src/modules/insert_instruction.rs
+++ b/rust/chains/tw_solana/src/modules/insert_instruction.rs
@@ -11,6 +11,13 @@ use std::iter;
 use tw_coin_entry::error::prelude::*;
 use tw_memory::Data;
 
+fn increment_counter(counter: &mut u8) -> SigningResult<()> {
+    *counter = counter
+        .checked_add(1)
+        .ok_or(SigningErrorType::Error_tx_too_big)?;
+    Ok(())
+}
+
 pub trait InsertInstruction {
     /// Pushes an instruction
     fn push_instruction(
@@ -174,10 +181,18 @@ pub trait InsertInstruction {
             return try_into_u8(existing_index);
         }
 
+        let accounts_number_before = self.account_keys_mut().len();
+
+        // 255u8 + 1 wraps to 0 in release builds; reject before header state is mutated.
+        if accounts_number_before > u8::MAX as usize {
+            return SigningError::err(SigningErrorType::Error_tx_too_big)
+                .context("There are too many accounts in the transaction");
+        }
+
         // Determine the insertion position based on is_signer and is_writable
         let insert_at = match (account.is_signer, account.is_writable) {
             (true, true) => {
-                self.message_header_mut().num_required_signatures += 1;
+                increment_counter(&mut self.message_header_mut().num_required_signatures)?;
                 // The account is added at the end of the writable and signer accounts
                 (self.message_header_mut().num_required_signatures
                     - self.message_header_mut().num_readonly_signed_accounts)
@@ -185,20 +200,21 @@ pub trait InsertInstruction {
                     - 1
             },
             (true, false) => {
-                self.message_header_mut().num_required_signatures += 1;
-                self.message_header_mut().num_readonly_signed_accounts += 1;
+                increment_counter(&mut self.message_header_mut().num_required_signatures)?;
+                increment_counter(&mut self.message_header_mut().num_readonly_signed_accounts)?;
                 // The account is added at the end of the read-only and signer accounts
                 self.message_header_mut().num_required_signatures as usize - 1
             },
             (false, true) => {
                 // The account is added at the end of the writable and non-signer accounts
-                self.account_keys_mut().len()
-                    - self.message_header_mut().num_readonly_unsigned_accounts as usize
+                accounts_number_before
+                    .checked_sub(self.message_header_mut().num_readonly_unsigned_accounts as usize)
+                    .ok_or(SigningErrorType::Error_internal)?
             },
             (false, false) => {
-                self.message_header_mut().num_readonly_unsigned_accounts += 1;
+                increment_counter(&mut self.message_header_mut().num_readonly_unsigned_accounts)?;
                 // The account is added at the end of the list
-                self.account_keys_mut().len()
+                accounts_number_before
             },
         };
 
@@ -209,18 +225,28 @@ pub trait InsertInstruction {
 
         // Update program ID and account indexes if the new account was added before its position
         let instructions = self.instructions_mut();
-        instructions.iter_mut().for_each(|ix| {
-            // Update program ID index
-            if ix.program_id_index >= account_added_at {
-                ix.program_id_index += 1;
-            }
+        instructions
+            .iter_mut()
+            .try_for_each(|ix| -> SigningResult<()> {
+                // Update program ID index
+                if ix.program_id_index >= account_added_at {
+                    ix.program_id_index = ix
+                        .program_id_index
+                        .checked_add(1)
+                        .ok_or(SigningErrorType::Error_tx_too_big)?;
+                }
 
-            // Update account indexes
-            ix.accounts
-                .iter_mut()
-                .filter(|ix_account_id| **ix_account_id >= account_added_at)
-                .for_each(|ix_account_id| *ix_account_id += 1);
-        });
+                // Update account indexes
+                ix.accounts
+                    .iter_mut()
+                    .filter(|ix_account_id| **ix_account_id >= account_added_at)
+                    .try_for_each(|ix_account_id| -> SigningResult<()> {
+                        *ix_account_id = ix_account_id
+                            .checked_add(1)
+                            .ok_or(SigningErrorType::Error_tx_too_big)?;
+                        Ok(())
+                    })
+            })?;
 
         Ok(account_added_at)
     }
@@ -232,7 +258,7 @@ pub trait InsertInstruction {
         );
 
         self.account_keys_mut().push(account);
-        self.message_header_mut().num_readonly_unsigned_accounts += 1;
+        increment_counter(&mut self.message_header_mut().num_readonly_unsigned_accounts)?;
 
         let account_added_at = try_into_u8(self.account_keys_mut().len() - 1)?;
 
@@ -255,7 +281,12 @@ pub trait InsertInstruction {
             })
             // Update every instruction account id that points to the address table lookups.
             .filter(|ix_account_id| **ix_account_id >= account_added_at)
-            .for_each(|ix_account_id| *ix_account_id += 1);
+            .try_for_each(|ix_account_id| -> SigningResult<()> {
+                *ix_account_id = ix_account_id
+                    .checked_add(1)
+                    .ok_or(SigningErrorType::Error_tx_too_big)?;
+                Ok(())
+            })?;
 
         Ok(account_added_at)
     }
@@ -276,17 +307,32 @@ pub trait InsertInstruction {
                 .context("Fee payer account is already in the account list");
         }
 
+        if self.account_keys_mut().len() > u8::MAX as usize {
+            return SigningError::err(SigningErrorType::Error_tx_too_big)
+                .context("There are too many accounts in the transaction");
+        }
+
         // Insert the fee payer account at the beginning of the account list.
         self.account_keys_mut().insert(0, account);
-        self.message_header_mut().num_required_signatures += 1;
+        increment_counter(&mut self.message_header_mut().num_required_signatures)?;
 
         // Update `program id indexes` and `account id indexes` in every instruction as we inserted the account at the beginning of the list.
-        self.instructions_mut().iter_mut().for_each(|ix| {
-            ix.program_id_index += 1; // Update `program id indexes`
-            ix.accounts
-                .iter_mut()
-                .for_each(|account_id| *account_id += 1); // Update `account id indexes`
-        });
+        self.instructions_mut()
+            .iter_mut()
+            .try_for_each(|ix| -> SigningResult<()> {
+                ix.program_id_index = ix
+                    .program_id_index
+                    .checked_add(1)
+                    .ok_or(SigningErrorType::Error_tx_too_big)?;
+                ix.accounts
+                    .iter_mut()
+                    .try_for_each(|account_id| -> SigningResult<()> {
+                        *account_id = account_id
+                            .checked_add(1)
+                            .ok_or(SigningErrorType::Error_tx_too_big)?;
+                        Ok(())
+                    })
+            })?;
 
         Ok(())
     }

--- a/rust/chains/tw_solana/src/modules/utils.rs
+++ b/rust/chains/tw_solana/src/modules/utils.rs
@@ -124,8 +124,9 @@ impl SolanaTransaction {
         }
 
         // `ComputeBudgetInstruction::SetComputeUnitPrice` can be pushed to the end of the instructions list.
-        tx.message
-            .push_simple_instruction(set_price_ix.program_id, set_price_ix.data)?;
+        tx.message =
+            tx.message
+                .with_simple_instruction(set_price_ix.program_id, set_price_ix.data)?;
 
         tx.to_base64().tw_err(SigningErrorType::Error_internal)
     }
@@ -156,7 +157,7 @@ impl SolanaTransaction {
             _ => 0,
         };
 
-        tx.message.insert_simple_instruction(
+        tx.message = tx.message.with_simple_instruction_at(
             insert_at,
             set_limit_ix.program_id,
             set_limit_ix.data,
@@ -167,13 +168,13 @@ impl SolanaTransaction {
 
     pub fn set_fee_payer(encoded_tx: &str, fee_payer: SolanaAddress) -> SigningResult<String> {
         let tx_bytes = base64::decode(encoded_tx, STANDARD)?;
-        let mut tx: VersionedTransaction =
+        let tx: VersionedTransaction =
             bincode::deserialize(&tx_bytes).map_err(|_| SigningErrorType::Error_input_parse)?;
 
-        tx.message.set_fee_payer(fee_payer)?;
+        let message = tx.message.with_fee_payer(fee_payer)?;
 
         // Set the correct number of zero signatures
-        let unsigned_tx = VersionedTransaction::unsigned(tx.message);
+        let unsigned_tx = VersionedTransaction::unsigned(message);
         unsigned_tx
             .to_base64()
             .tw_err(SigningErrorType::Error_internal)
@@ -185,7 +186,7 @@ impl SolanaTransaction {
         instruction: &str,
     ) -> SigningResult<String> {
         let tx_bytes = base64::decode(encoded_tx, STANDARD)?;
-        let mut tx: VersionedTransaction =
+        let tx: VersionedTransaction =
             bincode::deserialize(&tx_bytes).map_err(|_| SigningErrorType::Error_input_parse)?;
 
         let instruction: Instruction =
@@ -201,7 +202,7 @@ impl SolanaTransaction {
             insert_at as usize // Use the specified position
         };
 
-        tx.message.insert_instruction(
+        let message = tx.message.with_instruction_at(
             final_insert_at,
             instruction.program_id,
             instruction.accounts,
@@ -209,7 +210,7 @@ impl SolanaTransaction {
         )?;
 
         // Set the correct number of zero signatures
-        let unsigned_tx = VersionedTransaction::unsigned(tx.message);
+        let unsigned_tx = VersionedTransaction::unsigned(message);
         unsigned_tx
             .to_base64()
             .tw_err(SigningErrorType::Error_internal)
@@ -233,7 +234,7 @@ impl SolanaTransaction {
             .and_then(u64::try_from)
             .map_err(|_| SigningErrorType::Error_input_parse)?;
 
-        let mut tx: VersionedTransaction =
+        let tx: VersionedTransaction =
             bincode::deserialize(&tx_bytes).map_err(|_| SigningErrorType::Error_input_parse)?;
 
         if insert_at >= 0 && insert_at as usize > tx.message.instructions().len() {
@@ -248,7 +249,7 @@ impl SolanaTransaction {
 
         // Create transfer instruction and insert it at the specified position.
         let transfer_ix = SystemInstructionBuilder::transfer(from, to, lamports);
-        tx.message.insert_instruction(
+        let message = tx.message.with_instruction_at(
             final_insert_at,
             transfer_ix.program_id,
             transfer_ix.accounts,
@@ -256,7 +257,7 @@ impl SolanaTransaction {
         )?;
 
         // Set the correct number of zero signatures
-        let unsigned_tx = VersionedTransaction::unsigned(tx.message);
+        let unsigned_tx = VersionedTransaction::unsigned(message);
         unsigned_tx
             .to_base64()
             .tw_err(SigningErrorType::Error_internal)

--- a/rust/chains/tw_solana/src/modules/utils.rs
+++ b/rust/chains/tw_solana/src/modules/utils.rs
@@ -124,9 +124,9 @@ impl SolanaTransaction {
         }
 
         // `ComputeBudgetInstruction::SetComputeUnitPrice` can be pushed to the end of the instructions list.
-        tx.message =
-            tx.message
-                .with_simple_instruction(set_price_ix.program_id, set_price_ix.data)?;
+        tx.message = tx
+            .message
+            .with_simple_instruction(set_price_ix.program_id, set_price_ix.data)?;
 
         tx.to_base64().tw_err(SigningErrorType::Error_internal)
     }

--- a/rust/tw_tests/tests/chains/solana/solana_transaction_ffi.rs
+++ b/rust/tw_tests/tests/chains/solana/solana_transaction_ffi.rs
@@ -633,3 +633,173 @@ fn test_solana_transaction_insert_transfer_instruction_and_sign() {
     let expected = "Acms/WrZj/mOpUTTBFHLtBFKrMSAJPBBkD8qYK+oqgE0gFT5aoEfw5dlJZZl1edVde325gi0qVPai7ddgoP2WQUBAAMHgKRCBGe2W59ezw1CyHDoV4KZVuJFTtmsN0F25EL3I8228PMELJSiAl2nvEzyY4v/LfSQnxkFNlH4pjU2F3nMpcBeC+e4AaQzF6GCh63HW7KnhG+YuIbF1AvkM6nwOXMjzDg4vU3/xSfZJTqguxQVNsgitkm5dHCm6V6l4NCCDp7OAQ5gr+2yJxe9YxkvVBRaP5ZaM7uC0scCnrLOHiCCZAbd9uHXZaGT2cvhRs7reawctIXtX1s3kTqM9YV+/wCpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACbeRZf0sbtT6rwdYyf6Z9h66lKwNsb48euTgiPa0h+WAIFBAEEAgAKDBAnAAAAAAAABgYCAAMMAgAAAEANAwAAAAAA";
     assert_eq!(output.encoded, expected);
 }
+
+/// Builds a base64-encoded legacy transaction with `num_accounts` dummy accounts.
+///
+/// Account layout: `num_accounts` entries where account[i] has bytes `[1, 0, …, 0, i]`.
+/// A single transfer-like instruction is appended:
+///   - program:    last account  (index `num_accounts - 1`)
+///   - sender:     first account (index 0, writable + signer)
+///   - recipient:  second-to-last account (index `num_accounts - 2`)
+///
+/// The fee-payer address returned alongside is guaranteed not to appear in `account_keys`
+/// (its bytes are `[2, 0, …, 0]`, distinct from the `[1, …]` pattern used for accounts).
+fn make_dummy_tx(num_accounts: usize) -> (String, tw_solana::address::SolanaAddress) {
+    use tw_hash::H256;
+    use tw_solana::address::SolanaAddress;
+    use tw_solana::transaction::legacy;
+    use tw_solana::transaction::versioned::{VersionedMessage, VersionedTransaction};
+    use tw_solana::transaction::{CompiledInstruction, MessageHeader, Signature};
+
+    assert!(
+        num_accounts >= 2,
+        "need at least 2 accounts for a transfer instruction"
+    );
+    assert!(num_accounts <= 256, "Solana u8 index space is 0..=255");
+
+    let account_keys: Vec<SolanaAddress> = (0..num_accounts)
+        .map(|i| {
+            let mut b = [0u8; 32];
+            b[0] = 1;
+            b[31] = i as u8;
+            SolanaAddress::with_public_key_bytes(H256::from_array(b))
+        })
+        .collect();
+
+    let program_idx = (num_accounts - 1) as u8;
+    let recipient_idx = (num_accounts - 2) as u8;
+    let transfer_ix = CompiledInstruction {
+        program_id_index: program_idx,
+        accounts: vec![0, recipient_idx],
+        data: vec![2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0], // SystemInstruction::Transfer(1)
+    };
+
+    let encoded = VersionedTransaction {
+        signatures: vec![Signature::default()],
+        message: VersionedMessage::Legacy(legacy::Message {
+            header: MessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 1,
+            },
+            account_keys,
+            recent_blockhash: H256::from_array([1u8; 32]),
+            instructions: vec![transfer_ix],
+        }),
+    }
+    .to_base64()
+    .unwrap();
+
+    // Fee payer: bytes[0] = 2, all others 0 — never matches the [1, …] account pattern
+    let fee_payer = SolanaAddress::with_public_key_bytes(H256::from_array({
+        let mut b = [0u8; 32];
+        b[0] = 2;
+        b
+    }));
+
+    (encoded, fee_payer)
+}
+
+/// A transaction with 256 accounts completely fills the u8 index space (max index = 255).
+/// Calling `set_fee_payer` on it would require incrementing each existing index by one,
+/// wrapping 255 → 0 in release builds.  The fix must reject the call with an error (null).
+#[test]
+fn test_solana_transaction_set_fee_payer_256_accounts_fails() {
+    let (encoded_tx_str, fee_payer_addr) = make_dummy_tx(256);
+
+    let encoded_tx = TWStringHelper::create(&encoded_tx_str);
+    let fee_payer = TWStringHelper::create(&fee_payer_addr.to_string());
+
+    let result = TWStringHelper::wrap(unsafe {
+        tw_solana_transaction_set_fee_payer(encoded_tx.ptr(), fee_payer.ptr())
+    });
+
+    assert_eq!(result.to_string(), None);
+}
+
+/// 255 accounts is the safe boundary: max existing index is 254, which shifts to 255 after
+/// fee-payer insertion — still within u8.  This must succeed and produce correct indexes.
+#[test]
+fn test_solana_transaction_set_fee_payer_255_accounts_succeeds() {
+    use tw_solana::transaction::versioned::{VersionedMessage, VersionedTransaction};
+
+    let (encoded_tx_str, fee_payer_addr) = make_dummy_tx(255);
+
+    let encoded_tx = TWStringHelper::create(&encoded_tx_str);
+    let fee_payer = TWStringHelper::create(&fee_payer_addr.to_string());
+
+    let result = TWStringHelper::wrap(unsafe {
+        tw_solana_transaction_set_fee_payer(encoded_tx.ptr(), fee_payer.ptr())
+    });
+
+    let updated_b64 = result
+        .to_string()
+        .expect("set_fee_payer must succeed for a 255-account transaction");
+
+    let updated_tx = VersionedTransaction::from_base64(&updated_b64).unwrap();
+    let updated_msg = match updated_tx.message {
+        VersionedMessage::Legacy(m) => m,
+        _ => panic!("expected legacy message"),
+    };
+
+    // Fee payer inserted at index 0; all prior indexes shifted by +1.
+    assert_eq!(updated_msg.account_keys[0], fee_payer_addr);
+    assert_eq!(updated_msg.instructions[0].program_id_index, 255); // was 254
+    assert_eq!(updated_msg.instructions[0].accounts, vec![1, 254]); // was [0, 253]
+}
+
+/// A crafted transaction has only 5 accounts but sets `program_id_index = 255` in an instruction.
+/// The upfront `len > u8::MAX` guard does not fire (5 < 256), but `checked_add` inside
+/// `set_fee_payer` must still reject the 255 → 0 wrap.
+#[test]
+fn test_solana_transaction_set_fee_payer_program_id_index_overflow() {
+    use tw_hash::H256;
+    use tw_solana::address::SolanaAddress;
+    use tw_solana::transaction::legacy;
+    use tw_solana::transaction::versioned::{VersionedMessage, VersionedTransaction};
+    use tw_solana::transaction::{CompiledInstruction, MessageHeader, Signature};
+
+    let account_keys: Vec<SolanaAddress> = (0u8..5)
+        .map(|i| {
+            let mut b = [0u8; 32];
+            b[0] = 1;
+            b[31] = i;
+            SolanaAddress::with_public_key_bytes(H256::from_array(b))
+        })
+        .collect();
+
+    let encoded_tx_str = VersionedTransaction {
+        signatures: vec![Signature::default()],
+        message: VersionedMessage::Legacy(legacy::Message {
+            header: MessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 1,
+            },
+            account_keys,
+            recent_blockhash: H256::from_array([1u8; 32]),
+            instructions: vec![CompiledInstruction {
+                program_id_index: 255, // out-of-bounds; wraps to 0 after +1 without checked_add
+                accounts: vec![0, 1],
+                data: vec![2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
+            }],
+        }),
+    }
+    .to_base64()
+    .unwrap();
+
+    let fee_payer_addr = SolanaAddress::with_public_key_bytes(H256::from_array({
+        let mut b = [0u8; 32];
+        b[0] = 2;
+        b
+    }));
+
+    let encoded_tx = TWStringHelper::create(&encoded_tx_str);
+    let fee_payer = TWStringHelper::create(&fee_payer_addr.to_string());
+
+    let result = TWStringHelper::wrap(unsafe {
+        tw_solana_transaction_set_fee_payer(encoded_tx.ptr(), fee_payer.ptr())
+    });
+
+    assert_eq!(result.to_string(), None);
+}


### PR DESCRIPTION
This pull request strengthens the safety of Solana transaction account and instruction handling by preventing overflows when incrementing account-related counters and updating instruction indexes. It introduces a helper for safe counter increments, replaces unchecked arithmetic with checked operations, and adds comprehensive tests to ensure transactions with too many accounts or index overflows are correctly rejected.

**Overflow protection and error handling:**

- Introduced a new `increment_counter` helper function to safely increment `u8` counters, returning an error if an overflow would occur. All increments of `num_required_signatures`, `num_readonly_signed_accounts`, and `num_readonly_unsigned_accounts` now use this helper.
- Replaced unchecked arithmetic with checked operations (`checked_add`, `checked_sub`) for updating instruction indexes and account positions, returning descriptive errors on overflow.
- Added explicit checks to reject transactions with more than 255 accounts, preventing silent wrapping of `u8` indexes.
**Testing improvements:**

- Added new tests to verify that:
  - Transactions with 256 accounts are rejected when attempting to set a fee payer.
  - Transactions with 255 accounts succeed and correctly update indexes when a fee payer is set.
  - Transactions with crafted index overflows (e.g., `program_id_index = 255`) are safely rejected.
- Introduced a `make_dummy_tx` utility for generating test transactions with a configurable number of accounts.