### PR TITLE
ci: import test coverage into SonarCloud analysis

### DIFF
--- a/.github/workflows/linux-ci-sonarcloud.yml
+++ b/.github/workflows/linux-ci-sonarcloud.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Build and run tests
         run: |
           ninja -Cbuild tests TrezorCryptoTests
-          find . -name "*.gcda" -exec rm {} \;
+          find build -name "*.gcda" -delete
           build/trezor-crypto/crypto/tests/TrezorCryptoTests
           build/tests/tests --gtest_output=xml
         env:

--- a/.github/workflows/linux-ci-sonarcloud.yml
+++ b/.github/workflows/linux-ci-sonarcloud.yml
@@ -60,6 +60,21 @@ jobs:
           CC: /usr/bin/clang
           CXX: /usr/bin/clang++
 
+      - name: Build and run tests
+        run: |
+          ninja -Cbuild tests TrezorCryptoTests
+          find . -name "*.gcda" -exec rm {} \;
+          build/trezor-crypto/crypto/tests/TrezorCryptoTests
+          build/tests/tests --gtest_output=xml
+        env:
+          CC: /usr/bin/clang
+          CXX: /usr/bin/clang++
+          CK_TIMEOUT_MULTIPLIER: 4
+
+      - name: Generate coverage report for SonarCloud
+        run: |
+          tools/coverage sonar
+
       - name: SonarCloud Scan
         run: |
           ./tools/sonarcloud-analysis

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,8 @@
 sonar.organization=trustwallet-1
 sonar.projectKey=trustwallet_wallet-core
 sonar.cfamily.compile-commands=build/compile_commands.json
+# Test coverage, converted from the lcov tracefile by `tools/coverage sonar`.
+sonar.coverageReportPaths=coverage-sonar.xml
 sonar.cfamily.reportingCppStandardOverride=c++20
 sonar.cfamily.cache.enabled=false
 sonar.lang.patterns.cpp=**/*.cc,**/*.cpp,**/*.cxx,**/*.c++,**/*.hh,**/*.hpp,**/*.hxx,**/*.h++,**/*.ipp,**/*.h
@@ -8,4 +10,4 @@ sonar.lang.patterns.c=**/*.c
 
 # The scanner CLI is unzipped into the working directory by
 # tools/sonarcloud-analysis — keep it out of the analysis scope.
-sonar.exclusions=sonar-scanner-*/**,sonar-scanner-cli-*.zip
+sonar.exclusions=sonar-scanner-*/**,sonar-scanner-cli-*.zip,coverage-sonar.xml,coverage.info,test_detail.xml

--- a/tools/coverage
+++ b/tools/coverage
@@ -55,4 +55,11 @@ if [[ "$1" == "html" ]]; then
         coverage.info
 fi
 
+# Convert to SonarQube generic coverage format if requested; the regression
+# check against coverage.stats is skipped in this mode (linux-ci owns it).
+if [[ "$1" == "sonar" ]]; then
+    tools/lcov-to-sonar-xml coverage.info coverage-sonar.xml
+    exit 0
+fi
+
 tools/check-coverage coverage.stats coverage.info

--- a/tools/lcov-to-sonar-xml
+++ b/tools/lcov-to-sonar-xml
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Convert an LCOV tracefile to the SonarQube generic coverage format.
+
+Usage: tools/lcov-to-sonar-xml coverage.info coverage-sonar.xml
+
+SonarCloud cannot ingest LCOV for C/C++ directly, so the CI converts the
+tracefile produced by tools/coverage into the generic format consumed via
+the sonar.coverageReportPaths property.
+"""
+
+import os
+import sys
+import xml.sax.saxutils
+
+
+def parse_lcov(path):
+    files = {}
+    current = None
+    with open(path) as fp:
+        for line in fp:
+            line = line.strip()
+            if line.startswith("SF:"):
+                source = os.path.relpath(line[3:], os.getcwd())
+                current = files.setdefault(source, {})
+            elif line.startswith("DA:") and current is not None:
+                lineno, hits = line[3:].split(",")[:2]
+                lineno = int(lineno)
+                current[lineno] = max(current.get(lineno, 0), int(hits))
+            elif line == "end_of_record":
+                current = None
+    return files
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit(__doc__.strip().splitlines()[2])
+    files = parse_lcov(sys.argv[1])
+    with open(sys.argv[2], "w") as out:
+        out.write('<coverage version="1">\n')
+        for source in sorted(files):
+            # Files outside the repository (system headers, build output)
+            # are already stripped by the lcov filters in tools/coverage.
+            if source.startswith(".."):
+                continue
+            out.write('  <file path=%s>\n' % xml.sax.saxutils.quoteattr(source))
+            for lineno, hits in sorted(files[source].items()):
+                out.write('    <lineToCover lineNumber="%d" covered="%s"/>\n'
+                          % (lineno, "true" if hits > 0 else "false"))
+            out.write('  </file>\n')
+        out.write('</coverage>\n')
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/lcov-to-sonar-xml
+++ b/tools/lcov-to-sonar-xml
@@ -33,7 +33,7 @@ def parse_lcov(path):
 
 def main():
     if len(sys.argv) != 3:
-        sys.exit(__doc__.strip().splitlines()[2])
+        sys.exit("Usage: tools/lcov-to-sonar-xml coverage.info coverage-sonar.xml")
     files = parse_lcov(sys.argv[1])
     with open(sys.argv[2], "w") as out:
         out.write('<coverage version="1">\n')


### PR DESCRIPTION
## Description

SonarCloud shows **0% coverage** because the analysis workflow configures the build with `TW_CODE_COVERAGE=ON` but never runs the tests, and no coverage report is handed to the scanner. This makes the `new_coverage` quality gate condition (>= 80%) permanently red.

## Changes

- **`.github/workflows/linux-ci-sonarcloud.yml`**: build and run the C++ and TrezorCrypto test suites before the scan (same steps as `linux-ci.yml`).
- **`tools/coverage`**: new `sonar` mode: captures lcov data with the existing filters and converts it, skipping the `coverage.stats` regression check (that check stays owned by `linux-ci.yml`).
- **`tools/lcov-to-sonar-xml`**: new stdlib-only Python converter from an lcov tracefile to the SonarQube generic coverage format, since SonarCloud has no native lcov import for C/C++.
- **`sonar-project.properties`**: point `sonar.coverageReportPaths` at the generated report and exclude coverage artifacts from analysis scope.

## How to test

The SonarCloud Code Analysis check on this PR should report coverage on new code instead of 0%; after merge, the project dashboard picks up overall coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
