### PR TITLE
chore: Enhance error handling for staking operations in LiquidStaking

### DIFF
--- a/src/LiquidStaking/LiquidStaking.cpp
+++ b/src/LiquidStaking/LiquidStaking.cpp
@@ -4,6 +4,7 @@
 
 #include "LiquidStaking/LiquidStaking.h"
 #include "Data.h"
+#include "Result.h"
 
 // Stride
 #include "proto/Cosmos.pb.h"
@@ -56,36 +57,53 @@ namespace internal {
         transfer.set_amount(amountData.data(), amountData.size());
     }
 
-    void handleStake(const Proto::Stake& stake, const Proto::Blockchain& blockchain, Data& payload, uint256_t& amount, const Proto::Protocol protocol) {
+    Result<void> handleStake(const Proto::Stake& stake, const Proto::Blockchain& blockchain, Data& payload, uint256_t& amount, const Proto::Protocol protocol) {
+        auto protocolIt = gEVMLiquidStakingRegistry.find(protocol);
+        if (protocolIt == gEVMLiquidStakingRegistry.end()) {
+            return Result<void>::failure("The selected protocol is not supported for EVM liquid staking");
+        }
+        auto actionIt = protocolIt->second.find({blockchain, Action::Stake});
+        if (actionIt == protocolIt->second.end()) {
+            return Result<void>::failure("The selected protocol does not support the stake operation on the targeted blockchain");
+        }
         Ethereum::ABI::BaseParams params;
         if (protocol == Proto::Lido) {
             params.emplace_back(std::make_shared<Ethereum::ABI::ProtoAddress>());
         }
-        auto funcData = Ethereum::ABI::Function::encodeFunctionCall(gEVMLiquidStakingRegistry.at(protocol).at({blockchain, Action::Stake}), params);
+        auto funcData = Ethereum::ABI::Function::encodeFunctionCall(actionIt->second, params);
         if (funcData.has_value()) {
             payload = funcData.value();
         }
         amount = uint256_t(stake.amount());
+        return Result<void>::success();
     }
 
-    void handleUnstake(const Proto::Unstake& unstake, const Proto::Blockchain& blockchain, Data& payload) {
+    Result<void> handleUnstake(const Proto::Unstake& unstake, const Proto::Blockchain& blockchain, Data& payload) {
+        auto it = gStraderFunctionRegistry.find({blockchain, Action::Unstake});
+        if (it == gStraderFunctionRegistry.end()) {
+            return Result<void>::failure("Strader protocol does not support the unstake operation on the targeted blockchain");
+        }
         Ethereum::ABI::BaseParams params;
         params.emplace_back(std::make_shared<Ethereum::ABI::ProtoUInt256>(uint256_t(unstake.amount())));
-        auto functionName = gStraderFunctionRegistry.at({blockchain, Action::Unstake});
-        auto funcData = Ethereum::ABI::Function::encodeFunctionCall(functionName, params);
+        auto funcData = Ethereum::ABI::Function::encodeFunctionCall(it->second, params);
         if (funcData.has_value()) {
             payload = funcData.value();
         }
+        return Result<void>::success();
     }
 
-    void handleWithdraw(const Proto::Withdraw& withdraw, const Proto::Blockchain& blockchain, Data& payload) {
+    Result<void> handleWithdraw(const Proto::Withdraw& withdraw, const Proto::Blockchain& blockchain, Data& payload) {
+        auto it = gStraderFunctionRegistry.find({blockchain, Action::Withdraw});
+        if (it == gStraderFunctionRegistry.end()) {
+            return Result<void>::failure("Strader protocol does not support the withdraw operation on the targeted blockchain");
+        }
         Ethereum::ABI::BaseParams params;
         params.emplace_back(std::make_shared<Ethereum::ABI::ProtoUInt256>(uint256_t(withdraw.idx())));
-        auto functionName = gStraderFunctionRegistry.at({blockchain, Action::Withdraw});
-        auto funcData = Ethereum::ABI::Function::encodeFunctionCall(functionName, params);
+        auto funcData = Ethereum::ABI::Function::encodeFunctionCall(it->second, params);
         if (funcData.has_value()) {
             payload = funcData.value();
         }
+        return Result<void>::success();
     }
 }
 
@@ -104,17 +122,29 @@ Proto::Output Builder::buildStraderEVM() const {
 
     auto& transfer = *input.mutable_transaction()->mutable_contract_generic();
 
-    auto visitFunctor = [&transfer, this](const TAction& value) {
+    auto visitFunctor = [&transfer, &output, this](const TAction& value) {
         Data payload;
         uint256_t amount;
 
         if (auto* stake = std::get_if<Proto::Stake>(&value); stake) {
-            internal::handleStake(*stake, mBlockchain, payload, amount, Proto::Protocol::Strader);
+            auto result = internal::handleStake(*stake, mBlockchain, payload, amount, Proto::Protocol::Strader);
+            if (!result) {
+                *output.mutable_status() = generateError(Proto::ERROR_OPERATION_NOT_SUPPORTED_BY_PROTOCOL, result.error());
+                return;
+            }
         } else if (auto* unstake = std::get_if<Proto::Unstake>(&value); unstake) {
-            internal::handleUnstake(*unstake, mBlockchain, payload);
+            auto result = internal::handleUnstake(*unstake, mBlockchain, payload);
+            if (!result) {
+                *output.mutable_status() = generateError(Proto::ERROR_OPERATION_NOT_SUPPORTED_BY_PROTOCOL, result.error());
+                return;
+            }
             amount = uint256_t(0);
         } else if (auto* withdraw = std::get_if<Proto::Withdraw>(&value); withdraw) {
-            internal::handleWithdraw(*withdraw, mBlockchain, payload);
+            auto result = internal::handleWithdraw(*withdraw, mBlockchain, payload);
+            if (!result) {
+                *output.mutable_status() = generateError(Proto::ERROR_OPERATION_NOT_SUPPORTED_BY_PROTOCOL, result.error());
+                return;
+            }
             amount = uint256_t(0);
         }
 
@@ -216,7 +246,11 @@ Proto::Output Builder::buildLidoEVM() const {
         uint256_t amount;
 
         if (auto* stake = std::get_if<Proto::Stake>(&value); stake) {
-            internal::handleStake(*stake, mBlockchain, payload, amount, Proto::Lido);
+            auto result = internal::handleStake(*stake, mBlockchain, payload, amount, Proto::Lido);
+            if (!result) {
+                *output.mutable_status() = generateError(Proto::ERROR_OPERATION_NOT_SUPPORTED_BY_PROTOCOL, result.error());
+                return;
+            }
         } else {
             *output.mutable_status() = generateError(Proto::ERROR_OPERATION_NOT_SUPPORTED_BY_PROTOCOL, "Lido protocol only support stake action for now");
         }

--- a/src/LiquidStaking/LiquidStaking.cpp
+++ b/src/LiquidStaking/LiquidStaking.cpp
@@ -71,9 +71,10 @@ namespace internal {
             params.emplace_back(std::make_shared<Ethereum::ABI::ProtoAddress>());
         }
         auto funcData = Ethereum::ABI::Function::encodeFunctionCall(actionIt->second, params);
-        if (funcData.has_value()) {
-            payload = funcData.value();
+        if (!funcData.has_value()) {
+            return Result<void>::failure("Failed to encode stake function call");
         }
+        payload = funcData.value();
         amount = uint256_t(stake.amount());
         return Result<void>::success();
     }
@@ -86,9 +87,10 @@ namespace internal {
         Ethereum::ABI::BaseParams params;
         params.emplace_back(std::make_shared<Ethereum::ABI::ProtoUInt256>(uint256_t(unstake.amount())));
         auto funcData = Ethereum::ABI::Function::encodeFunctionCall(it->second, params);
-        if (funcData.has_value()) {
-            payload = funcData.value();
+        if (!funcData.has_value()) {
+            return Result<void>::failure("Failed to encode unstake function call");
         }
+        payload = funcData.value();
         return Result<void>::success();
     }
 
@@ -100,9 +102,10 @@ namespace internal {
         Ethereum::ABI::BaseParams params;
         params.emplace_back(std::make_shared<Ethereum::ABI::ProtoUInt256>(uint256_t(withdraw.idx())));
         auto funcData = Ethereum::ABI::Function::encodeFunctionCall(it->second, params);
-        if (funcData.has_value()) {
-            payload = funcData.value();
+        if (!funcData.has_value()) {
+            return Result<void>::failure("Failed to encode withdraw function call");
         }
+        payload = funcData.value();
         return Result<void>::success();
     }
 }

--- a/src/LiquidStaking/LiquidStaking.cpp
+++ b/src/LiquidStaking/LiquidStaking.cpp
@@ -5,6 +5,7 @@
 #include "LiquidStaking/LiquidStaking.h"
 #include "Data.h"
 #include "Result.h"
+#include <cerrno>
 
 // Stride
 #include "proto/Cosmos.pb.h"
@@ -70,12 +71,16 @@ namespace internal {
         if (protocol == Proto::Lido) {
             params.emplace_back(std::make_shared<Ethereum::ABI::ProtoAddress>());
         }
-        auto funcData = Ethereum::ABI::Function::encodeFunctionCall(actionIt->second, params);
-        if (!funcData.has_value()) {
-            return Result<void>::failure("Failed to encode stake function call");
+        try {
+            auto funcData = Ethereum::ABI::Function::encodeFunctionCall(actionIt->second, params);
+            if (!funcData.has_value()) {
+                return Result<void>::failure("Failed to encode stake function call");
+            }
+            payload = funcData.value();
+            amount = uint256_t(stake.amount());
+        } catch (const std::exception& ex) {
+            return Result<void>::failure(std::string("handleStake failed: ") + ex.what());
         }
-        payload = funcData.value();
-        amount = uint256_t(stake.amount());
         return Result<void>::success();
     }
 
@@ -84,13 +89,17 @@ namespace internal {
         if (it == gStraderFunctionRegistry.end()) {
             return Result<void>::failure("Strader protocol does not support the unstake operation on the targeted blockchain");
         }
-        Ethereum::ABI::BaseParams params;
-        params.emplace_back(std::make_shared<Ethereum::ABI::ProtoUInt256>(uint256_t(unstake.amount())));
-        auto funcData = Ethereum::ABI::Function::encodeFunctionCall(it->second, params);
-        if (!funcData.has_value()) {
-            return Result<void>::failure("Failed to encode unstake function call");
+        try {
+            Ethereum::ABI::BaseParams params;
+            params.emplace_back(std::make_shared<Ethereum::ABI::ProtoUInt256>(uint256_t(unstake.amount())));
+            auto funcData = Ethereum::ABI::Function::encodeFunctionCall(it->second, params);
+            if (!funcData.has_value()) {
+                return Result<void>::failure("Failed to encode unstake function call");
+            }
+            payload = funcData.value();
+        } catch (const std::exception& ex) {
+            return Result<void>::failure(std::string("handleUnstake failed: ") + ex.what());
         }
-        payload = funcData.value();
         return Result<void>::success();
     }
 
@@ -99,14 +108,31 @@ namespace internal {
         if (it == gStraderFunctionRegistry.end()) {
             return Result<void>::failure("Strader protocol does not support the withdraw operation on the targeted blockchain");
         }
-        Ethereum::ABI::BaseParams params;
-        params.emplace_back(std::make_shared<Ethereum::ABI::ProtoUInt256>(uint256_t(withdraw.idx())));
-        auto funcData = Ethereum::ABI::Function::encodeFunctionCall(it->second, params);
-        if (!funcData.has_value()) {
-            return Result<void>::failure("Failed to encode withdraw function call");
+        try {
+            Ethereum::ABI::BaseParams params;
+            params.emplace_back(std::make_shared<Ethereum::ABI::ProtoUInt256>(uint256_t(withdraw.idx())));
+            auto funcData = Ethereum::ABI::Function::encodeFunctionCall(it->second, params);
+            if (!funcData.has_value()) {
+                return Result<void>::failure("Failed to encode withdraw function call");
+            }
+            payload = funcData.value();
+        } catch (const std::exception& ex) {
+            return Result<void>::failure(std::string("handleWithdraw failed: ") + ex.what());
         }
-        payload = funcData.value();
         return Result<void>::success();
+    }
+
+    Result<uint64_t> parseUInt64(const std::string& str) {
+        if (str.empty()) {
+            return Result<uint64_t>::failure("Failed to parse amount: empty string");
+        }
+        char* end = nullptr;
+        errno = 0;
+        const unsigned long long val = std::strtoull(str.c_str(), &end, 0);
+        if (end == str.c_str() || *end != '\0' || errno == ERANGE) {
+            return Result<uint64_t>::failure("Failed to parse amount: " + str);
+        }
+        return Result<uint64_t>::success(static_cast<uint64_t>(val));
     }
 }
 
@@ -173,20 +199,38 @@ Proto::Output Builder::buildTortugaAptos() const {
     auto &liquid_staking_message = *input.mutable_liquid_staking_message();
     liquid_staking_message.set_smart_contract_address(*mSmartContractAddress);
 
-    auto visitFunctor = [&liquid_staking_message](const TAction& value) {
+    auto visitFunctor = [&liquid_staking_message, &output](const TAction& value) {
         if (auto* stake = std::get_if<Proto::Stake>(&value); stake) {
+            auto amount = internal::parseUInt64(stake->amount());
+            if (!amount) {
+                *output.mutable_status() = generateError(Proto::ERROR_INPUT_PROTO_DESERIALIZATION, amount.error());
+                return;
+            }
             auto& tortuga_stake = *liquid_staking_message.mutable_stake();
-            tortuga_stake.set_amount(std::strtoull(stake->amount().c_str(), nullptr, 0));
+            tortuga_stake.set_amount(amount.payload());
         } else if (auto* unstake = std::get_if<Proto::Unstake>(&value); unstake) {
+            auto amount = internal::parseUInt64(unstake->amount());
+            if (!amount) {
+                *output.mutable_status() = generateError(Proto::ERROR_INPUT_PROTO_DESERIALIZATION, amount.error());
+                return;
+            }
             auto& tortuga_unstake = *liquid_staking_message.mutable_unstake();
-            tortuga_unstake.set_amount(std::strtoull(unstake->amount().c_str(), nullptr, 0));
+            tortuga_unstake.set_amount(amount.payload());
         } else if (auto* withdraw = std::get_if<Proto::Withdraw>(&value); withdraw) {
+            auto idx = internal::parseUInt64(withdraw->idx());
+            if (!idx) {
+                *output.mutable_status() = generateError(Proto::ERROR_INPUT_PROTO_DESERIALIZATION, idx.error());
+                return;
+            }
             auto& tortuga_claim = *liquid_staking_message.mutable_claim();
-            tortuga_claim.set_idx(std::strtoull(withdraw->idx().c_str(), nullptr, 0));
+            tortuga_claim.set_idx(idx.payload());
         }
     };
 
     std::visit(visitFunctor, this->mAction);
+    if (output.status().code() != Proto::OK) {
+        return output;
+    }
     *output.mutable_aptos() = input;
     return output;
 }
@@ -218,6 +262,9 @@ Proto::Output Builder::buildStride() const {
     };
 
     std::visit(visitFunctor, this->mAction);
+    if (output.status().code() != Proto::OK) {
+        return output;
+    }
     *output.mutable_cosmos() = input;
     return output;
 }

--- a/src/LiquidStaking/LiquidStaking.cpp
+++ b/src/LiquidStaking/LiquidStaking.cpp
@@ -156,6 +156,9 @@ Proto::Output Builder::buildStraderEVM() const {
 
     std::visit(visitFunctor, this->mAction);
 
+    if (output.status().code() != Proto::OK) {
+        return output;
+    }
     *output.mutable_ethereum() = input;
     return output;
 }
@@ -256,12 +259,17 @@ Proto::Output Builder::buildLidoEVM() const {
             }
         } else {
             *output.mutable_status() = generateError(Proto::ERROR_OPERATION_NOT_SUPPORTED_BY_PROTOCOL, "Lido protocol only support stake action for now");
+            return;
         }
 
         internal::setTransferDataAndAmount(transfer, payload, amount);
     };
 
     std::visit(visitFunctor, this->mAction);
+
+    if (output.status().code() != Proto::OK) {
+        return output;
+    }
     *output.mutable_ethereum() = input;
     return output;
 }

--- a/tests/common/LiquidStaking/LiquidStakingTests.cpp
+++ b/tests/common/LiquidStaking/LiquidStakingTests.cpp
@@ -768,4 +768,17 @@ namespace TW::LiquidStaking::tests {
             // Successfully broadcasted https://etherscan.io/tx/0x4d509fd50f474a568419ade4df13b43943b5c8233e980d2217784c512941b3bd
         }
     }
+
+    TEST(LiquidStaking, StraderBnbWithdrawError) {
+        Proto::Input input;
+        input.set_blockchain(Proto::BNB_BSC);
+        input.set_protocol(Proto::Strader);
+        input.set_smart_contract_address("0x7276241a669489e4bbb76f63d2a43bfe63080f2f");
+        Proto::Withdraw withdraw;
+        withdraw.set_idx("3");
+        *input.mutable_withdraw() = withdraw;
+
+        auto output = build(input);
+        ASSERT_EQ(output.status().code(), Proto::ERROR_OPERATION_NOT_SUPPORTED_BY_PROTOCOL);
+    }
 }


### PR DESCRIPTION
This pull request enhances error handling and robustness in the liquid staking module by updating internal handler functions to return detailed error information, and propagating these errors to the output when operations are not supported. Additionally, a new test case is added to verify correct error reporting for unsupported operations.

Error handling improvements:

* Updated the `handleStake`, `handleUnstake`, and `handleWithdraw` functions in `LiquidStaking.cpp` to return a `Result<void>` type, allowing them to signal specific errors when a protocol or operation is not supported, rather than failing silently.
* Modified the `buildStraderEVM` and `buildLidoEVM` builder functions to check the result of handler calls and set the output status with an appropriate error code and message if an operation is not supported. [[1]](diffhunk://#diff-452f6cb4d60c9cb7381f04c74f3ccdabff5771cd4c03719240e94aac39a0dca8L107-R147) [[2]](diffhunk://#diff-452f6cb4d60c9cb7381f04c74f3ccdabff5771cd4c03719240e94aac39a0dca8L219-R253)

Code quality and maintainability:

* Replaced repeated registry lookups with more efficient iterator usage in handler functions, reducing redundant code and improving clarity.
* Added missing include for `Result.h` in `LiquidStaking.cpp` to support the new error handling mechanism.

Testing:

* Added a new test case `StraderBnbWithdrawError` to verify that attempting to withdraw with the Strader protocol on BNB_BSC correctly returns an error status, ensuring the new error handling is functioning as intended.