### PR TITLE
feat(keystore): sealed signing (TWStoredKeySign), Ethereum — Security Layer S2.1

### DIFF
--- a/include/TrustWalletCore/TWStoredKey.h
+++ b/include/TrustWalletCore/TWStoredKey.h
@@ -353,6 +353,19 @@ TWString* _Nullable TWStoredKeyDecryptMnemonic(struct TWStoredKey* _Nonnull key,
 TW_EXPORT_METHOD
 struct TWPrivateKey* _Nullable TWStoredKeyPrivateKey(struct TWStoredKey* _Nonnull key, enum TWCoinType coin, TWData* _Nonnull password);
 
+/// Sealed signing: signs a transaction inside the keystore.  Derives the key from the stored key,
+/// signs the given serialized SigningInput, and wipes the key — the private key never leaves the
+/// library (the caller receives only the signature).
+///
+/// \param key Non-null pointer to a stored key
+/// \param coin Coin type to sign for
+/// \param password Non-null block of data, password of the stored key
+/// \param input Non-null block of data, serialized SigningInput protobuf (without a private key)
+/// \note Returned object needs to be deleted with \TWDataDelete
+/// \return Null pointer on failure or if the coin is not supported by the sealed path; serialized SigningOutput otherwise
+TW_EXPORT_METHOD
+TWData* _Nullable TWStoredKeySign(struct TWStoredKey* _Nonnull key, enum TWCoinType coin, TWData* _Nonnull password, TWData* _Nonnull input);
+
 /// Decrypts and returns the HD Wallet for mnemonic phrase keys.  Returned object needs to be deleted.
 ///
 /// \param key Non-null pointer to a stored key

--- a/include/TrustWalletCore/TWStoredKey.h
+++ b/include/TrustWalletCore/TWStoredKey.h
@@ -362,6 +362,10 @@ struct TWPrivateKey* _Nullable TWStoredKeyPrivateKey(struct TWStoredKey* _Nonnul
 /// \param password Non-null block of data, password of the stored key
 /// \param input Non-null block of data, serialized SigningInput protobuf (without a private key)
 /// \note Returned object needs to be deleted with \TWDataDelete
+/// \note LIMITATION (S2.1): the key is derived at the coin's DEFAULT derivation and DEFAULT account.
+///       A custom derivation path or a non-default account is NOT yet supported — signing such a
+///       wallet here uses the default account's key and will not match its address. Passing the
+///       derivation/path through to wallet-core is a planned S2.1 follow-up.
 /// \return Null pointer on failure or if the coin is not supported by the sealed path; serialized SigningOutput otherwise
 TW_EXPORT_METHOD
 TWData* _Nullable TWStoredKeySign(struct TWStoredKey* _Nonnull key, enum TWCoinType coin, TWData* _Nonnull password, TWData* _Nonnull input);

--- a/src/Keystore/SealedSigner.cpp
+++ b/src/Keystore/SealedSigner.cpp
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+
+#include "SealedSigner.h"
+
+#include "Coin.h"
+#include "PrivateKey.h"
+#include "proto/Ethereum.pb.h"
+
+#include <TrezorCrypto/memzero.h>
+
+namespace TW::Keystore {
+
+static void wipe(Data& d) {
+    if (!d.empty()) {
+        memzero(d.data(), d.size());
+    }
+}
+
+// EVM chains share the Ethereum SigningInput, which carries a singular `private_key` field.
+// Returns the input bytes with the derived key injected.
+static Data injectKeyEthereum(const Data& input, const PrivateKey& key) {
+    Ethereum::Proto::SigningInput in;
+    in.ParseFromArray(input.data(), static_cast<int>(input.size()));
+    in.set_private_key(key.bytes.data(), key.bytes.size());
+    Data out = TW::data(in.SerializeAsString());
+    in.clear_private_key(); // drop protobuf's copy of the key
+    return out;
+}
+
+Data sealedSign(StoredKey& storedKey, TWCoinType coin, const Data& password, const Data& signingInput) {
+    // Coins supported by the sealed path so far. Each must have a per-coin byte-identical test
+    // proving flag-ON output == flag-OFF output before it is added here.
+    switch (coin) {
+    case TWCoinTypeEthereum:
+        break;
+    default:
+        return {}; // not yet supported by sealed signing
+    }
+
+    // (1) Decrypt + derive the signing key ONCE, inside the library.
+    //     (Account-based coins need a single key; the UTXO multi-key path — decrypt once, derive
+    //      many from the in-memory HDWallet — is added in a later increment.)
+    PrivateKey privateKey = storedKey.privateKey(coin, password);
+
+    // (2) Inject the key into the coin's SigningInput proto.
+    Data injected = injectKeyEthereum(signingInput, privateKey);
+
+    // (3) Sign through the normal internal dispatcher.
+    Data output;
+    anyCoinSign(coin, injected, output);
+
+    // (4) Zeroize key material — it never leaves this function.
+    //     (Best-effort here; full SecureBytes-based wiping of PrivateKey internals is a later
+    //      hardening step.)
+    Data keyCopy = privateKey.bytes;
+    wipe(keyCopy);
+    wipe(injected);
+
+    return output;
+}
+
+} // namespace TW::Keystore

--- a/src/Keystore/SealedSigner.cpp
+++ b/src/Keystore/SealedSigner.cpp
@@ -42,6 +42,12 @@ Data sealedSign(StoredKey& storedKey, TWCoinType coin, const Data& password, con
     // (1) Decrypt + derive the signing key ONCE, inside the library.
     //     (Account-based coins need a single key; the UTXO multi-key path — decrypt once, derive
     //      many from the in-memory HDWallet — is added in a later increment.)
+    //
+    // TODO(S2.1 follow-up): this derives at the coin's DEFAULT derivation and DEFAULT account only.
+    //   A custom derivation path or a non-default account is not yet threaded through, so signing
+    //   such a wallet uses the default account's key and won't match its address. Add a
+    //   derivation/path parameter (see claude-handoff-S2-UTXO-sealed-sign-findings.md) so callers on
+    //   custom paths / multi-account wallets are supported.
     PrivateKey privateKey = storedKey.privateKey(coin, password);
 
     // (2) Inject the key into the coin's SigningInput proto.

--- a/src/Keystore/SealedSigner.h
+++ b/src/Keystore/SealedSigner.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+
+#pragma once
+
+#include "Data.h"
+#include "StoredKey.h"
+
+#include <TrustWalletCore/TWCoinType.h>
+
+namespace TW::Keystore {
+
+/// Sealed signing (Security Layer, Phase 2).
+///
+/// Signs `signingInput` for `coin` using the key held inside `storedKey`, decrypting it with
+/// `password`. The private key is derived, injected into the signing input, used, and wiped
+/// entirely inside the library — it is NEVER returned to the caller.
+///
+/// Returns the serialized SigningOutput, or an empty `Data` if `coin` is not yet supported by the
+/// sealed path (caller should fall back / treat as error).
+///
+/// Design invariant: the keystore is decrypted at most once per call (see SealedSigner.cpp).
+Data sealedSign(StoredKey& storedKey, TWCoinType coin, const Data& password, const Data& signingInput);
+
+} // namespace TW::Keystore

--- a/src/interface/TWStoredKey.cpp
+++ b/src/interface/TWStoredKey.cpp
@@ -8,6 +8,7 @@
 #include "Data.h"
 #include "../HDWallet.h"
 #include "../Keystore/StoredKey.h"
+#include "../Keystore/SealedSigner.h"
 #include "../HexCoding.h"
 #include <stdexcept>
 #include <cassert>
@@ -277,6 +278,20 @@ struct TWPrivateKey* _Nullable TWStoredKeyPrivateKey(struct TWStoredKey* _Nonnul
     try {
         const auto passwordData = TW::data(TWDataBytes(password), TWDataSize(password));
         return new TWPrivateKey{ key->impl.privateKey(coin, passwordData) };
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+TWData* _Nullable TWStoredKeySign(struct TWStoredKey* _Nonnull key, enum TWCoinType coin, TWData* _Nonnull password, TWData* _Nonnull input) {
+    try {
+        const auto passwordData = TW::data(TWDataBytes(password), TWDataSize(password));
+        const auto inputData = TW::data(TWDataBytes(input), TWDataSize(input));
+        const auto output = TW::Keystore::sealedSign(key->impl, coin, passwordData, inputData);
+        if (output.empty()) {
+            return nullptr;
+        }
+        return TWDataCreateWithBytes(output.data(), output.size());
     } catch (...) {
         return nullptr;
     }

--- a/tests/common/Keystore/SealedSignerTests.cpp
+++ b/tests/common/Keystore/SealedSignerTests.cpp
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+//
+// S2.1 — real sealed-signing implementation tests (Security Layer, Phase 2).
+// Proves the sealed path (key never leaves the library) is byte-identical to the current
+// extract-then-sign flow.
+
+#include "Coin.h"
+#include "Data.h"
+#include "HexCoding.h"
+#include "PrivateKey.h"
+#include "uint256.h"
+#include "Keystore/SealedSigner.h"
+#include "Keystore/StoredKey.h"
+#include "proto/Common.pb.h"
+#include "proto/Ethereum.pb.h"
+
+#include <TrustWalletCore/TWCoinType.h>
+
+#include <gtest/gtest.h>
+
+namespace TW::Keystore::tests {
+
+static const auto gPassword = TW::data(std::string("password"));
+static const char* gMnemonic = "team engine square letter hero song dizzy scrub tornado fabric divert saddle";
+
+static Ethereum::Proto::SigningInput ethTransferNoKey() {
+    Ethereum::Proto::SigningInput in;
+    auto chainId = store(uint256_t(1));
+    in.set_chain_id(chainId.data(), chainId.size());
+    auto nonce = store(uint256_t(0));
+    in.set_nonce(nonce.data(), nonce.size());
+    auto gasPrice = store(uint256_t(20000000000ULL));
+    in.set_gas_price(gasPrice.data(), gasPrice.size());
+    auto gasLimit = store(uint256_t(21000));
+    in.set_gas_limit(gasLimit.data(), gasLimit.size());
+    in.set_to_address("0x3535353535353535353535353535353535353535");
+    auto& transfer = *in.mutable_transaction()->mutable_transfer();
+    auto amount = store(uint256_t(1000000000000000000ULL));
+    transfer.set_amount(amount.data(), amount.size());
+    return in;
+}
+
+// Sealed sign produces byte-identical output to extract-then-sign for Ethereum.
+TEST(SealedSigner, EthereumByteIdentical) {
+    auto key = StoredKey::createWithMnemonic("n", gPassword, gMnemonic, TWStoredKeyEncryptionLevelDefault);
+
+    // Baseline (today): app extracts the key, sets it in the proto, then signs.
+    PrivateKey pk = key.privateKey(TWCoinTypeEthereum, gPassword);
+    auto baseInput = ethTransferNoKey();
+    baseInput.set_private_key(pk.bytes.data(), pk.bytes.size());
+    Data baseline;
+    anyCoinSign(TWCoinTypeEthereum, TW::data(baseInput.SerializeAsString()), baseline);
+
+    // Sealed: key derived, used, and wiped inside the library.
+    Data sealed = sealedSign(key, TWCoinTypeEthereum, gPassword, TW::data(ethTransferNoKey().SerializeAsString()));
+
+    Ethereum::Proto::SigningOutput baseOut, sealedOut;
+    ASSERT_TRUE(baseOut.ParseFromArray(baseline.data(), static_cast<int>(baseline.size())));
+    ASSERT_TRUE(sealedOut.ParseFromArray(sealed.data(), static_cast<int>(sealed.size())));
+    EXPECT_EQ(baseOut.error(), Common::Proto::OK);
+    EXPECT_FALSE(baseOut.encoded().empty());
+    EXPECT_EQ(hex(sealedOut.encoded()), hex(baseOut.encoded()));
+    EXPECT_EQ(sealed, baseline);
+}
+
+// Coins not yet wired into the sealed path return empty (caller falls back).
+TEST(SealedSigner, UnsupportedCoinReturnsEmpty) {
+    auto key = StoredKey::createWithMnemonic("n", gPassword, gMnemonic, TWStoredKeyEncryptionLevelDefault);
+    Data out = sealedSign(key, TWCoinTypeBitcoin, gPassword, TW::data(std::string("anything")));
+    EXPECT_TRUE(out.empty());
+}
+
+} // namespace TW::Keystore::tests

--- a/tests/interface/TWStoredKeySignTests.cpp
+++ b/tests/interface/TWStoredKeySignTests.cpp
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2017 Trust Wallet.
+//
+// S2.1 — C ABI sealed-signing test (Security Layer, Phase 2).
+// Drives TWStoredKeySign across the extern "C" boundary and proves it is byte-identical to the
+// current extract-key-then-sign flow (TWStoredKeyPrivateKey + TWAnySignerSign) for Ethereum.
+
+#include "Data.h"
+#include "HexCoding.h"
+#include "uint256.h"
+#include "proto/Common.pb.h"
+#include "proto/Ethereum.pb.h"
+
+#include <TrustWalletCore/TWAnySigner.h>
+#include <TrustWalletCore/TWPrivateKey.h>
+#include <TrustWalletCore/TWStoredKey.h>
+
+#include "TestUtilities.h"
+#include <gtest/gtest.h>
+
+using namespace TW;
+
+static Data ethTransferNoKey() {
+    Ethereum::Proto::SigningInput in;
+    auto chainId = store(uint256_t(1));
+    in.set_chain_id(chainId.data(), chainId.size());
+    auto nonce = store(uint256_t(0));
+    in.set_nonce(nonce.data(), nonce.size());
+    auto gasPrice = store(uint256_t(20000000000ULL));
+    in.set_gas_price(gasPrice.data(), gasPrice.size());
+    auto gasLimit = store(uint256_t(21000));
+    in.set_gas_limit(gasLimit.data(), gasLimit.size());
+    in.set_to_address("0x3535353535353535353535353535353535353535");
+    auto& transfer = *in.mutable_transaction()->mutable_transfer();
+    auto amount = store(uint256_t(1000000000000000000ULL));
+    transfer.set_amount(amount.data(), amount.size());
+    return data(in.SerializeAsString());
+}
+
+TEST(TWStoredKeySign, EthereumEndToEndByteIdentical) {
+    const auto mnemonic = STRING("team engine square letter hero song dizzy scrub tornado fabric divert saddle");
+    const auto name = STRING("name");
+    const auto password = WRAPD(TWDataCreateWithBytes(reinterpret_cast<const uint8_t*>("password"), 8));
+    const auto key = WRAP(TWStoredKey, TWStoredKeyImportHDWallet(mnemonic.get(), name.get(), password.get(), TWCoinTypeEthereum));
+    ASSERT_NE(key.get(), nullptr);
+
+    const auto inputBytes = ethTransferNoKey();
+    const auto input = WRAPD(TWDataCreateWithBytes(inputBytes.data(), inputBytes.size()));
+
+    // Sealed path over the C ABI.
+    const auto sealed = WRAPD(TWStoredKeySign(key.get(), TWCoinTypeEthereum, password.get(), input.get()));
+    ASSERT_NE(sealed.get(), nullptr);
+    const auto sealedData = data(TWDataBytes(sealed.get()), TWDataSize(sealed.get()));
+
+    // Baseline: extract the key (C ABI) and sign via TWAnySigner.
+    const auto pk = WRAP(TWPrivateKey, TWStoredKeyPrivateKey(key.get(), TWCoinTypeEthereum, password.get()));
+    const auto pkData = WRAPD(TWPrivateKeyData(pk.get()));
+    Ethereum::Proto::SigningInput baseInput;
+    baseInput.ParseFromArray(inputBytes.data(), static_cast<int>(inputBytes.size()));
+    baseInput.set_private_key(TWDataBytes(pkData.get()), TWDataSize(pkData.get()));
+    const auto baseInBytes = data(baseInput.SerializeAsString());
+    const auto baseIn = WRAPD(TWDataCreateWithBytes(baseInBytes.data(), baseInBytes.size()));
+    const auto baseline = WRAPD(TWAnySignerSign(baseIn.get(), TWCoinTypeEthereum));
+    const auto baselineData = data(TWDataBytes(baseline.get()), TWDataSize(baseline.get()));
+
+    EXPECT_EQ(hex(sealedData), hex(baselineData)); // byte-identical through the C boundary
+
+    Ethereum::Proto::SigningOutput out;
+    ASSERT_TRUE(out.ParseFromArray(sealedData.data(), static_cast<int>(sealedData.size())));
+    EXPECT_EQ(out.error(), Common::Proto::OK);
+    EXPECT_FALSE(out.encoded().empty());
+}
+
+TEST(TWStoredKeySign, UnsupportedCoinReturnsNull) {
+    const auto mnemonic = STRING("team engine square letter hero song dizzy scrub tornado fabric divert saddle");
+    const auto name = STRING("name");
+    const auto password = WRAPD(TWDataCreateWithBytes(reinterpret_cast<const uint8_t*>("password"), 8));
+    const auto key = WRAP(TWStoredKey, TWStoredKeyImportHDWallet(mnemonic.get(), name.get(), password.get(), TWCoinTypeEthereum));
+
+    const auto input = DATA("00");
+    // Bitcoin is not yet wired into the sealed path -> null (caller falls back).
+    TWData* out = TWStoredKeySign(key.get(), TWCoinTypeBitcoin, password.get(), input.get());
+    EXPECT_EQ(out, nullptr);
+    if (out != nullptr) {
+        TWDataDelete(out);
+    }
+}

--- a/tools/run-sealed-tests
+++ b/tools/run-sealed-tests
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Build the C++ tests and run the sealed-signing (Security Layer S2.1) tests.
+#
+# Usage:
+#   tools/run-sealed-tests                 # run *SealedSigner* + *TWStoredKeySign*
+#   tools/run-sealed-tests "*Ethereum*"    # custom gtest filter
+#
+set -e
+
+cd "$(dirname "$0")/.."
+
+# cmake needs BOOST_ROOT (brew boost) on macOS; make rust/protoc reachable for fresh shells.
+if command -v brew >/dev/null 2>&1; then
+  export BOOST_ROOT="${BOOST_ROOT:-$(brew --prefix boost 2>/dev/null)}"
+fi
+export PATH="/opt/homebrew/opt/rustup/bin:$HOME/.cargo/bin:$PWD/build/local/bin:$PATH"
+
+FILTER="${1:-*SealedSigner*:*TWStoredKeySign*}"
+
+# Configure once if the build tree isn't there yet.
+if [ ! -f build/CMakeCache.txt ]; then
+  cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+fi
+
+make -Cbuild -j12 tests
+./build/tests/tests --gtest_filter="$FILTER"


### PR DESCRIPTION
## Security Layer — Phase 2 (sealed signing), S2.1 increment 1+2

Adds **sealed signing** to wallet-core: the app passes an encrypted `StoredKey` + password +
`SigningInput`, and the library derives the key, signs, and wipes it — **the private key never
leaves wallet-core** (the caller receives only the signature). This is the first, working slice
(Ethereum) of the Phase-2 signing hardening (Epic 151885 / SC-149301; decision gate **G1 = GO**).

### What's in this PR

- **`Keystore::sealedSign(storedKey, coin, password, signingInput)`** (`src/Keystore/SealedSigner.*`):
  decrypt-once → derive → inject key into the coin's `SigningInput` → `anyCoinSign` → `memzero`.
  Ethereum wired first; unsupported coins return empty so callers fall back.
- **C ABI `TWStoredKeySign`** (`include/TrustWalletCore/TWStoredKey.h`, `src/interface/TWStoredKey.cpp`).
  Language bindings are generated from the header: Swift `storedKey.sign(coin:password:input:)`,
  Kotlin/Java `StoredKey.sign(coin, password, input)`.
- **Tests**: `tests/common/Keystore/SealedSignerTests.cpp` (core) and
  `tests/interface/TWStoredKeySignTests.cpp` (C ABI) prove the sealed output is **byte-identical** to
  today's extract-key-then-sign flow for Ethereum, and that unsupported coins return null.
- `tools/run-sealed-tests` — local runner for the sealed tests.

### Verification

- **C++**: `tools/run-sealed-tests` → 4/4 pass (byte-identical at both the C++ and C-ABI layers).
- **iOS**: verified end-to-end in a host app against a locally-built `WalletCore.xcframework`.

### Scope / known limitations (tracked)

- **Ethereum only** in this PR. UTXO (BitcoinV2/PSBT), Cosmos, Solana, Tron, … land as follow-up
  increments, each gated by its own byte-identical test (fund-risk UTXO coins also need on-chain
  verification before default-ON).
- **Default account/derivation only**: `sign()` derives at the coin's default derivation and default
  account; a custom path / non-default account isn't threaded through yet (documented in the header
  `\note` and a `TODO(S2.1 follow-up)` in `SealedSigner.cpp`). Verify with the primary account first.

No existing behavior changes — valid signatures are byte-identical to the current path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
