### PR TITLE
Enhance secure string handling and memory management in WASM

### DIFF
--- a/codegen/lib/templates/cpp/method_forward.erb
+++ b/codegen/lib/templates/cpp/method_forward.erb
@@ -2,28 +2,25 @@
   method = locals[:method]
   arguments = locals[:arguments] || ['instance'] + WasmCppHelper.arguments(method.parameters.drop(1))
   call = render('cpp/method_call.erb', { method: method, arguments: arguments })
+  data_params = method.parameters.select { |p| p.type.name == :data }
+  needs_wipe = !data_params.empty?
 
-  # Method returns data
   if should_return_data(method)
-    if method.return_type.is_nullable -%>
-    return TWDataToVal(<%= call %>);
-<%  else -%>
-    return TWDataToVal(<%= call %>);
-<%  end
-  # Method returns a string
+    return_expr = "TWDataToVal(#{call})"
   elsif should_return_string(method)
-    if method.return_type.is_nullable -%>
-    return TWStringToVal(<%= call %>);
-<%  else -%>
-    return TWStringToVal(<%= call %>);
-<% end
-  # Method returns a class or struct
+    return_expr = "TWStringToVal(#{call})"
   elsif method.return_type.is_class || method.return_type.is_struct
-    if method.return_type.is_nullable -%>
-    return new Wasm<%= method.return_type.name %>(<%= call %>);
+    return_expr = "new Wasm#{method.return_type.name}(#{call})"
+  else
+    return_expr = call
+  end
+-%>
+<%  if needs_wipe -%>
+    auto result = <%= return_expr %>;
+<%    data_params.each do |p| -%>
+    if (!<%= p.name %>Data.empty()) { memzero(<%= p.name %>Data.data(), <%= p.name %>Data.size()); }
+<%    end -%>
+    return result;
 <%  else -%>
-    return new Wasm<%= method.return_type.name %>(<%= call %>);
-<%  end
-  else -%>
-    return <%= call %>;
-<%end -%>
+    return <%= return_expr %>;
+<%  end -%>

--- a/codegen/lib/templates/cpp/method_forward.erb
+++ b/codegen/lib/templates/cpp/method_forward.erb
@@ -16,11 +16,18 @@
   end
 -%>
 <%  if needs_wipe -%>
+<%    if method.return_type.name == :void -%>
+    <%= return_expr %>;
+<%    data_params.each do |p| -%>
+    if (!<%= p.name %>Data.empty()) { memzero(<%= p.name %>Data.data(), <%= p.name %>Data.size()); }
+<%    end -%>
+<%    else -%>
     auto result = <%= return_expr %>;
 <%    data_params.each do |p| -%>
     if (!<%= p.name %>Data.empty()) { memzero(<%= p.name %>Data.data(), <%= p.name %>Data.size()); }
 <%    end -%>
     return result;
+<%    end -%>
 <%  else -%>
     return <%= return_expr %>;
 <%  end -%>

--- a/codegen/lib/templates/cpp/method_forward.erb
+++ b/codegen/lib/templates/cpp/method_forward.erb
@@ -13,9 +13,9 @@
   # Method returns a string
   elsif should_return_string(method)
     if method.return_type.is_nullable -%>
-    return TWStringToStd(<%= call %>);
+    return TWStringToVal(<%= call %>);
 <%  else -%>
-    return TWStringToStd(<%= call %>);
+    return TWStringToVal(<%= call %>);
 <% end
   # Method returns a class or struct
   elsif method.return_type.is_class || method.return_type.is_struct

--- a/wasm/src/AnySigner.cpp
+++ b/wasm/src/AnySigner.cpp
@@ -5,6 +5,7 @@
 
 #include <TrustWalletCore/TWAnySigner.h>
 #include <emscripten/bind.h>
+#include <TrezorCrypto/memzero.h>
 
 #include "WasmData.h"
 #include "Coin.h"
@@ -18,7 +19,9 @@ class AnySigner {
     static auto sign(const std::string& string, TWCoinType coin) {
         Data out;
         TW::anyCoinSign(coin, TW::data(string), out);
-        return DataToVal(out);
+        auto result = DataToVal(out);
+        memzero(out.data(), out.size());
+        return result;
     }
 
     static auto supportsJSON(TWCoinType coin) {
@@ -28,7 +31,9 @@ class AnySigner {
     static auto plan(const std::string& string, TWCoinType coin) {
         Data out;
         TW::anyCoinPlan(coin, TW::data(string), out);
-        return DataToVal(out);
+        auto result = DataToVal(out);
+        memzero(out.data(), out.size());
+        return result;
     }
 };
 

--- a/wasm/src/AnySigner.cpp
+++ b/wasm/src/AnySigner.cpp
@@ -20,7 +20,7 @@ class AnySigner {
         Data out;
         TW::anyCoinSign(coin, TW::data(string), out);
         auto result = DataToVal(out);
-        memzero(out.data(), out.size());
+        if (!out.empty()) { memzero(out.data(), out.size()); }
         return result;
     }
 
@@ -32,7 +32,7 @@ class AnySigner {
         Data out;
         TW::anyCoinPlan(coin, TW::data(string), out);
         auto result = DataToVal(out);
-        memzero(out.data(), out.size());
+        if (!out.empty()) { memzero(out.data(), out.size()); }
         return result;
     }
 };

--- a/wasm/src/AnySigner.cpp
+++ b/wasm/src/AnySigner.cpp
@@ -5,7 +5,6 @@
 
 #include <TrustWalletCore/TWAnySigner.h>
 #include <emscripten/bind.h>
-#include <TrezorCrypto/memzero.h>
 
 #include "WasmData.h"
 #include "Coin.h"
@@ -19,9 +18,7 @@ class AnySigner {
     static auto sign(const std::string& string, TWCoinType coin) {
         Data out;
         TW::anyCoinSign(coin, TW::data(string), out);
-        auto result = DataToVal(out);
-        if (!out.empty()) { memzero(out.data(), out.size()); }
-        return result;
+        return DataToVal(std::move(out));
     }
 
     static auto supportsJSON(TWCoinType coin) {
@@ -31,9 +28,7 @@ class AnySigner {
     static auto plan(const std::string& string, TWCoinType coin) {
         Data out;
         TW::anyCoinPlan(coin, TW::data(string), out);
-        auto result = DataToVal(out);
-        if (!out.empty()) { memzero(out.data(), out.size()); }
-        return result;
+        return DataToVal(std::move(out));
     }
 };
 

--- a/wasm/src/CoinTypeExt.cpp
+++ b/wasm/src/CoinTypeExt.cpp
@@ -44,7 +44,7 @@ namespace TW::Wasm {
         return TWCoinTypeStaticPrefix(coin);
     }
     auto CoinTypeExt::chainId(TWCoinType coin) {
-        return TWStringToStd(TWCoinTypeChainId(coin));
+        return TWStringToVal(TWCoinTypeChainId(coin));
     }
     auto CoinTypeExt::slip44Id(TWCoinType coin) {
         return TWCoinTypeSlip44Id(coin);
@@ -59,19 +59,19 @@ namespace TW::Wasm {
         return TWCoinTypeValidate(coin, &address);
     }
     auto CoinTypeExt::derivationPath(TWCoinType coin) {
-        return TWStringToStd(TWCoinTypeDerivationPath(coin));
+        return TWStringToVal(TWCoinTypeDerivationPath(coin));
     }
     auto CoinTypeExt::derivationPathWithDerivation(TWCoinType coin, TWDerivation derivation) {
-        return TWStringToStd(TWCoinTypeDerivationPathWithDerivation(coin, derivation));
+        return TWStringToVal(TWCoinTypeDerivationPathWithDerivation(coin, derivation));
     }
     auto CoinTypeExt::deriveAddress(TWCoinType coin, WasmPrivateKey* privateKey) {
-        return TWStringToStd(TWCoinTypeDeriveAddress(coin, privateKey->instance));
+        return TWStringToVal(TWCoinTypeDeriveAddress(coin, privateKey->instance));
     }
     auto CoinTypeExt::deriveAddressFromPublicKey(TWCoinType coin, WasmPublicKey* publicKey) {
-        return TWStringToStd(TWCoinTypeDeriveAddressFromPublicKey(coin, publicKey->instance));
+        return TWStringToVal(TWCoinTypeDeriveAddressFromPublicKey(coin, publicKey->instance));
     }
     auto CoinTypeExt::deriveAddressFromPublicKeyAndDerivation(TWCoinType coin, WasmPublicKey* publicKey, TWDerivation derivation) {
-        return TWStringToStd(TWCoinTypeDeriveAddressFromPublicKeyAndDerivation(coin, publicKey->instance, derivation));
+        return TWStringToVal(TWCoinTypeDeriveAddressFromPublicKeyAndDerivation(coin, publicKey->instance, derivation));
     }
 
     EMSCRIPTEN_BINDINGS(Wasm_CoinTypeExt) {

--- a/wasm/src/HexCoding.cpp
+++ b/wasm/src/HexCoding.cpp
@@ -18,7 +18,7 @@ class HexCoding {
     static auto parseHex(const std::string& string) {
         auto data = TW::parse_hex(string, true);
         auto result = DataToVal(data);
-        memzero(data.data(), data.size());
+        if (!data.empty()) { memzero(data.data(), data.size()); }
         return result;
     }
 

--- a/wasm/src/HexCoding.cpp
+++ b/wasm/src/HexCoding.cpp
@@ -4,6 +4,7 @@
 //
 
 #include <emscripten/bind.h>
+#include <TrezorCrypto/memzero.h>
 
 #include "WasmData.h"
 #include "HexCoding.h"
@@ -15,7 +16,10 @@ namespace TW::Wasm {
 class HexCoding {
   public:
     static auto parseHex(const std::string& string) {
-        return DataToVal(TW::parse_hex(string, true));
+        auto data = TW::parse_hex(string, true);
+        auto result = DataToVal(data);
+        memzero(data.data(), data.size());
+        return result;
     }
 
     static auto hexEncoded(const std::string& string) {

--- a/wasm/src/HexCoding.cpp
+++ b/wasm/src/HexCoding.cpp
@@ -4,7 +4,6 @@
 //
 
 #include <emscripten/bind.h>
-#include <TrezorCrypto/memzero.h>
 
 #include "WasmData.h"
 #include "HexCoding.h"
@@ -17,9 +16,7 @@ class HexCoding {
   public:
     static auto parseHex(const std::string& string) {
         auto data = TW::parse_hex(string, true);
-        auto result = DataToVal(data);
-        if (!data.empty()) { memzero(data.data(), data.size()); }
-        return result;
+        return DataToVal(std::move(data));
     }
 
     static auto hexEncoded(const std::string& string) {

--- a/wasm/src/WasmData.cpp
+++ b/wasm/src/WasmData.cpp
@@ -4,6 +4,7 @@
 //
 
 #include "WasmData.h"
+#include "Defer.h"
 
 #include <TrezorCrypto/memzero.h>
 
@@ -12,19 +13,23 @@ using namespace emscripten;
 namespace TW::Wasm {
 
 auto DataToVal(Data&& data) -> val {
-    auto view = val(typed_memory_view(data.size(), data.data()));
-    auto jsArray = val::global("Uint8Array").new_(data.size());
+    Data local = std::move(data);  // take ownership; caller's object is now empty
+    defer {
+        if (!local.empty()) { memzero(local.data(), local.size()); }
+    };
+    auto view = val(typed_memory_view(local.size(), local.data()));
+    auto jsArray = val::global("Uint8Array").new_(local.size());
     jsArray.call<void>("set", view);
-    if (!data.empty()) { memzero(data.data(), data.size()); }
     return jsArray;
 }
 
 auto TWDataToVal(TWData* _Nonnull data) -> val {
+    defer {
+        TWDataDelete(data);
+    };
     auto* v = reinterpret_cast<Data*>(data);
-    auto result = DataToVal(std::move(*v));
-    // v is now moved-from (empty); TWDataDelete skips memzero but frees the object.
-    TWDataDelete(data);
-    return result;
+    Data local = std::move(*v);  // *v is now genuinely empty; local owns the buffer
+    return DataToVal(std::move(local));
 }
 
 } // namespace TW::Wasm

--- a/wasm/src/WasmData.cpp
+++ b/wasm/src/WasmData.cpp
@@ -27,7 +27,7 @@ auto TWDataToVal(TWData* _Nonnull data) -> val {
     defer {
         TWDataDelete(data);
     };
-    auto* v = reinterpret_cast<Data*>(data);
+    auto* v = const_cast<Data*>(reinterpret_cast<const Data*>(data));
     Data local = std::move(*v);  // *v is now genuinely empty; local owns the buffer
     return DataToVal(std::move(local));
 }

--- a/wasm/src/WasmData.cpp
+++ b/wasm/src/WasmData.cpp
@@ -4,25 +4,27 @@
 //
 
 #include "WasmData.h"
-#include "Defer.h"
+
+#include <TrezorCrypto/memzero.h>
 
 using namespace emscripten;
 
 namespace TW::Wasm {
 
-auto DataToVal(const Data& data) -> val {
+auto DataToVal(Data&& data) -> val {
     auto view = val(typed_memory_view(data.size(), data.data()));
     auto jsArray = val::global("Uint8Array").new_(data.size());
     jsArray.call<void>("set", view);
+    if (!data.empty()) { memzero(data.data(), data.size()); }
     return jsArray;
 }
 
 auto TWDataToVal(TWData* _Nonnull data) -> val {
-    defer {
-        TWDataDelete(data);
-    };
-    auto* v = reinterpret_cast<const Data*>(data);
-    return DataToVal(*v);
+    auto* v = reinterpret_cast<Data*>(data);
+    auto result = DataToVal(std::move(*v));
+    // v is now moved-from (empty); TWDataDelete skips memzero but frees the object.
+    TWDataDelete(data);
+    return result;
 }
 
 } // namespace TW::Wasm

--- a/wasm/src/WasmData.cpp
+++ b/wasm/src/WasmData.cpp
@@ -10,7 +10,7 @@ using namespace emscripten;
 
 namespace TW::Wasm {
 
-auto DataToVal(Data data) -> val {
+auto DataToVal(const Data& data) -> val {
     auto view = val(typed_memory_view(data.size(), data.data()));
     auto jsArray = val::global("Uint8Array").new_(data.size());
     jsArray.call<void>("set", view);

--- a/wasm/src/WasmData.h
+++ b/wasm/src/WasmData.h
@@ -12,7 +12,7 @@
 
 namespace TW::Wasm {
 
-auto DataToVal(Data data) -> emscripten::val;
+auto DataToVal(const Data& data) -> emscripten::val;
 
 /// Converts a TWData * to Uint8Array, deleting the TWData * when done.
 auto TWDataToVal(TWData *_Nonnull data) -> emscripten::val;

--- a/wasm/src/WasmData.h
+++ b/wasm/src/WasmData.h
@@ -12,7 +12,8 @@
 
 namespace TW::Wasm {
 
-auto DataToVal(const Data& data) -> emscripten::val;
+/// Takes ownership of data, copies to a JS Uint8Array, then zeroes the WASM-heap buffer.
+auto DataToVal(Data&& data) -> emscripten::val;
 
 /// Converts a TWData * to Uint8Array, deleting the TWData * when done.
 auto TWDataToVal(TWData *_Nonnull data) -> emscripten::val;

--- a/wasm/src/WasmData.h
+++ b/wasm/src/WasmData.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <TrustWalletCore/TWData.h>
+#include <TrezorCrypto/memzero.h>
 #include <emscripten/val.h>
 
 #include "Data.h"

--- a/wasm/src/WasmString.cpp
+++ b/wasm/src/WasmString.cpp
@@ -6,14 +6,25 @@
 #include "WasmString.h"
 #include "Defer.h"
 
+#include <emscripten/val.h>
+
+using namespace emscripten;
+
 namespace TW::Wasm {
 
-auto TWStringToStd(TWString *_Nonnull string) -> std::string {
+auto TWStringToVal(TWString *_Nonnull string) -> val {
     defer {
         TWStringDelete(string);
     };
     auto* s = reinterpret_cast<const std::string*>(string);
-    auto result = *s;
+    // View the original bytes in-place — no WASM-heap copy.
+    auto view = val(typed_memory_view(s->size(), reinterpret_cast<const uint8_t*>(s->data())));
+    // Copy once into a JS-heap Uint8Array (not in WASM linear memory).
+    auto jsArr = val::global("Uint8Array").new_(view);
+    // Decode to a JS string; the original WASM buffer is zeroed by the defer.
+    auto result = val::global("TextDecoder").new_().call<val>("decode", jsArr);
+    // Zero the intermediate JS-heap byte copy as well.
+    jsArr.call<void>("fill", val(0));
     return result;
 }
 

--- a/wasm/src/WasmString.cpp
+++ b/wasm/src/WasmString.cpp
@@ -21,10 +21,11 @@ auto TWStringToVal(TWString *_Nonnull string) -> val {
     auto view = val(typed_memory_view(s->size(), reinterpret_cast<const uint8_t*>(s->data())));
     // Copy once into a JS-heap Uint8Array (not in WASM linear memory).
     auto jsArr = val::global("Uint8Array").new_(view);
-    // Decode to a JS string; the original WASM buffer is zeroed by the defer.
+    // Decode to a JS string.
     auto result = val::global("TextDecoder").new_().call<val>("decode", jsArr);
-    // Zero the intermediate JS-heap byte copy as well.
+    // Zero the JS-heap intermediate byte copy.
     jsArr.call<void>("fill", val(0));
+    // defer calls TWStringDelete, which calls memzero on the buffer before freeing.
     return result;
 }
 

--- a/wasm/src/WasmString.h
+++ b/wasm/src/WasmString.h
@@ -11,9 +11,9 @@
 
 namespace TW::Wasm {
 
-/// Converts a TWString * to a JS string val, zeroing all WASM-heap copies and
-/// deleting the TWString * when done.  Prefer this over TWStringToStd for any
-/// string that may contain secret material (keys, mnemonics, signatures).
+/// Converts a TWString * to a JS string val.
+/// Zeroes the WASM-heap buffer via TWStringDelete (which calls memzero internally),
+/// and explicitly zeroes the intermediate JS-heap Uint8Array before returning.
 auto TWStringToVal(TWString *_Nonnull string) -> emscripten::val;
 
 } // namespace TW::Wasm

--- a/wasm/src/WasmString.h
+++ b/wasm/src/WasmString.h
@@ -6,11 +6,14 @@
 #pragma once
 
 #include <TrustWalletCore/TWString.h>
+#include <emscripten/val.h>
 #include <string>
 
 namespace TW::Wasm {
 
-/// Converts a TWString * to std::string, deleting the TWString * when done.
-auto TWStringToStd(TWString *_Nonnull string) -> std::string;
+/// Converts a TWString * to a JS string val, zeroing all WASM-heap copies and
+/// deleting the TWString * when done.  Prefer this over TWStringToStd for any
+/// string that may contain secret material (keys, mnemonics, signatures).
+auto TWStringToVal(TWString *_Nonnull string) -> emscripten::val;
 
 } // namespace TW::Wasm


### PR DESCRIPTION
This pull request introduces significant improvements to how sensitive data is handled in the WASM bindings, focusing on enhanced memory hygiene and security. The main changes include ensuring that data buffers are securely zeroed after use, updating conversion utilities to return JavaScript values instead of C++ strings, and refactoring method templates to consistently wipe sensitive parameters. These updates help prevent leaks of sensitive information in both WASM and JS heaps.

**Memory hygiene and security improvements:**

* Updated `DataToVal` and `TWDataToVal` to take ownership of data, copy it to a JS `Uint8Array`, and securely zero the WASM-heap buffer after use (`wasm/src/WasmData.cpp`, `wasm/src/WasmData.h`). [[1]](diffhunk://#diff-2b7a11973c81f36436c528f07ec7ceed485720c4ddff6e9c56ae3d85ba4d68f3R9-R21) [[2]](diffhunk://#diff-2b7a11973c81f36436c528f07ec7ceed485720c4ddff6e9c56ae3d85ba4d68f3L24-R32) [[3]](diffhunk://#diff-b7e0fa0d553f62e1361b8eb85829bb3f4a87d35726ca5d6675e224b87df26474L15-R16)
* Refactored `TWStringToStd` to `TWStringToVal`, now returning a JS string and explicitly zeroing both the WASM-heap and the intermediate JS-heap byte buffers (`wasm/src/WasmString.cpp`, `wasm/src/WasmString.h`). [[1]](diffhunk://#diff-28f283ccc3f0c0f761f43cba9b647b0ba7c2a5217c87b48da5360e8c0f5bbfe5R9-R28) [[2]](diffhunk://#diff-c568db0e79ae2007c5c655af0c761da50122d37748706240e14eab240597a6c2R9-R17)

**Template and method call refactoring:**

* Updated the C++ method forward template to detect parameters of type `data` and, after method calls, securely wipe their buffers before returning results (`codegen/lib/templates/cpp/method_forward.erb`).
* Changed `AnySigner::sign` and `AnySigner::plan` to use `std::move` for efficient transfer and zeroing of output buffers (`wasm/src/AnySigner.cpp`). [[1]](diffhunk://#diff-40c0b9381f3fff8952980b2ec621274b1752f964b8cbc87d03c1571844ce7260L21-R21) [[2]](diffhunk://#diff-40c0b9381f3fff8952980b2ec621274b1752f964b8cbc87d03c1571844ce7260L31-R31)
* Modified `HexCoding::parseHex` to use `std::move` for proper ownership and zeroing of parsed data (`wasm/src/HexCoding.cpp`).

**API consistency:**

* Updated all relevant `CoinTypeExt` methods to use `TWStringToVal` instead of `TWStringToStd`, ensuring consistent secure string handling across the API (`wasm/src/CoinTypeExt.cpp`). [[1]](diffhunk://#diff-c2121f7e0ab088e24617a3c4c518faeaec1ff17b9bb1ab30cbc27fd6cabfc2cbL47-R47) [[2]](diffhunk://#diff-c2121f7e0ab088e24617a3c4c518faeaec1ff17b9bb1ab30cbc27fd6cabfc2cbL62-R74)