### PR TITLE
Reject negative Stellar fees and prevent Binance WalletConnect HTLT/Send message confusion

### DIFF
--- a/rust/chains/tw_binance/src/transaction/message/htlt_order.rs
+++ b/rust/chains/tw_binance/src/transaction/message/htlt_order.rs
@@ -14,6 +14,7 @@ use tw_memory::Data;
 use tw_proto::Binance::Proto;
 
 #[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct HTLTOrder {
     pub amount: Vec<Token>,
     pub cross_chain: bool,
@@ -81,6 +82,7 @@ impl TWBinanceProto for HTLTOrder {
 }
 
 #[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DepositHTLTOrder {
     pub amount: Vec<Token>,
     pub from: BinanceAddress,
@@ -125,6 +127,7 @@ impl TWBinanceProto for DepositHTLTOrder {
 }
 
 #[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ClaimHTLTOrder {
     pub from: BinanceAddress,
     #[serde(with = "as_hex")]
@@ -169,6 +172,7 @@ impl TWBinanceProto for ClaimHTLTOrder {
 }
 
 #[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct RefundHTLTOrder {
     pub from: BinanceAddress,
     #[serde(with = "as_hex")]

--- a/rust/chains/tw_binance/src/transaction/message/mod.rs
+++ b/rust/chains/tw_binance/src/transaction/message/mod.rs
@@ -186,6 +186,7 @@ impl<'a> AsRef<dyn BinanceMessage + 'a> for BinanceMessageEnum {
 }
 
 #[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Token {
     /// Amount.
     pub amount: i64,

--- a/rust/chains/tw_binance/src/transaction/message/send_order.rs
+++ b/rust/chains/tw_binance/src/transaction/message/send_order.rs
@@ -39,6 +39,7 @@ impl InOut {
 }
 
 #[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SendOrder {
     pub inputs: Vec<InOut>,
     pub outputs: Vec<InOut>,

--- a/rust/chains/tw_binance/src/transaction/message/send_order.rs
+++ b/rust/chains/tw_binance/src/transaction/message/send_order.rs
@@ -14,6 +14,7 @@ use tw_proto::Binance::Proto;
 
 /// Either an input or output of a `SendOrder`.
 #[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct InOut {
     /// Source address.
     pub address: BinanceAddress,

--- a/src/Stellar/Signer.cpp
+++ b/src/Stellar/Signer.cpp
@@ -53,6 +53,9 @@ std::string Signer::sign() const {
 Data Signer::encode(const Proto::SigningInput& input) const {
     //    Address account, uint32_t fee, uint64_t sequence, uint32_t memoType,
     //    Data memoData, Address destination, uint64_t amount;
+    if (input.fee() < 0) {
+        throw std::invalid_argument("Fee must be non-negative");
+    }
     auto data = Data();
 
     encodeAddress(Address(input.account()), data);


### PR DESCRIPTION
This pull request introduces stricter data validation for several Binance transaction message structs in Rust and adds input validation to the Stellar signing logic in C++. The main goal is to prevent deserialization of unexpected fields and ensure input values are within valid ranges.

**Rust: Struct Validation Improvements**
- Added `#[serde(deny_unknown_fields)]` to the following structs to ensure that only known fields are accepted during deserialization, improving data integrity and error detection:
  - `HTLTOrder` (`htlt_order.rs`)
  - `DepositHTLTOrder` (`htlt_order.rs`)
  - `ClaimHTLTOrder` (`htlt_order.rs`)
  - `RefundHTLTOrder` (`htlt_order.rs`)
  - `SendOrder` (`send_order.rs`)

**C++: Input Validation**
- Added a check in `Signer::encode` to throw an exception if the `fee` field is negative, preventing invalid transaction signing requests (`Signer.cpp`)