### PR TITLE
Harden input validation across RustCoinEntry, NULS, Hedera, and NEO signers

### DIFF
--- a/src/Hedera/Signer.cpp
+++ b/src/Hedera/Signer.cpp
@@ -91,6 +91,12 @@ Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) {
 
     switch (input.body().data_case()) {
     case Proto::TransactionBody::kTransfer: {
+        if (input.body().transfer().amount() <= 0) {
+            auto output = Proto::SigningOutput();
+            output.set_error(Common::Proto::Error_invalid_params);
+            output.set_error_message("Transfer amount must be positive");
+            return output;
+        }
         *body.mutable_cryptotransfer() = internals::cryptoTransferFromInput(input);
         break;
     }

--- a/src/NEO/Signer.cpp
+++ b/src/NEO/Signer.cpp
@@ -254,7 +254,10 @@ std::shared_ptr<Transaction> Signer::prepareUnsignedTransaction(const Proto::Sig
             transaction->attributes.push_back(attr);
         }
         return transaction;
+    } catch (const Common::Proto::SigningError&) {
+        throw;
     } catch (...) {
+        throw Common::Proto::SigningError(Common::Proto::Error_general);
     }
 
     return transaction;

--- a/src/NEO/Signer.cpp
+++ b/src/NEO/Signer.cpp
@@ -85,6 +85,10 @@ Proto::TransactionPlan Signer::plan(const Proto::SigningInput& input) {
         for (int i = 0; i < input.outputs_size(); i++) {
             auto* outputPlan = plan.add_outputs();
 
+            if (input.outputs(i).amount() < 0) {
+                throw Common::Proto::SigningError(Common::Proto::Error_invalid_params);
+            }
+
             if (available.find(input.outputs(i).asset_id()) == available.end() ||
                 available[input.outputs(i).asset_id()] < required[input.outputs(i).asset_id()]) {
                 throw Common::Proto::SigningError(Common::Proto::Error_low_balance);
@@ -106,6 +110,9 @@ Proto::TransactionPlan Signer::plan(const Proto::SigningInput& input) {
             for (int j = 0; j < input.outputs(i).extra_outputs_size(); j++) {
                 auto* extra_plan = outputPlan->add_extra_outputs();
 
+                if (input.outputs(i).extra_outputs(j).amount() < 0) {
+                    throw Common::Proto::SigningError(Common::Proto::Error_invalid_params);
+                }
                 extra_plan->set_to_address(input.outputs(i).extra_outputs(j).to_address());
                 extra_plan->set_amount(input.outputs(i).extra_outputs(j).amount());
                 changeAmount -= input.outputs(i).extra_outputs(j).amount();

--- a/src/NULS/Signer.cpp
+++ b/src/NULS/Signer.cpp
@@ -28,6 +28,9 @@ Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) {
 }
 
 Signer::Signer(const Proto::SigningInput& input) : input(input) {
+    if (input.chain_id() > 0xFFFF || input.idassets_id() > 0xFFFF) {
+        throw std::invalid_argument("chain_id and idassets_id must fit in 16 bits");
+    }
     uint256_t balance = load(input.balance());
 
     Proto::TransactionCoinTo coinTo;

--- a/src/rust/RustCoinEntry.cpp
+++ b/src/rust/RustCoinEntry.cpp
@@ -8,6 +8,9 @@
 namespace TW::Rust {
 
 bool RustCoinEntry::validateAddress(TWCoinType coin, const std::string &address, const PrefixVariant &addressPrefix) const {
+    if (address.find('\0') != std::string::npos) {
+        return false;
+    }
     Rust::TWStringWrapper addressStr = address;
 
     if (std::holds_alternative<std::monostate>(addressPrefix)) {
@@ -23,6 +26,9 @@ bool RustCoinEntry::validateAddress(TWCoinType coin, const std::string &address,
 }
 
 std::string RustCoinEntry::normalizeAddress(TWCoinType coin, const std::string& address) const {
+    if (address.find('\0') != std::string::npos) {
+        return {};
+    }
     Rust::TWStringWrapper addressStr = address;
 
     // `CoinEntry::normalizeAddress` is used when a `TWAnyAddress` has been created already, therefore validated.
@@ -73,6 +79,9 @@ std::string RustCoinEntry::deriveAddress(TWCoinType coin, const PublicKey& publi
 }
 
 Data RustCoinEntry::addressToData(TWCoinType coin, const std::string& address) const {
+    if (address.find('\0') != std::string::npos) {
+        return {};
+    }
     Rust::TWStringWrapper addressStr = address;
 
     // `CoinEntry::normalizeAddress` is used when a `TWAnyAddress` has been created already, therefore validated.


### PR DESCRIPTION
This pull request introduces several important validation and error-handling improvements across multiple blockchain signing modules. The main focus is on strengthening input validation for transaction signing, especially for addresses and transaction parameters, and improving error reporting.

**Input validation improvements:**

* Added a check in `Hedera/Signer.cpp` to ensure that the transfer amount is positive before proceeding with signing; returns an error if the amount is not valid.
* In `NULS/Signer.cpp`, added validation to ensure `chain_id` and `idassets_id` fit within 16 bits, throwing an exception if not.
* In `RustCoinEntry.cpp`, added checks in `validateAddress`, `normalizeAddress`, and `addressToData` to reject addresses containing null bytes, preventing invalid or malformed addresses from being processed. [[1]](diffhunk://#diff-53944d1590a352512b1610b401ce35684d55ca8310b18f63e684df18d3e705e7R11-R13) [[2]](diffhunk://#diff-53944d1590a352512b1610b401ce35684d55ca8310b18f63e684df18d3e705e7R29-R31) [[3]](diffhunk://#diff-53944d1590a352512b1610b401ce35684d55ca8310b18f63e684df18d3e705e7R82-R84)

**Error handling enhancements:**

* Improved error handling in `NEO/Signer.cpp` by rethrowing known signing errors and wrapping unknown exceptions as a general signing error, ensuring more robust and consistent error reporting.