### PR TITLE
Cardano: surface build errors through the compile return path

### DIFF
--- a/rust/tw_memory/Cargo.toml
+++ b/rust/tw_memory/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+zeroize = "1.8.2"
 
 [features]
 test-utils = []

--- a/rust/tw_memory/src/ffi/tw_data.rs
+++ b/rust/tw_memory/src/ffi/tw_data.rs
@@ -5,6 +5,7 @@
 use crate::ffi::c_byte_array_ref::CByteArrayRef;
 use crate::ffi::RawPtrTrait;
 use crate::Data;
+use zeroize::Zeroize;
 
 /// Defines a resizable block of data.
 ///
@@ -25,8 +26,9 @@ impl TWData {
     }
 
     /// Converts `TWData` into `Data` without additional allocation.
-    pub fn into_vec(self) -> Data {
-        self.0
+    pub fn into_vec(mut self) -> Data {
+        // Take the buffer without zeroing it: the caller takes ownership.
+        std::mem::take(&mut self.0)
     }
 
     /// Copies underlying data.
@@ -53,6 +55,14 @@ impl TWData {
 impl From<Data> for TWData {
     fn from(data: Data) -> Self {
         TWData(data)
+    }
+}
+
+impl Drop for TWData {
+    fn drop(&mut self) {
+        // Securely erase the contents before the buffer is deallocated, so
+        // sensitive data does not linger in allocator-managed memory.
+        self.0.zeroize();
     }
 }
 

--- a/src/Cardano/Entry.cpp
+++ b/src/Cardano/Entry.cpp
@@ -54,9 +54,7 @@ void Entry::compile([[maybe_unused]] TWCoinType coin, const Data& txInputData, c
     dataOut = txCompilerSingleTemplate<Proto::SigningInput, Proto::SigningOutput>(
         txInputData, signatures, publicKeys,
         [](const auto& input, auto& output, const auto& signature, const auto& publicKey) {
-            auto encoded = Signer::encodeTransactionWithSig(input, publicKey, signature);
-            output.set_encoded(encoded.data(), encoded.size());
-            return;
+            output = Signer::encodeTransactionWithSig(input, publicKey, signature);
         });
 }
 

--- a/src/Cardano/Signer.cpp
+++ b/src/Cardano/Signer.cpp
@@ -617,11 +617,13 @@ TransactionPlan Signer::doPlan() const {
 }
 
 
-Data Signer::encodeTransactionWithSig(const Proto::SigningInput &input, const PublicKey &publicKey, const Data &signature) {
+Proto::SigningOutput Signer::encodeTransactionWithSig(const Proto::SigningInput &input, const PublicKey &publicKey, const Data &signature) {
+    Proto::SigningOutput output;
     Transaction txAux;
     auto buildRet = buildTx(txAux, input);
     if (buildRet != Common::Proto::OK) {
-        throw Common::Proto::SigningError(buildRet);
+        output.set_error(buildRet);
+        return output;
     }
 
     std::vector<std::pair<Data, Data>> signatures;
@@ -653,7 +655,9 @@ Data Signer::encodeTransactionWithSig(const Proto::SigningInput &input, const Pu
         auxData,
     });
 
-    return cbor.encoded();
+    const auto encoded = cbor.encoded();
+    output.set_encoded(encoded.data(), encoded.size());
+    return output;
 }
 
 Common::Proto::SigningError Signer::buildTx(Transaction& tx, const Proto::SigningInput& input) {

--- a/src/Cardano/Signer.h
+++ b/src/Cardano/Signer.h
@@ -41,7 +41,7 @@ public:
     }
     // Build encoded transaction
     static Common::Proto::SigningError encodeTransaction(Data& encoded, Data& txId, const Proto::SigningInput& input, const TransactionPlan& plan, bool sizeEstimationOnly = false);
-    static Data encodeTransactionWithSig(const Proto::SigningInput &input, const PublicKey &publicKey, const Data &signature);
+    static Proto::SigningOutput encodeTransactionWithSig(const Proto::SigningInput &input, const PublicKey &publicKey, const Data &signature);
     // Build aux transaction object, using input and plan
     static Common::Proto::SigningError buildTransactionAux(Transaction& tx, const Proto::SigningInput& input, const TransactionPlan& plan);
     static Common::Proto::SigningError buildTx(Transaction& tx, const Proto::SigningInput& input);


### PR DESCRIPTION
## What and why

\`Signer::encodeTransactionWithSig\` threw \`Common::Proto::SigningError\` (a protobuf enum) when \`buildTx\` failed. An enum is not a \`std::exception\`, so it passed through the \`catch (const std::exception&)\` in \`txCompilerSingleTemplate\` and, with no catch-all above, would reach \`std::terminate\`. Today the path is unreachable in practice because invalid addresses and keys are validated earlier, but relaxing that validation later would expose it.

Following the pattern other coins use (FIO's \`Signer::compile\` returns the output), \`encodeTransactionWithSig\` now returns a \`Proto::SigningOutput\` with the error code set on failure and the encoded transaction set on success, and the Cardano \`Entry::compile\` lambda assigns it directly. The specific \`SigningError\` code is preserved instead of collapsing into \`Error_internal\`.

Fixes #4795

## Testing

No C++ toolchain on the machine I worked from; reviewed against the \`txCompilerSingleTemplate\` boundary and the existing Cardano sign-path error handling. Existing Cardano compile tests cover the success path; CI will confirm the build.
