### PR TITLE
fix(CI): Fix CI pipeline for wallet-core fork pull requests

### DIFF
--- a/.github/workflows/claude-bc-risk-router.yml
+++ b/.github/workflows/claude-bc-risk-router.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Download scan result
         id: download
         continue-on-error: true   # gracefully handles skipped scanner jobs (e.g. draft PRs)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bc-scan-result
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-bc-risk-router.yml
+++ b/.github/workflows/claude-bc-risk-router.yml
@@ -157,10 +157,13 @@ jobs:
             });
 
   verify-bc-check-comment:
-    needs: [post-reminder-comment]
+    # No `needs` — runs independently on both workflow_run and issue_comment events.
+    # Uses the Checks API to post a check run directly onto pr.head.sha, so the result
+    # always lands on the right commit regardless of which event triggered this job.
     runs-on: ubuntu-latest
     if: always()
     permissions:
+      checks: write
       contents: read
       pull-requests: read
       issues: read
@@ -209,16 +212,31 @@ jobs:
               return;
             }
 
+            // Posts a check run pinned to the PR head commit. Works from any trigger event —
+            // issue_comment-triggered runs are not automatically associated with a PR commit
+            // by GitHub, so this explicit API call is the only way to update the PR check.
+            async function postCheck(conclusion, title, summary) {
+              await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'verify-bc-check-comment',
+                head_sha: pr.head.sha,
+                status: 'completed',
+                conclusion,
+                output: { title, summary },
+              });
+            }
+
             if (pr.draft) {
               core.info('PR is a draft; skipping.');
               return;
             }
             if (!['master', 'dev'].includes(pr.base.ref)) {
               core.info(`PR targets '${pr.base.ref}'; BC gate only applies to master and dev. Skipping.`);
+              await postCheck('success', 'Not applicable', `BC gate only applies to master and dev; this PR targets '${pr.base.ref}'.`);
               return;
             }
 
-            // Fetch comments — needed for both the reminder-gate check and sign-off search.
             const comments = await github.paginate(github.rest.issues.listComments, {
               issue_number: prNumber,
               owner: context.repo.owner,
@@ -226,15 +244,11 @@ jobs:
               per_page: 100,
             });
 
-            // Gate on the reminder comment's presence. The cascade that enforces the gate is:
-            // post-reminder-comment posts the reminder (needs: dependency ensures this job
-            // runs after it) → this job finds the reminder and fails until a sign-off exists.
-            // On issue_comment events, post-reminder-comment is skipped but this job still
-            // runs (if: always()) so it re-checks after every comment posted by a reviewer.
             const reminderMarker = '<!-- bc-risk-router:reminder -->';
             const hasReminder = comments.some(c => c.body.includes(reminderMarker));
             if (!hasReminder) {
               core.info('No BC-risk reminder posted; nothing to verify.');
+              await postCheck('success', 'No hot-path files changed', 'This PR does not touch persistence-sensitive files; no BC audit required.');
               return;
             }
 
@@ -272,7 +286,7 @@ jobs:
             });
 
             if (!signoff) {
-              core.setFailed(
+              const msg =
                 'No fresh, evidence-backed sign-off found. Required:\n' +
                 '  * Token: `[bc-check: Pass|Mitigated|Risk-Accepted|N/A]`\n' +
                 `  * Token + reasoning >= ${minChars} chars.\n` +
@@ -280,8 +294,10 @@ jobs:
                 '  * Pass / Mitigated / Risk-Accepted: must include audit output (a `# BC-risk audit ...` header or a `Verdict:` line).\n' +
                 '  * Risk-Accepted: must also include explicit evidence that blast radius is effectively zero.\n' +
                 "  * N/A is only valid when the change has zero BC relevance; rejected if the audit shows a RISK or BLOCKER verdict.\n" +
-                'If you pushed new commits after a previous sign-off, edit the existing comment (any edit counts as a refresh) so it reflects the current diff.'
-              );
+                'If you pushed new commits after a previous sign-off, edit the existing comment (any edit counts as a refresh) so it reflects the current diff.';
+              await postCheck('failure', 'BC sign-off required', msg);
+              core.setFailed('BC sign-off required — see the verify-bc-check-comment check on this PR.');
               return;
             }
+            await postCheck('success', 'BC sign-off verified', `Sign-off by @${signoff.user.login} is valid and current (posted at ${signoff.updated_at}).`);
             core.info(`Found fresh sign-off by @${signoff.user.login} at ${signoff.updated_at}.`);

--- a/.github/workflows/claude-bc-risk-router.yml
+++ b/.github/workflows/claude-bc-risk-router.yml
@@ -4,7 +4,7 @@ name: bc-risk-router
 # status check in Settings -> Branches -> branch protection rules for master and dev.
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ master, dev ]
     types: [ opened, synchronize, reopened, edited, ready_for_review ]
   issue_comment:
@@ -20,13 +20,17 @@ env:
 
 jobs:
   scan-and-flag:
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       flags: ${{ steps.scan.outputs.flags }}
     steps:
       - uses: actions/checkout@v4
         with:
+          # Checkout the PR head so the diff reflects the fork's changes.
+          # pull_request_target defaults to the base ref; this override is required.
+          # Only git diff --name-only runs against this ref — no fork code is executed.
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Detect hot-path changes

--- a/.github/workflows/claude-bc-risk-router.yml
+++ b/.github/workflows/claude-bc-risk-router.yml
@@ -2,87 +2,67 @@ name: bc-risk-router
 
 # To make verify-bc-check-comment actually BLOCK merging, add it as a required
 # status check in Settings -> Branches -> branch protection rules for master and dev.
+#
+# Security model:
+#   bc-scanner    — pull_request, fork context, no secrets, does the checkout + file detection.
+#   bc-risk-router — workflow_run (base-repo context, write token) reads the artifact and
+#                    posts the gating comment. No checkout ever happens here.
 
 on:
-  pull_request_target:
-    branches: [ master, dev ]
-    types: [ opened, synchronize, reopened, edited, ready_for_review ]
+  workflow_run:
+    workflows: [ "bc-scanner" ]
+    types: [ completed ]
   issue_comment:
     types: [ created, edited, deleted ]
-
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
 
 env:
   BC_SIGNOFF_MIN_CHARS: 60
 
 jobs:
-  scan-and-flag:
-    if: github.event_name == 'pull_request_target' && github.event.pull_request.draft == false
+  post-reminder-comment:
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    outputs:
-      flags: ${{ steps.scan.outputs.flags }}
+    permissions:
+      actions: read       # download artifact from the scanner run
+      issues: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Download scan result
+        id: download
+        continue-on-error: true   # gracefully handles skipped scanner jobs (e.g. draft PRs)
+        uses: actions/download-artifact@v4
         with:
-          # Checkout the PR head so the diff reflects the fork's changes.
-          # pull_request_target defaults to the base ref; this override is required.
-          # Only git diff --name-only runs against this ref — no fork code is executed.
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
-      - name: Detect hot-path changes
-        id: scan
-        run: |
-          set -e
-          BASE="origin/${{ github.base_ref }}"
-
-          # Any change to a persistence-sensitive path warrants a BC audit.
-          # The auditor decides what's risky — not grep patterns.
-          CHANGED=$(git diff --name-only "$BASE"...HEAD -- \
-            'src/Keystore/' \
-            'src/proto/' \
-            'include/TrustWalletCore/' \
-            'registry.json' \
-            'src/PrivateKey*' \
-            'src/PublicKey*' \
-            'src/HDWallet*' \
-            'swift/Sources/KeyStore*' \
-            'swift/Sources/Wallet.swift' \
-            'swift/Sources/Watch.swift' \
-            'wasm/src/keystore/' \
-            '**/Migration*' \
-            '**/StoredKey*' \
-            '**/backup/**' \
-            '**/schema*.sql' \
-            2>/dev/null || true)
-
-          if [ -n "$CHANGED" ]; then
-            echo "flags=$(echo "$CHANGED" | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
-          else
-            echo "flags=" >> "$GITHUB_OUTPUT"
-          fi
+          name: bc-scan-result
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Post reminder comment (once per PR)
-        if: steps.scan.outputs.flags != ''
+        if: steps.download.outcome == 'success'
         uses: actions/github-script@v7
         env:
-          FLAGS: ${{ steps.scan.outputs.flags }}
+          BC_SIGNOFF_MIN_CHARS: ${{ env.BC_SIGNOFF_MIN_CHARS }}
         with:
           script: |
-            const changedFiles = (process.env.FLAGS || '').trim().split(/\s+/).filter(Boolean);
-            const marker = '<!-- bc-risk-router:reminder -->';
+            const fs = require('fs');
 
-            const { data: comments } = await github.rest.issues.listComments({
-              issue_number: context.issue.number,
+            const changedContent = fs.readFileSync('changed-files.txt', 'utf8').trim();
+            if (!changedContent) {
+              core.info('No hot-path files changed; skipping.');
+              return;
+            }
+            const changedFiles = changedContent.split('\n').filter(Boolean);
+
+            const prNumber = parseInt(fs.readFileSync('pr-number.txt', 'utf8').trim(), 10);
+            const base     = fs.readFileSync('base-ref.txt',     'utf8').trim();
+
+            const marker = '<!-- bc-risk-router:reminder -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              issue_number: prNumber,
               owner: context.repo.owner,
               repo: context.repo.repo,
+              per_page: 100,
             });
             if (comments.some(c => c.body.includes(marker))) return;
-
-            const base = context.payload.pull_request.base.ref;
 
             // Build the prompt as an array to avoid multi-line template literal
             // indentation problems inside this YAML block scalar.
@@ -152,7 +132,7 @@ jobs:
               '- `[bc-check: Risk-Accepted]` — audit found RISK or BLOCKER; **investigation confirms blast radius is effectively zero** (no user data in the wild can trigger it). Must include audit output + explicit evidence (who confirmed it, what data or reasoning).',
               "- `[bc-check: N/A]` — scanner fired on a file with **zero BC relevance** (comment edit, test fixture, renamed variable). **Invalid if the audit found a real risk.**",
               '',
-              'Each token must be accompanied by >=${{ env.BC_SIGNOFF_MIN_CHARS }} chars of reasoning. The reasoning must be fresh — posted or edited at or after the HEAD commit.',
+              `Each token must be accompanied by >=${process.env.BC_SIGNOFF_MIN_CHARS} chars of reasoning. The reasoning must be fresh — posted or edited at or after the HEAD commit.`,
               '',
               "**Why audit evidence is required for Pass / Mitigated:** humans don't reliably ask the right BC question on every PR. AI being in the loop is the whole point of this gate. The bot does not judge whether your reasoning is *correct* — reviewers do, like any other code review.",
               '',
@@ -170,30 +150,60 @@ jobs:
             ].join('\n');
 
             await github.rest.issues.createComment({
-              issue_number: context.issue.number,
+              issue_number: prNumber,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body
             });
 
   verify-bc-check-comment:
+    needs: [post-reminder-comment]
     runs-on: ubuntu-latest
     if: always()
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
     steps:
       - name: Verify sign-off token
         uses: actions/github-script@v7
+        env:
+          BC_SIGNOFF_MIN_CHARS: ${{ env.BC_SIGNOFF_MIN_CHARS }}
         with:
           script: |
             let prNumber, pr;
-            if (context.payload.pull_request) {
-              pr = context.payload.pull_request;
-              prNumber = pr.number;
-            } else if (context.payload.issue && context.payload.issue.pull_request) {
+            if (context.payload.issue && context.payload.issue.pull_request) {
               prNumber = context.payload.issue.number;
               const { data } = await github.rest.pulls.get({
                 owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber
               });
               pr = data;
+            } else if (context.payload.workflow_run) {
+              const prs = context.payload.workflow_run.pull_requests;
+              if (!prs || prs.length === 0) {
+                // Fork PRs: workflow_run.pull_requests is empty — look up by head SHA.
+                const headSha = context.payload.workflow_run.head_sha;
+                const headOwner = context.payload.workflow_run.head_repository.owner.login;
+                const headBranch = context.payload.workflow_run.head_branch;
+                const { data: openPRs } = await github.rest.pulls.list({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: 'open',
+                  head: `${headOwner}:${headBranch}`,
+                });
+                pr = openPRs.find(p => p.head.sha === headSha);
+                if (!pr) {
+                  core.info('Could not resolve PR from workflow_run; skipping.');
+                  return;
+                }
+                prNumber = pr.number;
+              } else {
+                prNumber = prs[0].number;
+                const { data } = await github.rest.pulls.get({
+                  owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber
+                });
+                pr = data;
+              }
             } else {
               core.info('Not a PR-related event; skipping.');
               return;
@@ -208,18 +218,19 @@ jobs:
               return;
             }
 
-            // Fetch comments early — needed for both the reminder-gate check and sign-off search.
-            const { data: comments } = await github.rest.issues.listComments({
+            // Fetch comments — needed for both the reminder-gate check and sign-off search.
+            const comments = await github.paginate(github.rest.issues.listComments, {
               issue_number: prNumber,
               owner: context.repo.owner,
               repo: context.repo.repo,
+              per_page: 100,
             });
 
-            // Gate on the reminder comment's presence. This job runs independently of
-            // scan-and-flag (no `needs` dependency) so that it fires on every
-            // issue_comment event. The cascade that enforces the gate on PR open is:
-            // scan-and-flag posts the reminder → that triggers an issue_comment event
-            // → this job runs, finds the reminder, and fails until a sign-off exists.
+            // Gate on the reminder comment's presence. The cascade that enforces the gate is:
+            // post-reminder-comment posts the reminder (needs: dependency ensures this job
+            // runs after it) → this job finds the reminder and fails until a sign-off exists.
+            // On issue_comment events, post-reminder-comment is skipped but this job still
+            // runs (if: always()) so it re-checks after every comment posted by a reviewer.
             const reminderMarker = '<!-- bc-risk-router:reminder -->';
             const hasReminder = comments.some(c => c.body.includes(reminderMarker));
             if (!hasReminder) {

--- a/.github/workflows/claude-bc-scanner.yml
+++ b/.github/workflows/claude-bc-scanner.yml
@@ -1,0 +1,67 @@
+name: bc-scanner
+
+# Runs in the fork's unprivileged context — no secrets, no write permissions.
+# Checks out PR code safely and detects hot-path file changes, then uploads
+# the result as an artifact for bc-risk-router (workflow_run) to consume.
+
+on:
+  pull_request:
+    branches: [ master, dev ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect hot-path changes
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -e
+          BASE="origin/$BASE_REF"
+
+          # Any change to a persistence-sensitive path warrants a BC audit.
+          # The auditor decides what's risky — not grep patterns.
+          git diff --name-only "$BASE"...HEAD -- \
+            'src/Keystore/' \
+            'src/proto/' \
+            'include/TrustWalletCore/' \
+            'registry.json' \
+            'src/PrivateKey*' \
+            'src/PublicKey*' \
+            'src/HDWallet*' \
+            'swift/Sources/KeyStore*' \
+            'swift/Sources/Wallet.swift' \
+            'swift/Sources/Watch.swift' \
+            'wasm/src/keystore/' \
+            '**/Migration*' \
+            '**/StoredKey*' \
+            '**/backup/**' \
+            '**/schema*.sql' \
+            2>/dev/null > changed-files.txt || true
+
+          printf '%s' "$PR_NUMBER" > pr-number.txt
+          printf '%s' "$BASE_REF"  > base-ref.txt
+          printf '%s' "$HEAD_SHA"  > head-sha.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bc-scan-result
+          path: |
+            changed-files.txt
+            pr-number.txt
+            base-ref.txt
+            head-sha.txt
+          retention-days: 1

--- a/.github/workflows/claude-bc-scanner.yml
+++ b/.github/workflows/claude-bc-scanner.yml
@@ -17,9 +17,9 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
           fetch-depth: 0
           persist-credentials: false
 
@@ -56,7 +56,7 @@ jobs:
           printf '%s' "$BASE_REF"  > base-ref.txt
           printf '%s' "$HEAD_SHA"  > head-sha.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: bc-scan-result
           path: |

--- a/.github/workflows/claude-bc-scanner.yml
+++ b/.github/workflows/claude-bc-scanner.yml
@@ -27,14 +27,14 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -e
-          BASE="origin/$BASE_REF"
 
           # Any change to a persistence-sensitive path warrants a BC audit.
           # The auditor decides what's risky — not grep patterns.
-          git diff --name-only "$BASE"...HEAD -- \
+          git diff --name-only "$BASE_SHA"...HEAD -- \
             'src/Keystore/' \
             'src/proto/' \
             'include/TrustWalletCore/' \
@@ -50,7 +50,7 @@ jobs:
             '**/StoredKey*' \
             '**/backup/**' \
             '**/schema*.sql' \
-            2>/dev/null > changed-files.txt || true
+            > changed-files.txt
 
           printf '%s' "$PR_NUMBER" > pr-number.txt
           printf '%s' "$BASE_REF"  > base-ref.txt


### PR DESCRIPTION
This pull request refactors the "BC risk router" workflow to improve security, reliability, and maintainability by splitting the process into two separate GitHub Actions workflows: `bc-scanner` and `bc-risk-router`. The scanner workflow runs in the unprivileged fork context to detect sensitive file changes and uploads the result as an artifact, while the router workflow runs in the base repository context to post comments and enforce gating based on the scan results. The PR also improves the logic for associating PRs with workflow runs, enhances check run posting, and clarifies environment variable usage in comments.

**Workflow separation and security model:**

* Introduced a new `bc-scanner` workflow (`.github/workflows/claude-bc-scanner.yml`) that runs on PR events in the fork context (no secrets, read-only), detects changes to persistence-sensitive files, and uploads the results as an artifact for downstream consumption.
* Refactored `bc-risk-router` (`.github/workflows/claude-bc-risk-router.yml`) to run on `workflow_run` events triggered by the scanner, ensuring it only runs with write permissions in the base repo context and never checks out code.

**Improved artifact handling and comment logic:**

* The router workflow now downloads the scan artifact, reads changed files and PR metadata from it, and posts a reminder comment only if relevant files were changed, ensuring accurate gating.
* Updated the logic for posting and verifying reminder comments to reference the correct PR number and use environment variables safely in comment templates. [[1]](diffhunk://#diff-f3fcb5455b1d2eaf2f253ff97b00ae0fd306e71254c6cd06e0ed1be0c2d41563L151-R135) [[2]](diffhunk://#diff-f3fcb5455b1d2eaf2f253ff97b00ae0fd306e71254c6cd06e0ed1be0c2d41563L169-R251)

**Enhanced check run and PR association:**

* Improved the method for associating workflow runs with PRs, including robust fallback logic for fork PRs, and introduced a helper to post check runs directly to the correct commit SHA regardless of trigger event.
* The verify job now posts detailed check runs with success or failure status, clear summaries, and actionable messages based on audit and sign-off status.

These changes collectively make the BC risk gating process more secure, reliable, and maintainable by clearly separating concerns, minimizing permission scopes, and ensuring that gating logic accurately tracks the state of each PR.