### PR TITLE
build: add watchOS support to the Swift framework and Rust bindgen

### DIFF
--- a/WalletCoreSwiftProtobuf.podspec
+++ b/WalletCoreSwiftProtobuf.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
     s.requires_arc = true
     s.ios.deployment_target = '11.0'
     s.osx.deployment_target = '10.13'
+    s.watchos.deployment_target = '6.0'
 
     s.cocoapods_version = '>= 1.13.0'
 

--- a/swift/Podfile
+++ b/swift/Podfile
@@ -9,9 +9,17 @@ project 'TrustWalletCore.xcodeproj'
 target 'WalletCore' do
   use_frameworks!
 
-  pod 'WalletCoreSwiftProtobuf'
+  # Repo-local podspec: the published pod does not declare watchOS yet.
+  pod 'WalletCoreSwiftProtobuf', :podspec => '../WalletCoreSwiftProtobuf.podspec'
 
   target 'WalletCoreTests'
+end
+
+target 'WalletCore-watchOS' do
+  platform :watchos, '10.0'
+  use_frameworks!
+
+  pod 'WalletCoreSwiftProtobuf', :podspec => '../WalletCoreSwiftProtobuf.podspec'
 end
 
 post_install do |installer|

--- a/swift/Podfile.lock
+++ b/swift/Podfile.lock
@@ -2,15 +2,15 @@ PODS:
   - WalletCoreSwiftProtobuf (1.29.0)
 
 DEPENDENCIES:
-  - WalletCoreSwiftProtobuf
+  - WalletCoreSwiftProtobuf (from `../WalletCoreSwiftProtobuf.podspec`)
 
-SPEC REPOS:
-  trunk:
-    - WalletCoreSwiftProtobuf
+EXTERNAL SOURCES:
+  WalletCoreSwiftProtobuf:
+    :podspec: "../WalletCoreSwiftProtobuf.podspec"
 
 SPEC CHECKSUMS:
-  WalletCoreSwiftProtobuf: a4798576a2d309511fc45f81843d348732ec571d
+  WalletCoreSwiftProtobuf: a2bdba44f654fa404a25e2906a24dd2c8f1b7c5f
 
-PODFILE CHECKSUM: bbbccdbb7b3665e060820f476dbf21d5b1f8e605
+PODFILE CHECKSUM: 14262b7ee64ddf1436fd633d34f7c66342986d19
 
 COCOAPODS: 1.16.2

--- a/swift/project.yml
+++ b/swift/project.yml
@@ -9,6 +9,7 @@ settings:
     CLANG_CXX_LANGUAGE_STANDARD: c++20
     SWIFT_VERSION: 5.1
     IPHONEOS_DEPLOYMENT_TARGET: 13.0
+    WATCHOS_DEPLOYMENT_TARGET: 10.0
   configs:
     release:
       SWIFT_OPTIMIZATION_LEVEL: -Owholemodule
@@ -17,7 +18,7 @@ targets:
   WalletCore:
     type: framework
     platform: iOS
-    sources:
+    sources: &wallet-core-sources
       - path: include
         headerVisibility: public
         excludes:
@@ -75,7 +76,7 @@ targets:
   trezor-crypto:
     type: library.static
     platform: iOS
-    sources:
+    sources: &trezor-crypto-sources
       - trezor-crypto/crypto/bignum.c
       - trezor-crypto/crypto/ecdsa.c
       - trezor-crypto/crypto/curves.c
@@ -136,14 +137,14 @@ targets:
       - trezor-crypto/crypto/sodium/private/ed25519_ref10.c
       - trezor-crypto/crypto/sodium/private/ed25519_ref10_fe_25_5.c
       - trezor-crypto/crypto/sodium/keypair.c
-    settings:
+    settings: &trezor-crypto-settings
       GCC_WARN_64_TO_32_BIT_CONVERSION: NO
       OTHER_CFLAGS: $(inherited) -Wno-comma
 
   protobuf:
     type: library.static
     platform: iOS
-    sources:
+    sources: &protobuf-sources
       - protobuf/google/protobuf/any.cc
       - protobuf/google/protobuf/any.pb.cc
       - protobuf/google/protobuf/any_lite.cc
@@ -228,6 +229,43 @@ targets:
       - protobuf/google/protobuf/wire_format.cc
       - protobuf/google/protobuf/wire_format_lite.cc
       - protobuf/google/protobuf/wrappers.pb.cc
-    settings:
+    settings: &protobuf-settings
       GCC_WARN_64_TO_32_BIT_CONVERSION: NO
       OTHER_CFLAGS: $(inherited) -DHAVE_PTHREAD=1 -Wno-comma -Wno-unreachable-code
+
+  # watchOS builds as separate targets so the iOS target names stay unchanged;
+  # PRODUCT_NAME keeps the framework and module named WalletCore on both platforms.
+  WalletCore-watchOS:
+    type: framework
+    platform: watchOS
+    sources: *wallet-core-sources
+    dependencies:
+      - target: trezor-crypto-watchOS
+        link: true
+      - target: protobuf-watchOS
+        link: true
+      - sdk: libc++.tbd
+      - framework: WalletCoreRs.xcframework
+    scheme:
+      testTargets: []
+    settings:
+      PRODUCT_NAME: WalletCore
+      SKIP_INSTALL: false
+      DEBUG_INFORMATION_FORMAT: dwarf-with-dsym
+      BUILD_LIBRARY_FOR_DISTRIBUTION: true
+      INFOPLIST_FILE: 'Info.plist'
+      CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION: YES_ERROR
+      CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER: $(inherited) false
+      OTHER_CFLAGS: $(inherited) -Wno-comma -DNDEBUG
+
+  trezor-crypto-watchOS:
+    type: library.static
+    platform: watchOS
+    sources: *trezor-crypto-sources
+    settings: *trezor-crypto-settings
+
+  protobuf-watchOS:
+    type: library.static
+    platform: watchOS
+    sources: *protobuf-sources
+    settings: *protobuf-settings

--- a/tools/rust-bindgen
+++ b/tools/rust-bindgen
@@ -21,7 +21,7 @@ HEADER_NAME="WalletCoreRSBindgen.h"
 
 create_xc_framework() {
   rm -rf $TARGET_XCFRAMEWORK_NAME
-  xcodebuild -create-xcframework -library $BUILD_FOLDER/$TARGET_NAME -library $BUILD_FOLDER/darwin_universal/$TARGET_NAME -library $BUILD_FOLDER/aarch64-apple-ios/release/$TARGET_NAME -output $TARGET_XCFRAMEWORK_NAME
+  xcodebuild -create-xcframework -library $BUILD_FOLDER/$TARGET_NAME -library $BUILD_FOLDER/darwin_universal/$TARGET_NAME -library $BUILD_FOLDER/aarch64-apple-ios/release/$TARGET_NAME -library $BUILD_FOLDER/watchos_device/$TARGET_NAME -library $BUILD_FOLDER/aarch64-apple-watchos-sim/release/$TARGET_NAME -output $TARGET_XCFRAMEWORK_NAME
   mkdir -p $TARGET_XCFRAMEWORK_NAME/ios-arm64_x86_64-maccatalyst
   cp $BUILD_FOLDER/catalyst/$TARGET_NAME $TARGET_XCFRAMEWORK_NAME/ios-arm64_x86_64-maccatalyst
 }
@@ -59,6 +59,14 @@ if isTargetSpecified "ios" && [[ $(uname -s) == "Darwin" ]]; then
   echo "Generating iOS targets"
   cargo build -Z build-std=std,panic_abort --target aarch64-apple-ios --target aarch64-apple-ios-sim --target x86_64-apple-ios --target aarch64-apple-darwin --target x86_64-apple-darwin --target aarch64-apple-ios-macabi --target x86_64-apple-ios-macabi --release --lib &
   wait
+
+  # watchOS. These are tier-3 targets, so they rely on the same -Zbuild-std
+  # the other targets here already use. arm64_32 is the ILP32 architecture
+  # required by Apple Watch Series 6-8 and Ultra 1.
+  cargo build -Z build-std=std,panic_abort --target aarch64-apple-watchos --target arm64_32-apple-watchos --target aarch64-apple-watchos-sim --release --lib &
+  wait
+  mkdir -p $BUILD_FOLDER/watchos_device
+  lipo $BUILD_FOLDER/aarch64-apple-watchos/release/$TARGET_NAME $BUILD_FOLDER/arm64_32-apple-watchos/release/$TARGET_NAME -create -output $BUILD_FOLDER/watchos_device/$TARGET_NAME
   lipo $BUILD_FOLDER/x86_64-apple-ios/release/$TARGET_NAME $BUILD_FOLDER/aarch64-apple-ios-sim/release/$TARGET_NAME -create -output $BUILD_FOLDER/$TARGET_NAME
   mkdir -p $BUILD_FOLDER/darwin_universal
   lipo $BUILD_FOLDER/x86_64-apple-darwin/release/$TARGET_NAME $BUILD_FOLDER/aarch64-apple-darwin/release/$TARGET_NAME -create -output $BUILD_FOLDER/darwin_universal/$TARGET_NAME
@@ -136,6 +144,33 @@ cat > $TARGET_XCFRAMEWORK_NAME/Info.plist << EOF
 			</array>
 			<key>SupportedPlatform</key>
 			<string>ios</string>
+			<key>SupportedPlatformVariant</key>
+			<string>simulator</string>
+		</dict>
+		<dict>
+			<key>LibraryIdentifier</key>
+			<string>watchos-arm64_arm64_32</string>
+			<key>LibraryPath</key>
+			<string>libwallet_core_rs.a</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+				<string>arm64_32</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>watchos</string>
+		</dict>
+		<dict>
+			<key>LibraryIdentifier</key>
+			<string>watchos-arm64-simulator</string>
+			<key>LibraryPath</key>
+			<string>libwallet_core_rs.a</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>watchos</string>
 			<key>SupportedPlatformVariant</key>
 			<string>simulator</string>
 		</dict>


### PR DESCRIPTION
## Description

Adds watchOS support to the Swift framework — device (`arm64` + `arm64_32`) and simulator. Context and motivation in #4858; opening the change itself for review alongside it.

Five files, all additive to iOS — **no existing target is renamed**:

| File | Change |
|---|---|
| `swift/project.yml` | new `WalletCore-watchOS`, `trezor-crypto-watchOS`, `protobuf-watchOS` targets alongside the untouched iOS ones (`WATCHOS_DEPLOYMENT_TARGET: 10.0`); YAML anchors share the source lists, and `PRODUCT_NAME` keeps the framework and module named `WalletCore` on both platforms |
| `tools/rust-bindgen` | three watchOS Rust targets, `lipo` for the device fat slice, two xcframework `Info.plist` entries |
| `WalletCoreSwiftProtobuf.podspec` | watchOS deployment target (same line as #4857, which can land independently; whichever merges first, the other rebases) |
| `swift/Podfile` | a `WalletCore-watchOS` target block; pod pointed at the repo-local podspec (the published pod doesn't declare watchOS yet; once a new pod version ships with #4857, that override can go away) |
| `swift/Podfile.lock` | regenerated |

The `WalletCore` / `trezor-crypto` / `protobuf` iOS targets, `WalletCoreTests`, and their scheme are byte-for-byte what they are on `master` — an earlier iteration made the targets multi-platform, which lets XcodeGen suffix them (`WalletCore_iOS`/`WalletCore_watchOS`); this version deliberately uses separate watchOS targets instead so downstream references to the `WalletCore` target and scheme keep working unchanged.

No C++, Rust or codegen source changes were needed. `trezor-crypto` and the protobuf runtime compile for watchOS unmodified, and `wallet-core-rs` cross-compiles without coaxing — `secp256k1-sys` builds clean, and there's no `ring` in the tree.

**The toolchain cost is zero.** Tier-3 Apple targets need nightly and `-Zbuild-std` — your build already requires both for the iOS Rust targets, so the three watchOS targets add no new toolchain requirement. `arm64_32` is the ILP32 architecture Apple Watch S6–S8 and Ultra 1 need; without it the result only runs on S9 and newer.

**Deliberately not in this PR** (draft partly for this reason — we'd like your read on the shape before going further):

- `Package.swift` → `.watchOS(...)` in `platforms:` — belongs with the release artifacts, since declaring the platform before the binary zips carry watch slices would invite link failures;
- `tools/ios-xcframework` / `tools/ios-xcframework-release` → producing and publishing the watchOS slices in the release zip;
- CI coverage for the new targets.

We're willing to do all three if you want the platform.

## How to test

```
cd swift && xcodegen generate && pod install
```

generates the project with the three new watchOS targets; the iOS targets and schemes are unchanged. Then:

- `xcodebuild -workspace TrustWalletCore.xcworkspace -scheme WalletCore-watchOS -destination 'generic/platform=watchOS' build` — the full framework builds for `arm64 + arm64_32` as `WalletCore.framework`, and the compiler/signing surface (`TWTransactionCompilerPreImageHashes`, `TWTransactionCompilerCompileWithSignatures`, `TWAnySignerSign`, `TWCoinTypeDerivationPath`) is present;
- `tools/rust-bindgen` additionally produces the `watchos-arm64_arm64_32` and `watchos-arm64-simulator` slices in `WalletCoreRs.xcframework`;
- iOS is unaffected: the `WalletCore` scheme builds and `WalletCoreTests` runs against it exactly as before.

## Types of changes

* New feature (non-breaking change which adds functionality)

## Checklist

- [x] Create pull request as draft initially, unless its complete.
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
- [x] If there is a related Issue, mention it in the description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQq8mFikRNUX1qrkepAKZq
