### PR TITLE
Harden input validation in Stellar asset encoding, Zilliqa signing preimage, and BIP32 derivation path parsing

### DIFF
--- a/src/DerivationPath.cpp
+++ b/src/DerivationPath.cpp
@@ -33,6 +33,9 @@ DerivationPath::DerivationPath(const std::string& string) {
         if (hardened) {
             ++it;
         }
+        if (!hardened && value >= 0x80000000) {
+            throw std::invalid_argument("Non-hardened index must be less than 2^31");
+        }
         indices.emplace_back(value, hardened);
 
         if (it == end) {

--- a/src/Stellar/Signer.cpp
+++ b/src/Stellar/Signer.cpp
@@ -8,6 +8,7 @@
 #include "../Hash.h"
 #include "../HexCoding.h"
 #include "../proto/Stellar.pb.h"
+#include <stdexcept>
 
 #include <TrustWalletCore/TWStellarMemoType.h>
 
@@ -17,7 +18,12 @@ namespace TW::Stellar {
 Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) {
     auto signer = Signer(input);
     auto output = Proto::SigningOutput();
-    output.set_signature(signer.sign());
+    try {
+        output.set_signature(signer.sign());
+    } catch (const std::invalid_argument& ex) {
+        output.set_error(Common::Proto::Error_invalid_params);
+        output.set_error_message(ex.what());
+    }
     return output;
 }
 
@@ -201,6 +207,9 @@ void Signer::encodeAsset(const Proto::Asset& asset, Data& data) {
     uint32_t assetType = 0; // native
     std::string alphaUse;
     if (asset.issuer().length() > 0 && Address::isValid(asset.issuer()) && asset.alphanum4().length() > 0) {
+        if (asset.alphanum4().length() > 4) {
+            throw std::invalid_argument("alphanum4 asset code must be 4 characters or fewer");
+        }
         assetType = 1; // alphanum4
         alphaUse = asset.alphanum4();
     }

--- a/src/Zilliqa/Signer.cpp
+++ b/src/Zilliqa/Signer.cpp
@@ -50,7 +50,7 @@ Data Signer::getPreImage(const Proto::SigningInput& input, Address& address) {
         return Data(0);
     }
     const auto pubKey = key.getPublicKey(TWPublicKeyTypeSECP256k1);
-    auto gasPrice = Data(input.gas_price().begin(), input.gas_price().end());
+    auto gasPrice = store(load(input.gas_price()));
 
     internal.set_version(input.version());
     internal.set_nonce(input.nonce());
@@ -63,12 +63,12 @@ Data Signer::getPreImage(const Proto::SigningInput& input, Address& address) {
     switch (input.transaction().message_oneof_case()) {
     case Proto::Transaction::kTransfer: {
         const auto transfer = input.transaction().transfer();
-        amount = Data(transfer.amount().begin(), transfer.amount().end());
+        amount = store(load(transfer.amount()));
         break;
     }
     case Proto::Transaction::kRawTransaction: {
         const auto raw = input.transaction().raw_transaction();
-        amount = Data(raw.amount().begin(), raw.amount().end());
+        amount = store(load(raw.amount()));
         if (!raw.code().empty()) {
             internal.set_code(raw.code());
         }


### PR DESCRIPTION
This pull request introduces improved input validation and error handling for Stellar and Zilliqa transaction signing, as well as minor refactoring for data handling. The most significant changes are the addition of explicit checks for invalid parameters in Stellar asset encoding and derivation path parsing, and the propagation of errors back to the caller.

**Stellar transaction signing improvements:**

* Added validation in `encodeAsset` to ensure `alphanum4` asset codes do not exceed 4 characters, throwing an `invalid_argument` exception if violated.
* Updated the `Signer::sign` method to catch `invalid_argument` exceptions and set error codes and messages in the output, improving error reporting for invalid signing inputs.
* Included `<stdexcept>` in `Signer.cpp` to support exception handling.

**Derivation path validation:**

* Added a check in `DerivationPath` constructor to ensure non-hardened indices are less than 2^31, throwing an exception if not.

**Zilliqa transaction signing refactor:**

* Replaced direct data construction from proto fields with `store(load(...))` pattern for `gasPrice` and `amount` fields in `Signer::getPreImage`, standardizing data handling. [[1]](diffhunk://#diff-f4b9acb25c700d7f7eb0b3a6d9983dbbfdcbabd7b0f562a61ee0fc1ff937772cL53-R53) [[2]](diffhunk://#diff-f4b9acb25c700d7f7eb0b3a6d9983dbbfdcbabd7b0f562a61ee0fc1ff937772cL66-R71)