### PR TITLE
fix(android): add ANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON for 16KB page size compliance

### DIFF
--- a/android/wallet-core/build.gradle
+++ b/android/wallet-core/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 23
         externalNativeBuild {
             cmake {
-                arguments "-DCMAKE_BUILD_TYPE=Release", "-DTW_UNITY_BUILD=ON"
+                arguments "-DCMAKE_BUILD_TYPE=Release", "-DTW_UNITY_BUILD=ON", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes #4643.

Google Play Store requires all apps targeting Android 15 (API 35) to support 16KB memory page sizes. Without the `-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON` CMake flag, the native `libTrustWalletCore.so` fails the 16KB page alignment check and apps integrating wallet-core cannot publish updates.

## Change

Adds the CMake flag to `android/wallet-core/build.gradle`:

```diff
- arguments "-DCMAKE_BUILD_TYPE=Release", "-DTW_UNITY_BUILD=ON"
+ arguments "-DCMAKE_BUILD_TYPE=Release", "-DTW_UNITY_BUILD=ON", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
```

This is the [recommended approach](https://developer.android.com/guide/practices/page-sizes#cmake) from the Android developer docs for enabling flexible page size support in NDK/CMake builds.

## Testing

After this change, building the Android library and running the 16KB page size verification tool (`adb shell "/data/local/tmp/page_size_compat_test"`) should pass for `arm64-v8a` builds.