### PR TITLE
fix(thorchain): prevent uncaught exception crossing C ABI in swap builder

### DIFF
--- a/src/THORChain/Swap.cpp
+++ b/src/THORChain/Swap.cpp
@@ -24,6 +24,8 @@
 #include "Binance/Address.h"
 #include "../proto/Binance.pb.h"
 
+#include <algorithm>
+#include <cctype>
 #include <cstdlib>
 
 /*
@@ -32,6 +34,15 @@
  */
 
 namespace TW::THORChainSwap {
+
+/// Returns true if the string is a non-empty sequence of decimal digits only.
+/// Used to reject non-numeric amount fields before they reach uint256_t()/std::stoull(),
+/// both of which throw on malformed input.
+static bool isValidUInt(const std::string& value) {
+    return !value.empty() && std::all_of(value.begin(), value.end(), [](unsigned char c) {
+        return std::isdigit(c) != 0;
+    });
+}
 
 static Data ethAddressStringToData(const std::string& asString) {
     Data asData(20);
@@ -110,6 +121,20 @@ SwapBundled SwapBuilder::build(bool shortened) {
         return {.status_code = static_cast<SwapErrorCode>(Proto::ErrorCode::Error_Invalid_to_address), .error = "Invalid to address"};
     }
 
+    // Validate numeric amount fields before parsing; uint256_t() and std::stoull() throw on
+    // malformed input, and this function is reached from an extern "C" boundary where an
+    // uncaught exception would terminate the host process.
+    if (!isValidUInt(mFromAmount)) {
+        return {.status_code = static_cast<SwapErrorCode>(Proto::ErrorCode::Error_general), .error = "Invalid from amount"};
+    }
+    if (!isValidUInt(mToAmountLimit)) {
+        return {.status_code = static_cast<SwapErrorCode>(Proto::ErrorCode::Error_general), .error = "Invalid to amount limit"};
+    }
+    if (mStreamParams.has_value() &&
+        (!isValidUInt(mStreamParams->mInterval) || !isValidUInt(mStreamParams->mQuantity))) {
+        return {.status_code = static_cast<SwapErrorCode>(Proto::ErrorCode::Error_general), .error = "Invalid stream params"};
+    }
+
     uint256_t fromAmountNum = uint256_t(mFromAmount);
     const auto memo = this->buildMemo(shortened);
 
@@ -134,7 +159,7 @@ SwapBundled SwapBuilder::build(bool shortened) {
         return {.status_code = static_cast<SwapErrorCode>(Proto::ErrorCode::Error_Unsupported_from_chain), .error = "Unsupported from chain: " + std::to_string(fromChain)};
     }
 }
-std::string SwapBuilder::buildMemo(bool shortened) noexcept {
+std::string SwapBuilder::buildMemo(bool shortened) {
     uint64_t toAmountLimitNum = std::stoull(mToAmountLimit);
 
     // Memo: 'SWAP', or shortened '='; see https://dev.thorchain.org/thorchain-dev/concepts/memos

--- a/src/THORChain/Swap.cpp
+++ b/src/THORChain/Swap.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>
+#include <limits>
 
 /*
  * References:
@@ -35,13 +36,20 @@
 
 namespace TW::THORChainSwap {
 
-/// Returns true if the string is a non-empty sequence of decimal digits only.
-/// Used to reject non-numeric amount fields before they reach uint256_t()/std::stoull(),
-/// both of which throw on malformed input.
+/// Returns true if the string is a canonical decimal uint256_t (no leading zeros, e.g. "0500"
+/// would otherwise be misparsed as octal 320) that doesn't exceed uint256_t's max (which would
+/// otherwise silently wrap around).
 static bool isValidUInt(const std::string& value) {
-    return !value.empty() && std::all_of(value.begin(), value.end(), [](unsigned char c) {
-        return std::isdigit(c) != 0;
-    });
+    if (value.empty() || !std::all_of(value.begin(), value.end(), [](unsigned char c) {
+            return std::isdigit(c) != 0;
+        })) {
+        return false;
+    }
+    if (value.size() > 1 && value.front() == '0') {
+        return false;
+    }
+    using boost::multiprecision::cpp_int;
+    return cpp_int(value) <= cpp_int(std::numeric_limits<uint256_t>::max());
 }
 
 static Data ethAddressStringToData(const std::string& asString) {

--- a/src/THORChain/Swap.h
+++ b/src/THORChain/Swap.h
@@ -168,7 +168,7 @@ public:
         return *this;
     }
 
-    std::string buildMemo(bool shortened = true) noexcept;
+    std::string buildMemo(bool shortened = true);
 
     SwapBundled build(bool shortened = true);
 };

--- a/src/THORChain/TWSwap.cpp
+++ b/src/THORChain/TWSwap.cpp
@@ -12,101 +12,113 @@ using namespace TW;
 TWData* _Nonnull TWTHORChainSwapBuildSwap(TWData* _Nonnull input) {
     THORChainSwap::Proto::SwapInput inputProto;
     THORChainSwap::Proto::SwapOutput outputProto;
-    if (!inputProto.ParseFromArray(TWDataBytes(input), static_cast<int>(TWDataSize(input)))) {
-        // error
-        outputProto.mutable_error()->set_code(THORChainSwap::Proto::ErrorCode::Error_Input_proto_deserialization);
-        outputProto.mutable_error()->set_message("Could not deserialize input proto");
-        auto outputData = TW::data(outputProto.SerializeAsString());
-        return TWDataCreateWithBytes(outputData.data(), outputData.size());
-    }
 
-    const auto fromChain = inputProto.from_asset().chain();
-    const auto toChain = inputProto.to_asset().chain();
-    auto builder = THORChainSwap::SwapBuilder::builder();
-    builder
-        .from(inputProto.from_asset())
-        .to(inputProto.to_asset())
-        .fromAddress(inputProto.from_address())
-        .toAddress(inputProto.to_address())
-        .vault(inputProto.vault_address())
-        .router(inputProto.router_address())
-        .fromAmount(inputProto.from_amount())
-        .toAmountLimit(inputProto.to_amount_limit())
-        .affFeeAddress(inputProto.affiliate_fee_address())
-        .affFeeRate(inputProto.affiliate_fee_rate_bp())
-        .extraMemo(inputProto.extra_memo())
-        .expirationPolicy(static_cast<size_t>(inputProto.expiration_time()));
-    if (inputProto.has_stream_params()) {
-        const auto& streamParams = inputProto.stream_params();
-        builder
-            .streamInterval(streamParams.interval())
-            .streamQuantity(streamParams.quantity());
-    }
-
-    auto&& [txInput, errorCode, error] = builder.build();
-    outputProto.set_from_chain(fromChain);
-    outputProto.set_to_chain(toChain);
-    if (errorCode != 0) {
-        // error
-        outputProto.mutable_error()->set_code(static_cast<THORChainSwap::Proto::ErrorCode>(errorCode));
-        outputProto.mutable_error()->set_message(error);
-    } else {
-        // no error
-        outputProto.mutable_error()->set_code(THORChainSwap::Proto::ErrorCode::OK);
-        outputProto.mutable_error()->set_message("");
-
-        switch (fromChain) {
-        case THORChainSwap::Proto::BTC:
-        case THORChainSwap::Proto::DOGE:
-        case THORChainSwap::Proto::BCH:
-        case THORChainSwap::Proto::LTC: {
-            Bitcoin::Proto::SigningInput btcInput;
-            if (!btcInput.ParseFromArray(txInput.data(), static_cast<int>(txInput.size()))) {
-                outputProto.mutable_error()->set_code(THORChainSwap::Proto::ErrorCode::Error_Input_proto_deserialization);
-                outputProto.mutable_error()->set_message("Could not deserialize BTC input");
-            } else {
-                *outputProto.mutable_bitcoin() = btcInput;
-            }
-        } break;
-
-        case THORChainSwap::Proto::ETH:
-        case THORChainSwap::Proto::BSC:
-        case THORChainSwap::Proto::AVAX: {
-            Ethereum::Proto::SigningInput ethInput;
-            if (!ethInput.ParseFromArray(txInput.data(), static_cast<int>(txInput.size()))) {
-                outputProto.mutable_error()->set_code(THORChainSwap::Proto::ErrorCode::Error_Input_proto_deserialization);
-                outputProto.mutable_error()->set_message("Could not deserialize ETH input");
-            } else {
-                *outputProto.mutable_ethereum() = ethInput;
-            }
-        } break;
-
-        case THORChainSwap::Proto::BNB: {
-            Binance::Proto::SigningInput bnbInput;
-            if (!bnbInput.ParseFromArray(txInput.data(), static_cast<int>(txInput.size()))) {
-                outputProto.mutable_error()->set_code(THORChainSwap::Proto::ErrorCode::Error_Input_proto_deserialization);
-                outputProto.mutable_error()->set_message("Could not deserialize BNB input");
-            } else {
-                *outputProto.mutable_binance() = bnbInput;
-            }
-        } break;
-
-        case THORChainSwap::Proto::THOR:
-        case THORChainSwap::Proto::ATOM: {
-            Cosmos::Proto::SigningInput cosmosInput;
-            if (!cosmosInput.ParseFromArray(txInput.data(), static_cast<int>(txInput.size()))) {
-                outputProto.mutable_error()->set_code(THORChainSwap::Proto::ErrorCode::Error_Input_proto_deserialization);
-                outputProto.mutable_error()->set_message("Could not deserialize ATOM input");
-            } else {
-                *outputProto.mutable_cosmos() = cosmosInput;
-            }
-        } break;
-
-        default:
-            outputProto.mutable_error()->set_code(THORChainSwap::Proto::ErrorCode::Error_Unsupported_from_chain);
-            outputProto.mutable_error()->set_message(std::string("Unsupported from chain ") + std::to_string(fromChain));
-            break;
+    // The whole builder pipeline runs inside a try/catch: this function is an extern "C"
+    // boundary, and any C++ exception that escaped it (e.g. from parsing malformed numeric
+    // amount fields) would cross the C ABI and call std::terminate, crashing the host process.
+    try {
+        if (!inputProto.ParseFromArray(TWDataBytes(input), static_cast<int>(TWDataSize(input)))) {
+            // error
+            outputProto.mutable_error()->set_code(THORChainSwap::Proto::ErrorCode::Error_Input_proto_deserialization);
+            outputProto.mutable_error()->set_message("Could not deserialize input proto");
+            auto outputData = TW::data(outputProto.SerializeAsString());
+            return TWDataCreateWithBytes(outputData.data(), outputData.size());
         }
+
+        const auto fromChain = inputProto.from_asset().chain();
+        const auto toChain = inputProto.to_asset().chain();
+        auto builder = THORChainSwap::SwapBuilder::builder();
+        builder
+            .from(inputProto.from_asset())
+            .to(inputProto.to_asset())
+            .fromAddress(inputProto.from_address())
+            .toAddress(inputProto.to_address())
+            .vault(inputProto.vault_address())
+            .router(inputProto.router_address())
+            .fromAmount(inputProto.from_amount())
+            .toAmountLimit(inputProto.to_amount_limit())
+            .affFeeAddress(inputProto.affiliate_fee_address())
+            .affFeeRate(inputProto.affiliate_fee_rate_bp())
+            .extraMemo(inputProto.extra_memo())
+            .expirationPolicy(static_cast<size_t>(inputProto.expiration_time()));
+        if (inputProto.has_stream_params()) {
+            const auto& streamParams = inputProto.stream_params();
+            builder
+                .streamInterval(streamParams.interval())
+                .streamQuantity(streamParams.quantity());
+        }
+
+        auto&& [txInput, errorCode, error] = builder.build();
+        outputProto.set_from_chain(fromChain);
+        outputProto.set_to_chain(toChain);
+        if (errorCode != 0) {
+            // error
+            outputProto.mutable_error()->set_code(static_cast<THORChainSwap::Proto::ErrorCode>(errorCode));
+            outputProto.mutable_error()->set_message(error);
+        } else {
+            // no error
+            outputProto.mutable_error()->set_code(THORChainSwap::Proto::ErrorCode::OK);
+            outputProto.mutable_error()->set_message("");
+
+            switch (fromChain) {
+            case THORChainSwap::Proto::BTC:
+            case THORChainSwap::Proto::DOGE:
+            case THORChainSwap::Proto::BCH:
+            case THORChainSwap::Proto::LTC: {
+                Bitcoin::Proto::SigningInput btcInput;
+                if (!btcInput.ParseFromArray(txInput.data(), static_cast<int>(txInput.size()))) {
+                    outputProto.mutable_error()->set_code(THORChainSwap::Proto::ErrorCode::Error_Input_proto_deserialization);
+                    outputProto.mutable_error()->set_message("Could not deserialize BTC input");
+                } else {
+                    *outputProto.mutable_bitcoin() = btcInput;
+                }
+            } break;
+
+            case THORChainSwap::Proto::ETH:
+            case THORChainSwap::Proto::BSC:
+            case THORChainSwap::Proto::AVAX: {
+                Ethereum::Proto::SigningInput ethInput;
+                if (!ethInput.ParseFromArray(txInput.data(), static_cast<int>(txInput.size()))) {
+                    outputProto.mutable_error()->set_code(THORChainSwap::Proto::ErrorCode::Error_Input_proto_deserialization);
+                    outputProto.mutable_error()->set_message("Could not deserialize ETH input");
+                } else {
+                    *outputProto.mutable_ethereum() = ethInput;
+                }
+            } break;
+
+            case THORChainSwap::Proto::BNB: {
+                Binance::Proto::SigningInput bnbInput;
+                if (!bnbInput.ParseFromArray(txInput.data(), static_cast<int>(txInput.size()))) {
+                    outputProto.mutable_error()->set_code(THORChainSwap::Proto::ErrorCode::Error_Input_proto_deserialization);
+                    outputProto.mutable_error()->set_message("Could not deserialize BNB input");
+                } else {
+                    *outputProto.mutable_binance() = bnbInput;
+                }
+            } break;
+
+            case THORChainSwap::Proto::THOR:
+            case THORChainSwap::Proto::ATOM: {
+                Cosmos::Proto::SigningInput cosmosInput;
+                if (!cosmosInput.ParseFromArray(txInput.data(), static_cast<int>(txInput.size()))) {
+                    outputProto.mutable_error()->set_code(THORChainSwap::Proto::ErrorCode::Error_Input_proto_deserialization);
+                    outputProto.mutable_error()->set_message("Could not deserialize ATOM input");
+                } else {
+                    *outputProto.mutable_cosmos() = cosmosInput;
+                }
+            } break;
+
+            default:
+                outputProto.mutable_error()->set_code(THORChainSwap::Proto::ErrorCode::Error_Unsupported_from_chain);
+                outputProto.mutable_error()->set_message(std::string("Unsupported from chain ") + std::to_string(fromChain));
+                break;
+            }
+        }
+    } catch (...) {
+        // Backstop: map any escaped exception to an error output instead of crossing the C ABI.
+        outputProto.set_from_chain(inputProto.from_asset().chain());
+        outputProto.set_to_chain(inputProto.to_asset().chain());
+        outputProto.mutable_error()->set_code(THORChainSwap::Proto::ErrorCode::Error_general);
+        outputProto.mutable_error()->set_message("Exception while building swap");
     }
 
     // serialize output

--- a/tests/chains/Cosmos/THORChain/SwapTests.cpp
+++ b/tests/chains/Cosmos/THORChain/SwapTests.cpp
@@ -57,6 +57,68 @@ TEST(THORChainSwap, OverflowFixEth) {
     ASSERT_EQ(errorCode, 0);
 }
 
+TEST(THORChainSwap, RejectNonNumericFromAmount) {
+    Proto::Asset fromAsset;
+    fromAsset.set_chain(static_cast<Proto::Chain>(Chain::BTC));
+    Proto::Asset toAsset;
+    toAsset.set_chain(static_cast<Proto::Chain>(Chain::ETH));
+    toAsset.set_symbol("ETH");
+    auto&& [out, errorCode, error] = SwapBuilder::builder()
+                                         .from(fromAsset)
+                                         .to(toAsset)
+                                         .fromAddress(Address1Btc)
+                                         .toAddress(Address1Eth)
+                                         .vault(VaultBtc)
+                                         .fromAmount("not_a_number")
+                                         .toAmountLimit("140000000000000000")
+                                         .build();
+    EXPECT_EQ(errorCode, static_cast<int>(Proto::ErrorCode::Error_general));
+    EXPECT_EQ(error, "Invalid from amount");
+    EXPECT_TRUE(out.empty());
+}
+
+TEST(THORChainSwap, RejectNonNumericToAmountLimit) {
+    Proto::Asset fromAsset;
+    fromAsset.set_chain(static_cast<Proto::Chain>(Chain::BTC));
+    Proto::Asset toAsset;
+    toAsset.set_chain(static_cast<Proto::Chain>(Chain::ETH));
+    toAsset.set_symbol("ETH");
+    auto&& [out, errorCode, error] = SwapBuilder::builder()
+                                         .from(fromAsset)
+                                         .to(toAsset)
+                                         .fromAddress(Address1Btc)
+                                         .toAddress(Address1Eth)
+                                         .vault(VaultBtc)
+                                         .fromAmount("1000000")
+                                         .toAmountLimit("abc")
+                                         .build();
+    EXPECT_EQ(errorCode, static_cast<int>(Proto::ErrorCode::Error_general));
+    EXPECT_EQ(error, "Invalid to amount limit");
+    EXPECT_TRUE(out.empty());
+}
+
+TEST(THORChainSwap, RejectNonNumericStreamParams) {
+    Proto::Asset fromAsset;
+    fromAsset.set_chain(static_cast<Proto::Chain>(Chain::BTC));
+    Proto::Asset toAsset;
+    toAsset.set_chain(static_cast<Proto::Chain>(Chain::ETH));
+    toAsset.set_symbol("ETH");
+    auto&& [out, errorCode, error] = SwapBuilder::builder()
+                                         .from(fromAsset)
+                                         .to(toAsset)
+                                         .fromAddress(Address1Btc)
+                                         .toAddress(Address1Eth)
+                                         .vault(VaultBtc)
+                                         .fromAmount("1000000")
+                                         .toAmountLimit("140000000000000000")
+                                         .streamInterval("x")
+                                         .streamQuantity("0")
+                                         .build();
+    EXPECT_EQ(errorCode, static_cast<int>(Proto::ErrorCode::Error_general));
+    EXPECT_EQ(error, "Invalid stream params");
+    EXPECT_TRUE(out.empty());
+}
+
 TEST(THORChainSwap, SwapBtcEth) {
     Proto::Asset fromAsset;
     fromAsset.set_chain(static_cast<Proto::Chain>(Chain::BTC));

--- a/tests/chains/Cosmos/THORChain/TWSwapTests.cpp
+++ b/tests/chains/Cosmos/THORChain/TWSwapTests.cpp
@@ -467,6 +467,65 @@ TEST(TWTHORChainSwap, NegativeOverflowToAmountLimit) {
     EXPECT_EQ(outputProto.error().code(), Proto::ErrorCode::Error_general);
     EXPECT_FALSE(outputProto.has_bitcoin());
 }
+
+// Regression: a from_amount with a leading zero used to pass the digit-only pre-check and then
+// be misparsed as octal by uint256_t's string constructor (e.g. "0500" -> 320), silently
+// building a swap for the wrong amount. It must now be rejected outright.
+TEST(TWTHORChainSwap, NegativeLeadingZeroFromAmount) {
+    Proto::SwapInput input;
+    Proto::Asset fromAsset;
+    fromAsset.set_chain(Proto::BTC);
+    *input.mutable_from_asset() = fromAsset;
+    input.set_from_address(Address1Btc);
+    Proto::Asset toAsset;
+    toAsset.set_chain(Proto::ETH);
+    toAsset.set_symbol("ETH");
+    *input.mutable_to_asset() = toAsset;
+    input.set_to_address(Address1Eth);
+    input.set_vault_address(VaultBtc);
+    input.set_from_amount("0500");
+    input.set_to_amount_limit("140000000000000000");
+
+    const auto inputData_ = input.SerializeAsString();
+    const auto inputTWData_ = WRAPD(TWDataCreateWithBytes((const uint8_t*)inputData_.data(), inputData_.size()));
+
+    const auto outputTWData_ = WRAPD(TWTHORChainSwapBuildSwap(inputTWData_.get()));
+    const auto outputData = data(TWDataBytes(outputTWData_.get()), TWDataSize(outputTWData_.get()));
+    Proto::SwapOutput outputProto;
+    ASSERT_TRUE(outputProto.ParseFromArray(outputData.data(), static_cast<int>(outputData.size())));
+    EXPECT_EQ(outputProto.error().code(), Proto::ErrorCode::Error_general);
+    EXPECT_FALSE(outputProto.has_bitcoin());
+}
+
+// Regression: an all-digit from_amount larger than 2^256-1 used to pass the digit-only
+// pre-check and then silently wrap around inside uint256_t's fixed-width arithmetic, building
+// a swap for an arbitrary, unrelated amount. It must now be rejected outright.
+TEST(TWTHORChainSwap, NegativeOverflowFromAmount) {
+    Proto::SwapInput input;
+    Proto::Asset fromAsset;
+    fromAsset.set_chain(Proto::BTC);
+    *input.mutable_from_asset() = fromAsset;
+    input.set_from_address(Address1Btc);
+    Proto::Asset toAsset;
+    toAsset.set_chain(Proto::ETH);
+    toAsset.set_symbol("ETH");
+    *input.mutable_to_asset() = toAsset;
+    input.set_to_address(Address1Eth);
+    input.set_vault_address(VaultBtc);
+    // 2^256 == 115792089237316195423570985008687907853269984665640564039457584007913129639936
+    input.set_from_amount("115792089237316195423570985008687907853269984665640564039457584007913129639936");
+    input.set_to_amount_limit("140000000000000000");
+
+    const auto inputData_ = input.SerializeAsString();
+    const auto inputTWData_ = WRAPD(TWDataCreateWithBytes((const uint8_t*)inputData_.data(), inputData_.size()));
+
+    const auto outputTWData_ = WRAPD(TWTHORChainSwapBuildSwap(inputTWData_.get()));
+    const auto outputData = data(TWDataBytes(outputTWData_.get()), TWDataSize(outputTWData_.get()));
+    Proto::SwapOutput outputProto;
+    ASSERT_TRUE(outputProto.ParseFromArray(outputData.data(), static_cast<int>(outputData.size())));
+    EXPECT_EQ(outputProto.error().code(), Proto::ErrorCode::Error_general);
+    EXPECT_FALSE(outputProto.has_bitcoin());
+}
 // clang-format on
 
 } // namespace TW::ThorChainSwap::tests

--- a/tests/chains/Cosmos/THORChain/TWSwapTests.cpp
+++ b/tests/chains/Cosmos/THORChain/TWSwapTests.cpp
@@ -411,6 +411,62 @@ TEST(TWTHORChainSwap, NegativeInvalidInput) {
     EXPECT_EQ(hex(outputData), "1a2508021221436f756c64206e6f7420646573657269616c697a6520696e7075742070726f746f");
     EXPECT_EQ(hex(data(std::string("Could not deserialize input proto"))), "436f756c64206e6f7420646573657269616c697a6520696e7075742070726f746f");
 }
+
+// Regression: a non-numeric from_amount used to make uint256_t() throw, and the exception
+// escaped the extern "C" boundary and called std::terminate. It must now return an error.
+TEST(TWTHORChainSwap, NegativeNonNumericFromAmount) {
+    Proto::SwapInput input;
+    Proto::Asset fromAsset;
+    fromAsset.set_chain(Proto::BTC);
+    *input.mutable_from_asset() = fromAsset;
+    input.set_from_address(Address1Btc);
+    Proto::Asset toAsset;
+    toAsset.set_chain(Proto::ETH);
+    toAsset.set_symbol("ETH");
+    *input.mutable_to_asset() = toAsset;
+    input.set_to_address(Address1Eth);
+    input.set_vault_address(VaultBtc);
+    input.set_from_amount("not_a_number");
+    input.set_to_amount_limit("140000000000000000");
+
+    const auto inputData_ = input.SerializeAsString();
+    const auto inputTWData_ = WRAPD(TWDataCreateWithBytes((const uint8_t*)inputData_.data(), inputData_.size()));
+
+    const auto outputTWData_ = WRAPD(TWTHORChainSwapBuildSwap(inputTWData_.get()));
+    const auto outputData = data(TWDataBytes(outputTWData_.get()), TWDataSize(outputTWData_.get()));
+    Proto::SwapOutput outputProto;
+    ASSERT_TRUE(outputProto.ParseFromArray(outputData.data(), static_cast<int>(outputData.size())));
+    EXPECT_EQ(outputProto.error().code(), Proto::ErrorCode::Error_general);
+    EXPECT_FALSE(outputProto.has_bitcoin());
+}
+
+// Regression: an all-digit but out-of-range to_amount_limit passes the numeric pre-check yet
+// still overflows std::stoull() inside buildMemo(); the FFI-level try/catch must absorb it.
+TEST(TWTHORChainSwap, NegativeOverflowToAmountLimit) {
+    Proto::SwapInput input;
+    Proto::Asset fromAsset;
+    fromAsset.set_chain(Proto::BTC);
+    *input.mutable_from_asset() = fromAsset;
+    input.set_from_address(Address1Btc);
+    Proto::Asset toAsset;
+    toAsset.set_chain(Proto::ETH);
+    toAsset.set_symbol("ETH");
+    *input.mutable_to_asset() = toAsset;
+    input.set_to_address(Address1Eth);
+    input.set_vault_address(VaultBtc);
+    input.set_from_amount("1000000");
+    input.set_to_amount_limit("99999999999999999999999999"); // > UINT64_MAX
+
+    const auto inputData_ = input.SerializeAsString();
+    const auto inputTWData_ = WRAPD(TWDataCreateWithBytes((const uint8_t*)inputData_.data(), inputData_.size()));
+
+    const auto outputTWData_ = WRAPD(TWTHORChainSwapBuildSwap(inputTWData_.get()));
+    const auto outputData = data(TWDataBytes(outputTWData_.get()), TWDataSize(outputTWData_.get()));
+    Proto::SwapOutput outputProto;
+    ASSERT_TRUE(outputProto.ParseFromArray(outputData.data(), static_cast<int>(outputData.size())));
+    EXPECT_EQ(outputProto.error().code(), Proto::ErrorCode::Error_general);
+    EXPECT_FALSE(outputProto.has_bitcoin());
+}
 // clang-format on
 
 } // namespace TW::ThorChainSwap::tests


### PR DESCRIPTION
## Summary
- Malformed numeric amount fields (non-numeric or overflowing `from_amount`, `to_amount_limit`, or stream `interval`/`quantity`) made `uint256_t()`/`std::stoull()` throw inside `SwapBuilder::build()`; the exception escaped the `extern "C"` `TWTHORChainSwapBuildSwap` boundary and called `std::terminate` — a remotely-triggerable DoS.
- Added `isValidUInt()` to validate numeric amount fields before parsing, returning a clean `Error_general` instead of crashing.
- Hardened `isValidUInt()` further: it now rejects non-canonical leading-zero strings (which `uint256_t`'s string constructor would otherwise silently misparse as octal, e.g. `"0500"` -> `320`) and bounds the value to fit in a `uint256_t` (preventing silent wraparound on oversized input).
- Wrapped the `TWTHORChainSwapBuildSwap` FFI entry point in `try`/`catch` as a backstop against any exception that still escapes.

## Test plan
- [x] `./build/tests/tests --gtest_filter="*THORChainSwap*:*TWTHORChainSwap*"` — 40/40 passing
- [x] Added regression tests for non-numeric input, `to_amount_limit` overflow, leading-zero `from_amount` (octal misparse), and `from_amount` overflow (2^256 wraparound)