### PR TITLE
[sc-144760] [sc-144909]: Fix Stellar and NEAR handling wrong input parameters

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -135,6 +135,7 @@ This list is generated from [./registry.json](../registry.json)
 | 10001285 | Moonriver        | MOVR   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/moonriver/info/logo.png" width="32" />    | <https://moonbeam.network/networks/moonriver> |
 | 10002020 | Ronin            | RON    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ronin/info/logo.png" width="32" />        | <https://whitepaper.axieinfinity.com/technology/ronin-ethereum-sidechain> |
 | 10002222 | KavaEvm          | KAVA   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/kavaevm/info/logo.png" width="32" />      | <https://www.kava.io/>        |
+| 10004663 | Robinhood Chain  | ETH    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/robinhoodchain/info/logo.png" width="32" /> | <https://robinhood.com>       |
 | 10004689 | IoTeX EVM        | IOTX   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/iotexevm/info/logo.png" width="32" />     | <https://iotex.io/>           |
 | 10007000 | NativeZetaChain  | ZETA   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/zetachain/info/logo.png" width="32" />    | <https://www.zetachain.com/>  |
 | 10007700 | NativeCanto      | CANTO  | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/nativecanto/info/logo.png" width="32" />  | <https://canto.io/>           |
@@ -143,7 +144,6 @@ This list is generated from [./registry.json](../registry.json)
 | 10009001 | Evmos            | EVMOS  | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/evmos/info/logo.png" width="32" />        | <https://evmos.org/>          |
 | 10042170 | Arbitrum Nova    | ETH    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrumnova/info/logo.png" width="32" /> | <https://nova.arbitrum.io>    |
 | 10042221 | Arbitrum         | ETH    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/info/logo.png" width="32" />     | <https://arbitrum.io>         |
-| 10046630 | Robinhood Chain  | ETH    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/robinhoodchain/info/logo.png" width="32" /> | <https://robinhood.com>       |
 | 11000118 | Sommelier        | SOMM   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/sommelier/info/logo.png" width="32" />    | <https://www.sommelier.finance/> |
 | 12000118 | Fetch AI         | FET    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/fetchai/info/logo.png" width="32" />      | <https://fetch.ai/>           |
 | 13000118 | Mars Hub         | MARS   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/mars/info/logo.png" width="32" />         | <https://marsprotocol.io/>    |

--- a/src/NEAR/Entry.cpp
+++ b/src/NEAR/Entry.cpp
@@ -40,8 +40,13 @@ void Entry::sign([[maybe_unused]] TWCoinType coin, const TW::Data& dataIn, TW::D
 Data Entry::preImageHashes([[maybe_unused]] TWCoinType coin, const Data& txInputData) const {
     return txCompilerTemplate<Proto::SigningInput, TxCompiler::Proto::PreSigningOutput>(
         txInputData, [](const auto& input, auto& output) {
-            const auto signer = Signer(input);
-            auto preImage = signer.signaturePreimage();
+            auto preImageResult = Signer(input).signaturePreimage();
+            if (!preImageResult) {
+                output.set_error(preImageResult.error());
+                output.set_error_message(Common::Proto::SigningError_Name(preImageResult.error()));
+                return;
+            }
+            auto preImage = preImageResult.payload();
             auto preImageHash = Hash::sha256(preImage);
             output.set_data_hash(preImageHash.data(), preImageHash.size());
             output.set_data(preImage.data(), preImage.size());

--- a/src/NEAR/Serialization.cpp
+++ b/src/NEAR/Serialization.cpp
@@ -161,7 +161,10 @@ static void writeAction(Data& data, const Proto::Action& action) {
     }
 }
 
-Data transactionData(const Proto::SigningInput& input) {
+Result<Data, Common::Proto::SigningError> transactionData(const Proto::SigningInput& input) {
+    if (input.block_hash().size() != 32) {
+        return Result<Data, Common::Proto::SigningError>::failure(Common::Proto::Error_invalid_params);
+    }
     Data data;
     writeString(data, input.signer_id());
     auto key = PrivateKey(input.private_key(), TWCurveED25519);
@@ -171,16 +174,18 @@ Data transactionData(const Proto::SigningInput& input) {
     writePublicKey(data, public_key_proto);
     writeU64(data, input.nonce());
     writeString(data, input.receiver_id());
-    const auto& block_hash = input.block_hash();
-    writeRawBuffer(data, block_hash);
+    writeRawBuffer(data, input.block_hash());
     writeU32(data, input.actions_size());
     for (const auto& action : input.actions()) {
         writeAction(data, action);
     }
-    return data;
+    return Result<Data, Common::Proto::SigningError>::success(std::move(data));
 }
 
-Data transactionDataWithPublicKey(const Proto::SigningInput& input) {
+Result<Data, Common::Proto::SigningError> transactionDataWithPublicKey(const Proto::SigningInput& input) {
+    if (input.block_hash().size() != 32) {
+        return Result<Data, Common::Proto::SigningError>::failure(Common::Proto::Error_invalid_params);
+    }
     Data data;
     writeString(data, input.signer_id());
     auto public_key_proto = Proto::PublicKey();
@@ -188,13 +193,12 @@ Data transactionDataWithPublicKey(const Proto::SigningInput& input) {
     writePublicKey(data, public_key_proto);
     writeU64(data, input.nonce());
     writeString(data, input.receiver_id());
-    const auto& block_hash = input.block_hash();
-    writeRawBuffer(data, block_hash);
+    writeRawBuffer(data, input.block_hash());
     writeU32(data, input.actions_size());
     for (const auto& action : input.actions()) {
         writeAction(data, action);
     }
-    return data;
+    return Result<Data, Common::Proto::SigningError>::success(std::move(data));
 }
 
 Data signedTransactionData(const Data& transactionData, const Data& signatureData) {

--- a/src/NEAR/Serialization.cpp
+++ b/src/NEAR/Serialization.cpp
@@ -12,6 +12,7 @@
 namespace TW::NEAR {
 
 using json = nlohmann::json;
+using SigningResult = Result<void, Common::Proto::SigningError>;
 
 static constexpr auto tokenTransferMethodName = "ft_transfer";
 
@@ -27,9 +28,12 @@ static void writeU64(Data& data, uint64_t number) {
     encode64LE(number, data);
 }
 
-static void writeU128(Data& data, const std::string& numberData) {
-    assert(numberData.size() == 16 && "U128 number should be 16 bytes long");
+static SigningResult writeU128(Data& data, const std::string& numberData) {
+    if (numberData.size() != 16) {
+        return SigningResult::failure(Common::Proto::Error_invalid_params);
+    }
     data.insert(std::end(data), std::begin(numberData), std::end(numberData));
+    return SigningResult::success();
 }
 
 template <class T>
@@ -48,57 +52,65 @@ static void writePublicKey(Data& data, const Proto::PublicKey& publicKey) {
     writeRawBuffer(data, keyData);
 }
 
-static void writeTransfer(Data& data, const Proto::Transfer& transfer) {
-    writeU128(data, transfer.deposit());
+static SigningResult writeTransfer(Data& data, const Proto::Transfer& transfer) {
+    return writeU128(data, transfer.deposit());
 }
 
-static void writeFunctionCall(Data& data, const Proto::FunctionCall& functionCall) {
+static SigningResult writeFunctionCall(Data& data, const Proto::FunctionCall& functionCall) {
     writeString(data, functionCall.method_name());
 
     writeU32(data, static_cast<uint32_t>(functionCall.args().size()));
     writeRawBuffer(data, functionCall.args());
 
     writeU64(data, functionCall.gas());
-    writeU128(data, functionCall.deposit());
+    return writeU128(data, functionCall.deposit());
 }
 
-static void writeStake(Data& data, const Proto::Stake& stake) {
-    writeU128(data, stake.stake());
+static SigningResult writeStake(Data& data, const Proto::Stake& stake) {
+    auto result = writeU128(data, stake.stake());
+    if (!result) {
+        return result;
+    }
     writePublicKey(data, stake.public_key());
+    return SigningResult::success();
 }
 
-static void writeFunctionCallPermission(Data& data, const Proto::FunctionCallPermission& functionCallPermission) {
+static SigningResult writeFunctionCallPermission(Data& data, const Proto::FunctionCallPermission& functionCallPermission) {
     if (functionCallPermission.allowance().empty()) {
         writeU8(data, 0);
     } else {
         writeU8(data, 1);
-        writeU128(data, functionCallPermission.allowance());
+        auto result = writeU128(data, functionCallPermission.allowance());
+        if (!result) {
+            return result;
+        }
     }
     writeString(data, functionCallPermission.receiver_id());
     writeU32(data, static_cast<uint32_t>(functionCallPermission.method_names().size()));
     for (auto&& methodName : functionCallPermission.method_names()) {
         writeString(data, methodName);
     }
+    return SigningResult::success();
 }
 
-static void writeAccessKey(Data& data, const Proto::AccessKey& accessKey) {
+static SigningResult writeAccessKey(Data& data, const Proto::AccessKey& accessKey) {
     writeU64(data, accessKey.nonce());
     switch (accessKey.permission_case()) {
     case Proto::AccessKey::kFunctionCall:
         writeU8(data, 0);
-        writeFunctionCallPermission(data, accessKey.function_call());
-        break;
+        return writeFunctionCallPermission(data, accessKey.function_call());
     case Proto::AccessKey::kFullAccess:
         writeU8(data, 1);
         break;
     case Proto::AccessKey::PERMISSION_NOT_SET:
         break;
     }
+    return SigningResult::success();
 }
 
-static void writeAddKey(Data& data, const Proto::AddKey& addKey) {
+static SigningResult writeAddKey(Data& data, const Proto::AddKey& addKey) {
     writePublicKey(data, addKey.public_key());
-    writeAccessKey(data, addKey.access_key());
+    return writeAccessKey(data, addKey.access_key());
 }
 
 static void writeDeleteKey(Data& data, const Proto::DeleteKey& deleteKey) {
@@ -109,7 +121,7 @@ static void writeDeleteAccount(Data& data, const Proto::DeleteAccount& deleteAcc
     writeString(data, deleteAccount.beneficiary_id());
 }
 
-static void writeTokenTransfer(Data& data, const Proto::TokenTransfer& tokenTransfer) {
+static SigningResult writeTokenTransfer(Data& data, const Proto::TokenTransfer& tokenTransfer) {
     writeString(data, tokenTransferMethodName);
 
     json functionCallArgs = {
@@ -122,10 +134,10 @@ static void writeTokenTransfer(Data& data, const Proto::TokenTransfer& tokenTran
     writeRawBuffer(data, functionCallArgsStr);
 
     writeU64(data, tokenTransfer.gas());
-    writeU128(data, tokenTransfer.deposit());
+    return writeU128(data, tokenTransfer.deposit());
 }
 
-static void writeAction(Data& data, const Proto::Action& action) {
+static SigningResult writeAction(Data& data, const Proto::Action& action) {
     uint8_t actionByte = action.payload_case() - Proto::Action::kCreateAccount;
     // `TokenTransfer` action is actually a `FunctionCall`,
     // so we need to set the actionByte to the proper value.
@@ -136,28 +148,23 @@ static void writeAction(Data& data, const Proto::Action& action) {
     writeU8(data, actionByte);
     switch (action.payload_case()) {
     case Proto::Action::kFunctionCall:
-        writeFunctionCall(data, action.function_call());
-        return;
+        return writeFunctionCall(data, action.function_call());
     case Proto::Action::kTransfer:
-        writeTransfer(data, action.transfer());
-        return;
+        return writeTransfer(data, action.transfer());
     case Proto::Action::kStake:
-        writeStake(data, action.stake());
-        return;
+        return writeStake(data, action.stake());
     case Proto::Action::kAddKey:
-        writeAddKey(data, action.add_key());
-        return;
+        return writeAddKey(data, action.add_key());
     case Proto::Action::kDeleteKey:
         writeDeleteKey(data, action.delete_key());
-        return;
+        return SigningResult::success();
     case Proto::Action::kDeleteAccount:
         writeDeleteAccount(data, action.delete_account());
-        return;
+        return SigningResult::success();
     case Proto::Action::kTokenTransfer:
-        writeTokenTransfer(data, action.token_transfer());
-        return;
+        return writeTokenTransfer(data, action.token_transfer());
     default:
-        return;
+        return SigningResult::success();
     }
 }
 
@@ -177,7 +184,10 @@ Result<Data, Common::Proto::SigningError> transactionData(const Proto::SigningIn
     writeRawBuffer(data, input.block_hash());
     writeU32(data, input.actions_size());
     for (const auto& action : input.actions()) {
-        writeAction(data, action);
+        auto result = writeAction(data, action);
+        if (!result) {
+            return Result<Data, Common::Proto::SigningError>::failure(result.error());
+        }
     }
     return Result<Data, Common::Proto::SigningError>::success(std::move(data));
 }
@@ -196,7 +206,10 @@ Result<Data, Common::Proto::SigningError> transactionDataWithPublicKey(const Pro
     writeRawBuffer(data, input.block_hash());
     writeU32(data, input.actions_size());
     for (const auto& action : input.actions()) {
-        writeAction(data, action);
+        auto result = writeAction(data, action);
+        if (!result) {
+            return Result<Data, Common::Proto::SigningError>::failure(result.error());
+        }
     }
     return Result<Data, Common::Proto::SigningError>::success(std::move(data));
 }

--- a/src/NEAR/Serialization.h
+++ b/src/NEAR/Serialization.h
@@ -5,11 +5,12 @@
 #pragma once
 
 #include "../proto/NEAR.pb.h"
+#include "../Result.h"
 #include "Data.h"
 
 namespace TW::NEAR {
 
-Data transactionData(const Proto::SigningInput& input);
+Result<Data, Common::Proto::SigningError> transactionData(const Proto::SigningInput& input);
 Data signedTransactionData(const Data& transactionData, const Data& signatureData);
-Data transactionDataWithPublicKey(const Proto::SigningInput& input);
+Result<Data, Common::Proto::SigningError> transactionDataWithPublicKey(const Proto::SigningInput& input);
 } // namespace TW::NEAR

--- a/src/NEAR/Signer.cpp
+++ b/src/NEAR/Signer.cpp
@@ -11,7 +11,14 @@
 namespace TW::NEAR {
 
 Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) {
-    auto transaction = transactionData(input);
+    auto txResult = transactionData(input);
+    if (!txResult) {
+        Proto::SigningOutput output;
+        output.set_error(txResult.error());
+        output.set_error_message(Common::Proto::SigningError_Name(txResult.error()));
+        return output;
+    }
+    auto transaction = txResult.payload();
     auto key = PrivateKey(input.private_key(), TWCurveED25519);
     auto hash = Hash::sha256(transaction);
     auto signature = key.sign(hash);
@@ -22,22 +29,28 @@ Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) {
     return output;
 }
 
-Data Signer::signaturePreimage() const {
+Result<Data, Common::Proto::SigningError> Signer::signaturePreimage() const {
     return TW::NEAR::transactionDataWithPublicKey(input);
-};
+}
 
 Proto::SigningOutput Signer::compile(const Data& signature, const PublicKey& publicKey) const {
-    // validate public key
     if (publicKey.type != TWPublicKeyTypeED25519) {
         throw std::invalid_argument("Invalid public key");
     }
-    auto preImage = signaturePreimage();
+    auto preImageResult = signaturePreimage();
+    if (!preImageResult) {
+        Proto::SigningOutput output;
+        output.set_error(preImageResult.error());
+        output.set_error_message(Common::Proto::SigningError_Name(preImageResult.error()));
+        return output;
+    }
+    auto preImage = preImageResult.payload();
     auto hash = Hash::sha256(preImage);
-    {
-        // validate correctness of signature
-        if (!publicKey.verify(signature, hash)) {
-            throw std::invalid_argument("Invalid signature/hash/publickey combination");
-        }
+    if (!publicKey.verify(signature, hash)) {
+        Proto::SigningOutput output;
+        output.set_error(Common::Proto::Error_signing);
+        output.set_error_message("Invalid signature/hash/publickey combination");
+        return output;
     }
     auto signedPreImage = TW::NEAR::signedTransactionData(preImage, signature);
     auto output = Proto::SigningOutput();

--- a/src/NEAR/Signer.cpp
+++ b/src/NEAR/Signer.cpp
@@ -35,7 +35,10 @@ Result<Data, Common::Proto::SigningError> Signer::signaturePreimage() const {
 
 Proto::SigningOutput Signer::compile(const Data& signature, const PublicKey& publicKey) const {
     if (publicKey.type != TWPublicKeyTypeED25519) {
-        throw std::invalid_argument("Invalid public key");
+        Proto::SigningOutput output;
+        output.set_error(Common::Proto::Error_invalid_params);
+        output.set_error_message("Invalid public key type: expected ED25519");
+        return output;
     }
     auto preImageResult = signaturePreimage();
     if (!preImageResult) {

--- a/src/NEAR/Signer.h
+++ b/src/NEAR/Signer.h
@@ -7,6 +7,7 @@
 #include "../proto/NEAR.pb.h"
 #include "../Data.h"
 #include "../PublicKey.h"
+#include "../Result.h"
 
 namespace TW::NEAR {
 
@@ -20,7 +21,7 @@ class Signer {
     /// Signs the given transaction.
     static Proto::SigningOutput sign(const Proto::SigningInput& input);
     Proto::SigningOutput compile(const Data& signature, const PublicKey& publicKey) const;
-    Data signaturePreimage() const;
+    Result<Data, Common::Proto::SigningError> signaturePreimage() const;
 };
 
 } // namespace TW::NEAR

--- a/src/Stellar/Entry.cpp
+++ b/src/Stellar/Entry.cpp
@@ -33,9 +33,13 @@ void Entry::sign([[maybe_unused]] TWCoinType coin, const TW::Data& dataIn, TW::D
 TW::Data Entry::preImageHashes([[maybe_unused]] TWCoinType coin, const Data& txInputData) const {
     return txCompilerTemplate<Proto::SigningInput, TxCompiler::Proto::PreSigningOutput>(
         txInputData, [](const auto& input, auto& output) {
-            Signer signer(input);
-
-            auto preImage = signer.signaturePreimage();
+            auto preImageResult = Signer(input).signaturePreimage();
+            if (!preImageResult) {
+                output.set_error(Common::Proto::Error_invalid_memo);
+                output.set_error_message(preImageResult.error());
+                return;
+            }
+            auto preImage = preImageResult.payload();
             auto preImageHash = Hash::sha256(preImage);
             output.set_data_hash(preImageHash.data(), preImageHash.size());
             output.set_data(preImage.data(), preImage.size());

--- a/src/Stellar/Entry.cpp
+++ b/src/Stellar/Entry.cpp
@@ -35,8 +35,8 @@ TW::Data Entry::preImageHashes([[maybe_unused]] TWCoinType coin, const Data& txI
         txInputData, [](const auto& input, auto& output) {
             auto preImageResult = Signer(input).signaturePreimage();
             if (!preImageResult) {
-                output.set_error(Common::Proto::Error_invalid_memo);
-                output.set_error_message(preImageResult.error());
+                output.set_error(preImageResult.error());
+                output.set_error_message(Common::Proto::SigningError_Name(preImageResult.error()));
                 return;
             }
             auto preImage = preImageResult.payload();

--- a/src/Stellar/Signer.cpp
+++ b/src/Stellar/Signer.cpp
@@ -6,7 +6,7 @@
 #include "Base64.h"
 #include "../BinaryCoding.h"
 #include "../Hash.h"
-#include "../HexCoding.h"
+#include "../PrivateKey.h"
 #include "../proto/Stellar.pb.h"
 
 #include <TrustWalletCore/TWStellarMemoType.h>
@@ -15,29 +15,28 @@ using namespace TW;
 
 namespace TW::Stellar {
 Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) {
-    if (input.has_memo_hash() && input.memo_hash().hash().size() != 32) {
-        auto output = Proto::SigningOutput();
-        output.set_error(Common::Proto::Error_invalid_memo);
-        output.set_error_message("memo_hash must be exactly 32 bytes");
-        return output;
-    }
-    if (input.has_memo_return_hash() && input.memo_return_hash().hash().size() != 32) {
-        auto output = Proto::SigningOutput();
-        output.set_error(Common::Proto::Error_invalid_memo);
-        output.set_error_message("memo_return_hash must be exactly 32 bytes");
-        return output;
-    }
     auto signer = Signer(input);
-    auto output = Proto::SigningOutput();
-    output.set_signature(signer.sign());
+    auto signResult = signer.sign();
+    if (!signResult) {
+        Proto::SigningOutput output;
+        output.set_error(Common::Proto::Error_invalid_memo);
+        output.set_error_message(signResult.error());
+        return output;
+    }
+    Proto::SigningOutput output;
+    output.set_signature(signResult.payload());
     return output;
 }
 
-std::string Signer::sign() const {
+Result<std::string> Signer::sign() const {
+    auto encodeResult = encode(_input);
+    if (!encodeResult) {
+        return Result<std::string>::failure(encodeResult.error());
+    }
+    auto encoded = encodeResult.payload();
 
     auto key = PrivateKey(_input.private_key(), TWCurveED25519);
     auto account = Address(_input.account());
-    auto encoded = encode(_input);
 
     auto encodedWithHeaders = Data();
     auto publicNetwork = _input.passphrase(); // Header
@@ -51,20 +50,25 @@ std::string Signer::sign() const {
     auto hash = Hash::sha256(encodedWithHeaders);
     auto data = Data(hash.begin(), hash.end());
 
-    auto sign = key.sign(data);
+    auto sig = key.sign(data);
 
     auto signature = Data();
     signature.insert(signature.end(), encoded.begin(), encoded.end());
     encode32BE(1, signature);
     signature.insert(signature.end(), account.bytes.end() - 4, account.bytes.end());
-    encode32BE(static_cast<uint32_t>(sign.size()), signature);
-    signature.insert(signature.end(), sign.begin(), sign.end());
-    return Base64::encode(signature);
+    encode32BE(static_cast<uint32_t>(sig.size()), signature);
+    signature.insert(signature.end(), sig.begin(), sig.end());
+    return Result<std::string>::success(Base64::encode(signature));
 }
 
-Data Signer::encode(const Proto::SigningInput& input) const {
-    //    Address account, uint32_t fee, uint64_t sequence, uint32_t memoType,
-    //    Data memoData, Address destination, uint64_t amount;
+Result<Data> Signer::encode(const Proto::SigningInput& input) const {
+    if (input.has_memo_hash() && input.memo_hash().hash().size() != 32) {
+        return Result<Data>::failure("memo_hash must be exactly 32 bytes");
+    }
+    if (input.has_memo_return_hash() && input.memo_return_hash().hash().size() != 32) {
+        return Result<Data>::failure("memo_return_hash must be exactly 32 bytes");
+    }
+
     auto data = Data();
 
     encodeAddress(Address(input.account()), data);
@@ -148,18 +152,22 @@ Data Signer::encode(const Proto::SigningInput& input) const {
         encode32BE((uint32_t)ClaimableBalanceIdTypeClaimableBalanceIdTypeV0, data);
         const auto balanceId = input.op_claim_claimable_balance().balance_id();
         if (balanceId.size() != 32) {
-            return Data();
+            return Result<Data>::failure("balance_id must be exactly 32 bytes");
         }
         data.insert(data.end(), balanceId.begin(), balanceId.end());
     } break;
     }
 
     encode32BE(0, data); // Ext
-    return data;
+    return Result<Data>::success(std::move(data));
 }
 
-Data Signer::signaturePreimage() const {
-    auto encoded = encode(_input);
+Result<Data> Signer::signaturePreimage() const {
+    auto encodeResult = encode(_input);
+    if (!encodeResult) {
+        return Result<Data>::failure(encodeResult.error());
+    }
+    auto encoded = encodeResult.payload();
 
     auto encodedWithHeaders = Data();
     auto publicNetwork = _input.passphrase(); // Header
@@ -169,12 +177,19 @@ Data Signer::signaturePreimage() const {
     encodedWithHeaders.insert(encodedWithHeaders.end(), transactionType.begin(),
                               transactionType.end());
     encodedWithHeaders.insert(encodedWithHeaders.end(), encoded.begin(), encoded.end());
-    return encodedWithHeaders;
+    return Result<Data>::success(std::move(encodedWithHeaders));
 }
 
 Proto::SigningOutput Signer::compile(const Data& sig) const {
+    auto encodeResult = encode(_input);
+    if (!encodeResult) {
+        Proto::SigningOutput output;
+        output.set_error(Common::Proto::Error_invalid_memo);
+        output.set_error_message(encodeResult.error());
+        return output;
+    }
+    auto encoded = encodeResult.payload();
     auto account = Address(_input.account());
-    auto encoded = encode(_input);
 
     auto signature = Data();
     signature.insert(signature.end(), encoded.begin(), encoded.end());

--- a/src/Stellar/Signer.cpp
+++ b/src/Stellar/Signer.cpp
@@ -15,6 +15,18 @@ using namespace TW;
 
 namespace TW::Stellar {
 Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) {
+    if (input.has_memo_hash() && input.memo_hash().hash().size() != 32) {
+        auto output = Proto::SigningOutput();
+        output.set_error(Common::Proto::Error_invalid_memo);
+        output.set_error_message("memo_hash must be exactly 32 bytes");
+        return output;
+    }
+    if (input.has_memo_return_hash() && input.memo_return_hash().hash().size() != 32) {
+        auto output = Proto::SigningOutput();
+        output.set_error(Common::Proto::Error_invalid_memo);
+        output.set_error_message("memo_return_hash must be exactly 32 bytes");
+        return output;
+    }
     auto signer = Signer(input);
     auto output = Proto::SigningOutput();
     output.set_signature(signer.sign());

--- a/src/Stellar/Signer.cpp
+++ b/src/Stellar/Signer.cpp
@@ -19,8 +19,8 @@ Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) {
     auto signResult = signer.sign();
     if (!signResult) {
         Proto::SigningOutput output;
-        output.set_error(Common::Proto::Error_invalid_memo);
-        output.set_error_message(signResult.error());
+        output.set_error(signResult.error());
+        output.set_error_message(Common::Proto::SigningError_Name(signResult.error()));
         return output;
     }
     Proto::SigningOutput output;
@@ -28,10 +28,10 @@ Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) {
     return output;
 }
 
-Result<std::string> Signer::sign() const {
+Result<std::string, Common::Proto::SigningError> Signer::sign() const {
     auto encodeResult = encode(_input);
     if (!encodeResult) {
-        return Result<std::string>::failure(encodeResult.error());
+        return Result<std::string, Common::Proto::SigningError>::failure(encodeResult.error());
     }
     auto encoded = encodeResult.payload();
 
@@ -58,15 +58,15 @@ Result<std::string> Signer::sign() const {
     signature.insert(signature.end(), account.bytes.end() - 4, account.bytes.end());
     encode32BE(static_cast<uint32_t>(sig.size()), signature);
     signature.insert(signature.end(), sig.begin(), sig.end());
-    return Result<std::string>::success(Base64::encode(signature));
+    return Result<std::string, Common::Proto::SigningError>::success(Base64::encode(signature));
 }
 
-Result<Data> Signer::encode(const Proto::SigningInput& input) const {
+Result<Data, Common::Proto::SigningError> Signer::encode(const Proto::SigningInput& input) const {
     if (input.has_memo_hash() && input.memo_hash().hash().size() != 32) {
-        return Result<Data>::failure("memo_hash must be exactly 32 bytes");
+        return Result<Data, Common::Proto::SigningError>::failure(Common::Proto::Error_invalid_memo);
     }
     if (input.has_memo_return_hash() && input.memo_return_hash().hash().size() != 32) {
-        return Result<Data>::failure("memo_return_hash must be exactly 32 bytes");
+        return Result<Data, Common::Proto::SigningError>::failure(Common::Proto::Error_invalid_memo);
     }
 
     auto data = Data();
@@ -152,20 +152,20 @@ Result<Data> Signer::encode(const Proto::SigningInput& input) const {
         encode32BE((uint32_t)ClaimableBalanceIdTypeClaimableBalanceIdTypeV0, data);
         const auto balanceId = input.op_claim_claimable_balance().balance_id();
         if (balanceId.size() != 32) {
-            return Result<Data>::failure("balance_id must be exactly 32 bytes");
+            return Result<Data, Common::Proto::SigningError>::failure(Common::Proto::Error_invalid_params);
         }
         data.insert(data.end(), balanceId.begin(), balanceId.end());
     } break;
     }
 
     encode32BE(0, data); // Ext
-    return Result<Data>::success(std::move(data));
+    return Result<Data, Common::Proto::SigningError>::success(std::move(data));
 }
 
-Result<Data> Signer::signaturePreimage() const {
+Result<Data, Common::Proto::SigningError> Signer::signaturePreimage() const {
     auto encodeResult = encode(_input);
     if (!encodeResult) {
-        return Result<Data>::failure(encodeResult.error());
+        return Result<Data, Common::Proto::SigningError>::failure(encodeResult.error());
     }
     auto encoded = encodeResult.payload();
 
@@ -177,15 +177,15 @@ Result<Data> Signer::signaturePreimage() const {
     encodedWithHeaders.insert(encodedWithHeaders.end(), transactionType.begin(),
                               transactionType.end());
     encodedWithHeaders.insert(encodedWithHeaders.end(), encoded.begin(), encoded.end());
-    return Result<Data>::success(std::move(encodedWithHeaders));
+    return Result<Data, Common::Proto::SigningError>::success(std::move(encodedWithHeaders));
 }
 
 Proto::SigningOutput Signer::compile(const Data& sig) const {
     auto encodeResult = encode(_input);
     if (!encodeResult) {
         Proto::SigningOutput output;
-        output.set_error(Common::Proto::Error_invalid_memo);
-        output.set_error_message(encodeResult.error());
+        output.set_error(encodeResult.error());
+        output.set_error_message(Common::Proto::SigningError_Name(encodeResult.error()));
         return output;
     }
     auto encoded = encodeResult.payload();

--- a/src/Stellar/Signer.h
+++ b/src/Stellar/Signer.h
@@ -23,10 +23,10 @@ class Signer {
     Signer(const Proto::SigningInput& input) : _input(input) {}
 
     /// Signs the given transaction.
-    Result<std::string> sign() const;
+    Result<std::string, Common::Proto::SigningError> sign() const;
 
-    Result<Data> encode(const Proto::SigningInput& input) const;
-    Result<Data> signaturePreimage() const;
+    Result<Data, Common::Proto::SigningError> encode(const Proto::SigningInput& input) const;
+    Result<Data, Common::Proto::SigningError> signaturePreimage() const;
     Proto::SigningOutput compile(const Data& sig) const;
 
   private:

--- a/src/Stellar/Signer.h
+++ b/src/Stellar/Signer.h
@@ -5,8 +5,7 @@
 
 #include "Address.h"
 #include "Data.h"
-#include "../Hash.h"
-#include "../PrivateKey.h"
+#include "../Result.h"
 #include "../proto/Stellar.pb.h"
 
 #include <string>
@@ -17,16 +16,17 @@ class Signer {
   public:
     /// Signs a Proto::SigningInput transaction
     static Proto::SigningOutput sign(const Proto::SigningInput& input);
+
   public:
     const Proto::SigningInput& _input;
 
     Signer(const Proto::SigningInput& input) : _input(input) {}
 
     /// Signs the given transaction.
-    std::string sign() const;
+    Result<std::string> sign() const;
 
-    Data encode(const Proto::SigningInput& input) const;
-    Data signaturePreimage() const;
+    Result<Data> encode(const Proto::SigningInput& input) const;
+    Result<Data> signaturePreimage() const;
     Proto::SigningOutput compile(const Data& sig) const;
 
   private:

--- a/tests/chains/NEAR/SerializationTests.cpp
+++ b/tests/chains/NEAR/SerializationTests.cpp
@@ -32,7 +32,7 @@ TEST(NEARSerialization, SerializeTransferTransaction) {
     auto privateKey = Base58::decode("3hoMW1HvnRLSFCLZnvPzWeoGwtdHzke34B2cTHM8rhcbG3TbuLKtShTv3DvyejnXKXKBiV7YPkLeqUHN1ghnqpFv");
     input.set_private_key(privateKey.data(), 32);
 
-    auto serialized = transactionData(input);
+    auto serialized = transactionData(input).payload();
     auto serializedHex = hex(serialized);
 
     ASSERT_EQ(serializedHex, "09000000746573742e6e65617200917b3d268d4b58f7fec1b150bd68d69be3ee5d4cc39855e341538465bb77860d01000000000000000d00000077686174657665722e6e6561720fa473fd26901df296be6adc4cc4df34d040efa2435224b6986910e630c2fef6010000000301000000000000000000000000000000");
@@ -68,7 +68,7 @@ TEST(NEARSerialization, SerializeFunctionCallTransaction) {
     auto privateKey = Base58::decode("3hoMW1HvnRLSFCLZnvPzWeoGwtdHzke34B2cTHM8rhcbG3TbuLKtShTv3DvyejnXKXKBiV7YPkLeqUHN1ghnqpFv");
     input.set_private_key(privateKey.data(), 32);
 
-    auto serialized = transactionData(input);
+    auto serialized = transactionData(input).payload();
     auto serializedHex = hex(serialized);
 
     ASSERT_EQ(serializedHex, "09000000746573742e6e65617200917b3d268d4b58f7fec1b150bd68d69be3ee5d4cc39855e341538465bb77860d01000000000000000d00000077686174657665722e6e6561720fa473fd26901df296be6adc4cc4df34d040efa2435224b6986910e630c2fef601000000020300000071717103000000010203e80300000000000001000000000000000000000000000000");
@@ -98,7 +98,7 @@ TEST(NEARSerialization, SerializeStakeTransaction) {
     auto privateKey = Base58::decode("3hoMW1HvnRLSFCLZnvPzWeoGwtdHzke34B2cTHM8rhcbG3TbuLKtShTv3DvyejnXKXKBiV7YPkLeqUHN1ghnqpFv");
     input.set_private_key(privateKey.data(), 32);
 
-    auto serialized = transactionData(input);
+    auto serialized = transactionData(input).payload();
     auto serializedHex = hex(serialized);
 
     ASSERT_EQ(serializedHex, "09000000746573742e6e65617200917b3d268d4b58f7fec1b150bd68d69be3ee5d4cc39855e341538465bb77860d01000000000000000d00000077686174657665722e6e6561720fa473fd26901df296be6adc4cc4df34d040efa2435224b6986910e630c2fef601000000040100000000000000000000000000000000917b3d268d4b58f7fec1b150bd68d69be3ee5d4cc39855e341538465bb77860d");
@@ -128,7 +128,7 @@ TEST(NEARSerialization, SerializeStakeTransaction2) {
     auto privateKey = Base58::decode("5Cfk7QBnmDxxFxQk75FFq4ADrQS9gxHKe6vtuGH6JCCm8WV8aRPEGVqp579JHNmmHMUt49gkCVcH2t7NRnh2v7Qu");
     input.set_private_key(privateKey.data(), 32);
 
-    auto serialized = transactionData(input);
+    auto serialized = transactionData(input).payload();
     auto serializedHex = hex(serialized);
 
     ASSERT_EQ(serializedHex, "0b0000007664782e746573746e657400a3cb23dbb9810abd4a6804328eec47a17236383b5c234cae903b064e9dc426dac5863d28b35400000b0000007664782e746573746e6574a2fbdae8a769c636d109952e4fe760b03688e629933cbf693aedfd97a470c7a50100000004000000fa4f3f757902ae0b080000000000a3cb23dbb9810abd4a6804328eec47a17236383b5c234cae903b064e9dc426da");
@@ -161,7 +161,7 @@ TEST(NEARSerialization, SerializeAddKeyFunctionCallTransaction) {
     auto privateKey = Base58::decode("3hoMW1HvnRLSFCLZnvPzWeoGwtdHzke34B2cTHM8rhcbG3TbuLKtShTv3DvyejnXKXKBiV7YPkLeqUHN1ghnqpFv");
     input.set_private_key(privateKey.data(), 32);
 
-    auto serialized = transactionData(input);
+    auto serialized = transactionData(input).payload();
     auto serializedHex = hex(serialized);
 
     ASSERT_EQ(serializedHex, "09000000746573742e6e65617200917b3d268d4b58f7fec1b150bd68d69be3ee5d4cc39855e341538465bb77860d01000000000000000d00000077686174657665722e6e6561720fa473fd26901df296be6adc4cc4df34d040efa2435224b6986910e630c2fef6010000000500917b3d268d4b58f7fec1b150bd68d69be3ee5d4cc39855e341538465bb77860d00000000000000000000030000007a7a7a0100000003000000777777");
@@ -193,7 +193,7 @@ TEST(NEARSerialization, SerializeAddKeyFullAccessTransaction) {
     auto privateKey = Base58::decode("3hoMW1HvnRLSFCLZnvPzWeoGwtdHzke34B2cTHM8rhcbG3TbuLKtShTv3DvyejnXKXKBiV7YPkLeqUHN1ghnqpFv");
     input.set_private_key(privateKey.data(), 32);
 
-    auto serialized = transactionData(input);
+    auto serialized = transactionData(input).payload();
     auto serializedHex = hex(serialized);
 
     ASSERT_EQ(serializedHex, "09000000746573742e6e65617200917b3d268d4b58f7fec1b150bd68d69be3ee5d4cc39855e341538465bb77860d01000000000000000d00000077686174657665722e6e6561720fa473fd26901df296be6adc4cc4df34d040efa2435224b6986910e630c2fef6010000000500917b3d268d4b58f7fec1b150bd68d69be3ee5d4cc39855e341538465bb77860d000000000000000001");
@@ -220,7 +220,7 @@ TEST(NEARSerialization, SerializeDeleteKeyTransaction) {
     auto privateKey = Base58::decode("3hoMW1HvnRLSFCLZnvPzWeoGwtdHzke34B2cTHM8rhcbG3TbuLKtShTv3DvyejnXKXKBiV7YPkLeqUHN1ghnqpFv");
     input.set_private_key(privateKey.data(), 32);
 
-    auto serialized = transactionData(input);
+    auto serialized = transactionData(input).payload();
     auto serializedHex = hex(serialized);
 
     ASSERT_EQ(serializedHex, "09000000746573742e6e65617200917b3d268d4b58f7fec1b150bd68d69be3ee5d4cc39855e341538465bb77860d01000000000000000d00000077686174657665722e6e6561720fa473fd26901df296be6adc4cc4df34d040efa2435224b6986910e630c2fef6010000000600917b3d268d4b58f7fec1b150bd68d69be3ee5d4cc39855e341538465bb77860d");
@@ -243,7 +243,7 @@ TEST(NEARSerialization, SerializeCreateAccountTransaction) {
     auto privateKey = Base58::decode("3hoMW1HvnRLSFCLZnvPzWeoGwtdHzke34B2cTHM8rhcbG3TbuLKtShTv3DvyejnXKXKBiV7YPkLeqUHN1ghnqpFv");
     input.set_private_key(privateKey.data(), 32);
 
-    auto serialized = transactionData(input);
+    auto serialized = transactionData(input).payload();
     auto serializedHex = hex(serialized);
 
     ASSERT_EQ(serializedHex, "09000000746573742e6e65617200917b3d268d4b58f7fec1b150bd68d69be3ee5d4cc39855e341538465bb77860d01000000000000000d00000077686174657665722e6e6561720fa473fd26901df296be6adc4cc4df34d040efa2435224b6986910e630c2fef60100000000");
@@ -267,7 +267,7 @@ TEST(NEARSerialization, SerializeDeleteAccountTransaction) {
     auto privateKey = Base58::decode("3hoMW1HvnRLSFCLZnvPzWeoGwtdHzke34B2cTHM8rhcbG3TbuLKtShTv3DvyejnXKXKBiV7YPkLeqUHN1ghnqpFv");
     input.set_private_key(privateKey.data(), 32);
 
-    auto serialized = transactionData(input);
+    auto serialized = transactionData(input).payload();
     auto serializedHex = hex(serialized);
 
     ASSERT_EQ(serializedHex, "09000000746573742e6e65617200917b3d268d4b58f7fec1b150bd68d69be3ee5d4cc39855e341538465bb77860d01000000000000000d00000077686174657665722e6e6561720fa473fd26901df296be6adc4cc4df34d040efa2435224b6986910e630c2fef6010000000703000000313233");

--- a/tests/chains/NEAR/TWAnySignerTests.cpp
+++ b/tests/chains/NEAR/TWAnySignerTests.cpp
@@ -159,4 +159,28 @@ TEST(TWAnySignerNEAR, SignTokenTransfer) {
     ASSERT_EQ(Base64::encode(data(output.signed_transaction())), "QAAAADEwNTM5NjIyOGFjMmUwZWYxNDRiOTNiY2M1MzIyZmNhMTE2N2Q1MjQ0MjJiYjczZDE3NDQwZDM1YzcxNGE1OGYAEFOWIorC4O8US5O8xTIvyhFn1SRCK7c9F0QNNccUpY8D5MPmo1QAABAAAAB0b2tlbi5wYXJhcy5uZWFyGC7O0jXN2b4SH1XfMtNISEnU8XATKOhZwxx0pLLZqTEBAAAAAgsAAABmdF90cmFuc2ZlcnAAAAB7ImFtb3VudCI6IjEwMDAwMDAwMDAwMDAwMDAwMCIsInJlY2VpdmVyX2lkIjoiYzZkNWUzZThmMzI4NDM2ZjU5NTg1NmE1OTgyMzliNjkxZDNkMTM2YjI0YzA1YTQ2MTRmOWU5NzE2ZWRjMTRmZSJ9APCrdaQNAAABAAAAAAAAAAAAAAAAAAAAANUjO7fmnTebSNW9EcHHwYwPNlQJcReGWJfJUuxWzPDAGEeo4JTcLB8pLCkqxKKsI0NE1Szv2+GAt5mCBum5mQY=");
 }
 
+TEST(TWAnySignerNEAR, Sign_InvalidBlockHash) {
+    auto privateKey = parse_hex("8737b99bf16fba78e1e753e23ba00c4b5423ac9c45d9b9caae9a519434786568");
+    auto deposit = parse_hex("01000000000000000000000000000000");
+
+    Proto::SigningInput input;
+    input.set_signer_id("test.near");
+    input.set_nonce(1);
+    input.set_receiver_id("whatever.near");
+    input.set_private_key(privateKey.data(), privateKey.size());
+
+    auto& action = *input.add_actions();
+    action.mutable_transfer()->set_deposit(deposit.data(), deposit.size());
+
+    // 31 bytes — one byte short of the required 32
+    auto shortHash = parse_hex("0fa473fd26901df296be6adc4cc4df34d040efa2435224b6986910e630c2f");
+    input.set_block_hash(shortHash.data(), shortHash.size());
+
+    Proto::SigningOutput output;
+    ANY_SIGN(input, TWCoinTypeNEAR);
+
+    EXPECT_EQ(output.error(), Common::Proto::Error_invalid_params);
+    EXPECT_TRUE(output.signed_transaction().empty());
+}
+
 } // namespace TW::NEAR

--- a/tests/chains/NEAR/TransactionCompilerTests.cpp
+++ b/tests/chains/NEAR/TransactionCompilerTests.cpp
@@ -89,3 +89,60 @@ TEST(NEARCompiler, CompileWithSignatures) {
         EXPECT_EQ(output.error(), Common::Proto::Error_no_support_n2n);
     }
 }
+
+TEST(NEARCompiler, PreImageHashes_InvalidBlockHash) {
+    const auto coin = TWCoinTypeNEAR;
+    auto input = TW::NEAR::Proto::SigningInput();
+    input.set_signer_id("test.near");
+    input.set_receiver_id("whatever.near");
+    input.set_nonce(1);
+    input.set_public_key(Base58::decode("Anu7LYDfpLtkP7E16LT9imXF694BdQaa9ufVkQiwTQxC").data(), 32);
+
+    Data deposit(16, 0);
+    deposit[0] = 1;
+    input.add_actions()->mutable_transfer()->set_deposit(deposit.data(), deposit.size());
+
+    // 31 bytes — one byte short of the required 32
+    auto shortHash = parse_hex("0fa473fd26901df296be6adc4cc4df34d040efa2435224b6986910e630c2f");
+    input.set_block_hash(shortHash.data(), shortHash.size());
+
+    const auto inputString = input.SerializeAsString();
+    const auto inputStrData = TW::Data(inputString.begin(), inputString.end());
+
+    const auto preImageHashesData = TransactionCompiler::preImageHashes(coin, inputStrData);
+    TW::TxCompiler::Proto::PreSigningOutput preSigningOutput;
+    ASSERT_TRUE(preSigningOutput.ParseFromArray(preImageHashesData.data(), (int)preImageHashesData.size()));
+
+    EXPECT_EQ(preSigningOutput.error(), Common::Proto::Error_invalid_params);
+    EXPECT_TRUE(preSigningOutput.data().empty());
+}
+
+TEST(NEARCompiler, Compile_InvalidBlockHash) {
+    const auto coin = TWCoinTypeNEAR;
+    auto input = TW::NEAR::Proto::SigningInput();
+    input.set_signer_id("test.near");
+    input.set_receiver_id("whatever.near");
+    input.set_nonce(1);
+    input.set_public_key(Base58::decode("Anu7LYDfpLtkP7E16LT9imXF694BdQaa9ufVkQiwTQxC").data(), 32);
+
+    Data deposit(16, 0);
+    deposit[0] = 1;
+    input.add_actions()->mutable_transfer()->set_deposit(deposit.data(), deposit.size());
+
+    // 31 bytes — one byte short of the required 32
+    auto shortHash = parse_hex("0fa473fd26901df296be6adc4cc4df34d040efa2435224b6986910e630c2f");
+    input.set_block_hash(shortHash.data(), shortHash.size());
+
+    const auto inputString = input.SerializeAsString();
+    const auto inputStrData = TW::Data(inputString.begin(), inputString.end());
+
+    auto dummySig = parse_hex("aabb");
+    auto outputData = TransactionCompiler::compileWithSignatures(
+        coin, inputStrData, {dummySig}, {Base58::decode("Anu7LYDfpLtkP7E16LT9imXF694BdQaa9ufVkQiwTQxC")});
+
+    TW::NEAR::Proto::SigningOutput output;
+    ASSERT_TRUE(output.ParseFromArray(outputData.data(), (int)outputData.size()));
+
+    EXPECT_EQ(output.error(), Common::Proto::Error_invalid_params);
+    EXPECT_TRUE(output.signed_transaction().empty());
+}

--- a/tests/chains/Stellar/TWAnySignerTests.cpp
+++ b/tests/chains/Stellar/TWAnySignerTests.cpp
@@ -200,8 +200,8 @@ TEST(TWAnySingerStellar, Sign_MemoHash_InvalidSize) {
     input.set_private_key(key.data(), key.size());
 
     // 31 bytes — one byte short of the required 32
-    const auto shortHash = parse_hex("0001020304050607080910111213141516171819202122232425262728293031");
-    input.mutable_memo_hash()->set_hash(shortHash.data(), 31);
+    const auto shortHash = parse_hex("00010203040506070809101112131415161718192021222324252627282930");
+    input.mutable_memo_hash()->set_hash(shortHash.data(), shortHash.size());
 
     Proto::SigningOutput output;
     ANY_SIGN(input, TWCoinTypeStellar);
@@ -210,8 +210,8 @@ TEST(TWAnySingerStellar, Sign_MemoHash_InvalidSize) {
     EXPECT_TRUE(output.signature().empty());
 
     // 33 bytes — one byte over
-    const auto longHash = parse_hex("000102030405060708091011121314151617181920212223242526272829303132");
-    input.mutable_memo_hash()->set_hash(longHash.data(), 33);
+    const auto longHash = parse_hex("0001020304050607080910111213141516171819202122232425262728293031" "33");
+    input.mutable_memo_hash()->set_hash(longHash.data(), longHash.size());
     ANY_SIGN(input, TWCoinTypeStellar);
 
     EXPECT_EQ(output.error(), Common::Proto::Error_invalid_memo);
@@ -230,8 +230,8 @@ TEST(TWAnySingerStellar, Sign_MemoReturnHash_InvalidSize) {
     input.set_private_key(key.data(), key.size());
 
     // 31 bytes — one byte short
-    const auto shortHash = parse_hex("0001020304050607080910111213141516171819202122232425262728293031");
-    input.mutable_memo_return_hash()->set_hash(shortHash.data(), 31);
+    const auto shortHash = parse_hex("00010203040506070809101112131415161718192021222324252627282930");
+    input.mutable_memo_return_hash()->set_hash(shortHash.data(), shortHash.size());
 
     Proto::SigningOutput output;
     ANY_SIGN(input, TWCoinTypeStellar);

--- a/tests/chains/Stellar/TWAnySignerTests.cpp
+++ b/tests/chains/Stellar/TWAnySignerTests.cpp
@@ -180,11 +180,12 @@ TEST(TWAnySingerStellar, Sign_Claim_Claimable_Balance_c1fb3c) {
     // curl -X POST -F "tx=AAAAAMpF..DQ==" "https://horizon.stellar.org/transactions"
     EXPECT_EQ(output.signature(), "AAAAAMpFJQVVMv16RJUPlzQUTlgZOHVurhw3igGacP1305F1AAAnEAH/8MgAAAAhAAAAAAAAAAAAAAABAAAAAAAAAA8AAAAAnHt5S3sVDz5Mbc+iYGcrvgwkizYBKREukn4PfuL5+vgAAAAAAAAAAXfTkXUAAABAWL7dKkR1JuPZGFbDTRDgGBHW/vLPMWNRkAew+wPfGiCnZhpJJDcyX197EDDZMsJ7ungPUyhczRaeQOwZKx4DDQ==");
 
-    { // negative test: hash wrong size
+    { // negative test: balance_id wrong size — must fail, not sign invalid data
         const Data invalidBalanceIdHash = parse_hex("010203");
         input.mutable_op_claim_claimable_balance()->set_balance_id(invalidBalanceIdHash.data(), invalidBalanceIdHash.size());
         ANY_SIGN(input, TWCoinTypeStellar);
-        EXPECT_EQ(output.signature(), "AAAAAXfTkXUAAABAFCywEfLs3q5Tv9eZCIcjhkJR0s8J4Us9G5YjVKUSaMoUz/AadC8dM2oQSLhpC5wjrNBi7hevg7jlkPx5/4AJCQ==");
+        EXPECT_EQ(output.error(), Common::Proto::Error_invalid_params);
+        EXPECT_TRUE(output.signature().empty());
     }
 }
 

--- a/tests/chains/Stellar/TWAnySignerTests.cpp
+++ b/tests/chains/Stellar/TWAnySignerTests.cpp
@@ -8,6 +8,7 @@
 #include "PrivateKey.h"
 #include "Stellar/Address.h"
 #include "proto/Stellar.pb.h"
+#include "proto/Common.pb.h"
 #include <TrustWalletCore/TWAnySigner.h>
 #include <TrustWalletCore/TWStellarPassphrase.h>
 #include <gtest/gtest.h>
@@ -185,6 +186,58 @@ TEST(TWAnySingerStellar, Sign_Claim_Claimable_Balance_c1fb3c) {
         ANY_SIGN(input, TWCoinTypeStellar);
         EXPECT_EQ(output.signature(), "AAAAAXfTkXUAAABAFCywEfLs3q5Tv9eZCIcjhkJR0s8J4Us9G5YjVKUSaMoUz/AadC8dM2oQSLhpC5wjrNBi7hevg7jlkPx5/4AJCQ==");
     }
+}
+
+TEST(TWAnySingerStellar, Sign_MemoHash_InvalidSize) {
+    auto key = parse_hex("59a313f46ef1c23a9e4f71cea10fc0c56a2a6bb8a4b9ea3d5348823e5a478722");
+    Proto::SigningInput input;
+    input.set_passphrase(TWStellarPassphrase_Stellar);
+    input.set_account("GAE2SZV4VLGBAPRYRFV2VY7YYLYGYIP5I7OU7BSP6DJT7GAZ35OKFDYI");
+    input.set_fee(1000);
+    input.set_sequence(2);
+    input.mutable_op_payment()->set_destination("GDCYBNRRPIHLHG7X7TKPUPAZ7WVUXCN3VO7WCCK64RIFV5XM5V5K4A52");
+    input.mutable_op_payment()->set_amount(10000000);
+    input.set_private_key(key.data(), key.size());
+
+    // 31 bytes — one byte short of the required 32
+    const auto shortHash = parse_hex("0001020304050607080910111213141516171819202122232425262728293031");
+    input.mutable_memo_hash()->set_hash(shortHash.data(), 31);
+
+    Proto::SigningOutput output;
+    ANY_SIGN(input, TWCoinTypeStellar);
+
+    EXPECT_EQ(output.error(), Common::Proto::Error_invalid_memo);
+    EXPECT_TRUE(output.signature().empty());
+
+    // 33 bytes — one byte over
+    const auto longHash = parse_hex("000102030405060708091011121314151617181920212223242526272829303132");
+    input.mutable_memo_hash()->set_hash(longHash.data(), 33);
+    ANY_SIGN(input, TWCoinTypeStellar);
+
+    EXPECT_EQ(output.error(), Common::Proto::Error_invalid_memo);
+    EXPECT_TRUE(output.signature().empty());
+}
+
+TEST(TWAnySingerStellar, Sign_MemoReturnHash_InvalidSize) {
+    auto key = parse_hex("59a313f46ef1c23a9e4f71cea10fc0c56a2a6bb8a4b9ea3d5348823e5a478722");
+    Proto::SigningInput input;
+    input.set_passphrase(TWStellarPassphrase_Stellar);
+    input.set_account("GAE2SZV4VLGBAPRYRFV2VY7YYLYGYIP5I7OU7BSP6DJT7GAZ35OKFDYI");
+    input.set_fee(1000);
+    input.set_sequence(2);
+    input.mutable_op_payment()->set_destination("GDCYBNRRPIHLHG7X7TKPUPAZ7WVUXCN3VO7WCCK64RIFV5XM5V5K4A52");
+    input.mutable_op_payment()->set_amount(10000000);
+    input.set_private_key(key.data(), key.size());
+
+    // 31 bytes — one byte short
+    const auto shortHash = parse_hex("0001020304050607080910111213141516171819202122232425262728293031");
+    input.mutable_memo_return_hash()->set_hash(shortHash.data(), 31);
+
+    Proto::SigningOutput output;
+    ANY_SIGN(input, TWCoinTypeStellar);
+
+    EXPECT_EQ(output.error(), Common::Proto::Error_invalid_memo);
+    EXPECT_TRUE(output.signature().empty());
 }
 
 } // namespace TW::Stellar::tests

--- a/tests/chains/Stellar/TWAnySignerTests.cpp
+++ b/tests/chains/Stellar/TWAnySignerTests.cpp
@@ -239,6 +239,14 @@ TEST(TWAnySingerStellar, Sign_MemoReturnHash_InvalidSize) {
 
     EXPECT_EQ(output.error(), Common::Proto::Error_invalid_memo);
     EXPECT_TRUE(output.signature().empty());
+
+    // 33 bytes — one byte over
+    const auto longHash = parse_hex("0001020304050607080910111213141516171819202122232425262728293031" "32");
+    input.mutable_memo_return_hash()->set_hash(longHash.data(), longHash.size());
+    ANY_SIGN(input, TWCoinTypeStellar);
+
+    EXPECT_EQ(output.error(), Common::Proto::Error_invalid_memo);
+    EXPECT_TRUE(output.signature().empty());
 }
 
 } // namespace TW::Stellar::tests

--- a/tests/chains/Stellar/TransactionCompilerTests.cpp
+++ b/tests/chains/Stellar/TransactionCompilerTests.cpp
@@ -106,7 +106,8 @@ TEST(StellarCompiler, PreImageHashes_MemoHash_InvalidSize) {
     const auto shortHash = parse_hex("00010203040506070809101112131415161718192021222324252627282930");
     input.mutable_memo_hash()->set_hash(shortHash.data(), shortHash.size()); // 31 bytes — invalid
 
-    auto inputStrData = TW::Data(input.SerializeAsString().begin(), input.SerializeAsString().end());
+    const auto serialized = input.SerializeAsString();
+    auto inputStrData = TW::Data(serialized.begin(), serialized.end());
     const auto preImageHashData = TransactionCompiler::preImageHashes(coin, inputStrData);
 
     TW::TxCompiler::Proto::PreSigningOutput preSigningOutput;
@@ -129,7 +130,8 @@ TEST(StellarCompiler, Compile_MemoHash_InvalidSize) {
     const auto shortHash = parse_hex("00010203040506070809101112131415161718192021222324252627282930");
     input.mutable_memo_hash()->set_hash(shortHash.data(), shortHash.size()); // 31 bytes — invalid
 
-    auto inputStrData = TW::Data(input.SerializeAsString().begin(), input.SerializeAsString().end());
+    const auto serialized = input.SerializeAsString();
+    auto inputStrData = TW::Data(serialized.begin(), serialized.end());
     const auto dummySig = parse_hex("aabb");
     const auto outputData = TransactionCompiler::compileWithSignatures(coin, inputStrData, {dummySig}, {});
 

--- a/tests/chains/Stellar/TransactionCompilerTests.cpp
+++ b/tests/chains/Stellar/TransactionCompilerTests.cpp
@@ -91,3 +91,50 @@ TEST(StellarCompiler, CompileWithSignatures) {
         EXPECT_EQ(output.error(), Common::Proto::Error_signatures_count);
     }
 }
+
+TEST(StellarCompiler, PreImageHashes_MemoHash_InvalidSize) {
+    const auto coin = TWCoinTypeStellar;
+    TW::Stellar::Proto::SigningInput input;
+    input.set_passphrase(TWStellarPassphrase_Stellar);
+    input.set_account("GAE2SZV4VLGBAPRYRFV2VY7YYLYGYIP5I7OU7BSP6DJT7GAZ35OKFDYI");
+    input.set_fee(1000);
+    input.set_sequence(2);
+    input.mutable_op_payment()->set_destination(
+        "GDCYBNRRPIHLHG7X7TKPUPAZ7WVUXCN3VO7WCCK64RIFV5XM5V5K4A52");
+    input.mutable_op_payment()->set_amount(10000000);
+
+    const auto shortHash = parse_hex("00010203040506070809101112131415161718192021222324252627282930");
+    input.mutable_memo_hash()->set_hash(shortHash.data(), shortHash.size()); // 31 bytes — invalid
+
+    auto inputStrData = TW::Data(input.SerializeAsString().begin(), input.SerializeAsString().end());
+    const auto preImageHashData = TransactionCompiler::preImageHashes(coin, inputStrData);
+
+    TW::TxCompiler::Proto::PreSigningOutput preSigningOutput;
+    ASSERT_TRUE(preSigningOutput.ParseFromArray(preImageHashData.data(), (int)preImageHashData.size()));
+    EXPECT_EQ(preSigningOutput.error(), Common::Proto::Error_invalid_memo);
+    EXPECT_TRUE(preSigningOutput.data().empty());
+}
+
+TEST(StellarCompiler, Compile_MemoHash_InvalidSize) {
+    const auto coin = TWCoinTypeStellar;
+    TW::Stellar::Proto::SigningInput input;
+    input.set_passphrase(TWStellarPassphrase_Stellar);
+    input.set_account("GAE2SZV4VLGBAPRYRFV2VY7YYLYGYIP5I7OU7BSP6DJT7GAZ35OKFDYI");
+    input.set_fee(1000);
+    input.set_sequence(2);
+    input.mutable_op_payment()->set_destination(
+        "GDCYBNRRPIHLHG7X7TKPUPAZ7WVUXCN3VO7WCCK64RIFV5XM5V5K4A52");
+    input.mutable_op_payment()->set_amount(10000000);
+
+    const auto shortHash = parse_hex("00010203040506070809101112131415161718192021222324252627282930");
+    input.mutable_memo_hash()->set_hash(shortHash.data(), shortHash.size()); // 31 bytes — invalid
+
+    auto inputStrData = TW::Data(input.SerializeAsString().begin(), input.SerializeAsString().end());
+    const auto dummySig = parse_hex("aabb");
+    const auto outputData = TransactionCompiler::compileWithSignatures(coin, inputStrData, {dummySig}, {});
+
+    TW::Stellar::Proto::SigningOutput output;
+    ASSERT_TRUE(output.ParseFromArray(outputData.data(), (int)outputData.size()));
+    EXPECT_EQ(output.error(), Common::Proto::Error_invalid_memo);
+    EXPECT_TRUE(output.signature().empty());
+}

--- a/tests/chains/Stellar/TransactionTests.cpp
+++ b/tests/chains/Stellar/TransactionTests.cpp
@@ -5,6 +5,7 @@
 #include "TestUtilities.h"
 
 #include "HexCoding.h"
+#include "PrivateKey.h"
 #include "Stellar/Signer.h"
 #include <TrustWalletCore/TWHDWallet.h>
 #include <TrustWalletCore/TWStellarPassphrase.h>
@@ -32,7 +33,7 @@ TEST(StellarTransaction, sign) {
 
     const auto signer = TW::Stellar::Signer(input);
 
-    const auto signature = signer.sign();
+    const auto signature = signer.sign().payload();
     ASSERT_EQ(signature, "AAAAAAmpZryqzBA+OIlrquP4wvBsIf1H3U+GT/DTP5gZ31yiAAAD6AAAAAAAAAACAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAxYC2MXoOs5v3/NT6PBn9q0uJu6u/YQle5FBa9uzteq4AAAAAAAAAAACYloAAAAAAAAAAARnfXKIAAABAocQZwTnVvGMQlpdGacWvgenxN5ku8YB8yhEGrDfEV48yDqcj6QaePAitDj/N2gxfYD9Q2pJ+ZpkQMsZZG4ACAg==");
 }
 
@@ -52,7 +53,7 @@ TEST(StellarTransaction, signWithMemoText) {
 
     const auto signer = Signer(input);
 
-    const auto signature = signer.sign();
+    const auto signature = signer.sign().payload();
     ASSERT_EQ(signature, "AAAAAAmpZryqzBA+OIlrquP4wvBsIf1H3U+GT/DTP5gZ31yiAAAD6AAAAAAAAAACAAAAAAAAAAEAAAANSGVsbG8sIHdvcmxkIQAAAAAAAAEAAAAAAAAAAQAAAADFgLYxeg6zm/f81Po8Gf2rS4m7q79hCV7kUFr27O16rgAAAAAAAAAAAJiWgAAAAAAAAAABGd9cogAAAEBQQldEkYJ6rMvOHilkwFCYyroGGUvrNeWVqr/sn3iFFqgz91XxgUT0ou7bMSPRgPROfBYDfQCFfFxbcDPrrCwB");
 }
 
@@ -73,7 +74,7 @@ TEST(StellarTransaction, signWithMemoHash) {
 
     const auto signer = Signer(input);
 
-    const auto signature = signer.sign();
+    const auto signature = signer.sign().payload();
     ASSERT_EQ(signature, "AAAAAAmpZryqzBA+OIlrquP4wvBsIf1H3U+GT/DTP5gZ31yiAAAD6AAAAAAAAAACAAAAAAAAAAMxX1vbdtB4xDuKwAZOSgFkYSsfznfIaTRb/JTHWJTt0wAAAAEAAAAAAAAAAQAAAADFgLYxeg6zm/f81Po8Gf2rS4m7q79hCV7kUFr27O16rgAAAAAAAAAAAJiWgAAAAAAAAAABGd9cogAAAECIyh1BG+hER5W+dgHDKe49X6VEYRWIjajM4Ufq3DUG/yw7Xv1MMF4eax3U0TRi7Qwj2fio/DRD3+/Ljtvip2MD");
 }
 
@@ -94,7 +95,7 @@ TEST(StellarTransaction, signWithMemoReturn) {
 
     const auto signer = Signer(input);
 
-    const auto signature = signer.sign();
+    const auto signature = signer.sign().payload();
     ASSERT_EQ(signature, "AAAAAAmpZryqzBA+OIlrquP4wvBsIf1H3U+GT/DTP5gZ31yiAAAD6AAAAAAAAAACAAAAAAAAAAQxX1vbdtB4xDuKwAZOSgFkYSsfznfIaTRb/JTHWJTt0wAAAAEAAAAAAAAAAQAAAADFgLYxeg6zm/f81Po8Gf2rS4m7q79hCV7kUFr27O16rgAAAAAAAAAAAJiWgAAAAAAAAAABGd9cogAAAEBd77iui04quoaoWMfeJO06nRfn3Z9bptbAj7Ol44j3ApU8c9dJwVhJbQ7La4mKgIkYviEhGx3AIulFYCkokb8M");
 }
 
@@ -114,7 +115,7 @@ TEST(StellarTransaction, signWithMemoID) {
 
     const auto signer = Signer(input);
 
-    const auto signature = signer.sign();
+    const auto signature = signer.sign().payload();
     ASSERT_EQ(signature, "AAAAAAmpZryqzBA+OIlrquP4wvBsIf1H3U+GT/DTP5gZ31yiAAAD6AAAAAAAAAACAAAAAAAAAAIAAAAASZYC0gAAAAEAAAAAAAAAAQAAAADFgLYxeg6zm/f81Po8Gf2rS4m7q79hCV7kUFr27O16rgAAAAAAAAAAAJiWgAAAAAAAAAABGd9cogAAAEAOJ8wwCizQPf6JmkCsCNZolQeqet2qN7fgLUUQlwx3TNzM0+/GJ6Qc2faTybjKy111rE60IlnfaPeMl/nyxKIB");
 }
 
@@ -134,7 +135,7 @@ TEST(StellarTransaction, signAcreateAccount) {
 
     const auto signer = Signer(input);
 
-    const auto signature = signer.sign();
+    const auto signature = signer.sign().payload();
     ASSERT_EQ(signature, "AAAAAAmpZryqzBA+OIlrquP4wvBsIf1H3U+GT/DTP5gZ31yiAAAD6AAAAAAAAAACAAAAAAAAAAIAAAAASZYC0gAAAAEAAAAAAAAAAAAAAADFgLYxeg6zm/f81Po8Gf2rS4m7q79hCV7kUFr27O16rgAAAAAAmJaAAAAAAAAAAAEZ31yiAAAAQNgqNDqbe0X60gyH+1xf2Tv2RndFiJmyfbrvVjsTfjZAVRrS2zE9hHlqPQKpZkGKEFka7+1ElOS+/m/1JDnauQg=");
 }
 


### PR DESCRIPTION
This pull request introduces improved error handling and result propagation for NEAR and Stellar transaction signing and serialization logic. The main changes involve updating the signing and serialization functions to return `Result` types instead of raw data, allowing error codes and messages to be surfaced to the caller. This ensures that invalid parameters, such as incorrect hash or memo sizes, are properly detected and reported. The changes also update the relevant tests and function signatures to accommodate these improvements.

### Error Handling and Result Propagation

* Updated NEAR and Stellar serialization and signing functions (e.g., `transactionData`, `transactionDataWithPublicKey`, `Signer::sign`, `Signer::encode`, `Signer::signaturePreimage`) to return `Result<T, Error>` types instead of raw `Data` or `std::string`, enabling error propagation and explicit error handling.
* Added validation checks for input parameters such as block hash size for NEAR and memo hash size for Stellar, returning appropriate error codes when validation fails.

### Interface and Signature Changes

* Updated function signatures in headers (`Serialization.h`, `Signer.h`) to use `Result` types, and adjusted all call sites accordingly.

### Output and Error Reporting

* Modified signing and serialization logic to set error codes and messages in output protobufs when errors are encountered, instead of throwing exceptions or returning empty data.

### Test Updates

* Updated NEAR serialization tests to extract the payload from the `Result` type returned by `transactionData`.

These changes improve the robustness and maintainability of the signing and serialization logic by ensuring that errors are handled explicitly and communicated clearly to the caller.