### PR TITLE
[sc-142674] feat: Update TON symbol to GRAM in registry files

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -65,7 +65,7 @@ This list is generated from [./registry.json](../registry.json)
 | 529     | Secret           | SCRT   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/secret/info/logo.png" width="32" />       | <https://scrt.network/>       |
 | 564     | Agoric           | BLD    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/agoric/info/logo.png" width="32" />       | <https://agoric.com>          |
 | 595     | Polymesh         | POLYX  | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/polymesh/info/logo.png" width="32" />     | <https://polymesh.network>    |
-| 607     | TON              | TON    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ton/info/logo.png" width="32" />          | <https://ton.org>             |
+| 607     | TON              | GRAM   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ton/info/logo.png" width="32" />          | <https://ton.org>             |
 | 637     | Aptos            | APT    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/aptos/info/logo.png" width="32" />        | <https://aptoslabs.com/>      |
 | 714     | BNB Beacon Chain | BNB    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/info/logo.png" width="32" />      | <https://www.bnbchain.org>    |
 | 784     | Sui              | SUI    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/sui/info/logo.png" width="32" />          | <https://sui.io/>             |

--- a/registry.json
+++ b/registry.json
@@ -4528,7 +4528,7 @@
     "id": "ton",
     "name": "TON",
     "coinId": 607,
-    "symbol": "TON",
+    "symbol": "GRAM",
     "decimals": 9,
     "blockchain": "TheOpenNetwork",
     "derivation": [

--- a/tests/chains/TheOpenNetwork/TWCoinTypeTests.cpp
+++ b/tests/chains/TheOpenNetwork/TWCoinTypeTests.cpp
@@ -24,7 +24,7 @@ TEST(TWTONCoinType, TWCoinType) {
 
     assertStringsEqual(id, "ton");
     assertStringsEqual(name, "TON");
-    assertStringsEqual(symbol, "TON");
+    assertStringsEqual(symbol, "GRAM");
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(coin), 9);
     ASSERT_EQ(TWCoinTypeBlockchain(coin), TWBlockchainTheOpenNetwork);
     ASSERT_EQ(TWCoinTypeP2shPrefix(coin), 0x0);


### PR DESCRIPTION
This pull request updates the symbol for the TON blockchain from "TON" to "GRAM" across the documentation, registry, and tests to ensure consistency.

Symbol update for TON:

* Updated the symbol for TON from "TON" to "GRAM" in the `registry.json` file to reflect the correct token symbol.
* Changed the symbol in the documentation table in `docs/registry.md` from "TON" to "GRAM" for consistency.
* Updated the test case in `TWCoinTypeTests.cpp` to expect "GRAM" as the symbol for TON.