### PR TITLE
tw_memory: zeroize TWData contents on drop

### DIFF
--- a/rust/tw_memory/Cargo.toml
+++ b/rust/tw_memory/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+zeroize = "1.8.2"
 
 [features]
 test-utils = []

--- a/rust/tw_memory/src/ffi/tw_data.rs
+++ b/rust/tw_memory/src/ffi/tw_data.rs
@@ -5,6 +5,7 @@
 use crate::ffi::c_byte_array_ref::CByteArrayRef;
 use crate::ffi::RawPtrTrait;
 use crate::Data;
+use zeroize::Zeroize;
 
 /// Defines a resizable block of data.
 ///
@@ -25,8 +26,9 @@ impl TWData {
     }
 
     /// Converts `TWData` into `Data` without additional allocation.
-    pub fn into_vec(self) -> Data {
-        self.0
+    pub fn into_vec(mut self) -> Data {
+        // Take the buffer without zeroing it: the caller takes ownership.
+        std::mem::take(&mut self.0)
     }
 
     /// Copies underlying data.
@@ -53,6 +55,14 @@ impl TWData {
 impl From<Data> for TWData {
     fn from(data: Data) -> Self {
         TWData(data)
+    }
+}
+
+impl Drop for TWData {
+    fn drop(&mut self) {
+        // Securely erase the contents before the buffer is deallocated, so
+        // sensitive data does not linger in allocator-managed memory.
+        self.0.zeroize();
     }
 }
 


### PR DESCRIPTION
## What and why

The Rust `TWData` owns a plain `Vec<u8>` that is deallocated without erasing its contents, so sensitive data (decrypted wallet plaintext, derived key material) can linger in allocator-managed memory after `tw_data_delete`. The C++ side of the same problem was fixed in #4667, but Rust `TWData` is an independent implementation and was not covered.

This implements `Drop` for `TWData` to zeroize the buffer before deallocation. `into_vec` now hands the buffer over via `mem::take` instead of moving the field out, so callers that convert to `Data` still receive it without an additional allocation and without triggering the zeroize path (the moved-out buffer belongs to the caller from that point).

Fixes #4841

## Testing

No Rust toolchain on the machine I worked from, so this was reviewed against the existing `tw_memory` tests and sibling-crate zeroize usage rather than run locally. Existing `tw_memory` tests cover `TWData` creation, conversion and deletion paths; behavior is unchanged except for the buffer being erased on drop. CI will confirm the build.