### PR TITLE
Ci/revive sonarcloud new org

### DIFF
--- a/.github/workflows/linux-ci-sonarcloud.yml
+++ b/.github/workflows/linux-ci-sonarcloud.yml
@@ -12,9 +12,9 @@ concurrency:
 
 jobs:
   build:
-    # if: github.event.pull_request.draft == false
-    # Temporarily disabled due to issues with SonarCloud account.
-    if: false
+    # Skip drafts; push events (dev/master) always run. Re-enabled after the
+    # analysis moved to the trustwallet-1 SonarCloud organization.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,3 +5,7 @@ sonar.cfamily.reportingCppStandardOverride=c++20
 sonar.cfamily.cache.enabled=false
 sonar.lang.patterns.cpp=**/*.cc,**/*.cpp,**/*.cxx,**/*.c++,**/*.hh,**/*.hpp,**/*.hxx,**/*.h++,**/*.ipp,**/*.h
 sonar.lang.patterns.c=**/*.c
+
+# The scanner CLI is unzipped into the working directory by
+# tools/sonarcloud-analysis — keep it out of the analysis scope.
+sonar.exclusions=sonar-scanner-*/**,sonar-scanner-cli-*.zip

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.organization=trustwallet
-sonar.projectKey=TrustWallet_wallet-core
+sonar.organization=trustwallet-1
+sonar.projectKey=trustwallet_wallet-core
 sonar.cfamily.compile-commands=build/compile_commands.json
 sonar.cfamily.reportingCppStandardOverride=c++20
 sonar.cfamily.cache.enabled=false

--- a/tools/sonarcloud-analysis
+++ b/tools/sonarcloud-analysis
@@ -5,8 +5,9 @@ set -euo pipefail
 # Since sonar-scanner-cli 6.x the Linux artifact is arch-suffixed (linux-x64).
 TARGET=sonar-scanner-cli-8.1.0.6389-linux-x64.zip
 TARGET_DIR=sonar-scanner-8.1.0.6389-linux-x64
-curl -sSfL https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/${TARGET} --output ${TARGET}
-unzip -q ${TARGET}
-cp tools/sonar-scanner.properties ${TARGET_DIR}/conf
-chmod +x ${TARGET_DIR}/bin/sonar-scanner
-./${TARGET_DIR}/bin/sonar-scanner
+curl -sSfL "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/${TARGET}" --output "${TARGET}"
+unzip -q "${TARGET}"
+rm -f "${TARGET}"
+cp tools/sonar-scanner.properties "${TARGET_DIR}/conf"
+chmod +x "${TARGET_DIR}/bin/sonar-scanner"
+"./${TARGET_DIR}/bin/sonar-scanner"

--- a/tools/sonarcloud-analysis
+++ b/tools/sonarcloud-analysis
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
-TARGET=sonar-scanner-cli-5.0.1.3006-linux.zip
-TARGET_DIR=sonar-scanner-5.0.1.3006-linux
-curl https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/${TARGET} --output ${TARGET}
-unzip ${TARGET}
+set -euo pipefail
+
+# Since sonar-scanner-cli 6.x the Linux artifact is arch-suffixed (linux-x64).
+TARGET=sonar-scanner-cli-8.1.0.6389-linux-x64.zip
+TARGET_DIR=sonar-scanner-8.1.0.6389-linux-x64
+curl -sSfL https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/${TARGET} --output ${TARGET}
+unzip -q ${TARGET}
 cp tools/sonar-scanner.properties ${TARGET_DIR}/conf
 chmod +x ${TARGET_DIR}/bin/sonar-scanner
 ./${TARGET_DIR}/bin/sonar-scanner


### PR DESCRIPTION
 Re-enables the \`Linux CI SonarCloud\` workflow, which was hard-disabled with \`if: false\` (\"Temporarily disabled due to issues with SonarCloud account\") after the previous SonarCloud account stopped working.

  - \`sonar-project.properties\`: retarget \`sonar.organization\` / \`sonar.projectKey\` to the organization where the project now lives.
  - \`linux-ci-sonarcloud.yml\`: \`if: false\` → draft gate (\`github.event_name != 'pull_request' || github.event.pull_request.draft == false\`); push events on \`dev\`/\`master\` always run.
  - \`tools/sonarcloud-analysis\`: bump sonar-scanner-cli 5.0.1 → 8.1.0 (the Linux artifact is arch-suffixed since 6.x) and make the download fail fast (\`set -euo pipefail\`, \`curl -sSfL\`).

  The \`SONAR_TOKEN\` repo secret has been updated for the new organization.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)"