### PR TITLE
WalletCoreSwiftProtobuf.podspec: declare the watchOS deployment target

### DIFF
--- a/WalletCoreSwiftProtobuf.podspec
+++ b/WalletCoreSwiftProtobuf.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
     s.requires_arc = true
     s.ios.deployment_target = '11.0'
     s.osx.deployment_target = '10.13'
+    s.watchos.deployment_target = '6.0'
 
     s.cocoapods_version = '>= 1.13.0'
 


### PR DESCRIPTION
## Description

`WalletCoreSwiftProtobuf.podspec` declares only iOS and macOS deployment targets, so the pod cannot be integrated into a watchOS target — `pod install` refuses it.

The podspec's own header points at the file it was derived from:

```ruby
# Original podspec:
# https://github.com/apple/swift-protobuf/blob/main/SwiftProtobuf.podspec
```

That original declares five platforms:

```ruby
s.ios.deployment_target = '11.0'
s.osx.deployment_target = '10.13'
s.tvos.deployment_target = '11.0'
s.watchos.deployment_target = '4.0'
s.visionos.deployment_target = "1.0"
```

The repackaged one keeps two. Since the sources are the same SwiftProtobuf sources, this looks like the platforms having been dropped in the repackaging rather than a deliberate narrowing.

This PR adds back only the one we need:

```ruby
s.watchos.deployment_target = '6.0'
```

`6.0` rather than upstream's `4.0` only because that is a realistic modern floor; happy to use `4.0` to match the original exactly, or any baseline you prefer.

tvOS and visionOS are dropped in the same way. I've left them out to keep this PR to the platform I can actually test, but if you'd like them restored too, say so and I'll add them.

No existing platform is affected — this is additive.

**Why:** we're evaluating WalletCore on watchOS. That is a larger conversation (filed separately), but this particular line is independent of it: the pod's declared platform set doesn't currently match the sources it ships, for anyone building for watchOS with CocoaPods.

## How to test

Add the pod to a watchOS target's Podfile and run `pod install`:

- before this change it fails with "The platform of the target ... (watchOS) is not compatible with `WalletCoreSwiftProtobuf`";
- with it, the pod integrates and the SwiftProtobuf sources compile for watchOS as-is (they already do in Apple's own distribution, which declares watchOS 4.0).

iOS and macOS integration is unchanged — the existing deployment targets are untouched.

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Create pull request as draft initially, unless its complete.
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
- [ ] If there is a related Issue, mention it in the description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
