### PR TITLE
fix(build): support arm64 in install-sys-dependencies-linux

### DIFF
--- a/tools/install-sys-dependencies-linux
+++ b/tools/install-sys-dependencies-linux
@@ -3,7 +3,12 @@
 set -e
 
 # build-essential clang-14 libc++-dev libc++abi-dev ruby-full cmake
-sudo apt-get update && sudo apt-get install ninja-build llvm-14 clang-tidy-14 libboost-all-dev rustc --fix-missing gcc-multilib g++-multilib
+PACKAGES=(ninja-build llvm-14 clang-tidy-14 libboost-all-dev rustc)
+# gcc-multilib/g++-multilib are 32-bit x86 cross-compile packages, available only on amd64
+if [ "$(dpkg --print-architecture)" = "amd64" ]; then
+  PACKAGES+=(gcc-multilib g++-multilib)
+fi
+sudo apt-get update && sudo apt-get install --fix-missing "${PACKAGES[@]}"
 
 # As of now, Ubuntu 24.04 has lcov 2.0-4ubuntu2 only, but we don't support it yet.
 # Install lcov 1.15-1 manually.


### PR DESCRIPTION
## Why

`tools/install-sys-dependencies-linux` installs `gcc-multilib` and `g++-multilib`. These are 32-bit x86 cross-compilation packages that only exist on amd64 — on arm64 (aarch64) Ubuntu, `apt` fails:

```
E: Package 'gcc-multilib' has no installation candidate
E: Unable to locate package g++-multilib
```

This blocks installing the build dependencies on an arm64 host.

## What

Install `gcc-multilib`/`g++-multilib` only when the host architecture is amd64 — the only architecture where they exist and are usable. Any other host (e.g. arm64) skips them. The package list is now a bash array, so the install no longer relies on word-splitting. amd64 behaviour is unchanged.

## Test

`tools/install-sys-dependencies-linux` completes on both `ubuntu-24.04` (amd64) and `ubuntu-24.04-arm` (arm64); existing amd64 behaviour is unchanged.
