### PR TITLE
chore: update native token names for Lightlink, MegaETH, and Merlin

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -24,7 +24,7 @@ jobs:
         distribution: 'temurin'
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+      uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       with:
         gradle-version: 8.10.2
 

--- a/.github/workflows/kotlin-ci.yml
+++ b/.github/workflows/kotlin-ci.yml
@@ -24,7 +24,7 @@ jobs:
         distribution: 'temurin'
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+      uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       with:
         gradle-version: 8.10.2
 

--- a/registry.json
+++ b/registry.json
@@ -4683,6 +4683,7 @@
   {
     "id": "merlin",
     "name": "Merlin",
+    "nativeTokenName": "Bitcoin",
     "coinId": 4200,
     "symbol": "BTC",
     "decimals": 18,
@@ -4714,6 +4715,7 @@
     "id": "lightlink",
     "name": "Lightlink",
     "displayName": "Lightlink Phoenix",
+    "nativeTokenName": "Ethereum",
     "coinId": 1890,
     "symbol": "ETH",
     "decimals": 18,
@@ -4990,6 +4992,7 @@
   {
     "id": "megaeth",
     "name": "MegaETH",
+    "nativeTokenName": "Ethereum",
     "coinId": 4326,
     "symbol": "ETH",
     "decimals": 18,

--- a/tests/chains/Lightlink/TWCoinTypeTests.cpp
+++ b/tests/chains/Lightlink/TWCoinTypeTests.cpp
@@ -19,7 +19,7 @@ TEST(TWLightlinkCoinType, TWCoinType) {
 
     assertStringsEqual(id, "lightlink");
     assertStringsEqual(name, "Lightlink Phoenix");
-    assertStringsEqual(nativeTokenName, "Lightlink Phoenix");
+    assertStringsEqual(nativeTokenName, "Ethereum");
     assertStringsEqual(symbol, "ETH");
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(coin), 18);
     ASSERT_EQ(TWCoinTypeBlockchain(coin), TWBlockchainEthereum);

--- a/tests/chains/MegaETH/TWCoinTypeTests.cpp
+++ b/tests/chains/MegaETH/TWCoinTypeTests.cpp
@@ -19,7 +19,7 @@ TEST(TWMegaETHCoinType, TWCoinType) {
 
     assertStringsEqual(id, "megaeth");
     assertStringsEqual(name, "MegaETH");
-    assertStringsEqual(nativeTokenName, "MegaETH");
+    assertStringsEqual(nativeTokenName, "Ethereum");
     assertStringsEqual(symbol, "ETH");
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(coin), 18);
     ASSERT_EQ(TWCoinTypeBlockchain(coin), TWBlockchainEthereum);

--- a/tests/chains/Merlin/TWCoinTypeTests.cpp
+++ b/tests/chains/Merlin/TWCoinTypeTests.cpp
@@ -19,7 +19,7 @@ TEST(TWMerlinCoinType, TWCoinType) {
 
     assertStringsEqual(id, "merlin");
     assertStringsEqual(name, "Merlin");
-    assertStringsEqual(nativeTokenName, "Merlin");
+    assertStringsEqual(nativeTokenName, "Bitcoin");
     assertStringsEqual(symbol, "BTC");
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(coin), 18);
     ASSERT_EQ(TWCoinTypeBlockchain(coin), TWBlockchainEthereum);


### PR DESCRIPTION
This pull request updates the `nativeTokenName` field for Merlin, Lightlink, and MegaETH in both the `registry.json` configuration and their corresponding unit tests. The changes ensure that the `nativeTokenName` accurately reflects the actual native token for each chain, improving consistency between configuration and code.

**Registry configuration updates:**
- Updated `nativeTokenName` for `merlin` from "Merlin" to "Bitcoin" in `registry.json`.
- Updated `nativeTokenName` for `lightlink` from missing to "Ethereum" in `registry.json`.
- Updated `nativeTokenName` for `megaeth` from missing to "Ethereum" in `registry.json`.

**Unit test updates:**
- Updated `nativeTokenName` assertion in `tests/chains/Merlin/TWCoinTypeTests.cpp` to expect "Bitcoin" for Merlin.
- Updated `nativeTokenName` assertion in `tests/chains/Lightlink/TWCoinTypeTests.cpp` to expect "Ethereum" for Lightlink.
- Updated `nativeTokenName` assertion in `tests/chains/MegaETH/TWCoinTypeTests.cpp` to expect "Ethereum" for MegaETH.