### PR TITLE
fix(arc): use USDC as nativeTokenName

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -5116,7 +5116,7 @@
     "id": "arc",
     "name": "Arc",
     "displayName": "Arc",
-    "nativeTokenName": "USD Coin",
+    "nativeTokenName": "USDC",
     "coinId": 10005042,
     "symbol": "USDC",
     "decimals": 18,

--- a/tests/chains/Arc/TWCoinTypeTests.cpp
+++ b/tests/chains/Arc/TWCoinTypeTests.cpp
@@ -19,7 +19,7 @@ TEST(TWArcCoinType, TWCoinType) {
 
     assertStringsEqual(id, "arc");
     assertStringsEqual(name, "Arc");
-    assertStringsEqual(nativeTokenName, "USD Coin");
+    assertStringsEqual(nativeTokenName, "USDC");
     assertStringsEqual(symbol, "USDC");
     ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(coin), 18);
     ASSERT_EQ(TWCoinTypeBlockchain(coin), TWBlockchainEthereum);


### PR DESCRIPTION
## Description

Changes Arc's `nativeTokenName` from `USD Coin` to `USDC`, matching its `symbol`.

Both conventions exist in the registry — 6 entries have `nativeTokenName == symbol` (`binance`, `tbinance`, `bsc`, `smartchain`, `greenfield`, `opbnb`), while 42 use the full token name (`base` → `Ethereum` / `ETH`). This moves Arc to the former.

The generated coin test asserts this value, so it's updated too.

No derivation inputs change — `coinId`, `chainId`, `curve`, `publicKeyType`, `addressHasher` and the derivation path are untouched, so no derived address is affected. `docs/registry.md` has no `nativeTokenName` column and is unchanged.

Follows #4863, which added Arc in `4.8.1`.

## How to test

```bash
cd rust && cargo test -p tw_tests --test coin_address_derivation_test

# C++ (requires ./bootstrap.sh for protoc)
./build/tests/tests --gtest_filter="*Arc*"
```

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Add tests to cover changes as needed. — *existing generated coin test updated*
- [x] Update documentation as needed. — *n/a, field not in `docs/registry.md`*
- [ ] If there is a related Issue, mention it in the description.