### PR TITLE
fix(webauthn): enforce strict challenge validation in clientDataJSON

### DIFF
--- a/rust/tw_evm/src/modules/barz/core.rs
+++ b/rust/tw_evm/src/modules/barz/core.rs
@@ -93,12 +93,38 @@ pub fn get_formatted_signature(
     client_data_json: &str,
 ) -> BarzResult<Vec<u8>> {
     let challenge_base64 = base64::encode(challenge, base64::URL_SAFE);
-
     let challenge_base64 = challenge_base64.trim_end_matches('=');
 
-    let Some(challenge_pos) = client_data_json.find(challenge_base64) else {
+    // Verify the "challenge" field is an exact match. A substring search would allow
+    // an assertion signed over a longer challenge to authorize a shorter UserOp hash.
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(client_data_json) else {
         return Ok(Vec::new());
     };
+    let Some(actual_challenge) = parsed.get("challenge").and_then(|v| v.as_str()) else {
+        return Ok(Vec::new());
+    };
+    if actual_challenge != challenge_base64 {
+        return Ok(Vec::new());
+    }
+
+    // Locate the split point: find the key pattern (static str, no allocation),
+    // then confirm the value and its closing quote match exactly at that position.
+    // Reject if the pattern appears more than once to avoid ambiguity.
+    const KEY_PATTERN: &str = r#""challenge":""#;
+    let mut occurrences = client_data_json.match_indices(KEY_PATTERN);
+    let Some((key_pos, _)) = occurrences.next() else {
+        return Ok(Vec::new());
+    };
+    if occurrences.next().is_some() {
+        return Ok(Vec::new());
+    }
+    let challenge_pos = key_pos + KEY_PATTERN.len();
+    let challenge_end = challenge_pos + challenge_base64.len();
+    if client_data_json.get(challenge_pos..challenge_end) != Some(challenge_base64)
+        || client_data_json.as_bytes().get(challenge_end) != Some(&b'"')
+    {
+        return Ok(Vec::new());
+    }
 
     let client_data_json_pre = &client_data_json[..challenge_pos];
     let client_data_json_post = &client_data_json[challenge_pos + challenge_base64.len()..];

--- a/rust/tw_evm/tests/barz.rs
+++ b/rust/tw_evm/tests/barz.rs
@@ -807,6 +807,25 @@ fn test_get_formatted_signature_rejects_challenge_in_wrong_field() {
     );
 }
 
+/// JSON with duplicate "challenge" keys must be rejected to prevent split-point ambiguity.
+#[test]
+fn test_get_formatted_signature_rejects_duplicate_challenge_key() {
+    let signature = hex::decode(SIGNATURE_HEX).unwrap();
+    let challenge = hex::decode(CHALLENGE_HEX).unwrap();
+    let authenticator_data = hex::decode(AUTHENTICATOR_DATA_HEX).unwrap();
+
+    // Both "challenge" fields carry the correct value — the key pattern appears twice.
+    let client_data_json = "{\"challenge\":\"zyZ6eMWtr5bzQaaW61doJChMVy8-Yb5hlpTVOdsZJfk\",\"challenge\":\"zyZ6eMWtr5bzQaaW61doJChMVy8-Yb5hlpTVOdsZJfk\",\"origin\":\"https://trustwallet.com\"}";
+
+    let result =
+        get_formatted_signature(&signature, &challenge, &authenticator_data, client_data_json)
+            .unwrap();
+    assert!(
+        result.is_empty(),
+        "should reject clientDataJSON with duplicate challenge keys"
+    );
+}
+
 /// Invalid JSON must be rejected.
 #[test]
 fn test_get_formatted_signature_rejects_invalid_json() {

--- a/rust/tw_evm/tests/barz.rs
+++ b/rust/tw_evm/tests/barz.rs
@@ -817,9 +817,13 @@ fn test_get_formatted_signature_rejects_duplicate_challenge_key() {
     // Both "challenge" fields carry the correct value — the key pattern appears twice.
     let client_data_json = "{\"challenge\":\"zyZ6eMWtr5bzQaaW61doJChMVy8-Yb5hlpTVOdsZJfk\",\"challenge\":\"zyZ6eMWtr5bzQaaW61doJChMVy8-Yb5hlpTVOdsZJfk\",\"origin\":\"https://trustwallet.com\"}";
 
-    let result =
-        get_formatted_signature(&signature, &challenge, &authenticator_data, client_data_json)
-            .unwrap();
+    let result = get_formatted_signature(
+        &signature,
+        &challenge,
+        &authenticator_data,
+        client_data_json,
+    )
+    .unwrap();
     assert!(
         result.is_empty(),
         "should reject clientDataJSON with duplicate challenge keys"

--- a/rust/tw_evm/tests/barz.rs
+++ b/rust/tw_evm/tests/barz.rs
@@ -751,6 +751,109 @@ fn test_get_formatted_signature() {
     assert_eq!(hex::encode(formatted_signature, true), "0x12d89e3b41e253dc9e90bd34dc1750d059b76d0b1d16af2059aa26e90b8960bf256d8a05572c654906ce422464693e280e243e6d9dbc5f96a681dba846bca27600000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000016000000000000000000000000000000000000000000000000000000000000000251a70842af8c1feb7133b81e6a160a6a2be45ee057f0eb6d3f7f5126daa202e071d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000247b2274797065223a22776562617574686e2e676574222c226368616c6c656e6765223a22000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000025222c226f726967696e223a2268747470733a2f2f747275737477616c6c65742e636f6d227d000000000000000000000000000000000000000000000000000000");
 }
 
+// The challenge used in the security tests below.
+// base64url (no padding): zyZ6eMWtr5bzQaaW61doJChMVy8-Yb5hlpTVOdsZJfk
+const CHALLENGE_HEX: &str =
+    "cf267a78c5adaf96f341a696eb576824284c572f3e61be619694d539db1925f9";
+const SIGNATURE_HEX: &str =
+    "3044022012d89e3b41e253dc9e90bd34dc1750d059b76d0b1d16af2059aa26e90b8960bf0220256d8a05572c654906ce422464693e280e243e6d9dbc5f96a681dba846bca276";
+const AUTHENTICATOR_DATA_HEX: &str =
+    "1a70842af8c1feb7133b81e6a160a6a2be45ee057f0eb6d3f7f5126daa202e071d00000000";
+
+/// An assertion signed over a longer challenge whose base64url starts with
+/// the target UserOp hash must be rejected (prefix attack).
+#[test]
+fn test_get_formatted_signature_rejects_challenge_prefix() {
+    let signature = hex::decode(SIGNATURE_HEX).unwrap();
+    let challenge = hex::decode(CHALLENGE_HEX).unwrap();
+    let authenticator_data = hex::decode(AUTHENTICATOR_DATA_HEX).unwrap();
+
+    // "challenge" field contains the correct base64url plus extra suffix characters.
+    let client_data_json = "{\"type\":\"webauthn.get\",\"challenge\":\"zyZ6eMWtr5bzQaaW61doJChMVy8-Yb5hlpTVOdsZJfkEXTRA\",\"origin\":\"https://trustwallet.com\"}";
+
+    let result =
+        get_formatted_signature(&signature, &challenge, &authenticator_data, client_data_json)
+            .unwrap();
+    assert!(
+        result.is_empty(),
+        "should reject clientDataJSON whose challenge is a longer value sharing the same prefix"
+    );
+}
+
+/// The challenge value appearing inside a different JSON field must not be
+/// used as the split point — the split must always land in the "challenge" field.
+#[test]
+fn test_get_formatted_signature_rejects_challenge_in_wrong_field() {
+    let signature = hex::decode(SIGNATURE_HEX).unwrap();
+    let challenge = hex::decode(CHALLENGE_HEX).unwrap();
+    let authenticator_data = hex::decode(AUTHENTICATOR_DATA_HEX).unwrap();
+
+    // "note" field contains the exact challenge base64url; "challenge" field has a different value.
+    let client_data_json = "{\"note\":\"zyZ6eMWtr5bzQaaW61doJChMVy8-Yb5hlpTVOdsZJfk\",\"challenge\":\"other\",\"origin\":\"https://trustwallet.com\"}";
+
+    let result =
+        get_formatted_signature(&signature, &challenge, &authenticator_data, client_data_json)
+            .unwrap();
+    assert!(
+        result.is_empty(),
+        "should reject clientDataJSON where the challenge value appears in the wrong field"
+    );
+}
+
+/// Invalid JSON must be rejected.
+#[test]
+fn test_get_formatted_signature_rejects_invalid_json() {
+    let signature = hex::decode(SIGNATURE_HEX).unwrap();
+    let challenge = hex::decode(CHALLENGE_HEX).unwrap();
+    let authenticator_data = hex::decode(AUTHENTICATOR_DATA_HEX).unwrap();
+
+    let result = get_formatted_signature(
+        &signature,
+        &challenge,
+        &authenticator_data,
+        "not json at all",
+    )
+    .unwrap();
+    assert!(result.is_empty(), "should reject malformed JSON");
+}
+
+/// JSON missing the "challenge" field must be rejected.
+#[test]
+fn test_get_formatted_signature_rejects_missing_challenge_field() {
+    let signature = hex::decode(SIGNATURE_HEX).unwrap();
+    let challenge = hex::decode(CHALLENGE_HEX).unwrap();
+    let authenticator_data = hex::decode(AUTHENTICATOR_DATA_HEX).unwrap();
+
+    let client_data_json =
+        "{\"type\":\"webauthn.get\",\"origin\":\"https://trustwallet.com\"}";
+
+    let result =
+        get_formatted_signature(&signature, &challenge, &authenticator_data, client_data_json)
+            .unwrap();
+    assert!(result.is_empty(), "should reject JSON without a challenge field");
+}
+
+/// JSON with whitespace between the key and colon (\"challenge\" : \"...\") must be
+/// rejected — consistent with the strictness applied in find_json_key_index.
+#[test]
+fn test_get_formatted_signature_rejects_spaced_json() {
+    let signature = hex::decode(SIGNATURE_HEX).unwrap();
+    let challenge = hex::decode(CHALLENGE_HEX).unwrap();
+    let authenticator_data = hex::decode(AUTHENTICATOR_DATA_HEX).unwrap();
+
+    // Space between key and colon — serde_json parses this fine, but the
+    // key pattern "challenge":" won't match, locking in the intended strictness.
+    let client_data_json = "{\"type\":\"webauthn.get\",\"challenge\" : \"zyZ6eMWtr5bzQaaW61doJChMVy8-Yb5hlpTVOdsZJfk\",\"origin\":\"https://trustwallet.com\"}";
+
+    let result =
+        get_formatted_signature(&signature, &challenge, &authenticator_data, client_data_json)
+            .unwrap();
+    assert!(
+        result.is_empty(),
+        "should reject JSON with whitespace between key and colon (matches find_json_key_index strictness)"
+    );
+}
+
 #[test]
 fn test_get_prefixed_msg_hash() {
     let msg_hash =

--- a/rust/tw_evm/tests/barz.rs
+++ b/rust/tw_evm/tests/barz.rs
@@ -753,8 +753,7 @@ fn test_get_formatted_signature() {
 
 // The challenge used in the security tests below.
 // base64url (no padding): zyZ6eMWtr5bzQaaW61doJChMVy8-Yb5hlpTVOdsZJfk
-const CHALLENGE_HEX: &str =
-    "cf267a78c5adaf96f341a696eb576824284c572f3e61be619694d539db1925f9";
+const CHALLENGE_HEX: &str = "cf267a78c5adaf96f341a696eb576824284c572f3e61be619694d539db1925f9";
 const SIGNATURE_HEX: &str =
     "3044022012d89e3b41e253dc9e90bd34dc1750d059b76d0b1d16af2059aa26e90b8960bf0220256d8a05572c654906ce422464693e280e243e6d9dbc5f96a681dba846bca276";
 const AUTHENTICATOR_DATA_HEX: &str =
@@ -771,9 +770,13 @@ fn test_get_formatted_signature_rejects_challenge_prefix() {
     // "challenge" field contains the correct base64url plus extra suffix characters.
     let client_data_json = "{\"type\":\"webauthn.get\",\"challenge\":\"zyZ6eMWtr5bzQaaW61doJChMVy8-Yb5hlpTVOdsZJfkEXTRA\",\"origin\":\"https://trustwallet.com\"}";
 
-    let result =
-        get_formatted_signature(&signature, &challenge, &authenticator_data, client_data_json)
-            .unwrap();
+    let result = get_formatted_signature(
+        &signature,
+        &challenge,
+        &authenticator_data,
+        client_data_json,
+    )
+    .unwrap();
     assert!(
         result.is_empty(),
         "should reject clientDataJSON whose challenge is a longer value sharing the same prefix"
@@ -791,9 +794,13 @@ fn test_get_formatted_signature_rejects_challenge_in_wrong_field() {
     // "note" field contains the exact challenge base64url; "challenge" field has a different value.
     let client_data_json = "{\"note\":\"zyZ6eMWtr5bzQaaW61doJChMVy8-Yb5hlpTVOdsZJfk\",\"challenge\":\"other\",\"origin\":\"https://trustwallet.com\"}";
 
-    let result =
-        get_formatted_signature(&signature, &challenge, &authenticator_data, client_data_json)
-            .unwrap();
+    let result = get_formatted_signature(
+        &signature,
+        &challenge,
+        &authenticator_data,
+        client_data_json,
+    )
+    .unwrap();
     assert!(
         result.is_empty(),
         "should reject clientDataJSON where the challenge value appears in the wrong field"
@@ -824,13 +831,19 @@ fn test_get_formatted_signature_rejects_missing_challenge_field() {
     let challenge = hex::decode(CHALLENGE_HEX).unwrap();
     let authenticator_data = hex::decode(AUTHENTICATOR_DATA_HEX).unwrap();
 
-    let client_data_json =
-        "{\"type\":\"webauthn.get\",\"origin\":\"https://trustwallet.com\"}";
+    let client_data_json = "{\"type\":\"webauthn.get\",\"origin\":\"https://trustwallet.com\"}";
 
-    let result =
-        get_formatted_signature(&signature, &challenge, &authenticator_data, client_data_json)
-            .unwrap();
-    assert!(result.is_empty(), "should reject JSON without a challenge field");
+    let result = get_formatted_signature(
+        &signature,
+        &challenge,
+        &authenticator_data,
+        client_data_json,
+    )
+    .unwrap();
+    assert!(
+        result.is_empty(),
+        "should reject JSON without a challenge field"
+    );
 }
 
 /// JSON with whitespace between the key and colon (\"challenge\" : \"...\") must be
@@ -845,9 +858,13 @@ fn test_get_formatted_signature_rejects_spaced_json() {
     // key pattern "challenge":" won't match, locking in the intended strictness.
     let client_data_json = "{\"type\":\"webauthn.get\",\"challenge\" : \"zyZ6eMWtr5bzQaaW61doJChMVy8-Yb5hlpTVOdsZJfk\",\"origin\":\"https://trustwallet.com\"}";
 
-    let result =
-        get_formatted_signature(&signature, &challenge, &authenticator_data, client_data_json)
-            .unwrap();
+    let result = get_formatted_signature(
+        &signature,
+        &challenge,
+        &authenticator_data,
+        client_data_json,
+    )
+    .unwrap();
     assert!(
         result.is_empty(),
         "should reject JSON with whitespace between key and colon (matches find_json_key_index strictness)"


### PR DESCRIPTION
This pull request strengthens the security of the `get_formatted_signature` function by ensuring that the "challenge" value in the provided JSON is matched exactly and unambiguously, preventing potential prefix attacks or accidental acceptance of incorrect fields. It also introduces comprehensive tests to verify these stricter behaviors.

**Security improvements to challenge matching:**

* Updated `get_formatted_signature` in `core.rs` to parse `client_data_json` as JSON and require the "challenge" field to match the expected base64url-encoded challenge exactly, rather than allowing substring matches. This prevents prefix attacks and ensures only the correct field is used.
* Added logic to reject cases where the "challenge" pattern appears more than once, or where the value does not match exactly at the expected position, further tightening the validation.

**Expanded test coverage:**

* Added multiple new tests in `barz.rs` to verify that the function rejects:
  - Challenges that are only a prefix of a longer value (prefix attack).
  - The challenge value appearing in a different field.
  - Invalid or malformed JSON.
  - JSON missing the "challenge" field.
  - JSON with whitespace between the "challenge" key and colon, ensuring strict key matching.