### PR TITLE
ci: stop billing macOS runners for changes they cannot affect

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -3,8 +3,44 @@ name: Android CI
 on:
   push:
     branches: [ dev, master ]
+    paths-ignore:
+      # Nothing below can change an Apple, Android, Kotlin or Rust build, and every
+      # run of these workflows bills macOS Large or XLarge minutes.
+      - '**/*.md'
+      - 'docs/**'
+      - 'audit/**'
+      - 'sonar-project.properties'
+      - 'tools/sonar-scanner.properties'
+      - 'tools/sonarcloud-analysis'
+      - 'tools/coverage'
+      - 'tools/check-coverage'
+      - 'tools/lcov-to-sonar-xml'
+      - '.github/workflows/linux-ci-sonarcloud.yml'
+      - '.github/workflows/docker.yml'
+      - '.github/workflows/claude-bc-risk-router.yml'
+      - 'Dockerfile'
+      - 'gitpod.Dockerfile'
+      - '.devcontainer/**'
   pull_request:
     branches: [ dev, master ]
+    paths-ignore:
+      # Nothing below can change an Apple, Android, Kotlin or Rust build, and every
+      # run of these workflows bills macOS Large or XLarge minutes.
+      - '**/*.md'
+      - 'docs/**'
+      - 'audit/**'
+      - 'sonar-project.properties'
+      - 'tools/sonar-scanner.properties'
+      - 'tools/sonarcloud-analysis'
+      - 'tools/coverage'
+      - 'tools/check-coverage'
+      - 'tools/lcov-to-sonar-xml'
+      - '.github/workflows/linux-ci-sonarcloud.yml'
+      - '.github/workflows/docker.yml'
+      - '.github/workflows/claude-bc-risk-router.yml'
+      - 'Dockerfile'
+      - 'gitpod.Dockerfile'
+      - '.devcontainer/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -3,8 +3,44 @@ name: iOS CI
 on:
   push:
     branches: [ dev, master ]
+    paths-ignore:
+      # Nothing below can change an Apple, Android, Kotlin or Rust build, and every
+      # run of these workflows bills macOS Large or XLarge minutes.
+      - '**/*.md'
+      - 'docs/**'
+      - 'audit/**'
+      - 'sonar-project.properties'
+      - 'tools/sonar-scanner.properties'
+      - 'tools/sonarcloud-analysis'
+      - 'tools/coverage'
+      - 'tools/check-coverage'
+      - 'tools/lcov-to-sonar-xml'
+      - '.github/workflows/linux-ci-sonarcloud.yml'
+      - '.github/workflows/docker.yml'
+      - '.github/workflows/claude-bc-risk-router.yml'
+      - 'Dockerfile'
+      - 'gitpod.Dockerfile'
+      - '.devcontainer/**'
   pull_request:
     branches: [ dev, master ]
+    paths-ignore:
+      # Nothing below can change an Apple, Android, Kotlin or Rust build, and every
+      # run of these workflows bills macOS Large or XLarge minutes.
+      - '**/*.md'
+      - 'docs/**'
+      - 'audit/**'
+      - 'sonar-project.properties'
+      - 'tools/sonar-scanner.properties'
+      - 'tools/sonarcloud-analysis'
+      - 'tools/coverage'
+      - 'tools/check-coverage'
+      - 'tools/lcov-to-sonar-xml'
+      - '.github/workflows/linux-ci-sonarcloud.yml'
+      - '.github/workflows/docker.yml'
+      - '.github/workflows/claude-bc-risk-router.yml'
+      - 'Dockerfile'
+      - 'gitpod.Dockerfile'
+      - '.devcontainer/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/kotlin-ci.yml
+++ b/.github/workflows/kotlin-ci.yml
@@ -3,8 +3,44 @@ name: Kotlin CI
 on:
   push:
     branches: [ dev, master ]
+    paths-ignore:
+      # Nothing below can change an Apple, Android, Kotlin or Rust build, and every
+      # run of these workflows bills macOS Large or XLarge minutes.
+      - '**/*.md'
+      - 'docs/**'
+      - 'audit/**'
+      - 'sonar-project.properties'
+      - 'tools/sonar-scanner.properties'
+      - 'tools/sonarcloud-analysis'
+      - 'tools/coverage'
+      - 'tools/check-coverage'
+      - 'tools/lcov-to-sonar-xml'
+      - '.github/workflows/linux-ci-sonarcloud.yml'
+      - '.github/workflows/docker.yml'
+      - '.github/workflows/claude-bc-risk-router.yml'
+      - 'Dockerfile'
+      - 'gitpod.Dockerfile'
+      - '.devcontainer/**'
   pull_request:
     branches: [ dev, master ]
+    paths-ignore:
+      # Nothing below can change an Apple, Android, Kotlin or Rust build, and every
+      # run of these workflows bills macOS Large or XLarge minutes.
+      - '**/*.md'
+      - 'docs/**'
+      - 'audit/**'
+      - 'sonar-project.properties'
+      - 'tools/sonar-scanner.properties'
+      - 'tools/sonarcloud-analysis'
+      - 'tools/coverage'
+      - 'tools/check-coverage'
+      - 'tools/lcov-to-sonar-xml'
+      - '.github/workflows/linux-ci-sonarcloud.yml'
+      - '.github/workflows/docker.yml'
+      - '.github/workflows/claude-bc-risk-router.yml'
+      - 'Dockerfile'
+      - 'gitpod.Dockerfile'
+      - '.devcontainer/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/kotlin-sample-ci.yml
+++ b/.github/workflows/kotlin-sample-ci.yml
@@ -3,8 +3,44 @@ name: Kotlin Multiplatform CI
 on:
   push:
     branches: [ dev, master ]
+    paths-ignore:
+      # Nothing below can change an Apple, Android, Kotlin or Rust build, and every
+      # run of these workflows bills macOS Large or XLarge minutes.
+      - '**/*.md'
+      - 'docs/**'
+      - 'audit/**'
+      - 'sonar-project.properties'
+      - 'tools/sonar-scanner.properties'
+      - 'tools/sonarcloud-analysis'
+      - 'tools/coverage'
+      - 'tools/check-coverage'
+      - 'tools/lcov-to-sonar-xml'
+      - '.github/workflows/linux-ci-sonarcloud.yml'
+      - '.github/workflows/docker.yml'
+      - '.github/workflows/claude-bc-risk-router.yml'
+      - 'Dockerfile'
+      - 'gitpod.Dockerfile'
+      - '.devcontainer/**'
   pull_request:
     branches: [ dev, master ]
+    paths-ignore:
+      # Nothing below can change an Apple, Android, Kotlin or Rust build, and every
+      # run of these workflows bills macOS Large or XLarge minutes.
+      - '**/*.md'
+      - 'docs/**'
+      - 'audit/**'
+      - 'sonar-project.properties'
+      - 'tools/sonar-scanner.properties'
+      - 'tools/sonarcloud-analysis'
+      - 'tools/coverage'
+      - 'tools/check-coverage'
+      - 'tools/lcov-to-sonar-xml'
+      - '.github/workflows/linux-ci-sonarcloud.yml'
+      - '.github/workflows/docker.yml'
+      - '.github/workflows/claude-bc-risk-router.yml'
+      - 'Dockerfile'
+      - 'gitpod.Dockerfile'
+      - '.devcontainer/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,46 @@ name: Rust CI
 on:
   push:
     branches: [ dev, master ]
+    paths-ignore:
+      # Nothing below can change an Apple, Android, Kotlin or Rust build, and every
+      # run of these workflows bills macOS Large or XLarge minutes.
+      - '**/*.md'
+      - 'docs/**'
+      - 'audit/**'
+      - 'sonar-project.properties'
+      - 'tools/sonar-scanner.properties'
+      - 'tools/sonarcloud-analysis'
+      # tools/check-coverage is NOT ignored here: this workflow runs it for the
+      # Rust coverage gate, unlike the Apple and Android ones.
+      - 'tools/coverage'
+      - 'tools/lcov-to-sonar-xml'
+      - '.github/workflows/linux-ci-sonarcloud.yml'
+      - '.github/workflows/docker.yml'
+      - '.github/workflows/claude-bc-risk-router.yml'
+      - 'Dockerfile'
+      - 'gitpod.Dockerfile'
+      - '.devcontainer/**'
   pull_request:
     branches: [ dev, master ]
+    paths-ignore:
+      # Nothing below can change an Apple, Android, Kotlin or Rust build, and every
+      # run of these workflows bills macOS Large or XLarge minutes.
+      - '**/*.md'
+      - 'docs/**'
+      - 'audit/**'
+      - 'sonar-project.properties'
+      - 'tools/sonar-scanner.properties'
+      - 'tools/sonarcloud-analysis'
+      # tools/check-coverage is NOT ignored here: this workflow runs it for the
+      # Rust coverage gate, unlike the Apple and Android ones.
+      - 'tools/coverage'
+      - 'tools/lcov-to-sonar-xml'
+      - '.github/workflows/linux-ci-sonarcloud.yml'
+      - '.github/workflows/docker.yml'
+      - '.github/workflows/claude-bc-risk-router.yml'
+      - 'Dockerfile'
+      - 'gitpod.Dockerfile'
+      - '.devcontainer/**'
 
 env:
   SCCACHE_GHA_ENABLED: "true"


### PR DESCRIPTION
## Why this is urgent

Actions spend on this repository is dominated by the Apple runners. The repository is public, so standard Linux runners are free, while the macOS Large and XLarge machines are billed for every minute. Nearly all of the current month's Actions cost for this repository comes from them.

## What was wrong

All five workflows on Apple runners - `ios-ci`, `kotlin-ci`, `kotlin-sample-ci`, `android-ci` and the macOS job in `rust` - triggered on every push and every pull request to `dev` and `master` with no path filter at all. A pull request changing nothing but `sonar-project.properties` started all five on Large or XLarge machines.

Two recent pull requests show the shape of it. #4852 and #4861 change only Sonar configuration and its helper scripts, and between them they ran all five Apple workflows repeatedly, for builds that could not have been affected by the change.

## What this does

Adds the same conservative `paths-ignore` to those five workflows, covering only files that provably cannot change an Apple, Android, Kotlin or Rust build: markdown and docs, the audit report, the Sonar configuration and its helper scripts, the Sonar/Docker/bc-router workflow files, and the container definitions.

It is deliberately a `paths-ignore` rather than a `paths` allowlist, so a new or unlisted path keeps triggering the builds. The failure mode is a build that runs unnecessarily, not one that silently stops running.

`tools/check-coverage` is ignored in four of the five but **not** in `rust`, which invokes it for its own coverage gate; there is a comment at that omission so it does not get tidied back in. Each remaining entry was checked against every workflow's job body, rather than its trigger block, to confirm the workflow ignoring a path never consumes it.

**On the required check:** `linux-ci.yml` is intentionally left without a filter. Its job is also named `build`, which is the context branch protection requires, so that context still reports on every pull request and no PR can hang waiting for a skipped workflow.

## Follow-ups, deliberately not in this PR

- `android-ci` runs on `macos-latest-large`. The Android SDK and NDK build fine on Linux, and this looks like history rather than a requirement - but the job drives an emulator through `reactivecircus/android-emulator-runner`, which needs KVM on Linux, so it deserves its own PR and its own verification.
- `kotlin-ci` needs macOS only for the KMP native Apple targets; the JVM and Android halves could move to Linux.

## How to test

Note this PR cannot demonstrate itself: it edits the five workflow files, and those paths are deliberately *not* in the ignore list, so all five correctly run here. Changing a workflow should test that workflow.

The check is against the file lists of the pull requests that motivated it:

- #4852 changed `.github/workflows/linux-ci-sonarcloud.yml`, `sonar-project.properties`, `tools/coverage`, `tools/lcov-to-sonar-xml`
- #4861 changed `.github/workflows/linux-ci-sonarcloud.yml`, `sonar-project.properties`

Every one of those paths is in the list added here, so with this in place both would have skipped all five macOS workflows. The first CI-only PR after this merges will show it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
