### PR TITLE
fix(ios): update simulator destination to iPhone 17 and iOS 26.2 in build scripts, fix implicit double conversion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ cd android && ./gradlew connectedAndroidTest
 ```bash
 tools/ios-test
 # Requires: xcodegen, xcbeautify
-# Runs on: iPhone 16 simulator, iOS 18.5
+# Runs on: iPhone 17 simulator, iOS 26.2
 ```
 
 ### WASM / TypeScript

--- a/src/Bitcoin/InputSelector.cpp
+++ b/src/Bitcoin/InputSelector.cpp
@@ -177,9 +177,10 @@ std::vector<TypeWithAmount> InputSelector<TypeWithAmount>::selectSimple(int64_t 
 
     // target value is larger than original, but not by a factor of 2 (optimized for large UTXO
     // cases)
-    const auto increasedTargetValue =
-        (uint64_t)((double)targetValue * 1.1 +
-                   feeCalculator.calculate(_inputs.size(), numOutputs, byteFee) + 1000);
+    const auto increasedTargetValueDouble = static_cast<double>(targetValue) * 1.1
+        + static_cast<double>(feeCalculator.calculate(_inputs.size(), numOutputs, byteFee))
+        + 1000.0;
+    const auto increasedTargetValue = static_cast<uint64_t>(increasedTargetValueDouble);
 
     const int64_t dustThreshold = dustCalculator->dustAmount(byteFee);
 

--- a/tools/ios-doc
+++ b/tools/ios-doc
@@ -9,7 +9,7 @@ pushd swift
 mkdir -p build && rm -rf build/*.doccarchive
 
 export DOCC_JSON_PRETTYPRINT="YES"
-xcodebuild -workspace TrustWalletCore.xcworkspace -derivedDataPath build/docsData -scheme WalletCore -destination 'platform=iOS Simulator,name=iPhone 16' -parallelizeTargets docbuild | xcbeautify
+xcodebuild -workspace TrustWalletCore.xcworkspace -derivedDataPath build/docsData -scheme WalletCore -destination 'platform=iOS Simulator,name=iPhone 17' -parallelizeTargets docbuild | xcbeautify
 
 pushd build
 

--- a/tools/ios-test
+++ b/tools/ios-test
@@ -12,7 +12,7 @@ pushd swift
 xcodebuild -workspace TrustWalletCore.xcworkspace \
 	-scheme WalletCore \
 	-sdk iphonesimulator \
-	-destination "platform=iOS Simulator,name=iPhone 16,OS=18.5" \
+	-destination "platform=iOS Simulator,name=iPhone 17,OS=26.2" \
 	test | xcbeautify
 
 popd


### PR DESCRIPTION
This pull request updates iOS simulator configurations and improves type safety in the input selection logic. The most important changes are:

**iOS Simulator Updates:**

* Updated all references to the iOS simulator from "iPhone 16, iOS 18.5" to "iPhone 17, iOS 26.2" in `tools/ios-test`, `tools/ios-doc`, and documentation in `CLAUDE.md`. This ensures tests and documentation use the latest simulator version. [[1]](diffhunk://#diff-5458bbdf85864dc3ad0fbef826f239a747ab4cb22f1e841b46be18e7f698ad30L15-R15) [[2]](diffhunk://#diff-acc446e77a93e263f9aa3ef2db305245a36d832f0bd3d352750d42a6037c1441L12-R12) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L82-R82)

**Fix Implicit Double Conversion:**

* Refactored the calculation of `increasedTargetValue` in `InputSelector.cpp` to use explicit `double` arithmetic and casting, improving type safety and clarity.