### PR TITLE
fix(derivation-path): Reject invalid derivation indices exceeding range

### DIFF
--- a/include/TrustWalletCore/TWAccount.h
+++ b/include/TrustWalletCore/TWAccount.h
@@ -24,14 +24,14 @@ struct TWAccount;
 /// \param derivationPath The derivation path of the Account.
 /// \param publicKey hex encoded public key.
 /// \param extendedPublicKey Base58 encoded extended public key.
-/// \return A new Account.
+/// \return A new Account, or null if the derivation path is invalid.
 TW_EXPORT_STATIC_METHOD
-struct TWAccount* _Nonnull TWAccountCreate(TWString* _Nonnull address,
-                                           enum TWCoinType coin,
-                                           enum TWDerivation derivation,
-                                           TWString* _Nonnull derivationPath,
-                                           TWString* _Nonnull publicKey,
-                                           TWString* _Nonnull extendedPublicKey);
+struct TWAccount* _Nullable TWAccountCreate(TWString* _Nonnull address,
+                                            enum TWCoinType coin,
+                                            enum TWDerivation derivation,
+                                            TWString* _Nonnull derivationPath,
+                                            TWString* _Nonnull publicKey,
+                                            TWString* _Nonnull extendedPublicKey);
 /// Deletes an account.
 ///
 /// \param account Account to delete.

--- a/include/TrustWalletCore/TWHDWallet.h
+++ b/include/TrustWalletCore/TWHDWallet.h
@@ -138,9 +138,9 @@ TWString* _Nonnull TWHDWalletGetAddressDerivation(struct TWHDWallet* _Nonnull wa
 /// \param coin a coin type
 /// \param derivationPath  a non-null derivation path
 /// \note Returned object needs to be deleted with \TWPrivateKeyDelete
-/// \return The private key for the specified derivation path/coin
+/// \return The private key for the specified derivation path/coin, or null if the path is invalid
 TW_EXPORT_METHOD
-struct TWPrivateKey* _Nonnull TWHDWalletGetKey(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin, TWString* _Nonnull derivationPath);
+struct TWPrivateKey* _Nullable TWHDWalletGetKey(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin, TWString* _Nonnull derivationPath);
 
 /// Generates the private key for the specified derivation.
 ///
@@ -160,9 +160,9 @@ struct TWPrivateKey* _Nonnull TWHDWalletGetKeyDerivation(struct TWHDWallet* _Non
 /// \param curve a curve
 /// \param derivationPath  a non-null derivation path
 /// \note Returned object needs to be deleted with \TWPrivateKeyDelete
-/// \return The private key for the specified derivation path/curve
+/// \return The private key for the specified derivation path/curve, or null if the path is invalid
 TW_EXPORT_METHOD
-struct TWPrivateKey* _Nonnull TWHDWalletGetKeyByCurve(struct TWHDWallet* _Nonnull wallet, enum TWCurve curve, TWString* _Nonnull derivationPath);
+struct TWPrivateKey* _Nullable TWHDWalletGetKeyByCurve(struct TWHDWallet* _Nonnull wallet, enum TWCurve curve, TWString* _Nonnull derivationPath);
 
 /// Shortcut method to generate private key with the specified account/change/address (bip44 standard).
 ///

--- a/src/DerivationPath.cpp
+++ b/src/DerivationPath.cpp
@@ -4,7 +4,7 @@
 
 #include "DerivationPath.h"
 
-#include <cstdio>
+#include <charconv>
 #include <stdexcept>
 
 using namespace TW;
@@ -21,22 +21,21 @@ DerivationPath::DerivationPath(const std::string& string) {
     }
 
     while (it != end) {
-        uint32_t value;
-        if (std::sscanf(it, "%ud", &value) != 1) {
+        uint64_t value{0};
+        auto [ptr, ec] = std::from_chars(it, end, value);
+        if (ec == std::errc::invalid_argument) {
             throw std::invalid_argument("Invalid component");
         }
-        while (it != end && isdigit(*it)) {
-            ++it;
-        }
-
-        if (value >= HardenedOffset) {
+        if (ec == std::errc::result_out_of_range || value >= HardenedOffset) {
             throw std::invalid_argument("Derivation index out of range");
         }
+        it = ptr;
+
         auto hardened = (it != end && *it == '\'');
         if (hardened) {
             ++it;
         }
-        indices.emplace_back(value, hardened);
+        indices.emplace_back(static_cast<uint32_t>(value), hardened);
 
         if (it == end) {
             break;

--- a/src/DerivationPath.cpp
+++ b/src/DerivationPath.cpp
@@ -29,6 +29,9 @@ DerivationPath::DerivationPath(const std::string& string) {
             ++it;
         }
 
+        if (value >= 0x80000000) {
+            throw std::invalid_argument("Derivation index out of range");
+        }
         auto hardened = (it != end && *it == '\'');
         if (hardened) {
             ++it;

--- a/src/DerivationPath.cpp
+++ b/src/DerivationPath.cpp
@@ -29,7 +29,7 @@ DerivationPath::DerivationPath(const std::string& string) {
             ++it;
         }
 
-        if (value >= 0x80000000) {
+        if (value >= HardenedOffset) {
             throw std::invalid_argument("Derivation index out of range");
         }
         auto hardened = (it != end && *it == '\'');

--- a/src/DerivationPath.h
+++ b/src/DerivationPath.h
@@ -14,6 +14,8 @@
 
 namespace TW {
 
+static constexpr uint32_t HardenedOffset = 0x80000000u;
+
 struct DerivationPathIndex {
     uint32_t value = 0;
     bool hardened = true;
@@ -25,7 +27,7 @@ struct DerivationPathIndex {
     /// The derivation index.
     uint32_t derivationIndex() const {
         if (hardened) {
-            return value | 0x80000000;
+            return value | HardenedOffset;
         } else {
             return value;
         }

--- a/src/interface/TWAccount.cpp
+++ b/src/interface/TWAccount.cpp
@@ -8,20 +8,24 @@
 
 using namespace TW;
 
-struct TWAccount* _Nonnull TWAccountCreate(TWString* _Nonnull address,
-                                           enum TWCoinType coin,
-                                           enum TWDerivation derivation, 
-                                           TWString* _Nonnull derivationPath,
-                                           TWString* _Nonnull publicKey,
-                                           TWString* _Nonnull extendedPublicKey) {
-    auto& addressString = *reinterpret_cast<const std::string*>(address);
-    auto& derivationPathString = *reinterpret_cast<const std::string*>(derivationPath);
-    auto& publicKeyString = *reinterpret_cast<const std::string*>(publicKey);
-    auto& extendedPublicKeyString = *reinterpret_cast<const std::string*>(extendedPublicKey);
-    const auto dp = DerivationPath(derivationPathString);
-    return new TWAccount{
-        Keystore::Account(addressString, coin, derivation, dp, publicKeyString, extendedPublicKeyString)
-    };
+struct TWAccount* _Nullable TWAccountCreate(TWString* _Nonnull address,
+                                            enum TWCoinType coin,
+                                            enum TWDerivation derivation,
+                                            TWString* _Nonnull derivationPath,
+                                            TWString* _Nonnull publicKey,
+                                            TWString* _Nonnull extendedPublicKey) {
+    try {
+        auto& addressString = *reinterpret_cast<const std::string*>(address);
+        auto& derivationPathString = *reinterpret_cast<const std::string*>(derivationPath);
+        auto& publicKeyString = *reinterpret_cast<const std::string*>(publicKey);
+        auto& extendedPublicKeyString = *reinterpret_cast<const std::string*>(extendedPublicKey);
+        const auto dp = DerivationPath(derivationPathString);
+        return new TWAccount{
+            Keystore::Account(addressString, coin, derivation, dp, publicKeyString, extendedPublicKeyString)
+        };
+    } catch (...) {
+        return nullptr;
+    }
 }
 
 void TWAccountDelete(struct TWAccount* _Nonnull account) {

--- a/src/interface/TWHDWallet.cpp
+++ b/src/interface/TWHDWallet.cpp
@@ -79,10 +79,14 @@ TWString *_Nonnull TWHDWalletGetAddressDerivation(struct TWHDWallet *wallet, TWC
     return TWStringCreateWithUTF8Bytes(address.c_str());
 }
 
-struct TWPrivateKey *_Nonnull TWHDWalletGetKey(struct TWHDWallet *_Nonnull wallet, enum TWCoinType coin, TWString *_Nonnull derivationPath) {
-    auto& s = *reinterpret_cast<const std::string*>(derivationPath);
-    const auto path = DerivationPath(s);
-    return new TWPrivateKey{ wallet->impl.getKey(coin, path) };
+struct TWPrivateKey *_Nullable TWHDWalletGetKey(struct TWHDWallet *_Nonnull wallet, enum TWCoinType coin, TWString *_Nonnull derivationPath) {
+    try {
+        auto& s = *reinterpret_cast<const std::string*>(derivationPath);
+        const auto path = DerivationPath(s);
+        return new TWPrivateKey{ wallet->impl.getKey(coin, path) };
+    } catch (...) {
+        return nullptr;
+    }
 }
 
 struct TWPrivateKey *_Nonnull TWHDWalletGetKeyDerivation(struct TWHDWallet *_Nonnull wallet, enum TWCoinType coin, enum TWDerivation derivation) {
@@ -95,10 +99,14 @@ struct TWPrivateKey *_Nonnull TWHDWalletGetDerivedKey(struct TWHDWallet *_Nonnul
     return new TWPrivateKey{ wallet->impl.getKey(coin, derivationPath) };
 }
 
-struct TWPrivateKey *_Nonnull TWHDWalletGetKeyByCurve(struct TWHDWallet *_Nonnull wallet, enum TWCurve curve, TWString *_Nonnull derivationPath) {
-    auto& s = *reinterpret_cast<const std::string*>(derivationPath);
-    const auto path = DerivationPath(s);
-    return new TWPrivateKey{ wallet->impl.getKeyByCurve(curve, path)};
+struct TWPrivateKey *_Nullable TWHDWalletGetKeyByCurve(struct TWHDWallet *_Nonnull wallet, enum TWCurve curve, TWString *_Nonnull derivationPath) {
+    try {
+        auto& s = *reinterpret_cast<const std::string*>(derivationPath);
+        const auto path = DerivationPath(s);
+        return new TWPrivateKey{ wallet->impl.getKeyByCurve(curve, path)};
+    } catch (...) {
+        return nullptr;
+    }
 }
 
 TWString *_Nonnull TWHDWalletGetExtendedPrivateKey(struct TWHDWallet *wallet, TWPurpose purpose, TWCoinType coin, TWHDVersion version) {
@@ -126,10 +134,14 @@ TWString *_Nonnull TWHDWalletGetExtendedPublicKeyDerivation(struct TWHDWallet *w
 }
 
 TWPublicKey *TWHDWalletGetPublicKeyFromExtended(TWString *_Nonnull extended, enum TWCoinType coin, TWString *_Nonnull derivationPath) {
-    const auto derivationPathObject = DerivationPath(*reinterpret_cast<const std::string*>(derivationPath));
-    auto publicKey = HDWallet<>::getPublicKeyFromExtended(*reinterpret_cast<const std::string*>(extended), coin, derivationPathObject);
-    if (!publicKey) {
+    try {
+        const auto derivationPathObject = DerivationPath(*reinterpret_cast<const std::string*>(derivationPath));
+        auto publicKey = HDWallet<>::getPublicKeyFromExtended(*reinterpret_cast<const std::string*>(extended), coin, derivationPathObject);
+        if (!publicKey) {
+            return nullptr;
+        }
+        return new TWPublicKey{ PublicKey(*publicKey) };
+    } catch (...) {
         return nullptr;
     }
-    return new TWPublicKey{ PublicKey(*publicKey) };
 }

--- a/src/interface/TWStoredKey.cpp
+++ b/src/interface/TWStoredKey.cpp
@@ -292,8 +292,12 @@ struct TWHDWallet* _Nullable TWStoredKeyWallet(struct TWStoredKey* _Nonnull key,
 }
 
 TWData* _Nullable TWStoredKeyExportJSON(struct TWStoredKey* _Nonnull key) {
-    const auto json = key->impl.json().dump();
-    return TWDataCreateWithBytes(reinterpret_cast<const uint8_t*>(json.data()), json.size());
+    try {
+        const auto json = key->impl.json().dump();
+        return TWDataCreateWithBytes(reinterpret_cast<const uint8_t*>(json.data()), json.size());
+    } catch (...) {
+        return nullptr;
+    }
 }
 
 bool TWStoredKeyFixAddresses(struct TWStoredKey* _Nonnull key, TWData* _Nonnull password) {

--- a/src/interface/TWStoredKey.cpp
+++ b/src/interface/TWStoredKey.cpp
@@ -195,16 +195,22 @@ void TWStoredKeyRemoveAccountForCoinDerivation(struct TWStoredKey* _Nonnull key,
 }
 
 void TWStoredKeyRemoveAccountForCoinDerivationPath(struct TWStoredKey* _Nonnull key, enum TWCoinType coin, TWString* _Nonnull derivationPath) {
-    const auto dp = TW::DerivationPath(*reinterpret_cast<const std::string*>(derivationPath));
-    key->impl.removeAccount(coin, dp);
+    try {
+        const auto dp = TW::DerivationPath(*reinterpret_cast<const std::string*>(derivationPath));
+        key->impl.removeAccount(coin, dp);
+    } catch (...) {
+    }
 }
 
 void TWStoredKeyAddAccountDerivation(struct TWStoredKey* _Nonnull key, TWString* _Nonnull address, enum TWCoinType coin, enum TWDerivation derivation, TWString* _Nonnull derivationPath, TWString* _Nonnull publicKey, TWString* _Nonnull extendedPublicKey) {
-    const auto& addressString = *reinterpret_cast<const std::string*>(address);
-    const auto& publicKeyString = *reinterpret_cast<const std::string*>(publicKey);
-    const auto& extendedPublicKeyString = *reinterpret_cast<const std::string*>(extendedPublicKey);
-    const auto dp = TW::DerivationPath(*reinterpret_cast<const std::string*>(derivationPath));
-    key->impl.addAccount(addressString, coin, derivation, dp, publicKeyString, extendedPublicKeyString);
+    try {
+        const auto& addressString = *reinterpret_cast<const std::string*>(address);
+        const auto& publicKeyString = *reinterpret_cast<const std::string*>(publicKey);
+        const auto& extendedPublicKeyString = *reinterpret_cast<const std::string*>(extendedPublicKey);
+        const auto dp = TW::DerivationPath(*reinterpret_cast<const std::string*>(derivationPath));
+        key->impl.addAccount(addressString, coin, derivation, dp, publicKeyString, extendedPublicKeyString);
+    } catch (...) {
+    }
 }
 
 void TWStoredKeyAddAccount(struct TWStoredKey* _Nonnull key, TWString* _Nonnull address, enum TWCoinType coin, TWString* _Nonnull derivationPath, TWString* _Nonnull publicKey, TWString* _Nonnull extendedPublicKey) {

--- a/swift/Sources/Extensions/Account+Codable.swift
+++ b/swift/Sources/Extensions/Account+Codable.swift
@@ -55,13 +55,19 @@ extension Account: Codable {
         let publicKey         = try container.decode(String.self, forKey: .publicKey)
         let extendedPublicKey = try container.decode(String.self, forKey: .extendedPublicKey)
 
-        self.init(
+        guard let account = Account(
             address: address,
             coin: CoinType(rawValue: rawCoin)!,
             derivation: Derivation(rawValue: rawDerivation)!,
             derivationPath: derivationPath,
             publicKey: publicKey,
             extendedPublicKey: extendedPublicKey
-        )
+        ) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(
+                codingPath: decoder.codingPath,
+                debugDescription: "Invalid derivation path: \(derivationPath)"
+            ))
+        }
+        self.init(rawValue: account.rawValue)
     }
 }

--- a/swift/Sources/Extensions/Account+Codable.swift
+++ b/swift/Sources/Extensions/Account+Codable.swift
@@ -55,19 +55,36 @@ extension Account: Codable {
         let publicKey         = try container.decode(String.self, forKey: .publicKey)
         let extendedPublicKey = try container.decode(String.self, forKey: .extendedPublicKey)
 
-        guard let account = Account(
-            address: address,
-            coin: CoinType(rawValue: rawCoin)!,
-            derivation: Derivation(rawValue: rawDerivation)!,
-            derivationPath: derivationPath,
-            publicKey: publicKey,
-            extendedPublicKey: extendedPublicKey
-        ) else {
-            throw DecodingError.dataCorrupted(DecodingError.Context(
-                codingPath: decoder.codingPath,
-                debugDescription: "Invalid derivation path: \(derivationPath)"
-            ))
+        guard let coin = CoinType(rawValue: rawCoin) else {
+            throw DecodingError.dataCorruptedError(forKey: .coin, in: container,
+                debugDescription: "Unknown coin type: \(rawCoin)")
         }
-        self.init(rawValue: account.rawValue)
+        guard let derivation = Derivation(rawValue: rawDerivation) else {
+            throw DecodingError.dataCorruptedError(forKey: .derivation, in: container,
+                debugDescription: "Unknown derivation: \(rawDerivation)")
+        }
+        // Call TWAccountCreate directly rather than using the Account failable init:
+        // if we created an intermediate Account and copied its rawValue, that wrapper's
+        // deinit would call TWAccountDelete before self uses the pointer (use-after-free).
+        let addressString = TWStringCreateWithNSString(address)
+        defer { TWStringDelete(addressString) }
+        let derivationPathString = TWStringCreateWithNSString(derivationPath)
+        defer { TWStringDelete(derivationPathString) }
+        let publicKeyString = TWStringCreateWithNSString(publicKey)
+        defer { TWStringDelete(publicKeyString) }
+        let extendedPublicKeyString = TWStringCreateWithNSString(extendedPublicKey)
+        defer { TWStringDelete(extendedPublicKeyString) }
+        guard let rawValue = TWAccountCreate(
+            addressString,
+            TWCoinType(rawValue: coin.rawValue),
+            TWDerivation(rawValue: derivation.rawValue),
+            derivationPathString,
+            publicKeyString,
+            extendedPublicKeyString
+        ) else {
+            throw DecodingError.dataCorruptedError(forKey: .derivationPath, in: container,
+                debugDescription: "Invalid derivation path: \(derivationPath)")
+        }
+        self.init(rawValue: rawValue)
     }
 }

--- a/swift/Tests/Blockchains/EthereumTests.swift
+++ b/swift/Tests/Blockchains/EthereumTests.swift
@@ -244,7 +244,7 @@ class EthereumTests: XCTestCase {
 
         XCTAssertEqual(xpub, "xpub6C7LtZJgtz1BKXG9mExKUxYvX7HSF38UMMmGbpqNQw3DfYwAw8E6sH7VSVxFipvEEm2afSqTjoRgcLmycXX4zfxCWJ4HY73a9KdgvfHEQGB")
 
-        let key = wallet.getKey(coin: .ethereum, derivationPath: path)
+        let key = try XCTUnwrap(wallet.getKey(coin: .ethereum, derivationPath: path))
         let pubkey = key.getPublicKeySecp256k1(compressed: true)
         XCTAssertEqual(pubkey.data.hexString, "024516c4aa5352035e1bb5be132694e1389a4ac37d32e5e717d35ee4c4dfab5132")
 

--- a/swift/Tests/Blockchains/KusamaTests.swift
+++ b/swift/Tests/Blockchains/KusamaTests.swift
@@ -30,11 +30,11 @@ class KusamaTests: XCTestCase {
         XCTAssertEqual(address.data.hexString, pubkey.data.hexString)
     }
 
-    func testSigningTransfer() {
+    func testSigningTransfer() throws {
         // https://kusama.subscan.io/extrinsic/0x9211b8f6500c78f4771d18289c6187ec59c2b1fb28e8324ee32a1f9a3303be7e
         // real key in 1p test
         let wallet = HDWallet.test
-        let key = wallet.getKey(coin: .kusama, derivationPath: "m/44'/434'/0'")
+        let key = try XCTUnwrap(wallet.getKey(coin: .kusama, derivationPath: "m/44'/434'/0'"))
 
         let genesisHash = Data(hexString: "0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe")!
         let input = PolkadotSigningInput.with {

--- a/swift/Tests/Blockchains/PolkadotTests.swift
+++ b/swift/Tests/Blockchains/PolkadotTests.swift
@@ -32,10 +32,10 @@ class PolkadotTests: XCTestCase {
         XCTAssertEqual(address.data, pubkey.data)
     }
 
-    func testSignTransfer() {
+    func testSignTransfer() throws {
         // real key in 1p test
         let wallet = HDWallet.test
-        let key = wallet.getKey(coin: .polkadot, derivationPath: "m/44'/354'/0'")
+        let key = try XCTUnwrap(wallet.getKey(coin: .polkadot, derivationPath: "m/44'/354'/0'"))
 
         let input = PolkadotSigningInput.with {
             $0.genesisHash = genesisHash
@@ -60,10 +60,10 @@ class PolkadotTests: XCTestCase {
         XCTAssertEqual(output.encoded.hexString, "410284008d96660f14babe708b5e61853c9f5929bc90dd9874485bf4d6dc32d3e6f22eaa0038ec4973ab9773dfcbf170b8d27d36d89b85c3145e038d68914de83cf1f7aca24af64c55ec51ba9f45c5a4d74a9917dee380e9171108921c3e5546e05be15206050104000500007120f76076bcb0efdf94c7219e116899d0163ea61cb428183d71324eb33b2bce0700e40b5402")
     }
 
-    func testSigningBond() {
+    func testSigningBond() throws {
         // real key in 1p test
         let wallet = HDWallet.test
-        let key = wallet.getKey(coin: .polkadot, derivationPath: "m/44'/354'/0'")
+        let key = try XCTUnwrap(wallet.getKey(coin: .polkadot, derivationPath: "m/44'/354'/0'"))
         let address = CoinType.polkadot.deriveAddress(privateKey: key)
 
         let input = PolkadotSigningInput.with {

--- a/swift/Tests/Keystore/AccountTests.swift
+++ b/swift/Tests/Keystore/AccountTests.swift
@@ -63,6 +63,38 @@ class AccountTests: XCTestCase {
         XCTAssertEqual(privateKey.data.hexString, "b511e175dc474c810ad567557a13a29f9e82576990d5f36dab342dd2d00fb5c4")
     }
 
+    func testDecodeValidAccount() throws {
+        let json = """
+        {
+            "coin": 60,
+            "address": "0xC2D7CF95645D33006175B78989035C7c9061d3F9",
+            "derivation": 0,
+            "derivationPath": "m/44'/60'/0'/0/0",
+            "publicKey": "0499c6f51ad6f98c9c583f8e92bb7758ab2ca9a5110343cd3c30cd8f9f58984eda1d37c02c45011f7b75d74659e9b3e039af69017b0feef0b9faf7adf57e6e7a4e",
+            "extendedPublicKey": ""
+        }
+        """.data(using: .utf8)!
+        let account = try JSONDecoder().decode(Account.self, from: json)
+        XCTAssertEqual(account.address, "0xC2D7CF95645D33006175B78989035C7c9061d3F9")
+        XCTAssertEqual(account.coin, .ethereum)
+        XCTAssertEqual(account.derivation, .default)
+        XCTAssertEqual(account.derivationPath, "m/44'/60'/0'/0/0")
+    }
+
+    func testDecodeInvalidDerivationPath() throws {
+        let json = """
+        {
+            "coin": 60,
+            "address": "0x1234",
+            "derivation": 0,
+            "derivationPath": "m/2147483648",
+            "publicKey": "",
+            "extendedPublicKey": ""
+        }
+        """.data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode(Account.self, from: json))
+    }
+
     func testBCHPrivateKeyWithPaths() throws {
         let key = StoredKey.importHDWallet(mnemonic: words, name: "name", password: password, coin: .bitcoinCash)!
         let wallet = Wallet(keyURL: URL(fileURLWithPath: "/"), key: key)

--- a/tests/common/Keystore/DerivationPathTests.cpp
+++ b/tests/common/Keystore/DerivationPathTests.cpp
@@ -39,6 +39,11 @@ TEST(DerivationPath, InitWithString) {
 TEST(DerivationPath, InitInvalid) {
     ASSERT_THROW(DerivationPath("a/b/c"), std::invalid_argument);
     ASSERT_THROW(DerivationPath("m/44'/60''/"), std::invalid_argument);
+    // Raw index >= 0x80000000 must be rejected: m/2147483648 would derive the
+    // same key as m/0' but string() would emit it without apostrophe.
+    ASSERT_THROW(DerivationPath("m/2147483648"), std::invalid_argument);
+    ASSERT_THROW(DerivationPath("m/2147483648'"), std::invalid_argument);
+    ASSERT_THROW(DerivationPath("m/44'/4294967295"), std::invalid_argument);
 }
 
 TEST(DerivationPath, IndexOutOfBounds) {

--- a/tests/interface/TWAccountTests.cpp
+++ b/tests/interface/TWAccountTests.cpp
@@ -33,3 +33,18 @@ TEST(TWAccount, Create) {
     assertStringsEqual(WRAPS(TWAccountExtendedPublicKey(account.get())), extPubKeyAdd);
     assertStringsEqual(WRAPS(TWAccountPublicKey(account.get())), pubKey);
 }
+
+TEST(TWAccount, CreateInvalidDerivationPath) {
+    const auto account = WRAP(
+        TWAccount,
+        TWAccountCreate(
+            WRAPS(TWStringCreateWithUTF8Bytes("bc1qturc268v0f2srjh4r2zu4t6zk4gdutqd5a6zny")).get(),
+            TWCoinTypeBitcoin,
+            TWDerivationDefault,
+            WRAPS(TWStringCreateWithUTF8Bytes("m/2147483648")).get(),
+            WRAPS(TWStringCreateWithUTF8Bytes("")).get(),
+            WRAPS(TWStringCreateWithUTF8Bytes("")).get()
+        )
+    );
+    EXPECT_EQ(account.get(), nullptr);
+}

--- a/tests/interface/TWHDWalletTests.cpp
+++ b/tests/interface/TWHDWalletTests.cpp
@@ -610,3 +610,22 @@ TEST(TWHDWallet, Derive_XpubPub_vs_PrivPub) {
         EXPECT_EQ(std::string(TWStringUTF8Bytes(WRAPS(TWSegwitAddressDescription(address2.get())).get())), expectedAddress2);
     }
 }
+
+TEST(HDWallet, GetKeyInvalidDerivationPath) {
+    const auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(gWords.get(), gPassphrase.get()));
+    // Raw index >= 0x80000000 without apostrophe must not throw — return null instead.
+    const auto key = WRAP(TWPrivateKey, TWHDWalletGetKey(wallet.get(), TWCoinTypeEthereum, STRING("m/2147483648").get()));
+    EXPECT_EQ(key.get(), nullptr);
+}
+
+TEST(HDWallet, GetKeyByCurveInvalidDerivationPath) {
+    const auto wallet = WRAP(TWHDWallet, TWHDWalletCreateWithMnemonic(gWords.get(), gPassphrase.get()));
+    const auto key = WRAP(TWPrivateKey, TWHDWalletGetKeyByCurve(wallet.get(), TWCurveSECP256k1, STRING("m/2147483648").get()));
+    EXPECT_EQ(key.get(), nullptr);
+}
+
+TEST(HDWallet, GetPublicKeyFromExtendedInvalidDerivationPath) {
+    // Derivation path parsing fails before the extended key is inspected.
+    const auto publicKey = WRAP(TWPublicKey, TWHDWalletGetPublicKeyFromExtended(STRING("xpub").get(), TWCoinTypeBitcoin, STRING("m/2147483648").get()));
+    EXPECT_EQ(publicKey.get(), nullptr);
+}

--- a/tests/interface/TWStoredKeyTests.cpp
+++ b/tests/interface/TWStoredKeyTests.cpp
@@ -800,3 +800,37 @@ TEST(TWStoredKey, FixEncryptionWrongPassword) {
     const auto jsonAfter = string(reinterpret_cast<const char*>(TWDataBytes(jsonDataAfter.get())), TWDataSize(jsonDataAfter.get()));
     EXPECT_EQ(jsonAfter, jsonBefore);
 }
+
+TEST(TWStoredKey, AddAccountDerivationInvalidPath) {
+    const auto passwordString = WRAPS(TWStringCreateWithUTF8Bytes("password"));
+    const auto password = WRAPD(TWDataCreateWithBytes(reinterpret_cast<const uint8_t*>(TWStringUTF8Bytes(passwordString.get())), TWStringSize(passwordString.get())));
+    const auto key = createAStoredKey(TWCoinTypeBitcoin, password.get());
+    const auto countBefore = TWStoredKeyAccountCount(key.get());
+
+    // Must not throw or crash — invalid path is silently ignored.
+    TWStoredKeyAddAccountDerivation(
+        key.get(),
+        WRAPS(TWStringCreateWithUTF8Bytes("bc1qturc268v0f2srjh4r2zu4t6zk4gdutqd5a6zny")).get(),
+        TWCoinTypeBitcoin,
+        TWDerivationDefault,
+        WRAPS(TWStringCreateWithUTF8Bytes("m/2147483648")).get(),
+        WRAPS(TWStringCreateWithUTF8Bytes("")).get(),
+        WRAPS(TWStringCreateWithUTF8Bytes("")).get()
+    );
+    EXPECT_EQ(TWStoredKeyAccountCount(key.get()), countBefore);
+}
+
+TEST(TWStoredKey, RemoveAccountForCoinDerivationPathInvalidPath) {
+    const auto passwordString = WRAPS(TWStringCreateWithUTF8Bytes("password"));
+    const auto password = WRAPD(TWDataCreateWithBytes(reinterpret_cast<const uint8_t*>(TWStringUTF8Bytes(passwordString.get())), TWStringSize(passwordString.get())));
+    const auto key = createAStoredKey(TWCoinTypeBitcoin, password.get());
+    const auto countBefore = TWStoredKeyAccountCount(key.get());
+
+    // Must not throw or crash — invalid path is silently ignored.
+    TWStoredKeyRemoveAccountForCoinDerivationPath(
+        key.get(),
+        TWCoinTypeBitcoin,
+        WRAPS(TWStringCreateWithUTF8Bytes("m/2147483648")).get()
+    );
+    EXPECT_EQ(TWStoredKeyAccountCount(key.get()), countBefore);
+}


### PR DESCRIPTION
This pull request adds stricter validation for derivation path indices to prevent invalid or ambiguous key derivations. The most important changes are:

**Validation improvements:**

* Added a check in the `DerivationPath` constructor to throw an exception if a derivation index is greater than or equal to `0x80000000`, preventing out-of-range indices that could lead to ambiguous key derivations.

**Test coverage:**

* Extended the `DerivationPath` invalid input tests to ensure that derivation paths with indices at or above `0x80000000` are correctly rejected, covering both hardened and non-hardened forms.