### PR TITLE
ci: update pinned rustup installer checksum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN ln -s /usr/bin/clang++-14 /usr/bin/clang++
 
 # Install rust
 RUN wget "https://sh.rustup.rs" -O rustup.sh \
-    && echo "6c30b75a75b28a96fd913a037c8581b580080b6ee9b8169a3c0feb1af7fe8caf  rustup.sh" | sha256sum -c - \
+    && echo "7d0ea0f8eba7fa1ebfe998091cd7ec4501e33ec5ca6b884eb4d894d7da5170af  rustup.sh" | sha256sum -c - \
     && sh rustup.sh -y \
     && rm rustup.sh
 ENV PATH="/root/.cargo/bin:${PATH}"


### PR DESCRIPTION
## Description

Docker CI has been failing on `master` since Sep 1. The sha256 pinned in #4837 no longer matches the script served by `https://sh.rustup.rs` — rustup rotated it upstream:

```
expected  6c30b75a75b28a96fd913a037c8581b580080b6ee9b8169a3c0feb1af7fe8caf
actual    7d0ea0f8eba7fa1ebfe998091cd7ec4501e33ec5ca6b884eb4d894d7da5170af
```

Nothing in the repo caused this. The first red run was `40616462e`, which only touched Sonar config; `424c7c7ea` (the commit that added the pin) passed earlier the same day, so rustup changed the file in between.

This is worth fixing promptly because it isn't only a red check — `docker-release.yml` in `wallet-core-releases` runs `docker build .` against this same Dockerfile before pushing to ECR Public, so the Docker publish step fails on the next release too.

### Follow-up worth considering

Pinning the hash of a URL whose contents upstream rotates will break again on rustup's next update. A versioned installer URL, or vendoring the script, would keep the integrity check without the recurring breakage. Left out of this PR to keep it to the one-line unblock — happy to follow up if @nikotw prefers a particular approach.

## How to test

```bash
curl -sL https://sh.rustup.rs -o rustup.sh
echo "7d0ea0f8eba7fa1ebfe998091cd7ec4501e33ec5ca6b884eb4d894d7da5170af  rustup.sh" | sha256sum -c -
# rustup.sh: OK
```

Docker CI runs on push and on PRs touching `Dockerfile`, so this PR exercises the real build.

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Add tests to cover changes as needed. — *n/a: CI's own Docker build is the test.*
- [x] Update documentation as needed. — *n/a*
- [x] If there is a related Issue, mention it in the description. — *references #4837*