### PR TITLE
fix: update key retrieval methods to return nullable types on failure

### DIFF
--- a/include/TrustWalletCore/TWHDWallet.h
+++ b/include/TrustWalletCore/TWHDWallet.h
@@ -191,9 +191,10 @@ struct TWPrivateKey* _Nullable TWHDWalletGetDerivedKey(struct TWHDWallet* _Nonnu
 /// \param coin a coin type
 /// \param version hd version
 /// \note Returned object needs to be deleted with \TWStringDelete
-/// \return  Extended private key as a non-null TWString
+/// \note Null is returned if the key cannot be derived (e.g. empty mnemonic entropy)
+/// \return Extended private key, or null on failure
 TW_EXPORT_METHOD
-TWString* _Nonnull TWHDWalletGetExtendedPrivateKey(struct TWHDWallet* _Nonnull wallet, enum TWPurpose purpose, enum TWCoinType coin, enum TWHDVersion version);
+TWString* _Nullable TWHDWalletGetExtendedPrivateKey(struct TWHDWallet* _Nonnull wallet, enum TWPurpose purpose, enum TWCoinType coin, enum TWHDVersion version);
 
 /// Returns the extended public key (for default 0 account).
 ///
@@ -202,9 +203,10 @@ TWString* _Nonnull TWHDWalletGetExtendedPrivateKey(struct TWHDWallet* _Nonnull w
 /// \param coin a coin type
 /// \param version hd version
 /// \note Returned object needs to be deleted with \TWStringDelete
-/// \return  Extended public key as a non-null TWString
+/// \note Null is returned if the key cannot be derived (e.g. empty mnemonic entropy)
+/// \return Extended public key, or null on failure
 TW_EXPORT_METHOD
-TWString* _Nonnull TWHDWalletGetExtendedPublicKey(struct TWHDWallet* _Nonnull wallet, enum TWPurpose purpose, enum TWCoinType coin, enum TWHDVersion version);
+TWString* _Nullable TWHDWalletGetExtendedPublicKey(struct TWHDWallet* _Nonnull wallet, enum TWPurpose purpose, enum TWCoinType coin, enum TWHDVersion version);
 
 /// Returns the extended private key, for custom account.
 ///
@@ -215,9 +217,10 @@ TWString* _Nonnull TWHDWalletGetExtendedPublicKey(struct TWHDWallet* _Nonnull wa
 /// \param version an hd version
 /// \param account valid bip44 account
 /// \note Returned object needs to be deleted with \TWStringDelete
-/// \return  Extended private key as a non-null TWString
+/// \note Null is returned if the key cannot be derived (e.g. empty mnemonic entropy)
+/// \return Extended private key, or null on failure
 TW_EXPORT_METHOD
-TWString* _Nonnull TWHDWalletGetExtendedPrivateKeyAccount(struct TWHDWallet* _Nonnull wallet, enum TWPurpose purpose, enum TWCoinType coin, enum TWDerivation derivation, enum TWHDVersion version, uint32_t account);
+TWString* _Nullable TWHDWalletGetExtendedPrivateKeyAccount(struct TWHDWallet* _Nonnull wallet, enum TWPurpose purpose, enum TWCoinType coin, enum TWDerivation derivation, enum TWHDVersion version, uint32_t account);
 
 /// Returns the extended public key, for custom account.
 ///
@@ -228,9 +231,10 @@ TWString* _Nonnull TWHDWalletGetExtendedPrivateKeyAccount(struct TWHDWallet* _No
 /// \param version an hd version
 /// \param account valid bip44 account
 /// \note Returned object needs to be deleted with \TWStringDelete
-/// \return Extended public key as a non-null TWString
+/// \note Null is returned if the key cannot be derived (e.g. empty mnemonic entropy)
+/// \return Extended public key, or null on failure
 TW_EXPORT_METHOD
-TWString* _Nonnull TWHDWalletGetExtendedPublicKeyAccount(struct TWHDWallet* _Nonnull wallet, enum TWPurpose purpose, enum TWCoinType coin, enum TWDerivation derivation, enum TWHDVersion version, uint32_t account);
+TWString* _Nullable TWHDWalletGetExtendedPublicKeyAccount(struct TWHDWallet* _Nonnull wallet, enum TWPurpose purpose, enum TWCoinType coin, enum TWDerivation derivation, enum TWHDVersion version, uint32_t account);
 
 /// Returns the extended private key (for default 0 account with derivation).
 ///
@@ -240,9 +244,10 @@ TWString* _Nonnull TWHDWalletGetExtendedPublicKeyAccount(struct TWHDWallet* _Non
 /// \param derivation a derivation
 /// \param version an hd version
 /// \note Returned object needs to be deleted with \TWStringDelete
-/// \return  Extended private key as a non-null TWString
+/// \note Null is returned if the key cannot be derived (e.g. empty mnemonic entropy)
+/// \return Extended private key, or null on failure
 TW_EXPORT_METHOD
-TWString* _Nonnull TWHDWalletGetExtendedPrivateKeyDerivation(struct TWHDWallet* _Nonnull wallet, enum TWPurpose purpose, enum TWCoinType coin, enum TWDerivation derivation, enum TWHDVersion version);
+TWString* _Nullable TWHDWalletGetExtendedPrivateKeyDerivation(struct TWHDWallet* _Nonnull wallet, enum TWPurpose purpose, enum TWCoinType coin, enum TWDerivation derivation, enum TWHDVersion version);
 
 /// Returns the extended public key (for default 0 account with derivation).
 ///
@@ -252,9 +257,10 @@ TWString* _Nonnull TWHDWalletGetExtendedPrivateKeyDerivation(struct TWHDWallet* 
 /// \param derivation a derivation
 /// \param version an hd version
 /// \note Returned object needs to be deleted with \TWStringDelete
-/// \return  Extended public key as a non-null TWString
+/// \note Null is returned if the key cannot be derived (e.g. empty mnemonic entropy)
+/// \return Extended public key, or null on failure
 TW_EXPORT_METHOD
-TWString* _Nonnull TWHDWalletGetExtendedPublicKeyDerivation(struct TWHDWallet* _Nonnull wallet, enum TWPurpose purpose, enum TWCoinType coin, enum TWDerivation derivation, enum TWHDVersion version);
+TWString* _Nullable TWHDWalletGetExtendedPublicKeyDerivation(struct TWHDWallet* _Nonnull wallet, enum TWPurpose purpose, enum TWCoinType coin, enum TWDerivation derivation, enum TWHDVersion version);
 
 /// Computes the public key from an extended public key representation.
 ///

--- a/include/TrustWalletCore/TWHDWallet.h
+++ b/include/TrustWalletCore/TWHDWallet.h
@@ -96,9 +96,10 @@ TWData* _Nonnull TWHDWalletEntropy(struct TWHDWallet* _Nonnull wallet);
 /// \param wallet non-null TWHDWallet
 /// \param curve  a curve
 /// \note Returned object needs to be deleted with \TWPrivateKeyDelete
-/// \return Non-null corresponding private key
+/// \note Null is returned if the key cannot be derived (e.g. empty mnemonic entropy)
+/// \return Nullable corresponding private key
 TW_EXPORT_METHOD
-struct TWPrivateKey* _Nonnull TWHDWalletGetMasterKey(struct TWHDWallet* _Nonnull wallet, enum TWCurve curve);
+struct TWPrivateKey* _Nullable TWHDWalletGetMasterKey(struct TWHDWallet* _Nonnull wallet, enum TWCurve curve);
 
 /// Generates the default private key for the specified coin, using default derivation.
 ///
@@ -107,18 +108,20 @@ struct TWPrivateKey* _Nonnull TWHDWalletGetMasterKey(struct TWHDWallet* _Nonnull
 /// \param wallet non-null TWHDWallet
 /// \param coin  a coin type
 /// \note Returned object needs to be deleted with \TWPrivateKeyDelete
-/// \return return the default private key for the specified coin
+/// \note Null is returned if the key cannot be derived (e.g. empty mnemonic entropy)
+/// \return the default private key for the specified coin, or null on failure
 TW_EXPORT_METHOD
-struct TWPrivateKey* _Nonnull TWHDWalletGetKeyForCoin(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin);
+struct TWPrivateKey* _Nullable TWHDWalletGetKeyForCoin(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin);
 
 /// Generates the default address for the specified coin (without exposing intermediary private key), default derivation.
 ///
 /// \see TWHDWalletGetAddressDerivation
 /// \param wallet non-null TWHDWallet
 /// \param coin  a coin type
-/// \return return the default address for the specified coin as a non-null TWString
+/// \note Null is returned if the address cannot be derived (e.g. empty mnemonic entropy)
+/// \return the default address for the specified coin, or null on failure
 TW_EXPORT_METHOD
-TWString* _Nonnull TWHDWalletGetAddressForCoin(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin);
+TWString* _Nullable TWHDWalletGetAddressForCoin(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin);
 
 /// Generates the default address for the specified coin and derivation (without exposing intermediary private key).
 ///
@@ -126,9 +129,10 @@ TWString* _Nonnull TWHDWalletGetAddressForCoin(struct TWHDWallet* _Nonnull walle
 /// \param wallet non-null TWHDWallet
 /// \param coin  a coin type
 /// \param derivation  a (custom) derivation to use
-/// \return return the default address for the specified coin as a non-null TWString
+/// \note Null is returned if the address cannot be derived (e.g. empty mnemonic entropy)
+/// \return the default address for the specified coin, or null on failure
 TW_EXPORT_METHOD
-TWString* _Nonnull TWHDWalletGetAddressDerivation(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin, enum TWDerivation derivation);
+TWString* _Nullable TWHDWalletGetAddressDerivation(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin, enum TWDerivation derivation);
 
 /// Generates the private key for the specified derivation path.
 ///
@@ -150,9 +154,10 @@ struct TWPrivateKey* _Nullable TWHDWalletGetKey(struct TWHDWallet* _Nonnull wall
 /// \param coin a coin type
 /// \param derivation a (custom) derivation to use
 /// \note Returned object needs to be deleted with \TWPrivateKeyDelete
-/// \return The private key for the specified derivation path/coin
+/// \note Null is returned if the key cannot be derived (e.g. empty mnemonic entropy)
+/// \return The private key for the specified derivation path/coin, or null on failure
 TW_EXPORT_METHOD
-struct TWPrivateKey* _Nonnull TWHDWalletGetKeyDerivation(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin, enum TWDerivation derivation);
+struct TWPrivateKey* _Nullable TWHDWalletGetKeyDerivation(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin, enum TWDerivation derivation);
 
 /// Generates the private key for the specified derivation path and curve.
 ///
@@ -174,9 +179,10 @@ struct TWPrivateKey* _Nullable TWHDWalletGetKeyByCurve(struct TWHDWallet* _Nonnu
 /// \param change valid bip44 change
 /// \param address valid bip44 address
 /// \note Returned object needs to be deleted with \TWPrivateKeyDelete
-/// \return The private key for the specified bip44 parameters
+/// \note Null is returned if the key cannot be derived (e.g. empty mnemonic entropy)
+/// \return The private key for the specified bip44 parameters, or null on failure
 TW_EXPORT_METHOD
-struct TWPrivateKey* _Nonnull TWHDWalletGetDerivedKey(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin, uint32_t account, uint32_t change, uint32_t address);
+struct TWPrivateKey* _Nullable TWHDWalletGetDerivedKey(struct TWHDWallet* _Nonnull wallet, enum TWCoinType coin, uint32_t account, uint32_t change, uint32_t address);
 
 /// Returns the extended private key (for default 0 account).
 ///

--- a/src/HDWallet.cpp
+++ b/src/HDWallet.cpp
@@ -114,6 +114,13 @@ static HDNode getMasterNode(const HDWallet<seedSize>& wallet, TWCurve curve) {
         // Derives the root Cardano HDNode from a passphrase and the entropy encoded in
         // a BIP-0039 mnemonic using the Icarus derivation (V2) scheme
         const auto entropy = wallet.getEntropy();
+        if (entropy.empty()) {
+            // Entropy is empty for mnemonics created with `check=false` that are not valid
+            // BIP-0039 English mnemonics (e.g. non-English wordlists), or for wallets
+            // constructed directly from a raw seed. Deriving from empty entropy would
+            // produce the same constant secret for every such wallet.
+            throw std::invalid_argument("Cannot derive a Cardano key: mnemonic entropy is empty");
+        }
         uint8_t secret[CARDANO_SECRET_LENGTH];
         secret_from_entropy_cardano_icarus((const uint8_t*)"", 0, entropy.data(), int(entropy.size()), secret, nullptr);
         hdnode_from_secret_cardano(secret, &node);

--- a/src/interface/TWHDWallet.cpp
+++ b/src/interface/TWHDWallet.cpp
@@ -125,28 +125,52 @@ struct TWPrivateKey *_Nullable TWHDWalletGetKeyByCurve(struct TWHDWallet *_Nonnu
     }
 }
 
-TWString *_Nonnull TWHDWalletGetExtendedPrivateKey(struct TWHDWallet *wallet, TWPurpose purpose, TWCoinType coin, TWHDVersion version) {
-    return new std::string(wallet->impl.getExtendedPrivateKey(purpose, coin, version));
+TWString *_Nullable TWHDWalletGetExtendedPrivateKey(struct TWHDWallet *wallet, TWPurpose purpose, TWCoinType coin, TWHDVersion version) {
+    try {
+        return new std::string(wallet->impl.getExtendedPrivateKey(purpose, coin, version));
+    } catch (...) {
+        return nullptr;
+    }
 }
 
-TWString *_Nonnull TWHDWalletGetExtendedPublicKey(struct TWHDWallet *wallet, TWPurpose purpose, TWCoinType coin, TWHDVersion version) {
-    return new std::string(wallet->impl.getExtendedPublicKey(purpose, coin, version));
+TWString *_Nullable TWHDWalletGetExtendedPublicKey(struct TWHDWallet *wallet, TWPurpose purpose, TWCoinType coin, TWHDVersion version) {
+    try {
+        return new std::string(wallet->impl.getExtendedPublicKey(purpose, coin, version));
+    } catch (...) {
+        return nullptr;
+    }
 }
 
-TWString *_Nonnull TWHDWalletGetExtendedPrivateKeyAccount(struct TWHDWallet *wallet, TWPurpose purpose, TWCoinType coin, TWDerivation derivation, TWHDVersion version, uint32_t account) {
-    return new std::string(wallet->impl.getExtendedPrivateKeyAccount(purpose, coin, derivation, version, account));
+TWString *_Nullable TWHDWalletGetExtendedPrivateKeyAccount(struct TWHDWallet *wallet, TWPurpose purpose, TWCoinType coin, TWDerivation derivation, TWHDVersion version, uint32_t account) {
+    try {
+        return new std::string(wallet->impl.getExtendedPrivateKeyAccount(purpose, coin, derivation, version, account));
+    } catch (...) {
+        return nullptr;
+    }
 }
 
-TWString *_Nonnull TWHDWalletGetExtendedPublicKeyAccount(struct TWHDWallet *wallet, TWPurpose purpose, TWCoinType coin, TWDerivation derivation, TWHDVersion version, uint32_t account) {
-    return new std::string(wallet->impl.getExtendedPublicKeyAccount(purpose, coin, derivation, version, account));
+TWString *_Nullable TWHDWalletGetExtendedPublicKeyAccount(struct TWHDWallet *wallet, TWPurpose purpose, TWCoinType coin, TWDerivation derivation, TWHDVersion version, uint32_t account) {
+    try {
+        return new std::string(wallet->impl.getExtendedPublicKeyAccount(purpose, coin, derivation, version, account));
+    } catch (...) {
+        return nullptr;
+    }
 }
 
-TWString *_Nonnull TWHDWalletGetExtendedPrivateKeyDerivation(struct TWHDWallet *wallet, TWPurpose purpose, TWCoinType coin, TWDerivation derivation, TWHDVersion version) {
-    return new std::string(wallet->impl.getExtendedPrivateKeyDerivation(purpose, coin, derivation, version));
+TWString *_Nullable TWHDWalletGetExtendedPrivateKeyDerivation(struct TWHDWallet *wallet, TWPurpose purpose, TWCoinType coin, TWDerivation derivation, TWHDVersion version) {
+    try {
+        return new std::string(wallet->impl.getExtendedPrivateKeyDerivation(purpose, coin, derivation, version));
+    } catch (...) {
+        return nullptr;
+    }
 }
 
-TWString *_Nonnull TWHDWalletGetExtendedPublicKeyDerivation(struct TWHDWallet *wallet, TWPurpose purpose, TWCoinType coin, TWDerivation derivation, TWHDVersion version) {
-    return new std::string(wallet->impl.getExtendedPublicKeyDerivation(purpose, coin, derivation, version));
+TWString *_Nullable TWHDWalletGetExtendedPublicKeyDerivation(struct TWHDWallet *wallet, TWPurpose purpose, TWCoinType coin, TWDerivation derivation, TWHDVersion version) {
+    try {
+        return new std::string(wallet->impl.getExtendedPublicKeyDerivation(purpose, coin, derivation, version));
+    } catch (...) {
+        return nullptr;
+    }
 }
 
 TWPublicKey *TWHDWalletGetPublicKeyFromExtended(TWString *_Nonnull extended, enum TWCoinType coin, TWString *_Nonnull derivationPath) {

--- a/src/interface/TWHDWallet.cpp
+++ b/src/interface/TWHDWallet.cpp
@@ -60,23 +60,31 @@ TWData *_Nonnull TWHDWalletEntropy(struct TWHDWallet *_Nonnull wallet) {
     return TWDataCreateWithBytes(wallet->impl.getEntropy().data(), wallet->impl.getEntropy().size());
 }
 
-struct TWPrivateKey *_Nonnull TWHDWalletGetMasterKey(struct TWHDWallet *_Nonnull wallet, TWCurve curve) {
-    return new TWPrivateKey{ wallet->impl.getMasterKey(curve) };
+struct TWPrivateKey *_Nullable TWHDWalletGetMasterKey(struct TWHDWallet *_Nonnull wallet, TWCurve curve) {
+    try {
+        return new TWPrivateKey{ wallet->impl.getMasterKey(curve) };
+    } catch (...) {
+        return nullptr;
+    }
 }
 
-struct TWPrivateKey *_Nonnull TWHDWalletGetKeyForCoin(struct TWHDWallet *wallet, TWCoinType coin) {
+struct TWPrivateKey *_Nullable TWHDWalletGetKeyForCoin(struct TWHDWallet *wallet, TWCoinType coin) {
     return TWHDWalletGetKeyDerivation(wallet, coin, TWDerivationDefault);
 }
 
-TWString *_Nonnull TWHDWalletGetAddressForCoin(struct TWHDWallet *wallet, TWCoinType coin) {
+TWString *_Nullable TWHDWalletGetAddressForCoin(struct TWHDWallet *wallet, TWCoinType coin) {
     return TWHDWalletGetAddressDerivation(wallet, coin, TWDerivationDefault);
 }
 
-TWString *_Nonnull TWHDWalletGetAddressDerivation(struct TWHDWallet *wallet, TWCoinType coin, enum TWDerivation derivation) {
-    auto derivationPath = TW::derivationPath(coin, derivation);
-    PrivateKey privateKey = wallet->impl.getKey(coin, derivationPath);
-    std::string address = deriveAddress(coin, privateKey, derivation);
-    return TWStringCreateWithUTF8Bytes(address.c_str());
+TWString *_Nullable TWHDWalletGetAddressDerivation(struct TWHDWallet *wallet, TWCoinType coin, enum TWDerivation derivation) {
+    try {
+        auto derivationPath = TW::derivationPath(coin, derivation);
+        PrivateKey privateKey = wallet->impl.getKey(coin, derivationPath);
+        std::string address = deriveAddress(coin, privateKey, derivation);
+        return TWStringCreateWithUTF8Bytes(address.c_str());
+    } catch (...) {
+        return nullptr;
+    }
 }
 
 struct TWPrivateKey *_Nullable TWHDWalletGetKey(struct TWHDWallet *_Nonnull wallet, enum TWCoinType coin, TWString *_Nonnull derivationPath) {
@@ -89,14 +97,22 @@ struct TWPrivateKey *_Nullable TWHDWalletGetKey(struct TWHDWallet *_Nonnull wall
     }
 }
 
-struct TWPrivateKey *_Nonnull TWHDWalletGetKeyDerivation(struct TWHDWallet *_Nonnull wallet, enum TWCoinType coin, enum TWDerivation derivation) {
-    auto derivationPath = TW::derivationPath(coin, derivation);
-    return new TWPrivateKey{ wallet->impl.getKey(coin, derivationPath) };
+struct TWPrivateKey *_Nullable TWHDWalletGetKeyDerivation(struct TWHDWallet *_Nonnull wallet, enum TWCoinType coin, enum TWDerivation derivation) {
+    try {
+        auto derivationPath = TW::derivationPath(coin, derivation);
+        return new TWPrivateKey{ wallet->impl.getKey(coin, derivationPath) };
+    } catch (...) {
+        return nullptr;
+    }
 }
 
-struct TWPrivateKey *_Nonnull TWHDWalletGetDerivedKey(struct TWHDWallet *_Nonnull wallet, enum TWCoinType coin, uint32_t account, uint32_t change, uint32_t address) {
-    const auto derivationPath = DerivationPath(TW::purpose(coin), TW::slip44Id(coin), account, change, address);
-    return new TWPrivateKey{ wallet->impl.getKey(coin, derivationPath) };
+struct TWPrivateKey *_Nullable TWHDWalletGetDerivedKey(struct TWHDWallet *_Nonnull wallet, enum TWCoinType coin, uint32_t account, uint32_t change, uint32_t address) {
+    try {
+        const auto derivationPath = DerivationPath(TW::purpose(coin), TW::slip44Id(coin), account, change, address);
+        return new TWPrivateKey{ wallet->impl.getKey(coin, derivationPath) };
+    } catch (...) {
+        return nullptr;
+    }
 }
 
 struct TWPrivateKey *_Nullable TWHDWalletGetKeyByCurve(struct TWHDWallet *_Nonnull wallet, enum TWCurve curve, TWString *_Nonnull derivationPath) {

--- a/swift/Example/Example/ContentView.swift
+++ b/swift/Example/Example/ContentView.swift
@@ -9,7 +9,7 @@ struct ContentView: View {
 
     let wallet = HDWallet(strength: 256, passphrase: "")!
     var body: some View {
-        Text("Ethereum address: \(wallet.getAddressForCoin(coin: .ethereum))")
+        Text("Ethereum address: \(wallet.getAddressForCoin(coin: .ethereum)!)")
             .padding()
     }
 }

--- a/swift/Example/ExampleMac/ContentView.swift
+++ b/swift/Example/ExampleMac/ContentView.swift
@@ -8,7 +8,7 @@ import WalletCore
 struct ContentView: View {
     let wallet = HDWallet(strength: 256, passphrase: "")!
     var body: some View {
-        Text("Ethereum address: \(wallet.getAddressForCoin(coin: .ethereum))")
+        Text("Ethereum address: \(wallet.getAddressForCoin(coin: .ethereum)!)")
             .padding()
     }
 }

--- a/swift/Example/ExampleTests/ExampleTests.swift
+++ b/swift/Example/ExampleTests/ExampleTests.swift
@@ -10,7 +10,7 @@ class ExampleTests: XCTestCase {
 
     func testEthereum() {
         let wallet = HDWallet(mnemonic: "ripple scissors kick mammal hire column oak again sun offer wealth tomorrow wagon turn fatal", passphrase: "TREZOR")!
-        let address = wallet.getAddressForCoin(coin: .ethereum)
+        let address = wallet.getAddressForCoin(coin: .ethereum)!
 
         XCTAssertEqual(address, "0x27Ef5cDBe01777D62438AfFeb695e33fC2335979")
     }

--- a/swift/Tests/Blockchains/AvalancheTests.swift
+++ b/swift/Tests/Blockchains/AvalancheTests.swift
@@ -20,14 +20,14 @@ class AvalancheTests: XCTestCase {
     func testXPub() {
         let wallet = HDWallet(mnemonic: "liquid spider narrow follow black west cabbage intact stadium resource gentle raccoon", passphrase: "")!
 
-        let xpub1 = wallet.getExtendedPublicKey(purpose: .bip44, coin: .ethereum, version: .xpub)
-        let xpub2 = wallet.getExtendedPublicKey(purpose: .bip44, coin: .avalancheCChain, version: .xpub)
+        let xpub1 = wallet.getExtendedPublicKey(purpose: .bip44, coin: .ethereum, version: .xpub)!
+        let xpub2 = wallet.getExtendedPublicKey(purpose: .bip44, coin: .avalancheCChain, version: .xpub)!
 
         XCTAssertEqual(xpub1, xpub2)
         XCTAssertEqual(xpub2, "xpub6Bmo35QfCNvffj8tZsTVRvFxA5ULv2aHDV8dDCa7q6SzkMLJffxWRNE5vSJ4hANoKpmSp3p7Nbcp1vEz5F785HV4Aq2A6jWwHoyWp3EFgYp")
 
-        let xpri1 = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .ethereum, version: .xprv)
-        let xpri2 = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .smartChain, version: .xprv)
+        let xpri1 = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .ethereum, version: .xprv)!
+        let xpri2 = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .smartChain, version: .xprv)!
 
         XCTAssertEqual(xpri1, xpri2)
         XCTAssertEqual(xpri2, "xprv9xnSdZsmN1NNTF4RTqvV4nKDc3drWZrRrGD2QpAWGkv1sZ1A88eFsZuc59vKRr4mxJELH7C18ymaHENodYzEbeLq1JmPUAy3CmpA2inVCwo")

--- a/swift/Tests/Blockchains/BinanceChainTests.swift
+++ b/swift/Tests/Blockchains/BinanceChainTests.swift
@@ -18,7 +18,7 @@ class BinanceChainTests: XCTestCase {
 
     func testBinanceMainnet() {
         let wallet = HDWallet(mnemonic: "rabbit tilt arm protect banner ill produce vendor april bike much identify pond upset front easily glass gallery address hair priority focus forest angle", passphrase: "")!
-        let key = wallet.getKeyForCoin(coin: .binance)
+        let key = wallet.getKeyForCoin(coin: .binance)!
         let address = CoinType.binance.deriveAddress(privateKey: key)
 
         XCTAssertEqual(key.data.hexString, "727f677b390c151caf9c206fd77f77918f56904b5504243db9b21e51182c4c06")
@@ -27,7 +27,7 @@ class BinanceChainTests: XCTestCase {
 
     func testBinanceTestnet() {
         let wallet = HDWallet(mnemonic: "rabbit tilt arm protect banner ill produce vendor april bike much identify pond upset front easily glass gallery address hair priority focus forest angle", passphrase: "")!
-        let privateKey = wallet.getKeyForCoin(coin: .binance)
+        let privateKey = wallet.getKeyForCoin(coin: .binance)!
         let publicKey = privateKey.getPublicKeySecp256k1(compressed: true)
         let address = AnyAddress(publicKey: publicKey, coin: .binance, hrp: "tbnb")
 

--- a/swift/Tests/Blockchains/BitconCashTests.swift
+++ b/swift/Tests/Blockchains/BitconCashTests.swift
@@ -10,8 +10,8 @@ class BitcoinCashTests: XCTestCase {
     func testExtendedKeys() {
         let wallet = HDWallet.test
 
-        let xprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .bitcoinCash, version: .xprv)
-        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .bitcoinCash, version: .xpub)
+        let xprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .bitcoinCash, version: .xprv)!
+        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .bitcoinCash, version: .xpub)!
 
         XCTAssertEqual(xprv, "xprv9yEvwSfPanK5gLYVnYvNyF2CEWJx1RsktQtKDeT6jnCnqASBiPCvFYHFSApXv39bZbF6hRaha1kWQBVhN1xjo7NHuhAn5uUfzy79TBuGiHh")
         XCTAssertEqual(xpub, "xpub6CEHLxCHR9sNtpcxtaTPLNxvnY9SQtbcFdov22riJ7jmhxmLFvXAoLbjHSzwXwNNuxC1jUP6tsHzFV9rhW9YKELfmR9pJaKFaM8C3zMPgjw")

--- a/swift/Tests/Blockchains/CardanoTests.swift
+++ b/swift/Tests/Blockchains/CardanoTests.swift
@@ -18,7 +18,7 @@ class CardanoTests: XCTestCase {
 
     func testDeriveAddressWallet() {
         let wallet = HDWallet(mnemonic: "cost dash dress stove morning robust group affair stomach vacant route volume yellow salute laugh", passphrase: "")!
-        let privateKey = wallet.getKeyForCoin(coin: .cardano)
+        let privateKey = wallet.getKeyForCoin(coin: .cardano)!
         XCTAssertEqual(privateKey.data.hexString, "e8c8c5b2df13f3abed4e6b1609c808e08ff959d7e6fc3d849e3f2880550b574437aa559095324d78459b9bb2da069da32337e1cc5da78f48e1bd084670107f3110f3245ddf9132ecef98c670272ef39c03a232107733d4a1d28cb53318df26fae0d152bb611cb9ff34e945e4ff627e6fba81da687a601a879759cd76530b5744424db69a75edd4780a5fbc05d1a3c84ac4166ff8e424808481dd8e77627ce5f5bf2eea84515a4e16c4ff06c92381822d910b5cbf9e9c144e1fb76a6291af7276")
         let address = CoinType.cardano.deriveAddress(privateKey: privateKey)
         XCTAssertEqual(address, "addr1qxxe304qg9py8hyyqu8evfj4wln7dnms943wsugpdzzsxnkvvjljtzuwxvx0pnwelkcruy95ujkq3aw6rl0vvg32x35qc92xkq")

--- a/swift/Tests/Blockchains/DashTests.swift
+++ b/swift/Tests/Blockchains/DashTests.swift
@@ -16,8 +16,8 @@ class DashAddressTests: XCTestCase {
     func testExtendedKeys() {
         let wallet = HDWallet.test
 
-        let xprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .dash, version: .xprv)
-        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .dash, version: .xpub)
+        let xprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .dash, version: .xprv)!
+        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .dash, version: .xpub)!
 
         XCTAssertEqual(xprv, "xprv9zSMAfz7nQUZDQXMifsT5Cbss1Kh8XgnsKsrFfx83bvbuubs6ra84k95XMpAJmt51jymfNrXid81bu9tUTW2W2g7CBU5e6F297XBuXfSmjJ")
         XCTAssertEqual(xpub, "xpub6DRhaBX1cn2rRtbpphQTSLYcR3ABXzQeEYoT44MjbwTanhw1ePtNcYTZNeHyrJMsMGTbig4iFMSvht7RviohzFxkpjURgHDThygLqbZ1tib")

--- a/swift/Tests/Blockchains/DecredTests.swift
+++ b/swift/Tests/Blockchains/DecredTests.swift
@@ -11,8 +11,8 @@ class DecredTests: XCTestCase {
         let wallet = HDWallet.test
 
         // .bip44
-        let dprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .decred, version: .dprv)
-        let dpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .decred, version: .dpub)
+        let dprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .decred, version: .dprv)!
+        let dpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .decred, version: .dpub)!
 
         XCTAssertEqual(dprv, "dprv3oggQ2FQ1chcr18hbW7Aur5x8SxQdES3FGa4WqeTZnFY88SNMzLdB7LkZLroF4bGAqWS8sDm3w4DKyYV7sDKfC6JMSVHnVJdpDLgHioq1vq")
         XCTAssertEqual(dpub, "dpubZFUmm9oh5zmQkR2Tr2AXS4tCkTWg4B27SpCPFkapZrrAqgU1EwgEFgrmi6EnLGXhak86yDHhXPxFAnGU58W5S4e8NCKG1ASUVaxwRqqNdfP")

--- a/swift/Tests/Blockchains/DogeTests.swift
+++ b/swift/Tests/Blockchains/DogeTests.swift
@@ -28,8 +28,8 @@ class DogeTests: XCTestCase {
         let wallet = HDWallet.test
 
         // .bip44
-        let dgpv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: coin, version: .dgpv)
-        let dgub = wallet.getExtendedPublicKey(purpose: .bip44, coin: coin, version: .dgub)
+        let dgpv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: coin, version: .dgpv)!
+        let dgub = wallet.getExtendedPublicKey(purpose: .bip44, coin: coin, version: .dgub)!
 
         XCTAssertEqual(dgpv, "dgpv57ru95KiYUB5oWm2CVQH4heh1f7E9dNGdRHHVThcQkLeQ2HHxVJfFYefnpKrWZ6L6EDKJHUVq4Yyd5kPZKnRePfkCz3EzkySTydXKbgjcxN")
         XCTAssertEqual(dgub, "dgub8rjvUmFc6cqR6NRBEj2FBZCHUDUrykPyv24Vea6bCsPex5PzNFrRtr4KN37XgwuVzzC2MikJRW2Ddcp99Ehsqp2iaU4eerNCJVruKxz6Gci")

--- a/swift/Tests/Blockchains/ECashTests.swift
+++ b/swift/Tests/Blockchains/ECashTests.swift
@@ -10,8 +10,8 @@ class ECashTests: XCTestCase {
     func testExtendedKeys() {
         let wallet = HDWallet.test
 
-        let xprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .ecash, version: .xprv)
-        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .ecash, version: .xpub)
+        let xprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .ecash, version: .xprv)!
+        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .ecash, version: .xpub)!
 
         XCTAssertEqual(xprv, "xprv9xjBcTizebJaV61xMkuMJ89vis7saMmwFgTYeF83KwinEksJ4frk7wB4mDiKiwXDCbJmgmh6Bp1FkF8SopNZhbF3B5wyX32cuDVFZtuUDvB")
         XCTAssertEqual(xpub, "xpub6BiY1yFtUxrsha6RTnSMfG6fGtxMypVncuP9SdXetHFm7ZCScDAzfjVYcW32bkNCGJ5DTqawAHSTbJdTBL8wVxqUDGpxnRtukrhhBoS7Wy7")

--- a/swift/Tests/Blockchains/EthereumTests.swift
+++ b/swift/Tests/Blockchains/EthereumTests.swift
@@ -266,8 +266,8 @@ class EthereumTests: XCTestCase {
         XCTAssertEqual(btcXpub, "xpub6Cq43Vqyvb2DwXzjzNeMpPuxXRCN1WnmRCmYLPaaSv2XZXM2yCwUHpWEyB3zQ3FGCQsvY21gecMaQR7b2zhhgiHnjzDYpKCE2LACueaSMuR")
         XCTAssertEqual(ethXpub, "xpub6Bgma7boPVudhExmB97iySvatGfnXkfBxYZYNTFYJvVzigUPk1X2iE8VhJPPxVuzjH8wBuTqRBMKCbwMYQNLrFCwYzMugYw4RM5VGNeVDpp")
 
-        let ethAddress = wallet.getAddressForCoin(coin: .ethereum)
-        let btcAddress = wallet.getAddressForCoin(coin: .bitcoin)
+        let ethAddress = wallet.getAddressForCoin(coin: .ethereum)!
+        let btcAddress = wallet.getAddressForCoin(coin: .bitcoin)!
 
         XCTAssertEqual(ethAddress, "0xa4531dE99E22B2166d340E7221669DF565c52024")
         XCTAssertEqual(btcAddress, "bc1q97jc0jdgsyvvhxydxxd6np8sa920c39l3qpscf")

--- a/swift/Tests/Blockchains/EthereumTests.swift
+++ b/swift/Tests/Blockchains/EthereumTests.swift
@@ -240,7 +240,7 @@ class EthereumTests: XCTestCase {
     func testGetPublicKeyFromXpub() throws {
         let wallet = HDWallet(mnemonic: "broom ramp luggage this language sketch door allow elbow wife moon impulse", passphrase: "")!
         let path = "m/44'/60'/0'/0/1"
-        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .ethereum, version: .xpub)
+        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .ethereum, version: .xpub)!
 
         XCTAssertEqual(xpub, "xpub6C7LtZJgtz1BKXG9mExKUxYvX7HSF38UMMmGbpqNQw3DfYwAw8E6sH7VSVxFipvEEm2afSqTjoRgcLmycXX4zfxCWJ4HY73a9KdgvfHEQGB")
 
@@ -260,8 +260,8 @@ class EthereumTests: XCTestCase {
         XCTAssertNil(HDWallet(mnemonic: mnemonic, passphrase: ""))
 
         let wallet = HDWallet(mnemonic: mnemonic, passphrase: "", check: false)!
-        let btcXpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .bitcoin, version: .xpub)
-        let ethXpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .ethereum, version: .xpub)
+        let btcXpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .bitcoin, version: .xpub)!
+        let ethXpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .ethereum, version: .xpub)!
 
         XCTAssertEqual(btcXpub, "xpub6Cq43Vqyvb2DwXzjzNeMpPuxXRCN1WnmRCmYLPaaSv2XZXM2yCwUHpWEyB3zQ3FGCQsvY21gecMaQR7b2zhhgiHnjzDYpKCE2LACueaSMuR")
         XCTAssertEqual(ethXpub, "xpub6Bgma7boPVudhExmB97iySvatGfnXkfBxYZYNTFYJvVzigUPk1X2iE8VhJPPxVuzjH8wBuTqRBMKCbwMYQNLrFCwYzMugYw4RM5VGNeVDpp")

--- a/swift/Tests/Blockchains/EvmosTests.swift
+++ b/swift/Tests/Blockchains/EvmosTests.swift
@@ -9,8 +9,8 @@ class EvmosTests: XCTestCase {
 
     func testAddressData() throws {
         let wallet = HDWallet(strength: 256, passphrase: "")!
-        let nativeEvmos = wallet.getAddressForCoin(coin: .nativeEvmos)
-        let evmos = wallet.getAddressForCoin(coin: .evmos)
+        let nativeEvmos = wallet.getAddressForCoin(coin: .nativeEvmos)!
+        let evmos = wallet.getAddressForCoin(coin: .evmos)!
 
         let addr1 = AnyAddress(string: nativeEvmos, coin: .nativeEvmos)
         let addr2 = AnyAddress(string: evmos, coin: .evmos)
@@ -21,7 +21,7 @@ class EvmosTests: XCTestCase {
     func testSigningNativeTransfer() {
 
         let wallet = HDWallet(mnemonic: "glue blanket noodle name bring castle degree vibrant great joy usual mother pyramid cat balance swear diagram green split goat token day arm shoe", passphrase: "")!
-        let privateKey = wallet.getKeyForCoin(coin: .nativeEvmos)
+        let privateKey = wallet.getKeyForCoin(coin: .nativeEvmos)!
         let publicKey = privateKey.getPublicKeySecp256k1(compressed: false)
 
         XCTAssertEqual(publicKey.data.hexString, "049475c9fa23ec693667baa76c4da69b49cccfdf058c4dcb27ba67cfbc9082d9ed9074786560aa698b19bb9729526b1c75934f3d4a78f7be719e4386b749b36310")

--- a/swift/Tests/Blockchains/GroestlcoinTests.swift
+++ b/swift/Tests/Blockchains/GroestlcoinTests.swift
@@ -34,21 +34,21 @@ class GroestlcoinTests: XCTestCase {
         let wallet = HDWallet(mnemonic: "all all all all all all all all all all all all", passphrase: "")!
 
         // .bip44
-        let xprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .groestlcoin, version: .xprv)
-        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .groestlcoin, version: .xpub)
+        let xprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .groestlcoin, version: .xprv)!
+        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .groestlcoin, version: .xpub)!
 
         XCTAssertEqual(xprv, "xprv9zHDfLCJPTf5UrS16CrJ56WzSSoAYhJriX8Lfsco3TtPhG2DkwkVXjaDxZKU5USfmq5xjp1CZhpSrpHAPFwZWN75egb19TxWmMMmkd3csxP")
         XCTAssertEqual(xpub, "xpub6DGa4qjCDqDNhLWUCEPJSETizUdexA2i5k3wUG2QboRNa4MNJV4k5XthorGcogStY5K5iJ6NHtsznNK599ir8PmA3d1jqEoZHsixDTddNA9")
 
         // .bip49
-        let yprv = wallet.getExtendedPrivateKey(purpose: .bip49, coin: .groestlcoin, version: .yprv)
-        let ypub = wallet.getExtendedPublicKey(purpose: .bip49, coin: .groestlcoin, version: .ypub)
+        let yprv = wallet.getExtendedPrivateKey(purpose: .bip49, coin: .groestlcoin, version: .yprv)!
+        let ypub = wallet.getExtendedPublicKey(purpose: .bip49, coin: .groestlcoin, version: .ypub)!
         XCTAssertEqual(yprv, "yprvAJkRD9AD6QrU1hvSdcJT1Cdc1DwEMsBHFt4Gqd5NsK8Vhdn3ArEHYGaJhWotcn24VWx9rC6dDutHNea9zws8owL1qWEt3pVD2GGk4DSXyvm")
         XCTAssertEqual(ypub, "ypub6Xjmceh6vnQmEBzujdqTNLaLZFmimKu8d6yse1UzRefUaS7BiPYY64tnYpQQydp1gnb2cGkccBd1RtHRDtGXagqmRLxTStV88GWaeYh8ndG")
 
         // .bip84
-        let zprv = wallet.getExtendedPrivateKey(purpose: .bip84, coin: .groestlcoin, version: .zprv)
-        let zpub = wallet.getExtendedPublicKey(purpose: .bip84, coin: .groestlcoin, version: .zpub)
+        let zprv = wallet.getExtendedPrivateKey(purpose: .bip84, coin: .groestlcoin, version: .zprv)!
+        let zpub = wallet.getExtendedPublicKey(purpose: .bip84, coin: .groestlcoin, version: .zpub)!
         XCTAssertEqual(zprv, "zprvAcXuP1BeFt59rhLMnqTEL9j2TUz5mzXkj8NPcfvLKGzHm5mofJAeJMvFzzbNizahKxVEvptBpSxdhBcGbxdbaFP58caWLWAjZWMT7Jb6pFW")
         XCTAssertEqual(zpub, "zpub6qXFnWiY6FdT5BQptrzEhHfm1WpaBTFc6MHzR4KwscXGdt6xCqUtrAEjrHdeEsjaYEwVMgjtTvENQ83yo2fmkYYGjTpJoH7vFWKQJp1bg1X")
     }

--- a/swift/Tests/Blockchains/LitecoinTests.swift
+++ b/swift/Tests/Blockchains/LitecoinTests.swift
@@ -38,21 +38,21 @@ class LitecoinTests: XCTestCase {
         let wallet = HDWallet.test
 
         // .bip44
-        let lptv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .litecoin, version: .ltpv)
-        let ltub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .litecoin, version: .ltub)
+        let lptv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .litecoin, version: .ltpv)!
+        let ltub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .litecoin, version: .ltub)!
 
         XCTAssertEqual(lptv, "Ltpv77Tkf73NsKY3NQWVr6sHXeDQHWV6EVBXStcyxfnwEVebFuz1URxi16SBzj4v7n3mSYh8PQXhSFM2aXNFdx8bvWBLZGXeik3UQXeXn5vudGj")
         XCTAssertEqual(ltub, "Ltub2Ye6FtTv7U4zzHDL6iMfcE3cj5BHJjkBXQj1deZEAgSBrHB5oM191hYTF8BC34r7vRDGng59yfP6FH4m3nttc3TLDg944G8QK7d5NnygCRu")
 
         // .bip49
-        let mtpv = wallet.getExtendedPrivateKey(purpose: .bip49, coin: .litecoin, version: .mtpv)
-        let mtub = wallet.getExtendedPublicKey(purpose: .bip49, coin: .litecoin, version: .mtub)
+        let mtpv = wallet.getExtendedPrivateKey(purpose: .bip49, coin: .litecoin, version: .mtpv)!
+        let mtub = wallet.getExtendedPublicKey(purpose: .bip49, coin: .litecoin, version: .mtub)!
         XCTAssertEqual(mtpv, "Mtpv7SPQ3PnRFU5yMidTBbXKxb6pgrE1Ny1yVssVvTz8VLDppPrhdydSaoMp6fm58VbtBTrVZVacMrSUim44RccBLu8NFAqj7ZaB5JBzb8cgQHp")
         XCTAssertEqual(mtub, "Mtub2sZjeBCxVccvybLHSD1i3Aw38QvCTDadaPyXbSkRRX1RQm3mxtfsbQU5M3PdCSP4xAFHCceEQ3FmQF69Du2wbcmebt3CaWAGALBSe8c4Gvw")
 
         // .bip84
-        let zprv = wallet.getExtendedPrivateKey(purpose: .bip84, coin: .litecoin, version: .zprv)
-        let zpub = wallet.getExtendedPublicKey(purpose: .bip84, coin: .litecoin, version: .zpub)
+        let zprv = wallet.getExtendedPrivateKey(purpose: .bip84, coin: .litecoin, version: .zprv)!
+        let zpub = wallet.getExtendedPublicKey(purpose: .bip84, coin: .litecoin, version: .zpub)!
         XCTAssertEqual(zprv, "zprvAeCuQd5okFvvK1oeAQEPtgtPd5feXtcmszyCDK8HUPob28R79tUgtpCga79KgtDkUBn72AMig5NNzUCFY1JeRsZcEitDVEYuB48uHt2YEDB")
         XCTAssertEqual(zpub, "zpub6sCFp8chadVDXVt7GRmQFpq8B7W8wMLdFDto1hXu2jLZtvkFhRnwScXARNfrGSeyhR8DBLJnaUUkBbkmB2GwUYkecEAMUcbUpFQV4v7PXcs")
     }

--- a/swift/Tests/Blockchains/MonacoinTests.swift
+++ b/swift/Tests/Blockchains/MonacoinTests.swift
@@ -38,21 +38,21 @@ class MonacoinTests: XCTestCase {
         let wallet = HDWallet.test
 
         // .bip44
-        let xprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .monacoin, version: .xprv)
-        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .monacoin, version: .xpub)
+        let xprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .monacoin, version: .xprv)!
+        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .monacoin, version: .xpub)!
 
         XCTAssertEqual(xprv, "xprv9ySV9MzJnFMm7bi5qVTcqva3oDJojNsMYuASBcj9yC4QRe4kehWYeGfUVYFiJQipELCHmiutHJVxosR7eSovWHrWCUTdhf49D1N7MGKVcUZ")
         XCTAssertEqual(xpub, "xpub6CRqYsXCccv4L5nYwWzdD4WnMF9J8qbCv862z18mXXbPJSPuCEpoC4yxLn5N81V5GWNuBsJ8g6tYsBb1V9hCipGn4WR6bc9FLUtyyRvDFse")
 
         // .bip49
-        let yprv = wallet.getExtendedPrivateKey(purpose: .bip49, coin: .monacoin, version: .yprv)
-        let ypub = wallet.getExtendedPublicKey(purpose: .bip49, coin: .monacoin, version: .ypub)
+        let yprv = wallet.getExtendedPrivateKey(purpose: .bip49, coin: .monacoin, version: .yprv)!
+        let ypub = wallet.getExtendedPublicKey(purpose: .bip49, coin: .monacoin, version: .ypub)!
         XCTAssertEqual(yprv, "yprvAJL1swHSWeFvfKdupcrsAvTCrtAiKUhLrUjteTj8JGCzD53YrJgiVbsChMPi5h119cn5tVVk1QAFSJtcnMSSxjGCNDXg8YaWbe4Hhc5bUfL")
         XCTAssertEqual(ypub, "ypub6XKNHSpLM1pDsoiNvePsY4PwQv1CiwRCDhfVSr8jrbjy5sNhPqzy3QBgYdCayJhq5st63XZTWrea8So84QYbPgP2EvVR5dhSrW18ud4GZaT")
 
         // .bip84
-        let zprv = wallet.getExtendedPrivateKey(purpose: .bip84, coin: .monacoin, version: .zprv)
-        let zpub = wallet.getExtendedPublicKey(purpose: .bip84, coin: .monacoin, version: .zpub)
+        let zprv = wallet.getExtendedPrivateKey(purpose: .bip84, coin: .monacoin, version: .zprv)!
+        let zpub = wallet.getExtendedPublicKey(purpose: .bip84, coin: .monacoin, version: .zpub)!
         XCTAssertEqual(zprv, "zprvAdi4KQxm5ofVJqh1Y5KxSTuC1CSEibkz3Ei4dnNMzyLt6FiW3rMPTgKUCiwv1cw4rVeDW9ju82ChFz27UNG2kxvtFsngJCYtHjDYURsefzX")
         XCTAssertEqual(zpub, "zpub6rhQivVevBDnXKmUe6rxobqvZEGj84UqQTdfSAmyZJsry43ebPfe1Udx3zUNDB3cHu2ozNCDhsy8BuNCjCvStNmodzdR2E2wWAsLyNFu5i1")
     }

--- a/swift/Tests/Blockchains/NervosTests.swift
+++ b/swift/Tests/Blockchains/NervosTests.swift
@@ -9,7 +9,7 @@ class NervosTests: XCTestCase {
 
     func testDerive() throws {
         let wallet = HDWallet(mnemonic: "disorder wolf eager ladder fence renew dynamic idea metal camera bread obscure", passphrase: "")!
-        let address = wallet.getAddressForCoin(coin: .nervos)
+        let address = wallet.getAddressForCoin(coin: .nervos)!
 
         XCTAssertEqual(address, "ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqga4k4agxexsd3zdq0wvrlyumfz7n5r7fsjxtnw8")
     }

--- a/swift/Tests/Blockchains/PolkadotTests.swift
+++ b/swift/Tests/Blockchains/PolkadotTests.swift
@@ -88,7 +88,7 @@ class PolkadotTests: XCTestCase {
 
     func testSigningBondAndNominate() {
         // real key in 1p test
-        let key = HDWallet.test.getKeyForCoin(coin: .polkadot)
+        let key = HDWallet.test.getKeyForCoin(coin: .polkadot)!
 
         let input = PolkadotSigningInput.with {
             $0.genesisHash = genesisHash
@@ -116,7 +116,7 @@ class PolkadotTests: XCTestCase {
 
     func testSigningBondExtra() {
         // real key in 1p test
-        let key = HDWallet.test.getKeyForCoin(coin: .polkadot)
+        let key = HDWallet.test.getKeyForCoin(coin: .polkadot)!
 
         let input = PolkadotSigningInput.with {
             $0.genesisHash = genesisHash

--- a/swift/Tests/Blockchains/QtumTests.swift
+++ b/swift/Tests/Blockchains/QtumTests.swift
@@ -31,21 +31,21 @@ class QtumTests: XCTestCase {
         let wallet = HDWallet.test
 
         // .bip44
-        let xprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .qtum, version: .xprv)
-        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .qtum, version: .xpub)
+        let xprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .qtum, version: .xprv)!
+        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .qtum, version: .xpub)!
 
         XCTAssertEqual(xprv, "xprv9yBPu3rkmyffD3A4TngwcpffYASEEfYnShyhuUsL3h9GiYdUjJh9S2s3vcYMoKi8L2cDqQcsFU5TkC1zgusTENCjatpnxp72X4uYkrej2tj")
         XCTAssertEqual(xpub, "xpub6CAkJZPecMDxRXEXZpDwyxcQ6CGie8GdovuJhsGwc2gFbLxdGr1PyqBXmsL7aYds1wfY2rB3YMVZiEE3CB3Lkj6KGoq1rEJ1wuaGkMDBf1m")
 
         // .bip49
-        let yprv = wallet.getExtendedPrivateKey(purpose: .bip49, coin: .qtum, version: .yprv)
-        let ypub = wallet.getExtendedPublicKey(purpose: .bip49, coin: .qtum, version: .ypub)
+        let yprv = wallet.getExtendedPrivateKey(purpose: .bip49, coin: .qtum, version: .yprv)!
+        let ypub = wallet.getExtendedPublicKey(purpose: .bip49, coin: .qtum, version: .ypub)!
         XCTAssertEqual(yprv, "yprvAJdTrS1VXxDTRFGxPLJmjSECVCwqePCeCH7i6pLP3SiDg6G5omNiwEt88ENDy9nWMPmErGT5c1nGBsZRUjaTunFqw1w6xhWsAsLG6x8fR7d")
         XCTAssertEqual(ypub, "ypub6XcpFwYPNKmkdjMRVMqn6aAw3EnL3qvVZW3JuCjzbnFCYtbEMJgyV3CbyY8jVCtSBfSB5H12uLcFYUSEtsBYNaf46Zv2smueAZKGmDgT8k8")
 
         // .bip84
-        let zprv = wallet.getExtendedPrivateKey(purpose: .bip84, coin: .qtum, version: .zprv)
-        let zpub = wallet.getExtendedPublicKey(purpose: .bip84, coin: .qtum, version: .zpub)
+        let zprv = wallet.getExtendedPrivateKey(purpose: .bip84, coin: .qtum, version: .zprv)!
+        let zpub = wallet.getExtendedPublicKey(purpose: .bip84, coin: .qtum, version: .zpub)!
         XCTAssertEqual(zprv, "zprvAdJxRo2izCdp1NZQShHqyXXwNrkAbYqi9YwAkG6kCJ2V5JZY7s2TdmbF2YxTzQKVx3SWQiHpVpsKyZ59Y8Th7edf2hJBWuyTvnCadLMLxAz")
         XCTAssertEqual(zpub, "zpub6rJJqJZcpaC7DrdsYiprLfUfvtaf11ZZWmrmYeWMkdZTx6tgfQLiBZuisraogskwBRLMGWfXoCyWRrXSypwPdNV2UWJXm5bDVQvBXvrzz9d")
     }

--- a/swift/Tests/Blockchains/SyscoinTests.swift
+++ b/swift/Tests/Blockchains/SyscoinTests.swift
@@ -38,21 +38,21 @@ class SyscoinTests: XCTestCase {
         let wallet = HDWallet.test
 
         // .bip44
-        let xprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .syscoin, version: .xprv)
-        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .syscoin, version: .xpub)
+        let xprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .syscoin, version: .xprv)!
+        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .syscoin, version: .xpub)!
 
         XCTAssertEqual(xprv, "xprv9yFNgN7z81uG6QtwFt7gvbmLeDGeGfS2ar3DunwEkZcC7uLBXyy4eaaV3ir769zMLe3eHuTaGUtWVXwp6dkunLsfmA7bf3XqEFpTjHxSijx")
         XCTAssertEqual(xpub, "xpub6CEj5sesxPTZJtyQMuehHji5CF78g89sx4xpiBLrJu9AzhfL5XHKCNtxtzPzyGxqb6jMbZfmbHeSGZZArL4hLttmdC6KEMuiWy7VocTYjzR")
 
         // .bip49
-        let yprv = wallet.getExtendedPrivateKey(purpose: .bip49, coin: .syscoin, version: .yprv)
-        let ypub = wallet.getExtendedPublicKey(purpose: .bip49, coin: .syscoin, version: .ypub)
+        let yprv = wallet.getExtendedPrivateKey(purpose: .bip49, coin: .syscoin, version: .yprv)!
+        let ypub = wallet.getExtendedPublicKey(purpose: .bip49, coin: .syscoin, version: .ypub)!
         XCTAssertEqual(yprv, "yprvAJAofBFEEQ1DLJJVMkPr4pufHLUKZ2VSbtHqPpphEgwgfvG8exgadM8vtW8AW52N7tqU4qM8JHk5xZkq3icnzoph5QA5kRVHBnhXuRMGw2b")
         XCTAssertEqual(ypub, "ypub6XAA4gn84mZWYnNxTmvrRxrPqNJoxVDHy7DSCDEJo2UfYibHCVzqB9TQjmL2TKSEZVFmTNcmdJXunEu6oV2AFQNeiszjzcnX4nbG27s4SgS")
 
         // .bip84
-        let zprv = wallet.getExtendedPrivateKey(purpose: .bip84, coin: .syscoin, version: .zprv)
-        let zpub = wallet.getExtendedPublicKey(purpose: .bip84, coin: .syscoin, version: .zpub)
+        let zprv = wallet.getExtendedPrivateKey(purpose: .bip84, coin: .syscoin, version: .zprv)!
+        let zpub = wallet.getExtendedPublicKey(purpose: .bip84, coin: .syscoin, version: .zpub)!
         XCTAssertEqual(zprv, "zprvAcdCiLx9ooAFnC1hXh7stnobLnnu7u25rqfLeJ9v632xdCXJrc8KvgNk2eZeQQbPQHvcUpsfJzgyDkRdfnkT6vjpYqkxFv1LsPxQ7uFwLGy")
         XCTAssertEqual(zpub, "zpub6qcZ7rV3eAiYzg6AdietFvkKtpdPXMjwE4awSgZXeNZwVzrTQ9SaUUhDswmdA4A5riyimx322es7niQvJ1Fbi3mJNSVz3d3f9GBsYBb8Wky")
     }

--- a/swift/Tests/CoinAddressDerivationTests.swift
+++ b/swift/Tests/CoinAddressDerivationTests.swift
@@ -12,7 +12,7 @@ class CoinAddressDerivationTests: XCTestCase {
 
         for _ in 0..<4 {
             for coin in CoinType.allCases {
-                let privateKey = wallet.getKeyForCoin(coin: coin)
+                let privateKey = wallet.getKeyForCoin(coin: coin)!
                 let derivedAddress = coin.deriveAddress(privateKey: privateKey)
                 let address = coin.address(string: derivedAddress)
 

--- a/swift/Tests/HDWalletTests.swift
+++ b/swift/Tests/HDWalletTests.swift
@@ -17,7 +17,7 @@ class HDWalletTests: XCTestCase {
         XCTAssertEqual(starkDerivationPath, "m/2645'/579218131'/211006541'/2124474935'/1609799702'/1")
 
         // Retrieve eth private key
-        let ethPrivateKey = wallet.getKeyForCoin(coin: CoinType.ethereum)
+        let ethPrivateKey = wallet.getKeyForCoin(coin: CoinType.ethereum)!
         XCTAssertEqual(ethPrivateKey.data.hexString, "03a9ca895dca1623c7dfd69693f7b4111f5d819d2e145536e0b03c136025a25d");
 
         // StarkKey Derivation Path
@@ -75,14 +75,14 @@ class HDWalletTests: XCTestCase {
     func testMasterKey() {
         let wallet = HDWallet(mnemonic: "tiny escape drive pupil flavor endless love walk gadget match filter luxury", passphrase: "")!
         XCTAssertEqual(wallet.seed.hexString, "d430216f5b506dfd281d6ff6e92150d205868923df00774bc301e5ffdc2f4d1ad38a602017ddea6fc7d6315345d8b9cadbd8213ed2ffce5dfc550fa918665eb8")
-        let masterKey = wallet.getMasterKey(curve: Curve.secp256k1)
+        let masterKey = wallet.getMasterKey(curve: Curve.secp256k1)!
         XCTAssertEqual(masterKey.data.hexString, "e120fc1ef9d193a851926ebd937c3985dc2c4e642fb3d0832317884d5f18f3b3")
     }
 
     func testGetKeyForCoinBitcoin() {
         let coin = CoinType.bitcoin
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: coin)
+        let key = wallet.getKeyForCoin(coin: coin)!
 
         let address = coin.deriveAddress(privateKey: key)
         XCTAssertEqual(address, "bc1qumwjg8danv2vm29lp5swdux4r60ezptzz7ce85")
@@ -92,16 +92,16 @@ class HDWalletTests: XCTestCase {
         let coin = CoinType.bitcoin
         let wallet = HDWallet.test
 
-        let key1 = wallet.getKeyDerivation(coin: coin, derivation: .bitcoinSegwit)
+        let key1 = wallet.getKeyDerivation(coin: coin, derivation: .bitcoinSegwit)!
         XCTAssertEqual(key1.data.hexString, "1901b5994f075af71397f65bd68a9fff8d3025d65f5a2c731cf90f5e259d6aac")
 
-        let key2 = wallet.getKeyDerivation(coin: coin, derivation: .bitcoinLegacy)
+        let key2 = wallet.getKeyDerivation(coin: coin, derivation: .bitcoinLegacy)!
         XCTAssertEqual(key2.data.hexString, "28071bf4e2b0340db41b807ed8a5514139e5d6427ff9d58dbd22b7ed187103a4")
 
-        let key3 = wallet.getKeyDerivation(coin: coin, derivation: .bitcoinTestnet)
+        let key3 = wallet.getKeyDerivation(coin: coin, derivation: .bitcoinTestnet)!
         XCTAssertEqual(key3.data.hexString, "ca5845e1b43e3adf577b7f110b60596479425695005a594c88f9901c3afe864f")
 
-        let key4 = wallet.getKeyDerivation(coin: coin, derivation: .bitcoinTaproot)
+        let key4 = wallet.getKeyDerivation(coin: coin, derivation: .bitcoinTaproot)!
         XCTAssertEqual(key4.data.hexString, "a2c4d6df786f118f20330affd65d248ffdc0750ae9cbc729d27c640302afd030")
     }
 
@@ -109,7 +109,7 @@ class HDWalletTests: XCTestCase {
         let coin = CoinType.bitcoin
         let wallet = HDWallet.test
 
-        let address = wallet.getAddressForCoin(coin: coin)
+        let address = wallet.getAddressForCoin(coin: coin)!
         XCTAssertEqual(address, "bc1qumwjg8danv2vm29lp5swdux4r60ezptzz7ce85")
     }
 
@@ -117,16 +117,16 @@ class HDWalletTests: XCTestCase {
         let coin = CoinType.bitcoin
         let wallet = HDWallet.test
 
-        let address1 = wallet.getAddressDerivation(coin: coin, derivation: .bitcoinSegwit)
+        let address1 = wallet.getAddressDerivation(coin: coin, derivation: .bitcoinSegwit)!
         XCTAssertEqual(address1, "bc1qumwjg8danv2vm29lp5swdux4r60ezptzz7ce85")
 
-        let address2 = wallet.getAddressDerivation(coin: coin, derivation: .bitcoinLegacy)
+        let address2 = wallet.getAddressDerivation(coin: coin, derivation: .bitcoinLegacy)!
         XCTAssertEqual(address2, "1PeUvjuxyf31aJKX6kCXuaqxhmG78ZUdL1")
 
-        let address3 = wallet.getAddressDerivation(coin: coin, derivation: .bitcoinTestnet)
+        let address3 = wallet.getAddressDerivation(coin: coin, derivation: .bitcoinTestnet)!
         XCTAssertEqual(address3, "tb1qwgpxgwn33z3ke9s7q65l976pseh4edrzfmyvl0")
 
-        let address4 = wallet.getAddressDerivation(coin: coin, derivation: .bitcoinTaproot)
+        let address4 = wallet.getAddressDerivation(coin: coin, derivation: .bitcoinTaproot)!
         XCTAssertEqual(address4, "bc1pgqks0cynn93ymve4x0jq3u7hne77908nlysp289hc44yc4cmy0hslyckrz")
     }
 
@@ -134,10 +134,10 @@ class HDWalletTests: XCTestCase {
         let coin = CoinType.pactus
         let wallet = HDWallet.test
 
-        let key1 = wallet.getKeyDerivation(coin: coin, derivation: .pactusMainnet)
+        let key1 = wallet.getKeyDerivation(coin: coin, derivation: .pactusMainnet)!
         XCTAssertEqual(key1.data.hexString, "153fefb8168f246f9f77c60ea10765c1c39828329e87284ddd316770717f3a5e")
 
-        let key2 = wallet.getKeyDerivation(coin: coin, derivation: .pactusTestnet)
+        let key2 = wallet.getKeyDerivation(coin: coin, derivation: .pactusTestnet)!
         XCTAssertEqual(key2.data.hexString, "54f3c54dd6af5794bea1f86de05b8b9f164215e8deee896f604919046399e54d")
     }
 
@@ -145,7 +145,7 @@ class HDWalletTests: XCTestCase {
         let coin = CoinType.pactus
         let wallet = HDWallet.test
 
-        let address = wallet.getAddressForCoin(coin: coin)
+        let address = wallet.getAddressForCoin(coin: coin)!
         XCTAssertEqual(address, "pc1rjkzc23l7qkkenx6xwy04srwppzfk6m5t7q46ff")
     }
 
@@ -153,18 +153,18 @@ class HDWalletTests: XCTestCase {
         let coin = CoinType.pactus
         let wallet = HDWallet.test
 
-        let address1 = wallet.getAddressDerivation(coin: coin, derivation: .pactusMainnet)
+        let address1 = wallet.getAddressDerivation(coin: coin, derivation: .pactusMainnet)!
         XCTAssertEqual(address1, "pc1rjkzc23l7qkkenx6xwy04srwppzfk6m5t7q46ff")
 
-        let address2 = wallet.getAddressDerivation(coin: coin, derivation: .pactusTestnet)
+        let address2 = wallet.getAddressDerivation(coin: coin, derivation: .pactusTestnet)!
         XCTAssertEqual(address2, "tpc1rjtamyqp203j4367q4plkp4qt32d7sv34kfmj5e")
     }
 
     func testDerive() {
         let wallet = HDWallet.test
 
-        let key0 = wallet.getDerivedKey(coin: .ethereum, account: 0, change: 0, address: 0)
-        let key1 = wallet.getDerivedKey(coin: .ethereum, account: 0, change: 0, address: 1)
+        let key0 = wallet.getDerivedKey(coin: .ethereum, account: 0, change: 0, address: 0)!
+        let key1 = wallet.getDerivedKey(coin: .ethereum, account: 0, change: 0, address: 1)!
 
         XCTAssertEqual(AnyAddress(publicKey: key0.getPublicKeySecp256k1(compressed: false), coin: .ethereum).description, "0x27Ef5cDBe01777D62438AfFeb695e33fC2335979")
         XCTAssertEqual(AnyAddress(publicKey: key1.getPublicKeySecp256k1(compressed: false), coin: .ethereum).description, "0x98f5438cDE3F0Ff6E11aE47236e93481899d1C47")
@@ -173,7 +173,7 @@ class HDWalletTests: XCTestCase {
     func testWanchain() {
         let wanChain = CoinType.wanchain
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: wanChain)
+        let key = wallet.getKeyForCoin(coin: wanChain)!
         let address = wanChain.deriveAddress(privateKey: key)
 
         XCTAssertEqual(address, "0x4DDa26870B4b3fa3FbA32222159359038f588318")
@@ -182,7 +182,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveBitcoin() {
         let bitcoin = CoinType.bitcoin
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: bitcoin)
+        let key = wallet.getKeyForCoin(coin: bitcoin)!
         let address = bitcoin.deriveAddress(privateKey: key)
 
         XCTAssertEqual("bc1qumwjg8danv2vm29lp5swdux4r60ezptzz7ce85", address)
@@ -191,7 +191,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveDigiByte() {
         let digibye = CoinType.digiByte
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: digibye)
+        let key = wallet.getKeyForCoin(coin: digibye)!
         let address = digibye.deriveAddress(privateKey: key)
 
         XCTAssertEqual("dgb1q7qk2vvetgldgq0eeh3ytsky2380l9wuessmhe3", address)
@@ -199,7 +199,7 @@ class HDWalletTests: XCTestCase {
 
     func testDeriveEthereum() {
         let ethereum = CoinType.ethereum
-        let key = HDWallet.test.getKeyForCoin(coin: ethereum)
+        let key = HDWallet.test.getKeyForCoin(coin: ethereum)!
         let address = ethereum.deriveAddress(privateKey: key)
 
         XCTAssertEqual("0x27Ef5cDBe01777D62438AfFeb695e33fC2335979", address)
@@ -208,7 +208,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveLitecoin() {
         let litecoin = CoinType.litecoin
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: litecoin)
+        let key = wallet.getKeyForCoin(coin: litecoin)!
         let address = litecoin.deriveAddress(privateKey: key)
 
         XCTAssertEqual("ltc1qmj6hw649d7q2teduv599zv9ls9akz60gkdwnp7", address)
@@ -217,7 +217,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveTron() {
         let tron = CoinType.tron
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: tron)
+        let key = wallet.getKeyForCoin(coin: tron)!
         let address = tron.deriveAddress(privateKey: key)
 
         XCTAssertEqual("THJrqfbBhoB1vX97da6S6nXWkafCxpyCNB", address)
@@ -226,8 +226,8 @@ class HDWalletTests: XCTestCase {
     func testDeriveIcon() {
         let icon = CoinType.icon
         let wallet = HDWallet.test
-        let key0 = wallet.getKeyForCoin(coin: icon)
-        let key1 = wallet.getDerivedKey(coin: icon, account: 0, change: 0, address: 1)
+        let key0 = wallet.getKeyForCoin(coin: icon)!
+        let key1 = wallet.getDerivedKey(coin: icon, account: 0, change: 0, address: 1)!
         let address0 = icon.deriveAddress(privateKey: key0)
         let address1 = icon.deriveAddress(privateKey: key1)
 
@@ -238,7 +238,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveOntology() {
         let ontology = CoinType.ontology
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: ontology)
+        let key = wallet.getKeyForCoin(coin: ontology)!
         let address = ontology.deriveAddress(privateKey: key)
 
         XCTAssertEqual("AH11LGtFk6VU9Z7suuM5eNpho1bAoE5Gbz", address)
@@ -247,7 +247,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveBitcoinCash() {
         let bitcoinCash = CoinType.bitcoinCash
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: bitcoinCash)
+        let key = wallet.getKeyForCoin(coin: bitcoinCash)!
         let address = bitcoinCash.deriveAddress(privateKey: key)
 
         XCTAssertEqual("bitcoincash:qqxktqe0pzf0yepvap9rf2g8zxq8t5mqx50dwpqlxl", address)
@@ -256,7 +256,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveDash() {
         let dash = CoinType.dash
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: dash)
+        let key = wallet.getKeyForCoin(coin: dash)!
         let address = dash.deriveAddress(privateKey: key)
 
         XCTAssertEqual("XsJg3pJaoyKEf5jMYTb5wGf3TKp9W3KX5a", address)
@@ -265,7 +265,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveZcoin() {
         let zcoin = CoinType.firo
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: zcoin)
+        let key = wallet.getKeyForCoin(coin: zcoin)!
         let address = zcoin.deriveAddress(privateKey: key)
 
         XCTAssertEqual("a5jgmKczLE7fbgBmVkDTvvAQx8pYZKL7LP", address)
@@ -274,7 +274,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveBinanceChain() {
         let binance = CoinType.binance
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: binance)
+        let key = wallet.getKeyForCoin(coin: binance)!
         let address = AnyAddress(publicKey: key.getPublicKeySecp256k1(compressed: true), coin: binance)
 
         XCTAssertEqual("bnb1wk7kxw0qrvxe2pj9mk6ydjx0t4j9jla8pja0td", address.description)
@@ -283,7 +283,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveBinanceTestnet() {
         let binance = CoinType.binance
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: binance)
+        let key = wallet.getKeyForCoin(coin: binance)!
         let address = AnyAddress(publicKey: key.getPublicKeySecp256k1(compressed: true), coin: binance, hrp: "tbnb")
 
         XCTAssertEqual("tbnb1wk7kxw0qrvxe2pj9mk6ydjx0t4j9jla8085ttu", address.description)
@@ -292,7 +292,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveZcash() {
         let zcash = CoinType.zcash
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: zcash)
+        let key = wallet.getKeyForCoin(coin: zcash)!
         let address = zcash.deriveAddress(privateKey: key)
         XCTAssertEqual("t1RygJmrLdNGgi98gUgEJDTVaELTAYWoMBy", address)
     }
@@ -300,7 +300,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveRipple() {
         let ripple = CoinType.xrp
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: ripple)
+        let key = wallet.getKeyForCoin(coin: ripple)!
         let address = ripple.deriveAddress(privateKey: key)
 
         XCTAssertEqual("r36yxStAh7qgTQNHTzjZvXybCTzUFhrfav", address)
@@ -308,7 +308,7 @@ class HDWalletTests: XCTestCase {
 
     func testDeriveAion() {
         let aion = CoinType.aion
-        let key = HDWallet.test.getKeyForCoin(coin: aion)
+        let key = HDWallet.test.getKeyForCoin(coin: aion)!
         let address = aion.deriveAddress(privateKey: key)
 
         XCTAssertEqual("0xa0dcc9e5e3bbd6a5a092f6b4975f6c5856e8eb750f37b7079bf7888e8cc1deb8", address)
@@ -316,7 +316,7 @@ class HDWalletTests: XCTestCase {
 
     func testDevieStellar() {
         let stellar = CoinType.stellar
-        let key = HDWallet.test.getKeyForCoin(coin: stellar)
+        let key = HDWallet.test.getKeyForCoin(coin: stellar)!
         let address = stellar.deriveAddress(privateKey: key)
 
         XCTAssertEqual(key.data.hexString, "4fd1cb3c9c15c171b7b90dc3fefc7b2fc54de09b869cc9d6708d26b114e8d9a5")
@@ -325,7 +325,7 @@ class HDWalletTests: XCTestCase {
 
     func testDeriveTezos() {
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: .tezos)
+        let key = wallet.getKeyForCoin(coin: .tezos)!
         let pubkey = key.getPublicKeyEd25519()
         let address = AnyAddress(publicKey: pubkey, coin: .tezos)
 
@@ -336,7 +336,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveTezos2() {
         let wallet = HDWallet(mnemonic: "kidney setup media hat relief plastic ghost census mouse science expect movie", passphrase: "")!
 
-        let key = wallet.getKeyForCoin(coin: .tezos)
+        let key = wallet.getKeyForCoin(coin: .tezos)!
         let address = CoinType.tezos.deriveAddress(privateKey: key)
 
         XCTAssertEqual("tz1M9ZMG1kthqQFK5dFi8rDCahqw6gHr1zoZ", address.description)
@@ -347,7 +347,7 @@ class HDWalletTests: XCTestCase {
         // but it's not compatible with safe.nimiq.com (can't import)
         let wallet = HDWallet(mnemonic: "insane mixed health squeeze physical trust pipe possible garage hero flock stand profit power tooth review note camera express vicious clock machine entire heavy", passphrase: "")!
         let coin = CoinType.nimiq
-        let key = wallet.getKeyForCoin(coin: coin)
+        let key = wallet.getKeyForCoin(coin: coin)!
         let address = coin.deriveAddress(privateKey: key)
 
         XCTAssertEqual("NQ77 XYYH YUNC V52U 5ADV 5JAY QXMD 2F9C Q440", address.description)
@@ -356,7 +356,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveDecred() {
         let wallet = HDWallet.test
         let coin = CoinType.decred
-        let key = wallet.getKeyForCoin(coin: coin)
+        let key = wallet.getKeyForCoin(coin: coin)!
         let address = coin.deriveAddress(privateKey: key)
 
         XCTAssertEqual("DsksmLD2wDoA8g8QfFvm99ASg8KsZL8eJFd", address.description)
@@ -365,7 +365,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveGroestlcoin() {
         let groestlcoin = CoinType.groestlcoin
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: groestlcoin)
+        let key = wallet.getKeyForCoin(coin: groestlcoin)!
         let address = groestlcoin.deriveAddress(privateKey: key)
 
         XCTAssertEqual("grs1qsjpmsmm4x34wlt6kk4zef9u0jtculguktwgwg4", address)
@@ -374,7 +374,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveDoge() {
         let doge = CoinType.dogecoin
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: doge)
+        let key = wallet.getKeyForCoin(coin: doge)!
         let address = doge.deriveAddress(privateKey: key)
 
         XCTAssertEqual("DJRoWqKj6hVmZMEMPahJ7UsqaYCtEJ3xv9", address)
@@ -383,7 +383,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveZilliqa() {
         let zil = CoinType.zilliqa
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: .zilliqa)
+        let key = wallet.getKeyForCoin(coin: .zilliqa)!
         let address = zil.deriveAddress(privateKey: key)
 
         XCTAssertEqual(key.data.hexString, "b49a9fb16cd2b46ee538be807f712073009ea528e407a25a4bf91a63c3e49f99")
@@ -393,7 +393,7 @@ class HDWalletTests: XCTestCase {
     func testSignHash() {
         let eth = CoinType.ethereum
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: eth)
+        let key = wallet.getKeyForCoin(coin: eth)!
         let hash = Data(hexString: "3F891FDA3704F0368DAB65FA81EBE616F4AA2A0854995DA4DC0B59D2CADBD64F")!
         let result = key.sign(digest: hash, curve: .secp256k1)!
 
@@ -500,7 +500,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveRavencoin() {
         let ravencoin = CoinType.ravencoin
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: ravencoin)
+        let key = wallet.getKeyForCoin(coin: ravencoin)!
         let address = ravencoin.deriveAddress(privateKey: key)
 
         XCTAssertEqual("RHQmrg7nNFnRUwg2mH7GafhRY3ZaF6FB2x", address)
@@ -508,7 +508,7 @@ class HDWalletTests: XCTestCase {
 
     func testDeriveTerraV2() {
         let coin = CoinType.terraV2
-        let key = HDWallet.test.getKeyForCoin(coin: coin)
+        let key = HDWallet.test.getKeyForCoin(coin: coin)!
         let address = CoinType.terraV2.deriveAddress(privateKey: key)
 
         XCTAssertEqual(address, "terra1jf9aaj9myrzsnmpdr7twecnaftzmku2mhs2hfe")
@@ -517,7 +517,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveMonacoin() {
         let monacoin = CoinType.monacoin
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: monacoin)
+        let key = wallet.getKeyForCoin(coin: monacoin)!
         let address = monacoin.deriveAddress(privateKey: key)
 
         XCTAssertEqual("MHkScH5duuiaAkdQ22NkLWmXqWnjq3hThM", address)
@@ -527,7 +527,7 @@ class HDWalletTests: XCTestCase {
         let fio = CoinType.fio
 
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: fio)
+        let key = wallet.getKeyForCoin(coin: fio)!
         let address = fio.deriveAddress(privateKey: key)
 
         XCTAssertEqual("FIO5J2xdfWygeNdHZNZRzRws8YGbVxjUXtp4eP8KoGkGKoLFQ7CaU", address)
@@ -536,7 +536,7 @@ class HDWalletTests: XCTestCase {
     func testDeriveAlgorand() {
         let algo = CoinType.algorand
         let wallet = HDWallet.test
-        let key = wallet.getKeyForCoin(coin: algo)
+        let key = wallet.getKeyForCoin(coin: algo)!
 
         let address = algo.deriveAddress(privateKey: key)
 
@@ -545,7 +545,7 @@ class HDWalletTests: XCTestCase {
 
     func testDeriveKava() {
         let coin = CoinType.kava
-        let key = HDWallet.test.getKeyForCoin(coin: coin)
+        let key = HDWallet.test.getKeyForCoin(coin: coin)!
         let address = coin.deriveAddress(privateKey: key)
 
         XCTAssertEqual(address, "kava1zrst72upua78pylhku9csxd5zmhsyrk7xhrdlf")
@@ -553,7 +553,7 @@ class HDWalletTests: XCTestCase {
 
     func testDeriveBandChain() {
         let coin = CoinType.bandChain
-        let key = HDWallet.test.getKeyForCoin(coin: coin)
+        let key = HDWallet.test.getKeyForCoin(coin: coin)!
         let address = coin.deriveAddress(privateKey: key)
 
         XCTAssertEqual(address, "band1pe8xm2r46rmctsukuqu7gl900vzprfsp4sguc3")

--- a/swift/Tests/HDWalletTests.swift
+++ b/swift/Tests/HDWalletTests.swift
@@ -405,20 +405,20 @@ class HDWalletTests: XCTestCase {
     func testExtendedKeys() {
         let wallet = HDWallet(mnemonic: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about", passphrase: "")!
 
-        let xprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .bitcoin, version: .xprv)
-        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .bitcoin, version: .xpub)
+        let xprv = wallet.getExtendedPrivateKey(purpose: .bip44, coin: .bitcoin, version: .xprv)!
+        let xpub = wallet.getExtendedPublicKey(purpose: .bip44, coin: .bitcoin, version: .xpub)!
 
         XCTAssertEqual(xprv, "xprv9xpXFhFpqdQK3TmytPBqXtGSwS3DLjojFhTGht8gwAAii8py5X6pxeBnQ6ehJiyJ6nDjWGJfZ95WxByFXVkDxHXrqu53WCRGypk2ttuqncb")
         XCTAssertEqual(xpub, "xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj")
 
-        let yprv = wallet.getExtendedPrivateKey(purpose: .bip49, coin: .bitcoin, version: .yprv)
-        let ypub = wallet.getExtendedPublicKey(purpose: .bip49, coin: .bitcoin, version: .ypub)
+        let yprv = wallet.getExtendedPrivateKey(purpose: .bip49, coin: .bitcoin, version: .yprv)!
+        let ypub = wallet.getExtendedPublicKey(purpose: .bip49, coin: .bitcoin, version: .ypub)!
 
         XCTAssertEqual(yprv, "yprvAHwhK6RbpuS3dgCYHM5jc2ZvEKd7Bi61u9FVhYMpgMSuZS613T1xxQeKTffhrHY79hZ5PsskBjcc6C2V7DrnsMsNaGDaWev3GLRQRgV7hxF")
         XCTAssertEqual(ypub, "ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9azLDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP")
 
-        let zprv = wallet.getExtendedPrivateKey(purpose: .bip84, coin: .bitcoin, version: .zprv)
-        let zpub = wallet.getExtendedPublicKey(purpose: .bip84, coin: .bitcoin, version: .zpub)
+        let zprv = wallet.getExtendedPrivateKey(purpose: .bip84, coin: .bitcoin, version: .zprv)!
+        let zpub = wallet.getExtendedPublicKey(purpose: .bip84, coin: .bitcoin, version: .zpub)!
 
         XCTAssertEqual(zprv, "zprvAdG4iTXWBoARxkkzNpNh8r6Qag3irQB8PzEMkAFeTRXxHpbF9z4QgEvBRmfvqWvGp42t42nvgGpNgYSJA9iefm1yYNZKEm7z6qUWCroSQnE")
         XCTAssertEqual(zpub, "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs")

--- a/swift/Tests/Keystore/AccountTests.swift
+++ b/swift/Tests/Keystore/AccountTests.swift
@@ -31,7 +31,7 @@ class AccountTests: XCTestCase {
 
         let hash = Data(hexString: "3F891FDA3704F0368DAB65FA81EBE616F4AA2A0854995DA4DC0B59D2CADBD64F")!
         let hdwallet = wallet.key.wallet(password: password)!
-        let privateKey = hdwallet.getKeyForCoin(coin: .ethereum)
+        let privateKey = hdwallet.getKeyForCoin(coin: .ethereum)!
         let result = privateKey.sign(digest: hash, curve: .secp256k1)!
 
         let publicKey = privateKey.getPublicKeySecp256k1(compressed: false)
@@ -58,7 +58,7 @@ class AccountTests: XCTestCase {
         let wallet = Wallet(keyURL: URL(fileURLWithPath: "/"), key: key)
 
         let hdwallet = wallet.key.wallet(password: password)!
-        let privateKey = hdwallet.getKeyForCoin(coin: .bitcoin)
+        let privateKey = hdwallet.getKeyForCoin(coin: .bitcoin)!
 
         XCTAssertEqual(privateKey.data.hexString, "b511e175dc474c810ad567557a13a29f9e82576990d5f36dab342dd2d00fb5c4")
     }
@@ -100,7 +100,7 @@ class AccountTests: XCTestCase {
         let wallet = Wallet(keyURL: URL(fileURLWithPath: "/"), key: key)
 
         let hdwallet = wallet.key.wallet(password: password)!
-        let privateKey = hdwallet.getKeyForCoin(coin: .bitcoinCash)
+        let privateKey = hdwallet.getKeyForCoin(coin: .bitcoinCash)!
 
         XCTAssertEqual(privateKey.data.hexString, "04b02272b75eaee0b7f1a96d667cb4629b400e2152a841c6791f802b336a8af8")
     }

--- a/tests/common/HDWallet/HDWalletTests.cpp
+++ b/tests/common/HDWallet/HDWalletTests.cpp
@@ -121,6 +121,19 @@ TEST(HDWallet, createFromSpanishMnemonic) {
     }
 }
 
+TEST(HDWallet, CardanoKeyFromEmptyEntropyThrows) {
+    // A mnemonic with words outside the English BIP-0039 wordlist, created unchecked, ends up
+    // with empty entropy (see createFromSpanishMnemonic above). Cardano key derivation relies on
+    // entropy, not just the seed, so it must reject this instead of deriving a constant key that
+    // would be shared by every wallet in this state.
+    HDWallet wallet = HDWallet("llanto radical atraer riesgo actuar masa fondo cielo dieta archivo sonrisa mamut", "", false);
+    ASSERT_TRUE(wallet.getEntropy().empty());
+    EXPECT_EXCEPTION(wallet.getKey(TWCoinTypeCardano, DerivationPath("m/1852'/1815'/0'/0/0")), "Cannot derive a Cardano key: mnemonic entropy is empty");
+
+    // Non-entropy-based coins are unaffected by empty entropy.
+    EXPECT_NO_THROW(wallet.getKey(TWCoinTypeEthereum, DerivationPath("m/44'/60'/0'/0/0")));
+}
+
 TEST(HDWallet, createFromMnemonicInvalid) {
     EXPECT_EXCEPTION(HDWallet("THIS IS AN INVALID MNEMONIC", gPassphrase), "Invalid mnemonic");
     EXPECT_EXCEPTION(HDWallet("", gPassphrase), "Invalid mnemonic");


### PR DESCRIPTION
This pull request improves the robustness of the HD wallet API by updating several methods to return nullable values when key or address derivation fails (such as when the mnemonic entropy is empty). The changes also update documentation to clarify these behaviors and adjust Swift test and example code to handle the possibility of nil returns. Additionally, the Cardano key derivation logic is hardened against invalid entropy.

API changes for error handling and nullability:

* Updated several HD wallet API methods in `TWHDWallet.h` to return nullable pointers (e.g., `TWPrivateKey* _Nullable`, `TWString* _Nullable`) and clarified documentation to indicate that null is returned if derivation fails, such as with empty mnemonic entropy.
* Modified the C++ and C interface implementations to use try-catch blocks and return `nullptr` on failure for key and address derivation methods.

Cardano derivation safety:

* Added a check in Cardano master node derivation to throw an exception if the mnemonic entropy is empty, preventing the generation of constant, insecure secrets.

Swift example and test code updates:

* Updated Swift example and test code to force unwrap results from key and address derivation methods, reflecting the new nullable return types and ensuring test correctness.