### PR TITLE
chore: add @trustwallet/core-services to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @trustwallet/onchain-corex-enabling @BSCSecChef
+* @trustwallet/core-services

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @trustwallet/onchain-corex-enabling @BSCSecChef
-* @trustwallet/core-services
+* @trustwallet/onchain-corex-enabling @BSCSecChef @trustwallet/core-services


### PR DESCRIPTION
This pull request makes a small update to the `.github/CODEOWNERS` file, adding ownership for all files to the `@trustwallet/core-services` team.